### PR TITLE
feat(client)!: Use failure classes for WorkflowClient errors

### DIFF
--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,51 +1,32 @@
-import { temporal } from '@temporalio/proto';
+import { RetryState, TemporalFailure } from '@temporalio/common';
 
 /**
- * Thrown by client when waiting on Workflow execution result if Workflow is terminated
+ * Thrown by the client while waiting on Workflow execution result if execution
+ * completes with failure.
+ *
+ * The failure type will be set in the `cause` attribute.
+ *
+ * For example if the workflow is cancelled, `cause` will be set to
+ * {@link CancelledFailure}.
  */
-export class WorkflowExecutionTerminatedError extends Error {
-  public readonly name: string = 'WorkflowExecutionTerminatedError';
-  public constructor(message: string, public readonly details: any[], public readonly identity?: string) {
-    super(message);
-  }
-}
-
-/**
- * Thrown by client when waiting on Workflow execution result if execution times out
- */
-export class WorkflowExecutionTimedOutError extends Error {
-  public readonly name: string = 'WorkflowExecutionTimedOutError';
-  public constructor(message: string, public readonly retryState: temporal.api.enums.v1.RetryState) {
-    super(message);
-  }
-}
-
-/**
- * Thrown by client when waiting on Workflow execution result if execution fails
- */
-export class WorkflowExecutionFailedError extends Error {
+export class WorkflowFailedError extends Error {
   public readonly name: string = 'WorkflowExecutionFailedError';
-  public constructor(message: string, public readonly cause: Error | undefined) {
+  public constructor(
+    message: string,
+    public readonly cause: TemporalFailure | undefined,
+    public readonly retryState: RetryState
+  ) {
     super(message);
   }
 }
 
 /**
- * Thrown by client when waiting on Workflow execution result if Workflow is cancelled
- */
-export class WorkflowExecutionCancelledError extends Error {
-  public readonly name: string = 'WorkflowExecutionCancelledError';
-  public constructor(message: string, public readonly details: any[]) {
-    super(message);
-  }
-}
-
-/**
- * Thrown by client when waiting on Workflow execution result if Workflow continues as new.
+ * Thrown the by client while waiting on Workflow execution result if Workflow
+ * continues as new.
  *
  * Only thrown if asked not to follow the chain of execution (see {@link WorkflowOptions.followRuns}).
  */
-export class WorkflowExecutionContinuedAsNewError extends Error {
+export class WorkflowContinuedAsNewError extends Error {
   public readonly name: string = 'WorkflowExecutionContinuedAsNewError';
   public constructor(message: string, public readonly newExecutionRunId: string) {
     super(message);

--- a/scripts/registry.js
+++ b/scripts/registry.js
@@ -36,7 +36,7 @@ class Registry {
 
   async ready() {
     const logPath = path.resolve(this.workdir, 'verdaccio.log');
-    await untilExists(logPath, 60);
+    await untilExists(logPath, 120);
     const tail = new Tail(logPath, {
       fromBeginning: true,
     });


### PR DESCRIPTION
BREAKING CHANGE: Error handling for `WorkflowClient` and
`WorkflowHandle` `execute` and `result` methods now throw
`WorkflowFailedError` with the specific `TemporalFailure` as the cause.
The following error classes were renamed:
- `WorkflowExecutionFailedError` was renamed `WorkflowFailedError`.
- `WorkflowExecutionContinuedAsNewError` was renamed
  `WorkflowContinuedAsNewError`.

Before:
```ts
try {
  await WorkflowClient.execute(myWorkflow, { taskQueue: 'example' });
} catch (err) {
  if (
    err instanceof WorkflowExecutionFailedError &&
    err.cause instanceof ApplicationFailure
  ) {
    console.log('Workflow failed');
  } else if (err instanceof WorkflowExecutionTimedOutError) {
    console.log('Workflow timed out');
  } else if (err instanceof WorkflowExecutionTerminatedError) {
    console.log('Workflow terminated');
  } else if (err instanceof WorkflowExecutionCancelledError) {
    console.log('Workflow cancelled');
  }
}
```

After:
```ts
try {
  await WorkflowClient.execute(myWorkflow, { taskQueue: 'example' });
} catch (err) {
  if (err instanceof WorkflowFailedError) {
  ) {
    if (err.cause instanceof ApplicationFailure) {
      console.log('Workflow failed');
    } else if (err.cause instanceof TimeoutFailure) {
      console.log('Workflow timed out');
    } else if (err.cause instanceof TerminatedFailure) {
      console.log('Workflow terminated');
    } else if (err.cause instanceof CancelledFailure) {
      console.log('Workflow cancelled');
    }
}
```

Closes #323 