### PR TITLE
feat!(client): Make workflowId required

### DIFF
--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -1,25 +1,39 @@
-import { v4 as uuid4 } from 'uuid';
-import {
-  WithWorkflowArgs,
-  WorkflowOptions as CommonWorkflowOptions,
-  WorkflowOptionsWithDefaults as CommonWorkflowOptionsWithDefaults,
-  SignalDefinition,
-  Workflow,
-} from '@temporalio/common';
+import { WithCompiledWorkflowDurationOptions, CommonWorkflowOptions, SignalDefinition } from '@temporalio/common';
 
-export { CompiledWorkflowOptions, compileWorkflowOptions } from '@temporalio/common';
+export { WithCompiledWorkflowDurationOptions, compileWorkflowOptions } from '@temporalio/common';
+
+export interface CompiledWorkflowOptions extends WithCompiledWorkflowDurationOptions<WorkflowOptions> {
+  args: unknown[];
+}
 
 export interface WorkflowOptions extends CommonWorkflowOptions {
+  /**
+   * Workflow id to use when starting.
+   *
+   * Assign a meaningful business id.
+   * This ID can be used to ensure starting Workflows is idempotent.
+   * Workflow IDs are unique, see also {@link WorkflowOptions.workflowIdReusePolicy}
+   */
+  workflowId: string;
+
   /**
    * Task queue to use for Workflow tasks. It should match a task queue specified when creating a
    * `Worker` that hosts the Workflow code.
    */
   taskQueue: string;
 
+  /**
+   * If set to true, instructs the client to follow the chain of execution before returning a Workflow's result.
+   *
+   * Workflow execution is chained if the Workflow has a cron schedule or continues-as-new or configured to retry
+   * after failure or timeout.
+   *
+   * @default true
+   */
   followRuns?: boolean;
 }
 
-export interface WorkflowSignalWithStartOptions<SA extends any[] = []> extends Partial<WorkflowOptions> {
+export interface WorkflowSignalWithStartOptions<SA extends any[] = []> extends WorkflowOptions {
   /**
    * SignalDefinition or name of signal
    */
@@ -30,29 +44,29 @@ export interface WorkflowSignalWithStartOptions<SA extends any[] = []> extends P
   signalArgs: SA;
 }
 
-export interface WorkflowOptionsWithDefaults<T extends Workflow> extends CommonWorkflowOptionsWithDefaults<T> {
-  /**
-   * If set to true, instructs the client to follow the chain of execution before returning a Workflow's result.
-   *
-   * Workflow execution is chained if the Workflow has a cron schedule or continues-as-new or configured to retry
-   * after failure or timeout.
-   *
-   * @default true
-   */
-  followRuns: boolean;
-}
-
-/**
- * Adds default values to `workflowId` and `workflowIdReusePolicy` to given workflow options.
- */
-export function addDefaults<T extends Workflow>(
-  opts: WithWorkflowArgs<T, WorkflowOptions>
-): WorkflowOptionsWithDefaults<T> {
-  const { workflowId, args, ...rest } = opts;
-  return {
-    followRuns: true,
-    args: args ?? [],
-    workflowId: workflowId ?? uuid4(),
-    ...rest,
-  };
-}
+// export interface WorkflowOptionsWithDefaults<T extends Workflow> extends CommonWorkflowOptionsWithDefaults<T> {
+//   /**
+//    * If set to true, instructs the client to follow the chain of execution before returning a Workflow's result.
+//    *
+//    * Workflow execution is chained if the Workflow has a cron schedule or continues-as-new or configured to retry
+//    * after failure or timeout.
+//    *
+//    * @default true
+//    */
+//   followRuns: boolean;
+// }
+//
+// /**
+//  * Adds default values to `workflowId` and `workflowIdReusePolicy` to given workflow options.
+//  */
+// export function addDefaults<T extends Workflow>(
+//   opts: WithWorkflowArgs<T, WorkflowOptions>
+// ): WorkflowOptionsWithDefaults<T> {
+//   const { workflowId, args, ...rest } = opts;
+//   return {
+//     followRuns: true,
+//     args: args ?? [],
+//     workflowId: workflowId ?? uuid4(),
+//     ...rest,
+//   };
+// }

--- a/packages/test/src/load/starter.ts
+++ b/packages/test/src/load/starter.ts
@@ -1,5 +1,6 @@
 import arg from 'arg';
 import pidusage from 'pidusage';
+import { v4 as uuid4 } from 'uuid';
 import { interval, range, Observable, OperatorFunction, ReplaySubject, pipe, lastValueFrom } from 'rxjs';
 import { bufferTime, map, mergeMap, tap, takeUntil } from 'rxjs/operators';
 import { Connection, WorkflowClient } from '@temporalio/client';
@@ -7,7 +8,7 @@ import { toMB } from '@temporalio/worker/lib/utils';
 import { StarterArgSpec, starterArgSpec, getRequired } from './args';
 
 async function runWorkflow(client: WorkflowClient, name: string, taskQueue: string) {
-  await client.execute(name, { args: [], taskQueue });
+  await client.execute(name, { args: [], taskQueue, workflowId: uuid4() });
 }
 
 class NumberOfWorkflows {

--- a/packages/test/src/test-core.ts
+++ b/packages/test/src/test-core.ts
@@ -3,6 +3,7 @@
  * Tests run serially because Core is a singleton.
  */
 import test from 'ava';
+import { v4 as uuid4 } from 'uuid';
 import { Worker, Core } from '@temporalio/worker';
 import { WorkflowClient } from '@temporalio/client';
 import { defaultOptions } from './mock-native-worker';
@@ -26,7 +27,7 @@ if (RUN_INTEGRATION_TESTS) {
     await worker1Drained;
     const connection = new WorkflowClient();
     // Run a simple workflow
-    await connection.execute(workflows.sleeper, { taskQueue: 'q2', args: [1] });
+    await connection.execute(workflows.sleeper, { taskQueue: 'q2', workflowId: uuid4(), args: [1] });
     worker2.shutdown();
     await worker2Drained;
 
@@ -40,7 +41,7 @@ if (RUN_INTEGRATION_TESTS) {
     });
     const worker3Drained = worker3.run();
     // Run a simple workflow
-    await connection.execute('sleeper', { taskQueue: 'q1', args: [1] });
+    await connection.execute('sleeper', { taskQueue: 'q1', workflowId: uuid4(), args: [1] });
     worker3.shutdown();
     await worker3Drained;
     // No exceptions, test passes

--- a/packages/test/src/test-interceptors.ts
+++ b/packages/test/src/test-interceptors.ts
@@ -91,7 +91,7 @@ if (RUN_INTEGRATION_TESTS) {
       {
         const wf = await client.start(interceptorExample, {
           taskQueue,
-          args: [],
+          workflowId: uuid4(),
         });
         // Send both signal and query to more consistently repro https://github.com/temporalio/sdk-node/issues/299
         await Promise.all([
@@ -104,7 +104,7 @@ if (RUN_INTEGRATION_TESTS) {
       {
         const wf = await client.signalWithStart(interceptorExample, {
           taskQueue,
-          args: [],
+          workflowId: uuid4(),
           signal: unblockWithSecretSignal,
           signalArgs: ['12345'],
         });
@@ -145,7 +145,7 @@ if (RUN_INTEGRATION_TESTS) {
     try {
       const wf = await client.start(unblockOrCancel, {
         taskQueue,
-        args: [],
+        workflowId: uuid4(),
       });
       await t.throwsAsync(wf.cancel(), {
         instanceOf: Error,
@@ -183,7 +183,7 @@ if (RUN_INTEGRATION_TESTS) {
         client
           .execute(continueAsNewToDifferentWorkflow, {
             taskQueue,
-            args: [],
+            workflowId: uuid4(),
           })
           .finally(() => worker.shutdown()),
         {
@@ -238,7 +238,7 @@ if (RUN_INTEGRATION_TESTS) {
       client
         .execute(internalsInterceptorExample, {
           taskQueue,
-          args: [],
+          workflowId: uuid4(),
         })
         .finally(() => worker.shutdown()),
     ]);

--- a/packages/test/src/test-otel.ts
+++ b/packages/test/src/test-otel.ts
@@ -2,6 +2,7 @@
  * Manual tests to inspect tracing output
  */
 import test from 'ava';
+import { v4 as uuid4 } from 'uuid';
 import { Core, DefaultLogger, InjectedSinks, Worker } from '@temporalio/worker';
 import { ExportResultCode } from '@opentelemetry/core';
 import { CollectorTraceExporter } from '@opentelemetry/exporter-collector-grpc';
@@ -62,7 +63,9 @@ if (RUN_INTEGRATION_TESTS) {
       },
     });
     await Promise.all([
-      client.execute(workflows.smorgasbord, { taskQueue: 'test-otel', args: [] }).finally(() => worker.shutdown()),
+      client
+        .execute(workflows.smorgasbord, { taskQueue: 'test-otel', workflowId: uuid4() })
+        .finally(() => worker.shutdown()),
       worker.run(),
     ]);
     await otel.shutdown();
@@ -172,7 +175,7 @@ if (RUN_INTEGRATION_TESTS) {
     });
     await Promise.all([
       client
-        .execute(workflows.cancelFakeProgress, { taskQueue: 'test-otel', args: [] })
+        .execute(workflows.cancelFakeProgress, { taskQueue: 'test-otel', workflowId: uuid4() })
         .finally(() => worker.shutdown()),
       worker.run(),
     ]);

--- a/packages/test/src/test-signals-are-always-delivered.ts
+++ b/packages/test/src/test-signals-are-always-delivered.ts
@@ -7,6 +7,7 @@
  * @module
  */
 import test from 'ava';
+import { v4 as uuid4 } from 'uuid';
 import { WorkflowClient } from '@temporalio/client';
 import { Worker, DefaultLogger, Core, InjectedSinks } from '@temporalio/worker';
 import { defaultOptions } from './mock-native-worker';
@@ -21,7 +22,7 @@ if (RUN_INTEGRATION_TESTS) {
   test('Signals are always delivered', async (t) => {
     const taskQueue = 'test-signal-delivery';
     const conn = new WorkflowClient();
-    const wf = await conn.start(workflows.signalsAreAlwaysProcessed, { taskQueue });
+    const wf = await conn.start(workflows.signalsAreAlwaysProcessed, { taskQueue, workflowId: uuid4() });
 
     const sinks: InjectedSinks<workflows.SignalProcessTestSinks> = {
       controller: {

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -1,5 +1,6 @@
 /* eslint @typescript-eslint/no-non-null-assertion: 0 */
 import test from 'ava';
+import { v4 as uuid4 } from 'uuid';
 import { WorkflowInfo } from '@temporalio/workflow';
 import { WorkflowClient } from '@temporalio/client';
 import { Worker, DefaultLogger, Core, InjectedSinks } from '@temporalio/worker';
@@ -73,7 +74,7 @@ if (RUN_INTEGRATION_TESTS) {
     });
     const p = worker.run();
     const conn = new WorkflowClient();
-    const wf = await conn.start(workflows.sinksWorkflow, { taskQueue });
+    const wf = await conn.start(workflows.sinksWorkflow, { taskQueue, workflowId: uuid4() });
     await wf.result();
     worker.shutdown();
     await p;

--- a/packages/test/src/test-worker-from-bundle.ts
+++ b/packages/test/src/test-worker-from-bundle.ts
@@ -27,7 +27,7 @@ if (RUN_INTEGRATION_TESTS) {
       worker.run(),
       (async () => {
         try {
-          await client.execute(successString, { taskQueue, args: [] });
+          await client.execute(successString, { taskQueue, workflowId: uuid4() });
         } finally {
           worker.shutdown();
         }
@@ -54,7 +54,7 @@ if (RUN_INTEGRATION_TESTS) {
         worker.run(),
         (async () => {
           try {
-            client.execute(successString, { taskQueue, args: [] });
+            client.execute(successString, { taskQueue, workflowId: uuid4() });
           } finally {
             worker.shutdown();
           }

--- a/packages/test/src/test-worker-no-activities.ts
+++ b/packages/test/src/test-worker-no-activities.ts
@@ -1,4 +1,5 @@
 import test from 'ava';
+import { v4 as uuid4 } from 'uuid';
 import { Worker } from '@temporalio/worker';
 import { WorkflowClient } from '@temporalio/client';
 import { defaultOptions } from './mock-native-worker';
@@ -13,7 +14,7 @@ if (RUN_INTEGRATION_TESTS) {
     const client = new WorkflowClient();
     const runAndShutdown = async () => {
       const result = await client.execute(successString, {
-        args: [],
+        workflowId: uuid4(),
         taskQueue: 'only-workflows',
       });
       t.is(result, 'success');

--- a/packages/test/src/test-worker-no-workflows.ts
+++ b/packages/test/src/test-worker-no-workflows.ts
@@ -1,4 +1,5 @@
 import test from 'ava';
+import { v4 as uuid4 } from 'uuid';
 import { Worker } from '@temporalio/worker';
 import { WorkflowClient } from '@temporalio/client';
 import { defaultOptions } from './mock-native-worker';
@@ -15,6 +16,7 @@ if (RUN_INTEGRATION_TESTS) {
       const result = await client.execute(runActivityInDifferentTaskQueue, {
         args: ['only-activities'],
         taskQueue: 'also-workflows',
+        workflowId: uuid4(),
       });
       t.is(result, 'hi');
       workflowlessWorker.shutdown();

--- a/packages/test/src/test-workflow-cancellation.ts
+++ b/packages/test/src/test-workflow-cancellation.ts
@@ -1,5 +1,5 @@
-/* eslint @typescript-eslint/no-non-null-assertion: 0 */
 import anyTest, { Constructor, Macro, TestInterface } from 'ava';
+import { v4 as uuid4 } from 'uuid';
 import { WorkflowClient, WorkflowFailedError } from '@temporalio/client';
 import { Worker } from '@temporalio/worker';
 import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
@@ -24,7 +24,11 @@ const testWorkflowCancellation: Macro<
   Context
 > = async (t, outcome, timing, expected) => {
   const client = new WorkflowClient();
-  const workflow = await client.start(workflowCancellationScenarios, { args: [outcome, timing], taskQueue });
+  const workflow = await client.start(workflowCancellationScenarios, {
+    args: [outcome, timing],
+    taskQueue,
+    workflowId: uuid4(),
+  });
   await workflow.cancel();
   if (expected === undefined) {
     await workflow.result();

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1,5 +1,5 @@
 import { coresdk } from '@temporalio/proto/lib/coresdk';
-import { WorkflowOptions } from '@temporalio/common';
+import { CommonWorkflowOptions } from '@temporalio/common';
 
 /**
  * Workflow execution information
@@ -84,7 +84,20 @@ export const ChildWorkflowCancellationType = coresdk.child_workflow.ChildWorkflo
 export type ParentClosePolicy = coresdk.child_workflow.ParentClosePolicy;
 export const ParentClosePolicy = coresdk.child_workflow.ParentClosePolicy;
 
-export interface ChildWorkflowOptions extends WorkflowOptions {
+export interface ChildWorkflowOptions extends CommonWorkflowOptions {
+  /**
+   * Workflow id to use when starting. If not specified a UUID is generated. Note that it is
+   * dangerous as in case of client side retries no deduplication will happen based on the
+   * generated id. So prefer assigning business meaningful ids if possible.
+   */
+  workflowId?: string;
+
+  /**
+   * Task queue to use for Workflow tasks. It should match a task queue specified when creating a
+   * `Worker` that hosts the Workflow code.
+   */
+  taskQueue?: string;
+
   /**
    * In case of a child workflow cancellation it fails with a CanceledFailure.
    * The type defines at which point the exception is thrown.


### PR DESCRIPTION
This also removes the `WorkflowClientOptions.workflowDefaults`.

Reasoning:
- Workflow IDs should represent a meaningful business ID
- Workflow IDs can be used as an idempotency key when starting workflows from an external signal
- `workflowDefaults` were removed because their presence made `taskQueue` optional in `WorkflowOptions`, omitting it from both the defaults and options resulted in runtime errors where we could have caught those at compile time.\

Migration:
```ts
// Before
const client = new WorkflowClient(conn.service, { workflowDefaults: { taskQueue: 'example' } });
const handle = await client.start(myWorkflow, { args: [foo, bar] });
// After
const client = new WorkflowClient(conn.service);
const handle = await client.start(myWorkflow, {
  args: [foo, bar],
  taskQueue: 'example',
  workflowId: 'a-meaningful-business-id',
});
```