### PR TITLE
feat(workflow)!: Rename `setListener` to `setHandler`

### DIFF
--- a/packages/test/src/workflows/async-fail-signal.ts
+++ b/packages/test/src/workflows/async-fail-signal.ts
@@ -1,8 +1,8 @@
-import { setListener, sleep } from '@temporalio/workflow';
+import { setHandler, sleep } from '@temporalio/workflow';
 import { failSignal } from './definitions';
 
 export async function asyncFailSignalWorkflow(): Promise<void> {
-  setListener(failSignal, async () => {
+  setHandler(failSignal, async () => {
     await sleep(100);
     throw new Error('Signal failed');
   });

--- a/packages/test/src/workflows/cancel-fake-progress.ts
+++ b/packages/test/src/workflows/cancel-fake-progress.ts
@@ -3,7 +3,7 @@ import {
   proxyActivities,
   CancellationScope,
   isCancellation,
-  setListener,
+  setHandler,
   condition,
 } from '@temporalio/workflow';
 import { activityStartedSignal } from './definitions';
@@ -17,7 +17,7 @@ const { fakeProgress } = proxyActivities<typeof activities>({
 
 export async function cancelFakeProgress(): Promise<void> {
   let activityStarted = false;
-  setListener(activityStartedSignal, () => void (activityStarted = true));
+  setHandler(activityStartedSignal, () => void (activityStarted = true));
   try {
     await CancellationScope.cancellable(async () => {
       const promise = fakeProgress();

--- a/packages/test/src/workflows/cancel-http-request.ts
+++ b/packages/test/src/workflows/cancel-http-request.ts
@@ -3,7 +3,7 @@ import {
   proxyActivities,
   CancellationScope,
   isCancellation,
-  setListener,
+  setHandler,
   condition,
 } from '@temporalio/workflow';
 import type * as activities from '../activities';
@@ -17,7 +17,7 @@ const { cancellableFetch } = proxyActivities<typeof activities>({
 
 export async function cancellableHTTPRequest(url: string): Promise<void> {
   let activityStarted = false;
-  setListener(activityStartedSignal, () => void (activityStarted = true));
+  setHandler(activityStartedSignal, () => void (activityStarted = true));
   try {
     await CancellationScope.cancellable(async () => {
       const promise = cancellableFetch(url, true);

--- a/packages/test/src/workflows/child-workflow-termination.ts
+++ b/packages/test/src/workflows/child-workflow-termination.ts
@@ -4,14 +4,14 @@
  */
 
 import { WorkflowExecution } from '@temporalio/common';
-import { startChild, defineQuery, setListener } from '@temporalio/workflow';
+import { startChild, defineQuery, setHandler } from '@temporalio/workflow';
 import { unblockOrCancel } from './unblock-or-cancel';
 
 export const childExecutionQuery = defineQuery<WorkflowExecution | undefined>('childExecution');
 
 export async function childWorkflowTermination(): Promise<void> {
   let workflowExecution: WorkflowExecution | undefined = undefined;
-  setListener(childExecutionQuery, () => workflowExecution);
+  setHandler(childExecutionQuery, () => workflowExecution);
 
   const child = await startChild(unblockOrCancel, {});
   workflowExecution = { workflowId: child.workflowId, runId: child.originalRunId };

--- a/packages/test/src/workflows/continue-as-new-same-workflow.ts
+++ b/packages/test/src/workflows/continue-as-new-same-workflow.ts
@@ -2,7 +2,7 @@
  * Tests continueAsNew for the same Workflow from execute and signal handler
  * @module
  */
-import { continueAsNew, CancellationScope, defineSignal, setListener } from '@temporalio/workflow';
+import { continueAsNew, CancellationScope, defineSignal, setHandler } from '@temporalio/workflow';
 
 export const continueAsNewSignal = defineSignal('continueAsNew');
 
@@ -10,7 +10,7 @@ export async function continueAsNewSameWorkflow(
   continueFrom: 'execute' | 'signal' | 'none' = 'execute',
   continueTo: 'execute' | 'signal' | 'none' = 'signal'
 ): Promise<void> {
-  setListener(continueAsNewSignal, async () => {
+  setHandler(continueAsNewSignal, async () => {
     await continueAsNew<typeof continueAsNewSameWorkflow>('none');
   });
   if (continueFrom === 'none') {

--- a/packages/test/src/workflows/fail-signal.ts
+++ b/packages/test/src/workflows/fail-signal.ts
@@ -1,8 +1,8 @@
-import { setListener, sleep } from '@temporalio/workflow';
+import { setHandler, sleep } from '@temporalio/workflow';
 import { failSignal } from './definitions';
 
 export async function failSignalWorkflow(): Promise<void> {
-  setListener(failSignal, () => {
+  setHandler(failSignal, () => {
     throw new Error('Signal failed');
   });
   // Don't complete to allow Workflow to be interrupted by fail() signal

--- a/packages/test/src/workflows/fail-unless-signaled-before-start.ts
+++ b/packages/test/src/workflows/fail-unless-signaled-before-start.ts
@@ -1,10 +1,10 @@
-import { defineSignal, setListener } from '@temporalio/workflow';
+import { defineSignal, setHandler } from '@temporalio/workflow';
 
 export const someShallPassSignal = defineSignal('someShallPass');
 
 export async function failUnlessSignaledBeforeStart(): Promise<void> {
   let pass = false;
-  setListener(someShallPassSignal, () => void (pass = true));
+  setHandler(someShallPassSignal, () => void (pass = true));
   if (!pass) {
     throw new Error('None shall pass');
   }

--- a/packages/test/src/workflows/interceptor-example.ts
+++ b/packages/test/src/workflows/interceptor-example.ts
@@ -6,7 +6,7 @@ import {
   condition,
   defineSignal,
   defineQuery,
-  setListener,
+  setHandler,
 } from '@temporalio/workflow';
 import { echo } from './configured-activities';
 
@@ -17,14 +17,14 @@ export const getSecretQuery = defineQuery<string>('getSecret');
 
 export async function interceptorExample(): Promise<string> {
   let unblocked = false;
-  setListener(unblockWithSecretSignal, (secret: string) => {
+  setHandler(unblockWithSecretSignal, (secret: string) => {
     if (secret !== '12345') {
       // Workflow execution should fail
       throw new Error('Wrong unblock secret');
     }
     unblocked = true;
   });
-  setListener(getSecretQuery, () => '12345');
+  setHandler(getSecretQuery, () => '12345');
 
   try {
     await sleep(1);

--- a/packages/test/src/workflows/interrupt-signal.ts
+++ b/packages/test/src/workflows/interrupt-signal.ts
@@ -1,12 +1,12 @@
 // @@@SNIPSTART typescript-workflow-signal-implementation
-import { defineSignal, setListener } from '@temporalio/workflow';
+import { defineSignal, setHandler } from '@temporalio/workflow';
 
 export const interruptSignal = defineSignal<[string]>('interrupt');
 
 export async function interruptableWorkflow(): Promise<void> {
   // When this Promise is rejected Workflow execution will fail
   await new Promise<never>((_resolve, reject) => {
-    setListener(interruptSignal, (reason) => reject(new Error(reason)));
+    setHandler(interruptSignal, (reason) => reject(new Error(reason)));
   });
 }
 // @@@SNIPEND

--- a/packages/test/src/workflows/invalid-or-failed-queries.ts
+++ b/packages/test/src/workflows/invalid-or-failed-queries.ts
@@ -5,14 +5,14 @@
  * @module
  */
 
-import { defineQuery, setListener } from '@temporalio/workflow';
+import { defineQuery, setHandler } from '@temporalio/workflow';
 
 export const invalidAsyncQuery = defineQuery<Promise<boolean>>('invalidAsyncMethod');
 export const failQuery = defineQuery<never>('fail');
 
 export async function invalidOrFailedQueries(): Promise<void> {
-  setListener(invalidAsyncQuery, async () => true);
-  setListener(failQuery, () => {
+  setHandler(invalidAsyncQuery, async () => true);
+  setHandler(failQuery, () => {
     throw new Error('fail');
   });
 }

--- a/packages/test/src/workflows/signal-target.ts
+++ b/packages/test/src/workflows/signal-target.ts
@@ -4,16 +4,16 @@
  *
  * @module
  */
-import { condition, setListener } from '@temporalio/workflow';
+import { condition, setHandler } from '@temporalio/workflow';
 import { failWithMessageSignal, unblockSignal } from './definitions';
 
 export async function signalTarget(): Promise<void> {
   let unblocked = false;
 
-  setListener(failWithMessageSignal, (message) => {
+  setHandler(failWithMessageSignal, (message) => {
     throw new Error(message);
   });
-  setListener(unblockSignal, () => void (unblocked = true));
+  setHandler(unblockSignal, () => void (unblocked = true));
 
   await condition(() => unblocked);
 }

--- a/packages/test/src/workflows/smorgasbord.ts
+++ b/packages/test/src/workflows/smorgasbord.ts
@@ -9,7 +9,7 @@ import {
   CancellationScope,
   isCancellation,
   defineQuery,
-  setListener,
+  setHandler,
   condition,
   continueAsNew,
 } from '@temporalio/workflow';
@@ -34,8 +34,8 @@ export const stepQuery = defineQuery<number>('step');
 export async function smorgasbord(iteration = 0): Promise<void> {
   let unblocked = false;
 
-  setListener(stepQuery, () => iteration);
-  setListener(activityStartedSignal, () => void (unblocked = true));
+  setHandler(stepQuery, () => iteration);
+  setHandler(activityStartedSignal, () => void (unblocked = true));
 
   try {
     await CancellationScope.cancellable(async () => {

--- a/packages/test/src/workflows/unblock-or-cancel.ts
+++ b/packages/test/src/workflows/unblock-or-cancel.ts
@@ -2,15 +2,15 @@
  * All-in-one sample showing cancellation, signals and queries
  * @module
  */
-import { CancelledFailure, defineQuery, setListener, condition } from '@temporalio/workflow';
+import { CancelledFailure, defineQuery, setHandler, condition } from '@temporalio/workflow';
 import { unblockSignal } from './definitions';
 
 export const isBlockedQuery = defineQuery<boolean>('isBlocked');
 
 export async function unblockOrCancel(): Promise<void> {
   let isBlocked = true;
-  setListener(unblockSignal, () => void (isBlocked = false));
-  setListener(isBlockedQuery, () => isBlocked);
+  setHandler(unblockSignal, () => void (isBlocked = false));
+  setHandler(isBlockedQuery, () => isBlocked);
   try {
     console.log('Blocked');
     await condition(() => !isBlocked);

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -179,7 +179,7 @@ export class Activator implements ActivationHandler {
   }
 
   protected async queryWorkflowNextHandler({ queryName, args }: QueryInput): Promise<unknown> {
-    const fn = state.queryListeners.get(queryName);
+    const fn = state.queryHandlers.get(queryName);
     if (fn === undefined) {
       // Fail the query
       throw new ReferenceError(`Workflow did not register a handler for ${queryName}`);
@@ -218,9 +218,9 @@ export class Activator implements ActivationHandler {
   }
 
   public async signalWorkflowNextHandler({ signalName, args }: SignalInput): Promise<void> {
-    const fn = state.signalListeners.get(signalName);
+    const fn = state.signalHandlers.get(signalName);
     if (fn === undefined) {
-      throw new IllegalStateError(`No registered signal listener for signal ${signalName}`);
+      throw new IllegalStateError(`No registered signal handler for signal ${signalName}`);
     }
     return fn(...args);
   }
@@ -231,7 +231,7 @@ export class Activator implements ActivationHandler {
       throw new TypeError('Missing activation signalName');
     }
 
-    const fn = state.signalListeners.get(signalName);
+    const fn = state.signalHandlers.get(signalName);
     if (fn === undefined) {
       let buffer = state.bufferedSignals.get(signalName);
       if (buffer === undefined) {
@@ -318,12 +318,12 @@ export class State {
   };
 
   /**
-   * Holds buffered signal calls until a listener is registered
+   * Holds buffered signal calls until a handler is registered
    */
   public readonly bufferedSignals = new Map<string, coresdk.workflow_activation.ISignalWorkflow[]>();
 
   /**
-   * Holds buffered query calls until a listener is registered.
+   * Holds buffered query calls until a handler is registered.
    *
    * **IMPORTANT** queries are only buffered until workflow is started.
    * This is required because async interceptors might block workflow function invocation
@@ -332,14 +332,14 @@ export class State {
   public readonly bufferedQueries = Array<coresdk.workflow_activation.IQueryWorkflow>();
 
   /**
-   * Mapping of signal name to listener
+   * Mapping of signal name to handler
    */
-  public readonly signalListeners = new Map<string, WorkflowSignalType>();
+  public readonly signalHandlers = new Map<string, WorkflowSignalType>();
 
   /**
-   * Mapping of signal name to listener
+   * Mapping of signal name to handler
    */
-  public readonly queryListeners = new Map<string, WorkflowQueryType>();
+  public readonly queryHandlers = new Map<string, WorkflowQueryType>();
 
   /**
    * Loaded in {@link initRuntime}

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -883,7 +883,7 @@ function conditionInner(fn: () => boolean): Promise<void> {
 /**
  * Define a signal method for a Workflow.
  *
- * Definitions are used to register listeners in the Workflow via {@link setListener} and to signal Workflows using a {@link WorkflowHandle}, {@link ChildWorkflowHandle} or {@link ExternalWorkflowHandle}.
+ * Definitions are used to register handler in the Workflow via {@link setHandler} and to signal Workflows using a {@link WorkflowHandle}, {@link ChildWorkflowHandle} or {@link ExternalWorkflowHandle}.
  * Definitions can be reused in multiple Workflows.
  */
 export function defineSignal<Args extends any[] = []>(name: string): SignalDefinition<Args> {
@@ -896,7 +896,7 @@ export function defineSignal<Args extends any[] = []>(name: string): SignalDefin
 /**
  * Define a query method for a Workflow.
  *
- * Definitions are used to register listeners in the Workflow via {@link setListener} and to query Workflows using a {@link WorkflowHandle}.
+ * Definitions are used to register handler in the Workflow via {@link setHandler} and to query Workflows using a {@link WorkflowHandle}.
  * Definitions can be reused in multiple Workflows.
  */
 export function defineQuery<Ret, Args extends any[] = []>(name: string): QueryDefinition<Ret, Args> {
@@ -907,9 +907,9 @@ export function defineQuery<Ret, Args extends any[] = []>(name: string): QueryDe
 }
 
 /**
- * A listener function capable of accepting the arguments for a given SignalDefinition or QueryDefinition.
+ * A handler function capable of accepting the arguments for a given SignalDefinition or QueryDefinition.
  */
-export type Listener<
+export type Handler<
   Ret,
   Args extends any[],
   T extends SignalDefinition<Args> | QueryDefinition<Ret, Args>
@@ -920,19 +920,19 @@ export type Listener<
   : never;
 
 /**
- * Set a listener function for a Workflow query or signal.
+ * Set a handler function for a Workflow query or signal.
  *
- * If this function is called multiple times for a given signal or query name the last listener will overwrite any previous calls.
+ * If this function is called multiple times for a given signal or query name the last handler will overwrite any previous calls.
  *
  * @param def a {@link SignalDefinition} or {@link QueryDefinition} as returned by {@link defineSignal} or {@link defineQuery} respectively.
- * @param listener  a compatible listener function for the given definition.
+ * @param handler  a compatible handler function for the given definition.
  */
-export function setListener<Ret, Args extends any[], T extends SignalDefinition<Args> | QueryDefinition<Ret, Args>>(
+export function setHandler<Ret, Args extends any[], T extends SignalDefinition<Args> | QueryDefinition<Ret, Args>>(
   def: T,
-  listener: Listener<Ret, Args, T>
+  handler: Handler<Ret, Args, T>
 ): void {
   if (def.type === 'signal') {
-    state.signalListeners.set(def.name, listener as any);
+    state.signalHandlers.set(def.name, handler as any);
     const bufferedSignals = state.bufferedSignals.get(def.name);
     if (bufferedSignals !== undefined) {
       for (const signal of bufferedSignals) {
@@ -941,7 +941,7 @@ export function setListener<Ret, Args extends any[], T extends SignalDefinition<
       state.bufferedSignals.delete(def.name);
     }
   } else if (def.type === 'query') {
-    state.queryListeners.set(def.name, listener as any);
+    state.queryHandlers.set(def.name, handler as any);
   } else {
     throw new TypeError(`Invalid definition type: ${(def as any).type}`);
   }


### PR DESCRIPTION
BREAKING CHANGE: The function's usage remains the same, only the name
was changed.

Before:
```ts
import { defineSignal, setListener, condition } from '@temporalio/workflow';
import { unblockSignal } from './definitions';

export const unblockSignal = defineSignal('unblock');

export async function myWorkflow() {
  let isBlocked = true;
  setListener(unblockSignal, () => void (isBlocked = false));
  await condition(() => !isBlocked);
}
```

After:
```ts
import { defineSignal, setHandler, condition } from '@temporalio/workflow';
import { unblockSignal } from './definitions';

export const unblockSignal = defineSignal('unblock');

export async function myWorkflow() {
  let isBlocked = true;
  setHandler(unblockSignal, () => void (isBlocked = false));
  await condition(() => !isBlocked);
}
```

Reasoning:
- It was our go-to name initially but we decided against it when to avoid confusion with the `WorkflowHandle` concept
- Handling seems more accurate about what the function is doing than listening
- With listeners it sounds like you can set multiple listeners, and handler doesn't