### PR TITLE
chore: include index.d.ts in @temporalio/core-bridge package

### DIFF
--- a/packages/core-bridge/package.json
+++ b/packages/core-bridge/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/temporalio/sdk-typescript/tree/main/packages/core-bridge",
   "files": [
+    "index.d.ts",
     "scripts",
     "src",
     "releases",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Typescript currently doesn't detect the exported and re-exported types from core-bridge because the index.d.ts file is not published with the npm package. This PR adds it.