### PR TITLE
Added comments for unused query and signal generics

### DIFF
--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -14,7 +14,7 @@ export type Workflow = (...args: any[]) => WorkflowReturnType;
 /**
  * An interface representing a Workflow signal definition, as returned from {@link defineSignal}
  *
- * @remarks `_Args` can be used for parameter type inference in handler functions.
+ * @remarks `_Args` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface SignalDefinition<_Args extends any[] = []> {
@@ -25,7 +25,7 @@ export interface SignalDefinition<_Args extends any[] = []> {
 /**
  * An interface representing a Workflow query definition as returned from {@link defineQuery}
  *
- * @remarks `_Args` can be used for parameter type inference in handler functions.
+ * @remarks `_Args` and `_Ret` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface QueryDefinition<_Ret, _Args extends any[] = []> {

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -13,6 +13,8 @@ export type Workflow = (...args: any[]) => WorkflowReturnType;
 
 /**
  * An interface representing a Workflow signal definition, as returned from {@link defineSignal}
+ *
+ * @remarks `_Args` can be used for parameter type inference in handler functions.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface SignalDefinition<_Args extends any[] = []> {
@@ -22,6 +24,8 @@ export interface SignalDefinition<_Args extends any[] = []> {
 
 /**
  * An interface representing a Workflow query definition as returned from {@link defineQuery}
+ *
+ * @remarks `_Args` can be used for parameter type inference in handler functions.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface QueryDefinition<_Ret, _Args extends any[] = []> {


### PR DESCRIPTION
## What was changed
Adds comments indicating why the seemingly unused generics are useful.

## Why?
I went through a whole investigation trying to remove them, only to have @sw-yx show me that the `Handler` type does, in fact, use the generics well.

## Checklist
1. How was this tested:
`npm run build` / `npm run build.watch`
