### PR TITLE
chore: Don't use fs-extra in create-project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2690,9 +2690,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.9.tgz",
-      "integrity": "sha512-MKmdASMf3LtPzwLyRrFjtFFZ48cMf8jmX5VRYrDQiJa8Ybu5VAmkqBWqKU8fdCwD8ysw4mQ9nrEHvzg6gunR7A=="
+      "version": "16.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.10.tgz",
+      "integrity": "sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -2743,9 +2743,9 @@
       "dev": true
     },
     "node_modules/@types/ramda": {
-      "version": "0.27.50",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.50.tgz",
-      "integrity": "sha512-9CIXC4laCxK1UxfYmLZhXj3AEJu8C/cGTKMapykAvP8gIbAJjdVfzMVR9vq9d8Cddt71UlDDwNvGZ5q/DE+83w==",
+      "version": "0.27.56",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.56.tgz",
+      "integrity": "sha512-fMloxwXvaL/nsLpYAkDKdoo4U8d6Gm2MSLz6Csv38Pst19MSCVs4tLf0HjsXETkBMj/wZmFZ0kUwoq0kluvi8w==",
       "dev": true,
       "dependencies": {
         "ts-toolbelt": "^6.15.1"
@@ -3923,18 +3923,18 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001282",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
-      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
+      "version": "1.0.30001283",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
+      "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/cargo-cp-artifact": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.5.tgz",
-      "integrity": "sha512-mWwNdfrEyvMPxDHoAhbCYwQBNP3RyW9bV+yi5VaaHtVZqoDXbGU5JQF5qG7s65SJhqP7HIVAQD7wZM6Fk2COuw==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.6.tgz",
+      "integrity": "sha512-CQw0doK/aaF7j041666XzuilHxqMxaKkn+I5vmBsd8SAwS0cO5CqVEVp0xJwOKstyqWZ6WK4Ww3O6p26x/Goyg==",
       "bin": {
         "cargo-cp-artifact": "bin/cargo-cp-artifact.js"
       }
@@ -4762,9 +4762,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -5030,9 +5030,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.904",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.904.tgz",
-      "integrity": "sha512-x5uZWXcVNYkTh4JubD7KSC1VMKz0vZwJUqVwY3ihsW0bst1BXDe494Uqbg3Y0fDGVjJqA8vEeGuvO5foyH2+qw=="
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.5.tgz",
+      "integrity": "sha512-YKaB+t8ul5crdh6OeqT2qXdxJGI0fAYb6/X8pDIyye+c3a7ndOCk5gVeKX+ABwivCGNS56vOAif3TN0qJMpEHw=="
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -7255,9 +7255,9 @@
       "dev": true
     },
     "node_modules/jest-worker": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.3.1.tgz",
-      "integrity": "sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.0.tgz",
+      "integrity": "sha512-4WuKcUxtzxBoKOUFbt1MtTY9fJwPVD4aN/4Cgxee7OLetPZn5as2bjfZz98XSf2Zq1JFfhqPZpS+43BmWXKgCA==",
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -7347,9 +7347,9 @@
       "dev": true
     },
     "node_modules/json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "node_modules/json-schema-traverse": {
@@ -7421,18 +7421,18 @@
       }
     },
     "node_modules/jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/keyv": {
@@ -7577,9 +7577,9 @@
       }
     },
     "node_modules/libnpmaccess/node_modules/socks-proxy-agent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz",
-      "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
       "dev": true,
       "dependencies": {
         "agent-base": "^6.0.2",
@@ -7651,9 +7651,9 @@
       }
     },
     "node_modules/libnpmpublish/node_modules/socks-proxy-agent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz",
-      "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
       "dev": true,
       "dependencies": {
         "agent-base": "^6.0.2",
@@ -7665,9 +7665,9 @@
       }
     },
     "node_modules/lines-and-columns": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
     "node_modules/load-json-file": {
@@ -7937,9 +7937,9 @@
       }
     },
     "node_modules/memfs": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.3.0.tgz",
-      "integrity": "sha512-BEE62uMfKOavX3iG7GYX43QJ+hAeeWnwIAuJ/R6q96jaMtiLzhsxHJC8B1L7fK7Pt/vXDRwb3SG/yBpNGDPqzg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.0.tgz",
+      "integrity": "sha512-o/RfP0J1d03YwsAxyHxAYs2kyJp55AFkMazlFAZFR2I2IXkxiUTXRabJ6RmNNCQ83LAD2jy52Khj0m3OffpNdA==",
       "dependencies": {
         "fs-monkey": "1.0.3"
       },
@@ -9334,9 +9334,9 @@
       }
     },
     "node_modules/pacote/node_modules/socks-proxy-agent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz",
-      "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
       "dev": true,
       "dependencies": {
         "agent-base": "^6.0.2",
@@ -9762,9 +9762,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
+      "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -11297,9 +11297,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.1.tgz",
-      "integrity": "sha512-6CiMNDrzv0ZR916u2T+iRunnD60uWmNn8SkdB44/6stVORUg0aAkWO7PkOhpCmjmW8f2I/G/xnowD66fxGyQJg==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -12065,9 +12065,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-      "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.0.tgz",
+      "integrity": "sha512-MnN0Q1OsvB/GGHETrFeZPQaOelWh/7O+EiFlj8sM9GPjtQkis7k01aAxrg/18kTfoIVcLL+haEVFlXDaSRwKRw==",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -12095,9 +12095,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.64.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.64.2.tgz",
-      "integrity": "sha512-4KGc0+Ozi0aS3EaLNRvEppfZUer+CaORKqL6OBjDLZOPf9YfN8leagFzwe6/PoBdHFxc/utKArl8LMC0Ivtmdg==",
+      "version": "5.64.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.64.4.tgz",
+      "integrity": "sha512-LWhqfKjCLoYJLKJY8wk2C3h77i8VyHowG3qYNZiIqD6D0ZS40439S/KVuc/PY48jp2yQmy0mhMknq8cys4jFMw==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
         "@types/estree": "^0.0.50",
@@ -12121,7 +12121,7 @@
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.2.0",
+        "watchpack": "^2.3.0",
         "webpack-sources": "^3.2.2"
       },
       "bin": {
@@ -12568,7 +12568,7 @@
       }
     },
     "packages/create-project": {
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "async-retry": "^1.3.3",
@@ -12576,7 +12576,6 @@
         "chalk-template": "^0.2.0",
         "commander": "^8.2.0",
         "dedent": "^0.7.0",
-        "fs-extra": "^10.0.0",
         "glob": "^7.2.0",
         "got": "^10.7.0",
         "prompts": "^2.4.1",
@@ -12653,7 +12652,7 @@
       }
     },
     "packages/interceptors-opentelemetry": {
-      "version": "0.16.0",
+      "version": "0.16.2",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.0.3",
@@ -12720,7 +12719,7 @@
       }
     },
     "packages/meta": {
-      "version": "0.16.0",
+      "version": "0.16.2",
       "license": "MIT",
       "dependencies": {
         "@temporalio/activity": "file:../activity",
@@ -12747,7 +12746,7 @@
       }
     },
     "packages/test": {
-      "version": "0.16.0",
+      "version": "0.16.2",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/exporter-collector-grpc": "^0.25.0",
@@ -12764,7 +12763,7 @@
       }
     },
     "packages/worker": {
-      "version": "0.16.0",
+      "version": "0.16.2",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.0.3",
@@ -14842,7 +14841,6 @@
         "chalk-template": "^0.2.0",
         "commander": "^8.2.0",
         "dedent": "^0.7.0",
-        "fs-extra": "^10.0.0",
         "glob": "^7.2.0",
         "got": "^10.7.0",
         "prompts": "^2.4.1",
@@ -15150,9 +15148,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.9.tgz",
-      "integrity": "sha512-MKmdASMf3LtPzwLyRrFjtFFZ48cMf8jmX5VRYrDQiJa8Ybu5VAmkqBWqKU8fdCwD8ysw4mQ9nrEHvzg6gunR7A=="
+      "version": "16.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.10.tgz",
+      "integrity": "sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA=="
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -15202,9 +15200,9 @@
       "dev": true
     },
     "@types/ramda": {
-      "version": "0.27.50",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.50.tgz",
-      "integrity": "sha512-9CIXC4laCxK1UxfYmLZhXj3AEJu8C/cGTKMapykAvP8gIbAJjdVfzMVR9vq9d8Cddt71UlDDwNvGZ5q/DE+83w==",
+      "version": "0.27.56",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.56.tgz",
+      "integrity": "sha512-fMloxwXvaL/nsLpYAkDKdoo4U8d6Gm2MSLz6Csv38Pst19MSCVs4tLf0HjsXETkBMj/wZmFZ0kUwoq0kluvi8w==",
       "dev": true,
       "requires": {
         "ts-toolbelt": "^6.15.1"
@@ -16121,14 +16119,14 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001282",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
-      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg=="
+      "version": "1.0.30001283",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
+      "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg=="
     },
     "cargo-cp-artifact": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.5.tgz",
-      "integrity": "sha512-mWwNdfrEyvMPxDHoAhbCYwQBNP3RyW9bV+yi5VaaHtVZqoDXbGU5JQF5qG7s65SJhqP7HIVAQD7wZM6Fk2COuw=="
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.6.tgz",
+      "integrity": "sha512-CQw0doK/aaF7j041666XzuilHxqMxaKkn+I5vmBsd8SAwS0cO5CqVEVp0xJwOKstyqWZ6WK4Ww3O6p26x/Goyg=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -16779,9 +16777,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -16989,9 +16987,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.904",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.904.tgz",
-      "integrity": "sha512-x5uZWXcVNYkTh4JubD7KSC1VMKz0vZwJUqVwY3ihsW0bst1BXDe494Uqbg3Y0fDGVjJqA8vEeGuvO5foyH2+qw=="
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.5.tgz",
+      "integrity": "sha512-YKaB+t8ul5crdh6OeqT2qXdxJGI0fAYb6/X8pDIyye+c3a7ndOCk5gVeKX+ABwivCGNS56vOAif3TN0qJMpEHw=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -18643,9 +18641,9 @@
       "dev": true
     },
     "jest-worker": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.3.1.tgz",
-      "integrity": "sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.0.tgz",
+      "integrity": "sha512-4WuKcUxtzxBoKOUFbt1MtTY9fJwPVD4aN/4Cgxee7OLetPZn5as2bjfZz98XSf2Zq1JFfhqPZpS+43BmWXKgCA==",
       "requires": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -18722,9 +18720,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -18779,14 +18777,14 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -18905,9 +18903,9 @@
           }
         },
         "socks-proxy-agent": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz",
-          "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+          "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
           "dev": true,
           "requires": {
             "agent-base": "^6.0.2",
@@ -18969,9 +18967,9 @@
           }
         },
         "socks-proxy-agent": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz",
-          "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+          "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
           "dev": true,
           "requires": {
             "agent-base": "^6.0.2",
@@ -18982,9 +18980,9 @@
       }
     },
     "lines-and-columns": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
     "load-json-file": {
@@ -19198,9 +19196,9 @@
       }
     },
     "memfs": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.3.0.tgz",
-      "integrity": "sha512-BEE62uMfKOavX3iG7GYX43QJ+hAeeWnwIAuJ/R6q96jaMtiLzhsxHJC8B1L7fK7Pt/vXDRwb3SG/yBpNGDPqzg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.0.tgz",
+      "integrity": "sha512-o/RfP0J1d03YwsAxyHxAYs2kyJp55AFkMazlFAZFR2I2IXkxiUTXRabJ6RmNNCQ83LAD2jy52Khj0m3OffpNdA==",
       "requires": {
         "fs-monkey": "1.0.3"
       }
@@ -20261,9 +20259,9 @@
           }
         },
         "socks-proxy-agent": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz",
-          "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+          "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
           "dev": true,
           "requires": {
             "agent-base": "^6.0.2",
@@ -20572,9 +20570,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
+      "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
       "dev": true
     },
     "pretty-ms": {
@@ -21751,9 +21749,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.8.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.1.tgz",
-          "integrity": "sha512-6CiMNDrzv0ZR916u2T+iRunnD60uWmNn8SkdB44/6stVORUg0aAkWO7PkOhpCmjmW8f2I/G/xnowD66fxGyQJg==",
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -22337,9 +22335,9 @@
       }
     },
     "watchpack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-      "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.0.tgz",
+      "integrity": "sha512-MnN0Q1OsvB/GGHETrFeZPQaOelWh/7O+EiFlj8sM9GPjtQkis7k01aAxrg/18kTfoIVcLL+haEVFlXDaSRwKRw==",
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -22361,9 +22359,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.64.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.64.2.tgz",
-      "integrity": "sha512-4KGc0+Ozi0aS3EaLNRvEppfZUer+CaORKqL6OBjDLZOPf9YfN8leagFzwe6/PoBdHFxc/utKArl8LMC0Ivtmdg==",
+      "version": "5.64.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.64.4.tgz",
+      "integrity": "sha512-LWhqfKjCLoYJLKJY8wk2C3h77i8VyHowG3qYNZiIqD6D0ZS40439S/KVuc/PY48jp2yQmy0mhMknq8cys4jFMw==",
       "requires": {
         "@types/eslint-scope": "^3.7.0",
         "@types/estree": "^0.0.50",
@@ -22387,7 +22385,7 @@
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.2.0",
+        "watchpack": "^2.3.0",
         "webpack-sources": "^3.2.2"
       }
     },

--- a/packages/create-project/package.json
+++ b/packages/create-project/package.json
@@ -25,7 +25,6 @@
     "chalk-template": "^0.2.0",
     "commander": "^8.2.0",
     "dedent": "^0.7.0",
-    "fs-extra": "^10.0.0",
     "glob": "^7.2.0",
     "got": "^10.7.0",
     "prompts": "^2.4.1",

--- a/packages/create-project/src/helpers/git.ts
+++ b/packages/create-project/src/helpers/git.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-empty */
 // Modified from: https://github.com/vercel/next.js/blob/2425f4703c4c6164cecfdb6aa8f80046213f0cc6/packages/create-next-app/helpers/git.ts
 import { execSync } from 'child_process';
+import { rm } from 'fs/promises';
 import path from 'path';
 import prompts from 'prompts';
-import { remove } from 'fs-extra';
 
 const NOT_A_GIT_REPOSITORY_STATUS_CODE = 128;
 
@@ -71,7 +71,7 @@ export async function tryGitInit(root: string, useGit?: boolean): Promise<boolea
   } catch (e) {
     if (didInit) {
       try {
-        await remove(path.join(root, '.git'));
+        await rm(path.join(root, '.git'), { recursive: true, force: true });
       } catch (_) {}
     }
     return false;


### PR DESCRIPTION
Fixes issue where `fs-extra` is incompatible with ESM as reported on slack.

Closes #408 