### PR TITLE
fix(workflow): Cancel timer created by condition

### DIFF
--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -1689,6 +1689,13 @@ test('conditionWaiter', async (t) => {
   }
   {
     const completion = await activate(t, makeFireTimer(2));
-    compareCompletion(t, completion, makeSuccess());
+    compareCompletion(
+      t,
+      completion,
+      makeSuccess([
+        makeSetPatchMarker('__temporal-internal-condition-cancels-timer', false),
+        makeCompleteWorkflowExecution(),
+      ])
+    );
   }
 });


### PR DESCRIPTION
Also clean up resources taken by the blocked condition.

Closes #363 