### PR TITLE
feat(workflow)!: Rename `createActivityHandle` to `proxyActivities`

### DIFF
--- a/packages/test/src/workflows/activity-failure.ts
+++ b/packages/test/src/workflows/activity-failure.ts
@@ -1,10 +1,10 @@
 /**
  * Tests that ActivityFailure is propagated correctly to client
  */
-import { createActivityHandle } from '@temporalio/workflow';
+import { proxyActivities } from '@temporalio/workflow';
 import type * as activities from '../activities';
 
-const { throwAnError } = createActivityHandle<typeof activities>({
+const { throwAnError } = proxyActivities<typeof activities>({
   startToCloseTimeout: '5s',
   retry: { initialInterval: '1s', maximumAttempts: 1 },
 });

--- a/packages/test/src/workflows/activity-failures.ts
+++ b/packages/test/src/workflows/activity-failures.ts
@@ -11,11 +11,11 @@
  * @module
  */
 
-import { createActivityHandle } from '@temporalio/workflow';
+import { proxyActivities } from '@temporalio/workflow';
 import { ActivityFailure, ApplicationFailure, RetryState } from '@temporalio/common';
 import type * as activities from '../activities';
 
-const { throwSpecificError } = createActivityHandle<typeof activities>({
+const { throwSpecificError } = proxyActivities<typeof activities>({
   startToCloseTimeout: '20s',
   retry: { initialInterval: 5, maximumAttempts: 1, nonRetryableErrorTypes: ['NonRetryableError'] },
 });

--- a/packages/test/src/workflows/cancel-fake-progress.ts
+++ b/packages/test/src/workflows/cancel-fake-progress.ts
@@ -1,6 +1,6 @@
 import {
   ActivityCancellationType,
-  createActivityHandle,
+  proxyActivities,
   CancellationScope,
   isCancellation,
   setListener,
@@ -9,7 +9,7 @@ import {
 import { activityStartedSignal } from './definitions';
 import type * as activities from '../activities';
 
-const { fakeProgress } = createActivityHandle<typeof activities>({
+const { fakeProgress } = proxyActivities<typeof activities>({
   startToCloseTimeout: '200s',
   heartbeatTimeout: '3s',
   cancellationType: ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,

--- a/packages/test/src/workflows/cancel-http-request.ts
+++ b/packages/test/src/workflows/cancel-http-request.ts
@@ -1,6 +1,6 @@
 import {
   ActivityCancellationType,
-  createActivityHandle,
+  proxyActivities,
   CancellationScope,
   isCancellation,
   setListener,
@@ -9,7 +9,7 @@ import {
 import type * as activities from '../activities';
 import { activityStartedSignal } from './definitions';
 
-const { cancellableFetch } = createActivityHandle<typeof activities>({
+const { cancellableFetch } = proxyActivities<typeof activities>({
   startToCloseTimeout: '20s',
   heartbeatTimeout: '3s',
   cancellationType: ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,

--- a/packages/test/src/workflows/cancel-requested-with-non-cancellable.ts
+++ b/packages/test/src/workflows/cancel-requested-with-non-cancellable.ts
@@ -3,10 +3,10 @@
  * Used in the documentation site.
  */
 // @@@SNIPSTART typescript-cancel-requested-with-non-cancellable
-import { CancelledFailure, CancellationScope, createActivityHandle } from '@temporalio/workflow';
+import { CancelledFailure, CancellationScope, proxyActivities } from '@temporalio/workflow';
 import type * as activities from '../activities';
 
-const { httpGetJSON } = createActivityHandle<typeof activities>({
+const { httpGetJSON } = proxyActivities<typeof activities>({
   startToCloseTimeout: '10m',
 });
 

--- a/packages/test/src/workflows/configured-activities.ts
+++ b/packages/test/src/workflows/configured-activities.ts
@@ -1,7 +1,7 @@
-import { createActivityHandle } from '@temporalio/workflow';
+import { proxyActivities } from '@temporalio/workflow';
 import * as activityInterfaces from '../activities';
 
-const activities = createActivityHandle<typeof activityInterfaces>({
+const activities = proxyActivities<typeof activityInterfaces>({
   startToCloseTimeout: '10m',
 });
 

--- a/packages/test/src/workflows/handle-external-workflow-cancellation-while-activity-running.ts
+++ b/packages/test/src/workflows/handle-external-workflow-cancellation-while-activity-running.ts
@@ -4,10 +4,10 @@
  * Used in the documentation site.
  */
 // @@@SNIPSTART typescript-handle-external-workflow-cancellation-while-activity-running
-import { CancellationScope, createActivityHandle, isCancellation } from '@temporalio/workflow';
+import { CancellationScope, proxyActivities, isCancellation } from '@temporalio/workflow';
 import type * as activities from '../activities';
 
-const { httpPostJSON, cleanup } = createActivityHandle<typeof activities>({
+const { httpPostJSON, cleanup } = proxyActivities<typeof activities>({
   startToCloseTimeout: '10m',
 });
 

--- a/packages/test/src/workflows/http.ts
+++ b/packages/test/src/workflows/http.ts
@@ -1,8 +1,8 @@
 // @@@SNIPSTART typescript-schedule-activity-workflow
-import { createActivityHandle } from '@temporalio/workflow';
+import { proxyActivities } from '@temporalio/workflow';
 import type * as activities from '../activities';
 
-const { httpGet } = createActivityHandle<typeof activities>({
+const { httpGet } = proxyActivities<typeof activities>({
   startToCloseTimeout: '1 minute',
 });
 

--- a/packages/test/src/workflows/multiple-activities-single-timeout.ts
+++ b/packages/test/src/workflows/multiple-activities-single-timeout.ts
@@ -1,9 +1,9 @@
 // @@@SNIPSTART typescript-multiple-activities-single-timeout-workflow
-import { CancellationScope, createActivityHandle } from '@temporalio/workflow';
+import { CancellationScope, proxyActivities } from '@temporalio/workflow';
 import type * as activities from '../activities';
 
 export function multipleActivitiesSingleTimeout(urls: string[], timeoutMs: number): Promise<any> {
-  const { httpGetJSON } = createActivityHandle<typeof activities>({
+  const { httpGetJSON } = proxyActivities<typeof activities>({
     startToCloseTimeout: timeoutMs,
   });
 

--- a/packages/test/src/workflows/nested-cancellation.ts
+++ b/packages/test/src/workflows/nested-cancellation.ts
@@ -1,9 +1,9 @@
 // @@@SNIPSTART typescript-nested-cancellation-scopes
-import { CancellationScope, createActivityHandle, isCancellation } from '@temporalio/workflow';
+import { CancellationScope, proxyActivities, isCancellation } from '@temporalio/workflow';
 
 import type * as activities from '../activities';
 
-const { setup, httpPostJSON, cleanup } = createActivityHandle<typeof activities>({
+const { setup, httpPostJSON, cleanup } = proxyActivities<typeof activities>({
   startToCloseTimeout: '10m',
 });
 

--- a/packages/test/src/workflows/non-cancellable-shields-children.ts
+++ b/packages/test/src/workflows/non-cancellable-shields-children.ts
@@ -1,8 +1,8 @@
 // @@@SNIPSTART typescript-non-cancellable-shields-children
-import { CancellationScope, createActivityHandle } from '@temporalio/workflow';
+import { CancellationScope, proxyActivities } from '@temporalio/workflow';
 import type * as activities from '../activities';
 
-const { httpGetJSON } = createActivityHandle<typeof activities>({ startToCloseTimeout: '10m' });
+const { httpGetJSON } = proxyActivities<typeof activities>({ startToCloseTimeout: '10m' });
 
 export async function nonCancellable(url: string): Promise<any> {
   // Prevent Activity from being cancelled and await completion.

--- a/packages/test/src/workflows/run-activity-in-different-task-queue.ts
+++ b/packages/test/src/workflows/run-activity-in-different-task-queue.ts
@@ -1,8 +1,8 @@
-import { createActivityHandle } from '@temporalio/workflow';
+import { proxyActivities } from '@temporalio/workflow';
 import type * as activities from '../activities';
 
 export async function runActivityInDifferentTaskQueue(taskQueue: string): Promise<string> {
-  const { echo } = createActivityHandle<typeof activities>({
+  const { echo } = proxyActivities<typeof activities>({
     taskQueue,
     scheduleToCloseTimeout: '30 minutes',
   });

--- a/packages/test/src/workflows/shared-promise-scopes.ts
+++ b/packages/test/src/workflows/shared-promise-scopes.ts
@@ -1,8 +1,8 @@
 // @@@SNIPSTART typescript-shared-promise-scopes
-import { CancellationScope, createActivityHandle } from '@temporalio/workflow';
+import { CancellationScope, proxyActivities } from '@temporalio/workflow';
 import type * as activities from '../activities';
 
-const { httpGetJSON } = createActivityHandle<typeof activities>({ startToCloseTimeout: '10m' });
+const { httpGetJSON } = proxyActivities<typeof activities>({ startToCloseTimeout: '10m' });
 
 export async function sharedScopes(): Promise<any> {
   // Start activities in the root scope

--- a/packages/test/src/workflows/shield-awaited-in-root-scope.ts
+++ b/packages/test/src/workflows/shield-awaited-in-root-scope.ts
@@ -1,8 +1,8 @@
 // @@@SNIPSTART typescript-shield-awaited-in-root-scope
-import { CancellationScope, createActivityHandle } from '@temporalio/workflow';
+import { CancellationScope, proxyActivities } from '@temporalio/workflow';
 import type * as activities from '../activities';
 
-const { httpGetJSON } = createActivityHandle<typeof activities>({ startToCloseTimeout: '10m' });
+const { httpGetJSON } = proxyActivities<typeof activities>({ startToCloseTimeout: '10m' });
 
 export async function shieldAwaitedInRootScope(): Promise<any> {
   let p: Promise<any> | undefined = undefined;

--- a/packages/test/src/workflows/smorgasbord.ts
+++ b/packages/test/src/workflows/smorgasbord.ts
@@ -4,7 +4,7 @@
 import {
   sleep,
   startChild,
-  createActivityHandle,
+  proxyActivities,
   ActivityCancellationType,
   CancellationScope,
   isCancellation,
@@ -17,13 +17,13 @@ import * as activities from '../activities/';
 import { signalTarget } from './signal-target';
 import { activityStartedSignal, unblockSignal } from './definitions';
 
-const { fakeProgress } = createActivityHandle<typeof activities>({
+const { fakeProgress } = proxyActivities<typeof activities>({
   startToCloseTimeout: '5s',
   scheduleToCloseTimeout: '10s',
   heartbeatTimeout: '3s',
   cancellationType: ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
 });
-const { queryOwnWf } = createActivityHandle<typeof activities>({
+const { queryOwnWf } = proxyActivities<typeof activities>({
   // This one needs a long timeout because of the queries getting dropped bug
   startToCloseTimeout: '35s',
   scheduleToCloseTimeout: '40s',

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -14,7 +14,7 @@
  *
  * ### Activities
  *
- * To schedule Activities, use {@link createActivityHandle} to obtain an Activity function and call.
+ * To schedule Activities, use {@link proxyActivities} to obtain an Activity function and call.
  *
  * <!--SNIPSTART typescript-schedule-activity-workflow-->
  * <!--SNIPEND-->

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -340,11 +340,11 @@ function signalWorkflowNextHandler({ seq, signalName, args, target }: SignalWork
  *
  * @example
  * ```ts
- * import { createActivityHandle, ActivityInterface } from '@temporalio/workflow';
+ * import { proxyActivities, ActivityInterface } from '@temporalio/workflow';
  * import * as activities from '../activities';
  *
  * // Setup Activities from module exports
- * const { httpGet, otherActivity } = createActivityHandle<typeof activities>({
+ * const { httpGet, otherActivity } = proxyActivities<typeof activities>({
  *   startToCloseTimeout: '30 minutes',
  * });
  *
@@ -357,7 +357,7 @@ function signalWorkflowNextHandler({ seq, signalName, args, target }: SignalWork
  * const {
  *   httpGetFromJava,
  *   someOtherJavaActivity
- * } = createActivityHandle<JavaActivities>({
+ * } = proxyActivities<JavaActivities>({
  *   taskQueue: 'java-worker-taskQueue',
  *   startToCloseTimeout: '5m',
  * });
@@ -368,9 +368,7 @@ function signalWorkflowNextHandler({ seq, signalName, args, target }: SignalWork
  * }
  * ```
  */
-export function createActivityHandle<A extends Record<string, ActivityFunction<any, any>>>(
-  options: ActivityOptions
-): A {
+export function proxyActivities<A extends Record<string, ActivityFunction<any, any>>>(options: ActivityOptions): A {
   if (options === undefined) {
     throw new TypeError('options must be defined');
   }


### PR DESCRIPTION
BREAKING CHANGE: The function's usage remains the same, only the name
was changed.

Before:
```ts
import { createActivityHandle } from '@temporalio/workflow';
import type * as activities from './activities';

const { greet } = createActivityHandle<typeof activities>({
  startToCloseTimeout: '1 minute',
});
```

After:
```ts
import { proxyActivities } from '@temporalio/workflow';
import type * as activities from './activities';

const { greet } = proxyActivities<typeof activities>({
  startToCloseTimeout: '1 minute',
});
```

Reasoning:
- Clarify that the method returns a proxy
- Avoid confusion with `WorkflowHandle`