### PR TITLE
fix(workflow): Fix argument wrapping in array when signaling from Workflow

### DIFF
--- a/packages/test/src/workflows/child-workflow-signals.ts
+++ b/packages/test/src/workflows/child-workflow-signals.ts
@@ -12,7 +12,7 @@ import {
   uuid4,
 } from '@temporalio/workflow';
 import { signalTarget } from './signal-target';
-import { unblockSignal, failWithMessageSignal } from './definitions';
+import { argsTestSignal, unblockSignal, failWithMessageSignal } from './definitions';
 
 /**
  * If this workflow completes successfully, it should make the test pass
@@ -22,6 +22,8 @@ export async function childWorkflowSignals(): Promise<void> {
   {
     // Happy path
     const child = await startChild(signalTarget, {});
+    // Args are transferred correctly
+    await child.signal(argsTestSignal, 123, 'kid');
     await child.signal(unblockSignal);
     await child.result();
   }
@@ -52,6 +54,8 @@ export async function childWorkflowSignals(): Promise<void> {
     // Happy path
     const child = await startChild(signalTarget, {});
     const external = getExternalWorkflowHandle(child.workflowId, child.originalRunId);
+    // Args are transferred correctly
+    await external.signal(argsTestSignal, 123, 'kid');
     await external.signal(unblockSignal);
     await child.result();
   }

--- a/packages/test/src/workflows/definitions.ts
+++ b/packages/test/src/workflows/definitions.ts
@@ -12,4 +12,5 @@ export interface LoggerSinks extends Sinks {
 export const activityStartedSignal = defineSignal('activityStarted');
 export const failSignal = defineSignal('fail');
 export const failWithMessageSignal = defineSignal<[string]>('fail');
+export const argsTestSignal = defineSignal<[number, string]>('argsTest');
 export const unblockSignal = defineSignal('unblock');

--- a/packages/test/src/workflows/signal-target.ts
+++ b/packages/test/src/workflows/signal-target.ts
@@ -5,11 +5,17 @@
  * @module
  */
 import { condition, setHandler } from '@temporalio/workflow';
-import { failWithMessageSignal, unblockSignal } from './definitions';
+import { argsTestSignal, failWithMessageSignal, unblockSignal } from './definitions';
 
 export async function signalTarget(): Promise<void> {
   let unblocked = false;
 
+  // Verify arguments are sent correctly
+  setHandler(argsTestSignal, (num, str) => {
+    if (!(num === 123 && str === 'kid')) {
+      throw new Error('Invalid arguments');
+    }
+  });
   setHandler(failWithMessageSignal, (message) => {
     throw new Error(message);
   });

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -309,7 +309,7 @@ function signalWorkflowNextHandler({ seq, signalName, args, target }: SignalWork
     state.pushCommand({
       signalExternalWorkflowExecution: {
         seq,
-        args: state.dataConverter.toPayloadsSync(args),
+        args: state.dataConverter.toPayloadsSync(...args),
         signalName,
         ...(target.type === 'external'
           ? {


### PR DESCRIPTION
Apparently argument passing did not have test coverage and the rest argument in the data converter method prevented us from catching this earlier.

Before this fix, signal arguments sent from a workflow would be wrapped in an array.

```ts
await child.signal(someSignal, 1, '2');
```

Was received in the child workflow as:

```ts
wf.setHandler(someSignal, (num, str) => {
  console.log(a, b) // [1, '2'], undefined
});
```
