### PR TITLE
fix(workflow): Ensure signals are always processed

### DIFF
--- a/packages/test/src/test-signals-are-always-delivered.ts
+++ b/packages/test/src/test-signals-are-always-delivered.ts
@@ -1,0 +1,48 @@
+import test from 'ava';
+import { WorkflowClient } from '@temporalio/client';
+import { Worker, DefaultLogger, Core, InjectedSinks } from '@temporalio/worker';
+import { defaultOptions } from './mock-native-worker';
+import { RUN_INTEGRATION_TESTS } from './helpers';
+import * as workflows from './workflows';
+
+if (RUN_INTEGRATION_TESTS) {
+  test.before(async () => {
+    await Core.install({ logger: new DefaultLogger('DEBUG') });
+  });
+
+  test('Signals are always delivered', async (t) => {
+    const taskQueue = 'test-signal-delivery';
+    const conn = new WorkflowClient();
+    const wf = await conn.start(workflows.signalsAreAlwaysProcessed, { taskQueue, workflowTaskTimeout: '3s' });
+
+    const sinks: InjectedSinks<workflows.SignalProcessTestSinks> = {
+      controller: {
+        sendSignal: {
+          async fn() {
+            await wf.signal(workflows.incrementSignal);
+          },
+        },
+      },
+    };
+
+    const worker = await Worker.create({
+      ...defaultOptions,
+      taskQueue,
+      sinks,
+    });
+
+    await Promise.all([
+      worker.run(),
+      (async () => {
+        try {
+          await wf.result();
+        } finally {
+          worker.shutdown();
+        }
+      })(),
+    ]);
+
+    // Workflow completes if it got the signal
+    t.pass();
+  });
+}

--- a/packages/test/src/test-signals-are-always-delivered.ts
+++ b/packages/test/src/test-signals-are-always-delivered.ts
@@ -1,3 +1,11 @@
+/**
+ * Tests that if a signal is delivered while the Worker is processing a Workflow
+ * Task, the Worker picks up a new Workflow Task (including the signal) and
+ * the Workflow library delivers the signal to user code before it starts the
+ * Workflow execution.
+ *
+ * @module
+ */
 import test from 'ava';
 import { WorkflowClient } from '@temporalio/client';
 import { Worker, DefaultLogger, Core, InjectedSinks } from '@temporalio/worker';
@@ -13,12 +21,13 @@ if (RUN_INTEGRATION_TESTS) {
   test('Signals are always delivered', async (t) => {
     const taskQueue = 'test-signal-delivery';
     const conn = new WorkflowClient();
-    const wf = await conn.start(workflows.signalsAreAlwaysProcessed, { taskQueue, workflowTaskTimeout: '3s' });
+    const wf = await conn.start(workflows.signalsAreAlwaysProcessed, { taskQueue });
 
     const sinks: InjectedSinks<workflows.SignalProcessTestSinks> = {
       controller: {
         sendSignal: {
           async fn() {
+            // Send a signal to the Workflow which will cause the WFT to fail
             await wf.signal(workflows.incrementSignal);
           },
         },

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -71,5 +71,6 @@ export * from './fail-unless-signaled-before-start';
 export * from './smorgasbord';
 export * from './condition';
 export * from './sleep-invalid-duration';
+export * from './signals-are-always-processed';
 export { interceptorExample } from './interceptor-example';
 export { internalsInterceptorExample } from './internals-interceptor-example';

--- a/packages/test/src/workflows/signals-are-always-processed.ts
+++ b/packages/test/src/workflows/signals-are-always-processed.ts
@@ -1,3 +1,9 @@
+/**
+ * Workflow used by test-signals-are-always-processed.ts
+ *
+ * @module
+ */
+
 import { proxySinks, Sinks, setHandler, defineSignal } from '@temporalio/workflow';
 
 export const incrementSignal = defineSignal('increment');
@@ -12,7 +18,10 @@ const { controller } = proxySinks<SignalProcessTestSinks>();
 
 export async function signalsAreAlwaysProcessed(): Promise<void> {
   let counter = 0;
+  // We expect the signal to be buffered by the runtime and delivered as soon
+  // as we set the handler.
   setHandler(incrementSignal, () => void ++counter);
+  // Use a sink to block the workflow from completing and send a signal
   if (counter === 0) {
     controller.sendSignal();
   }

--- a/packages/test/src/workflows/signals-are-always-processed.ts
+++ b/packages/test/src/workflows/signals-are-always-processed.ts
@@ -1,0 +1,19 @@
+import { proxySinks, Sinks, setHandler, defineSignal } from '@temporalio/workflow';
+
+export const incrementSignal = defineSignal('increment');
+
+export interface SignalProcessTestSinks extends Sinks {
+  controller: {
+    sendSignal(): void;
+  };
+}
+
+const { controller } = proxySinks<SignalProcessTestSinks>();
+
+export async function signalsAreAlwaysProcessed(): Promise<void> {
+  let counter = 0;
+  setHandler(incrementSignal, () => void ++counter);
+  if (counter === 0) {
+    controller.sendSignal();
+  }
+}

--- a/packages/worker/src/workflow/isolated-vm.ts
+++ b/packages/worker/src/workflow/isolated-vm.ts
@@ -212,9 +212,9 @@ export class IsolatedVMWorkflow implements Workflow {
     // 2. signals
     // 3. anything left except for queries
     // 4. queries
-    const [patches, nonPatches] = partition(activation.jobs, ({ notifyHasPatch }) => notifyHasPatch !== undefined);
-    const [signals, nonSignals] = partition(nonPatches, ({ signalWorkflow }) => signalWorkflow !== undefined);
-    const [queries, rest] = partition(nonSignals, ({ queryWorkflow }) => queryWorkflow !== undefined);
+    const [patches, nonPatches] = partition(activation.jobs, ({ notifyHasPatch }) => notifyHasPatch != null);
+    const [signals, nonSignals] = partition(nonPatches, ({ signalWorkflow }) => signalWorkflow != null);
+    const [queries, rest] = partition(nonSignals, ({ queryWorkflow }) => queryWorkflow != null);
     let batchIndex = 0;
 
     // Loop and invoke each batch and wait for microtasks to complete.

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -181,7 +181,7 @@ export async function activate(encodedActivation: Uint8Array, batchIndex: number
         if (!activation.jobs) {
           throw new TypeError('Got activation with no jobs');
         }
-        if (activation.timestamp !== null) {
+        if (activation.timestamp != null) {
           // timestamp will not be updated for activation that contain only queries
           state.now = tsToMs(activation.timestamp);
         }
@@ -197,6 +197,7 @@ export async function activate(encodedActivation: Uint8Array, batchIndex: number
           if (job.variant === undefined) {
             throw new TypeError('Expected job.variant to be defined');
           }
+
           const variant = job[job.variant];
           if (!variant) {
             throw new TypeError(`Expected job.${job.variant} to be set`);
@@ -207,7 +208,7 @@ export async function activate(encodedActivation: Uint8Array, batchIndex: number
           if (state.completed && job.variant !== 'queryWorkflow') {
             return;
           }
-          await state.activator[job.variant](variant as any /* TODO: TS is struggling with `true` and `{}` */);
+          await state.activator[job.variant](variant as any /* TS can't infer this type */);
           tryUnblockConditions();
         })
       );


### PR DESCRIPTION
BREAKING CHANGE: This fixes a critical issue where the SDK was not processing histories in the right order.
Workflows that have been processed with older versions of the SDK may get stuck if the SDK is upgraded.