### PR TITLE
feat!: Refactor WorkflowHandle creation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,8 @@
     "@typescript-eslint/no-unused-vars": [
       1,
       {
-        "argsIgnorePattern": "^_"
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
       }
     ]
   }

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -15,8 +15,6 @@ export { Next, Headers };
 export interface WorkflowStartInput {
   /** Name of Workflow to start */
   readonly workflowType: string;
-  /** Workflow arguments */
-  readonly args: unknown[];
   readonly headers: Headers;
   readonly options: CompiledWorkflowOptions;
 }
@@ -31,7 +29,6 @@ export interface WorkflowSignalInput {
 /** Input for WorkflowClientCallsInterceptor.signalWithStart */
 export interface WorkflowSignalWithStartInput {
   readonly workflowType: string;
-  readonly workflowArgs: unknown[];
   readonly signalName: string;
   readonly signalArgs: unknown[];
   readonly headers: Headers;

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -1,12 +1,15 @@
 import { v4 as uuid4 } from 'uuid';
 import {
-  WorkflowOptions as BaseWorkflowOptions,
-  WorkflowOptionsWithDefaults as BaseWorkflowOptionsWithDefaults,
-} from '@temporalio/common/lib/workflow-options';
+  WithWorkflowArgs,
+  WorkflowOptions as CommonWorkflowOptions,
+  WorkflowOptionsWithDefaults as CommonWorkflowOptionsWithDefaults,
+  SignalDefinition,
+  Workflow,
+} from '@temporalio/common';
 
-export { CompiledWorkflowOptions, compileWorkflowOptions } from '@temporalio/common/lib/workflow-options';
+export { CompiledWorkflowOptions, compileWorkflowOptions } from '@temporalio/common';
 
-export interface WorkflowOptions extends BaseWorkflowOptions {
+export interface WorkflowOptions extends CommonWorkflowOptions {
   /**
    * Task queue to use for Workflow tasks. It should match a task queue specified when creating a
    * `Worker` that hosts the Workflow code.
@@ -16,7 +19,18 @@ export interface WorkflowOptions extends BaseWorkflowOptions {
   followRuns?: boolean;
 }
 
-export interface WorkflowOptionsWithDefaults extends BaseWorkflowOptionsWithDefaults {
+export interface WorkflowSignalWithStartOptions<SA extends any[] = []> extends Partial<WorkflowOptions> {
+  /**
+   * SignalDefinition or name of signal
+   */
+  signal: SignalDefinition<SA> | string;
+  /**
+   * Arguments to invoke the signal handler with
+   */
+  signalArgs: SA;
+}
+
+export interface WorkflowOptionsWithDefaults<T extends Workflow> extends CommonWorkflowOptionsWithDefaults<T> {
   /**
    * If set to true, instructs the client to follow the chain of execution before returning a Workflow's result.
    *
@@ -31,10 +45,14 @@ export interface WorkflowOptionsWithDefaults extends BaseWorkflowOptionsWithDefa
 /**
  * Adds default values to `workflowId` and `workflowIdReusePolicy` to given workflow options.
  */
-export function addDefaults(opts: WorkflowOptions): WorkflowOptionsWithDefaults {
+export function addDefaults<T extends Workflow>(
+  opts: WithWorkflowArgs<T, WorkflowOptions>
+): WorkflowOptionsWithDefaults<T> {
+  const { workflowId, args, ...rest } = opts;
   return {
     followRuns: true,
-    workflowId: opts.workflowId ?? uuid4(),
-    ...opts,
+    args: args ?? [],
+    workflowId: workflowId ?? uuid4(),
+    ...rest,
   };
 }

--- a/packages/common/src/workflow-handle.ts
+++ b/packages/common/src/workflow-handle.ts
@@ -7,16 +7,6 @@ import { Workflow, WorkflowResultType, SignalDefinition } from './interfaces';
  */
 export interface BaseWorkflowHandle<T extends Workflow> {
   /**
-   * Start the Workflow with arguments, returns a Promise that resolves when the Workflow execution completes
-   */
-  execute(...args: Parameters<T>): Promise<WorkflowResultType<T>>;
-
-  /**
-   * Start the Workflow with arguments, returns a Promise that resolves with the execution runId
-   */
-  start(...args: Parameters<T>): Promise<string /* runId */>;
-
-  /**
    * Promise that resolves when Workflow execution completes
    */
   result(): Promise<WorkflowResultType<T>>;

--- a/packages/test/src/activities/index.ts
+++ b/packages/test/src/activities/index.ts
@@ -96,10 +96,8 @@ export async function queryOwnWf<R, A extends any[]>(queryDef: QueryDefinition<R
   const ctx = Context.current();
   const we = ctx.info.workflowExecution;
   const client = new WorkflowClient(getTestConnection().service, { namespace: ctx.info.workflowNamespace });
-  // TODO: Until server is released with the fix below, this fails often
-  //  https://github.com/temporalio/temporal/pull/2033
   try {
-    await client.createWorkflowHandle(we).query(queryDef, ...args);
+    await client.getHandle(we.workflowId, we.runId).query(queryDef, ...args);
   } catch (e) {
     console.log(`Workflow ${JSON.stringify(we)} query err`, e);
   }

--- a/packages/test/src/load/starter.ts
+++ b/packages/test/src/load/starter.ts
@@ -7,7 +7,7 @@ import { toMB } from '@temporalio/worker/lib/utils';
 import { StarterArgSpec, starterArgSpec, getRequired } from './args';
 
 async function runWorkflow(client: WorkflowClient, name: string, taskQueue: string) {
-  await client.execute(name, { taskQueue });
+  await client.execute(name, { args: [], taskQueue });
 }
 
 class NumberOfWorkflows {

--- a/packages/test/src/test-core.ts
+++ b/packages/test/src/test-core.ts
@@ -25,11 +25,8 @@ if (RUN_INTEGRATION_TESTS) {
     worker1.shutdown();
     await worker1Drained;
     const connection = new WorkflowClient();
-    {
-      // Run a simple workflow
-      const wf = connection.createWorkflowHandle(workflows.sleeper, { taskQueue: 'q2' });
-      await wf.execute(1);
-    }
+    // Run a simple workflow
+    await connection.execute(workflows.sleeper, { taskQueue: 'q2', args: [1] });
     worker2.shutdown();
     await worker2Drained;
 
@@ -42,11 +39,8 @@ if (RUN_INTEGRATION_TESTS) {
       taskQueue: 'q1', // Same as the first Worker created
     });
     const worker3Drained = worker3.run();
-    {
-      // Run a simple workflow
-      const wf = connection.createWorkflowHandle('sleeper', { taskQueue: 'q1' });
-      await wf.execute(1);
-    }
+    // Run a simple workflow
+    await connection.execute('sleeper', { taskQueue: 'q1', args: [1] });
     worker3.shutdown();
     await worker3Drained;
     // No exceptions, test passes

--- a/packages/test/src/test-dependencies.ts
+++ b/packages/test/src/test-dependencies.ts
@@ -73,8 +73,7 @@ if (RUN_INTEGRATION_TESTS) {
     });
     const p = worker.run();
     const conn = new WorkflowClient();
-    const wf = conn.createWorkflowHandle(workflows.dependenciesWorkflow, { taskQueue });
-    const runId = await wf.start();
+    const wf = await conn.start(workflows.dependenciesWorkflow, { taskQueue });
     await wf.result();
     worker.shutdown();
     await p;
@@ -82,7 +81,7 @@ if (RUN_INTEGRATION_TESTS) {
       namespace: 'default',
       taskQueue,
       workflowId: wf.workflowId,
-      runId,
+      runId: wf.originalRunId,
       workflowType: 'dependenciesWorkflow',
       isReplaying: false,
     };

--- a/packages/test/src/test-otel.ts
+++ b/packages/test/src/test-otel.ts
@@ -65,9 +65,10 @@ if (RUN_INTEGRATION_TESTS) {
         calls: [() => new OpenTelemetryWorkflowClientCallsInterceptor()],
       },
     });
-    const handle = client.createWorkflowHandle(workflows.smorgasbord, { taskQueue: 'test-otel' });
-
-    await Promise.all([handle.execute().finally(() => worker.shutdown()), worker.run()]);
+    await Promise.all([
+      client.execute(workflows.smorgasbord, { taskQueue: 'test-otel', args: [] }).finally(() => worker.shutdown()),
+      worker.run(),
+    ]);
     await otel.shutdown();
     const originalSpan = spans.find(({ name }) => name === `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}smorgasbord`);
     t.true(originalSpan !== undefined);
@@ -173,9 +174,12 @@ if (RUN_INTEGRATION_TESTS) {
         calls: [() => new OpenTelemetryWorkflowClientCallsInterceptor()],
       },
     });
-    const workflow = client.createWorkflowHandle(workflows.cancelFakeProgress, { taskQueue: 'test-otel' });
-
-    await Promise.all([workflow.execute().finally(() => worker.shutdown()), worker.run()]);
+    await Promise.all([
+      client
+        .execute(workflows.cancelFakeProgress, { taskQueue: 'test-otel', args: [] })
+        .finally(() => worker.shutdown()),
+      worker.run(),
+    ]);
     // Allow some time to ensure spans are flushed out to collector
     await new Promise((resolve) => setTimeout(resolve, 5000));
     t.pass();

--- a/packages/test/src/test-worker-from-bundle.ts
+++ b/packages/test/src/test-worker-from-bundle.ts
@@ -27,7 +27,7 @@ if (RUN_INTEGRATION_TESTS) {
       worker.run(),
       (async () => {
         try {
-          client.execute(successString, { taskQueue });
+          await client.execute(successString, { taskQueue, args: [] });
         } finally {
           worker.shutdown();
         }
@@ -54,7 +54,7 @@ if (RUN_INTEGRATION_TESTS) {
         worker.run(),
         (async () => {
           try {
-            client.execute(successString, { taskQueue });
+            client.execute(successString, { taskQueue, args: [] });
           } finally {
             worker.shutdown();
           }

--- a/packages/test/src/test-worker-no-activities.ts
+++ b/packages/test/src/test-worker-no-activities.ts
@@ -11,11 +11,11 @@ if (RUN_INTEGRATION_TESTS) {
     const { activities, taskQueue, ...rest } = defaultOptions;
     const worker = await Worker.create({ taskQueue: 'only-workflows', ...rest });
     const client = new WorkflowClient();
-    const runner = client.createWorkflowHandle(successString, {
-      taskQueue: 'only-workflows',
-    });
     const runAndShutdown = async () => {
-      const result = await runner.execute();
+      const result = await client.execute(successString, {
+        args: [],
+        taskQueue: 'only-workflows',
+      });
       t.is(result, 'success');
       worker.shutdown();
     };

--- a/packages/test/src/test-worker-no-workflows.ts
+++ b/packages/test/src/test-worker-no-workflows.ts
@@ -11,11 +11,11 @@ if (RUN_INTEGRATION_TESTS) {
     const workflowlessWorker = await Worker.create({ taskQueue: 'only-activities', activities });
     const normalWorker = await Worker.create({ ...defaultOptions, taskQueue: 'also-workflows' });
     const client = new WorkflowClient();
-    const runner = client.createWorkflowHandle(runActivityInDifferentTaskQueue, {
-      taskQueue: 'also-workflows',
-    });
     const runAndShutdown = async () => {
-      const result = await runner.execute('only-activities');
+      const result = await client.execute(runActivityInDifferentTaskQueue, {
+        args: ['only-activities'],
+        taskQueue: 'also-workflows',
+      });
       t.is(result, 'hi');
       workflowlessWorker.shutdown();
       normalWorker.shutdown();

--- a/packages/test/src/test-workflow-cancellation.ts
+++ b/packages/test/src/test-workflow-cancellation.ts
@@ -23,8 +23,7 @@ const testWorkflowCancellation: Macro<
   Context
 > = async (t, outcome, timing, expected) => {
   const client = new WorkflowClient();
-  const workflow = client.createWorkflowHandle(workflowCancellationScenarios, { taskQueue });
-  await workflow.start(outcome, timing);
+  const workflow = await client.start(workflowCancellationScenarios, { args: [outcome, timing], taskQueue });
   await workflow.cancel();
   if (expected === undefined) {
     await workflow.result();

--- a/packages/test/src/workflows/child-workflow-failure.ts
+++ b/packages/test/src/workflows/child-workflow-failure.ts
@@ -3,12 +3,11 @@
  * @module
  */
 
-import { createChildWorkflowHandle } from '@temporalio/workflow';
+import { executeChild } from '@temporalio/workflow';
 import { throwAsync } from './throw-async';
 
 export async function childWorkflowFailure(): Promise<void> {
-  const child = createChildWorkflowHandle(throwAsync, {
+  await executeChild(throwAsync, {
     taskQueue: 'test',
   });
-  await child.execute();
 }

--- a/packages/test/src/workflows/child-workflow-invoke.ts
+++ b/packages/test/src/workflows/child-workflow-invoke.ts
@@ -3,7 +3,7 @@
  * @module
  */
 
-import { createChildWorkflowHandle } from '@temporalio/workflow';
+import { startChild, executeChild } from '@temporalio/workflow';
 import { successString } from './success-string';
 
 export async function childWorkflowInvoke(): Promise<{
@@ -12,7 +12,7 @@ export async function childWorkflowInvoke(): Promise<{
   execResult: string;
   result: string;
 }> {
-  const child = createChildWorkflowHandle(successString);
-  const execResult = await createChildWorkflowHandle(successString).execute();
-  return { workflowId: child.workflowId, runId: await child.start(), result: await child.result(), execResult };
+  const child = await startChild(successString, {});
+  const execResult = await executeChild(successString, {});
+  return { workflowId: child.workflowId, runId: child.originalRunId, result: await child.result(), execResult };
 }

--- a/packages/test/src/workflows/child-workflow-sample.ts
+++ b/packages/test/src/workflows/child-workflow-sample.ts
@@ -1,9 +1,8 @@
-import { createChildWorkflowHandle } from '@temporalio/workflow';
+import { executeChild } from '@temporalio/workflow';
 // successString is a workflow implementation like childWorkflowExample below.
 // It is called with no arguments and return the string "success".
 import { successString } from './success-string';
 
 export async function childWorkflowExample(): Promise<string> {
-  const child = createChildWorkflowHandle(successString);
-  return await child.execute();
+  return await executeChild(successString, { args: [] });
 }

--- a/packages/test/src/workflows/child-workflow-start-fail.ts
+++ b/packages/test/src/workflows/child-workflow-start-fail.ts
@@ -3,36 +3,22 @@
  * @module
  */
 
-import {
-  createChildWorkflowHandle,
-  WorkflowExecutionAlreadyStartedError,
-  WorkflowIdReusePolicy,
-} from '@temporalio/workflow';
+import { startChild, WorkflowExecutionAlreadyStartedError, WorkflowIdReusePolicy } from '@temporalio/workflow';
 import { successString } from './success-string';
 
 export async function childWorkflowStartFail(): Promise<void> {
-  const child = createChildWorkflowHandle(successString, {
+  const child = await startChild(successString, {
     taskQueue: 'test',
     workflowIdReusePolicy: WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
   });
-  await child.start();
-  try {
-    await child.start();
-    throw new Error('Calling start on child workflow handle twice did not fail');
-  } catch (err) {
-    if (!(err instanceof WorkflowExecutionAlreadyStartedError)) {
-      throw new Error(`Got invalid error: ${err}`);
-    }
-  }
   await child.result();
 
   try {
-    const duplicate = createChildWorkflowHandle(successString, {
+    await startChild(successString, {
       taskQueue: 'test',
-      workflowId: child.workflowId,
+      workflowId: child.workflowId, // duplicate
       workflowIdReusePolicy: WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
     });
-    await duplicate.start();
     throw new Error('Managed to start a Workflow with duplicate workflowId');
   } catch (err) {
     if (!(err instanceof WorkflowExecutionAlreadyStartedError)) {

--- a/packages/test/src/workflows/child-workflow-termination.ts
+++ b/packages/test/src/workflows/child-workflow-termination.ts
@@ -4,7 +4,7 @@
  */
 
 import { WorkflowExecution } from '@temporalio/common';
-import { createChildWorkflowHandle, defineQuery, setListener } from '@temporalio/workflow';
+import { startChild, defineQuery, setListener } from '@temporalio/workflow';
 import { unblockOrCancel } from './unblock-or-cancel';
 
 export const childExecutionQuery = defineQuery<WorkflowExecution | undefined>('childExecution');
@@ -13,9 +13,7 @@ export async function childWorkflowTermination(): Promise<void> {
   let workflowExecution: WorkflowExecution | undefined = undefined;
   setListener(childExecutionQuery, () => workflowExecution);
 
-  const child = createChildWorkflowHandle(unblockOrCancel, {
-    taskQueue: 'test',
-  });
-  workflowExecution = { workflowId: child.workflowId, runId: await child.start() };
+  const child = await startChild(unblockOrCancel, {});
+  workflowExecution = { workflowId: child.workflowId, runId: child.originalRunId };
   await child.result();
 }

--- a/packages/test/src/workflows/child-workflow-timeout.ts
+++ b/packages/test/src/workflows/child-workflow-timeout.ts
@@ -3,13 +3,12 @@
  * @module
  */
 
-import { createChildWorkflowHandle } from '@temporalio/workflow';
+import { executeChild } from '@temporalio/workflow';
 import { unblockOrCancel } from './unblock-or-cancel';
 
 export async function childWorkflowTimeout(): Promise<void> {
-  const child = createChildWorkflowHandle(unblockOrCancel, {
+  await executeChild(unblockOrCancel, {
     workflowExecutionTimeout: '10ms',
     retryPolicy: { maximumAttempts: 1 },
   });
-  await child.execute(); // should time out
 }

--- a/packages/test/src/workflows/interceptor-example.ts
+++ b/packages/test/src/workflows/interceptor-example.ts
@@ -1,5 +1,5 @@
 import {
-  createChildWorkflowHandle,
+  executeChild,
   WorkflowInterceptors,
   defaultDataConverter,
   sleep,
@@ -37,7 +37,7 @@ export async function interceptorExample(): Promise<string> {
   await sleep(2);
   await condition(() => unblocked);
   // Untyped because we intercept the result
-  const result = await createChildWorkflowHandle('successString').execute();
+  const result = await executeChild('successString', {});
   if (result !== 3) {
     throw new Error('expected interceptor to change child workflow result');
   }

--- a/packages/test/src/workflows/smorgasbord.ts
+++ b/packages/test/src/workflows/smorgasbord.ts
@@ -3,7 +3,7 @@
  */
 import {
   sleep,
-  createChildWorkflowHandle,
+  startChild,
   createActivityHandle,
   ActivityCancellationType,
   CancellationScope,
@@ -43,9 +43,8 @@ export async function smorgasbord(iteration = 0): Promise<void> {
       const queryActPromise = queryOwnWf(stepQuery);
       const timerPromise = sleep(1000);
 
-      const childWf = createChildWorkflowHandle(signalTarget);
       const childWfPromise = (async () => {
-        await childWf.start();
+        const childWf = await startChild(signalTarget, {});
         await childWf.signal(unblockSignal);
         await childWf.result();
       })();

--- a/packages/workflow/src/interceptors.ts
+++ b/packages/workflow/src/interceptors.ts
@@ -8,7 +8,7 @@
 
 import { ActivityOptions, WorkflowExecution, Headers, Next } from '@temporalio/common';
 import { coresdk } from '@temporalio/proto/lib/coresdk';
-import { ChildWorkflowOptions, ContinueAsNewOptions } from './interfaces';
+import { ChildWorkflowOptionsWithDefaults, ContinueAsNewOptions } from './interfaces';
 
 export { Next, Headers };
 
@@ -71,8 +71,7 @@ export interface ActivityInput {
 /** Input for WorkflowOutboundCallsInterceptor.startChildWorkflowExecution */
 export interface StartChildWorkflowExecutionInput {
   readonly workflowType: string;
-  readonly args: unknown[];
-  readonly options: ChildWorkflowOptions;
+  readonly options: ChildWorkflowOptionsWithDefaults;
   readonly headers: Headers;
   readonly seq: number;
 }

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -97,6 +97,8 @@ export interface ChildWorkflowOptions extends WorkflowOptions {
   parentClosePolicy?: ParentClosePolicy;
 }
 
-export type RequiredChildWorkflowOptions = Required<Pick<ChildWorkflowOptions, 'workflowId' | 'cancellationType'>>;
+export type RequiredChildWorkflowOptions = Required<Pick<ChildWorkflowOptions, 'workflowId' | 'cancellationType'>> & {
+  args: unknown[];
+};
 
 export type ChildWorkflowOptionsWithDefaults = ChildWorkflowOptions & RequiredChildWorkflowOptions;

--- a/packages/workflow/src/workflow-handle.ts
+++ b/packages/workflow/src/workflow-handle.ts
@@ -36,7 +36,7 @@ export interface ExternalWorkflowHandle {
 
 /**
  * A client side handle to a single Workflow instance.
- * It can be used to start, signal, wait for completion, and cancel a Workflow execution.
+ * It can be used to signal, wait for completion, and cancel a Workflow execution.
  *
  * Given the following Workflow definition:
  * ```ts
@@ -44,13 +44,17 @@ export interface ExternalWorkflowHandle {
  * export async function counterWorkflow(initialValue: number): Promise<void>;
  * ```
  *
- * Create a handle for running and interacting with a single Workflow:
+ * Start a new Workflow execution and get a handle for interacting with it:
  * ```ts
- * const handle = createChildWorkflowHandle(counterWorkflow);
  * // Start the Workflow with initialValue of 2.
- * await handle.start(2);
+ * const handle = await startWorkflow(counterWorkflow, { args: [2] });
  * await handle.signal(incrementSignal, 2);
  * await handle.result(); // throws WorkflowExecutionTerminatedError
  * ```
  */
-export interface ChildWorkflowHandle<T extends Workflow> extends BaseWorkflowHandle<T> {} // eslint-disable-line @typescript-eslint/no-empty-interface
+export interface ChildWorkflowHandle<T extends Workflow> extends BaseWorkflowHandle<T> {
+  /**
+   * The runId of the initial run of the bound Workflow
+   */
+  readonly originalRunId: string;
+}


### PR DESCRIPTION
BREAKING CHANGE:
- `WorkflowClient.start` now returns a `WorkflowHandle`
- `WorkflowHandle` no longer has `start`, `signalWithStart` and
  `execute` methods
- `WorkflowClient.signalWithStart` was added
- To get a handle to an existing Workflow use `WorkflowClient.getHandle`
- `wf.createChildWorklowHandle` was renamed to `wf.startChild` and
  immediately starts the Workflow
- `wf.executeChild` replaces `ChildWorkflowHandle.execute`
- `wf.createExternalWorkflowHandle` was renamed to
  `wf.getExternalWorkflowHandle`

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
