### PR TITLE
feat(workflow): Handle unhandled rejections in workflow code

### DIFF
--- a/packages/test/src/run-a-worker.ts
+++ b/packages/test/src/run-a-worker.ts
@@ -1,8 +1,12 @@
+import arg from 'arg';
 import { Worker, Core, DefaultLogger } from '@temporalio/worker';
 import * as activities from './activities';
 
 async function main() {
-  if (['1', 'y', 'yes', 't', 'true'].includes((process.env.DEBUG ?? '').toLowerCase())) {
+  const argv = arg({
+    '--debug': Boolean,
+  });
+  if (argv['--debug']) {
     await Core.install({
       logger: new DefaultLogger('DEBUG'),
       telemetryOptions: {

--- a/packages/test/src/run-a-worker.ts
+++ b/packages/test/src/run-a-worker.ts
@@ -1,7 +1,16 @@
-import { Worker } from '@temporalio/worker';
+import { Worker, Core, DefaultLogger } from '@temporalio/worker';
 import * as activities from './activities';
 
 async function main() {
+  if (['1', 'y', 'yes', 't', 'true'].includes((process.env.DEBUG ?? '').toLowerCase())) {
+    await Core.install({
+      logger: new DefaultLogger('DEBUG'),
+      telemetryOptions: {
+        logForwardingLevel: 'DEBUG',
+        tracingFilter: 'temporal_sdk_core=DEBUG',
+      },
+    });
+  }
   const worker = await Worker.create({
     activities,
     workflowsPath: require.resolve('./workflows'),

--- a/packages/test/src/run-a-workflow.ts
+++ b/packages/test/src/run-a-workflow.ts
@@ -9,7 +9,7 @@ async function main() {
   const [workflowType, ...argsRaw] = argv._;
   const args = argsRaw.map((v) => JSON.parse(v));
   const workflowId = argv['--workflow-id'] ?? 'test';
-  if (!workflows.hasOwnProperty(workflowType)) {
+  if (!Object.prototype.hasOwnProperty.call(workflows, workflowType)) {
     throw new TypeError(`Invalid workflowType ${workflowType}`);
   }
   console.log('running', { workflowType, args });

--- a/packages/test/src/run-a-workflow.ts
+++ b/packages/test/src/run-a-workflow.ts
@@ -1,0 +1,32 @@
+import arg from 'arg';
+import { WorkflowClient } from '@temporalio/client';
+import * as workflows from './workflows';
+
+async function main() {
+  const argv = arg({
+    '--workflow-id': String,
+  });
+  const [workflowType, ...argsRaw] = argv._;
+  const args = argsRaw.map((v) => JSON.parse(v));
+  const workflowId = argv['--workflow-id'] ?? 'test';
+  if (!workflows.hasOwnProperty(workflowType)) {
+    throw new TypeError(`Invalid workflowType ${workflowType}`);
+  }
+  console.log('running', { workflowType, args });
+
+  const client = new WorkflowClient();
+  const result = await client.execute(workflowType, {
+    workflowId,
+    taskQueue: 'test',
+    args,
+  });
+  console.log('complete', { result });
+}
+
+main().then(
+  () => void process.exit(0),
+  (err) => {
+    console.error(err);
+    process.exit(1);
+  }
+);

--- a/packages/test/src/test-integration.ts
+++ b/packages/test/src/test-integration.ts
@@ -728,7 +728,7 @@ if (RUN_INTEGRATION_TESTS) {
         }
         t.is(wftFailedEvent.workflowTaskFailedEventAttributes?.failure?.message, 'Error: unhandled rejection');
       },
-      { minTimeout: 100, factor: 1.2, maxRetryTime: 10000 }
+      { minTimeout: 300, factor: 1, maxRetryTime: 10000 }
     );
     await handle.terminate();
   });

--- a/packages/test/src/test-workflow-unhandled-rejection-crash.ts
+++ b/packages/test/src/test-workflow-unhandled-rejection-crash.ts
@@ -1,0 +1,29 @@
+import test from 'ava';
+import { v4 as uuid4 } from 'uuid';
+import { Worker, UnexpectedError } from '@temporalio/worker';
+import { WorkflowClient } from '@temporalio/client';
+import { defaultOptions } from './mock-native-worker';
+import { RUN_INTEGRATION_TESTS } from './helpers';
+import { throwUnhandledRejection } from './workflows';
+
+if (RUN_INTEGRATION_TESTS) {
+  test('Worker crashes if workflow throws unhandled rejection that cannot be associated with a workflow run', async (t) => {
+    // To debug Workflows with this worker run the test with `ava debug` and add breakpoints to your Workflows
+    const taskQueue = 'unhandled-rejection-crash';
+    const worker = await Worker.create({ ...defaultOptions, taskQueue });
+    const client = new WorkflowClient();
+    const handle = await client.start(throwUnhandledRejection, {
+      workflowId: uuid4(),
+      taskQueue,
+      args: [{ crashWorker: true }],
+    });
+    await t.throwsAsync(worker.run(), {
+      instanceOf: UnexpectedError,
+      message:
+        'Worker thread shut down prematurely, this could be caused by an' +
+        ' unhandled rejection in workflow code that could not be' +
+        ' associated with a workflow run',
+    });
+    await handle.terminate();
+  });
+}

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -719,7 +719,9 @@ test('asyncFailSignalWorkflow', async (t) => {
           dedent`
           Error: Signal failed
               at eval
-              at processTicksAndRejections`,
+              at runNextTicks
+              at listOnTimeout
+              at processTimers`,
           'Error'
         ),
       ])

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -73,5 +73,6 @@ export * from './condition';
 export * from './sleep-invalid-duration';
 export * from './signals-are-always-processed';
 export * from './async-activity-completion-tester';
+export * from './unhandled-rejection';
 export { interceptorExample } from './interceptor-example';
 export { internalsInterceptorExample } from './internals-interceptor-example';

--- a/packages/test/src/workflows/unhandled-rejection.ts
+++ b/packages/test/src/workflows/unhandled-rejection.ts
@@ -1,0 +1,23 @@
+import { proxyActivities } from '@temporalio/workflow';
+import type * as activities from '../activities';
+
+const { echo } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '1 minute',
+});
+
+export async function throwUnhandledRejection({ crashWorker }: { crashWorker: boolean }): Promise<void> {
+  const p1 = (async () => {
+    await echo('a');
+  })();
+
+  const p2 = (async () => {
+    if (crashWorker) {
+      throw 'not an error to crash the worker';
+    } else {
+      throw new Error('unhandled rejection');
+    }
+  })();
+
+  await p1;
+  await p2;
+}

--- a/packages/test/src/workflows/unhandled-rejection.ts
+++ b/packages/test/src/workflows/unhandled-rejection.ts
@@ -12,7 +12,9 @@ export async function throwUnhandledRejection({ crashWorker }: { crashWorker: bo
 
   const p2 = (async () => {
     if (crashWorker) {
-      throw 'not an error to crash the worker';
+      // Create a Promise associated with the worker thread context
+      const Promise = globalThis.constructor.constructor('return Promise')();
+      Promise.reject(new Error('error to crash the worker'));
     } else {
       throw new Error('unhandled rejection');
     }

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -16,3 +16,4 @@ export * from './logger';
 export * from './sinks';
 export * from './interceptors';
 export { bundleWorkflowCode, BundleOptions } from './workflow/bundler';
+export * from './errors';

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -124,7 +124,7 @@ export class WorkflowCodeBundler {
       output: {
         path: distDir,
         filename: 'main.js',
-        library: 'lib',
+        library: '__TEMPORAL__',
       },
     });
 

--- a/packages/worker/src/workflow/threaded-vm.ts
+++ b/packages/worker/src/workflow/threaded-vm.ts
@@ -48,6 +48,8 @@ function errorNameToClass(name: string): ErrorConstructor {
 export class WorkerThreadClient {
   requestIdx = 0n;
   requestIdToCompletion = new Map<BigInt, Completion<WorkerThreadOutput>>();
+  shutDownRequested = false;
+  workerExited = false;
 
   constructor(protected workerThread: Worker) {
     workerThread.on('message', ({ requestId, result }: WorkerThreadResponse) => {
@@ -65,6 +67,23 @@ export class WorkerThreadClient {
       }
 
       completion.resolve(result.output);
+    });
+    workerThread.on('exit', () => {
+      this.workerExited = true;
+      if (this.shutDownRequested) {
+        return; // ignore
+      }
+      const completions = this.requestIdToCompletion.values();
+      this.requestIdToCompletion = new Map();
+      for (const completion of completions) {
+        completion.reject(
+          new UnexpectedError(
+            'Worker thread shut down prematurely, this could be caused by an' +
+              ' unhandled rejection in workflow code that could not be' +
+              ' associated with a workflow run'
+          )
+        );
+      }
     });
   }
 
@@ -85,6 +104,10 @@ export class WorkerThreadClient {
    * Request destruction of the worker thread and await for it to terminate correctly
    */
   async destroy(): Promise<void> {
+    if (this.workerExited) {
+      return;
+    }
+    this.shutDownRequested = true;
     await this.send({ type: 'destroy' });
     const exitCode = await this.workerThread.terminate();
     if (exitCode !== TERMINATED_EXIT_CODE) {

--- a/packages/worker/src/workflow/vm.ts
+++ b/packages/worker/src/workflow/vm.ts
@@ -2,7 +2,7 @@ import vm from 'vm';
 import { coresdk } from '@temporalio/proto';
 import * as internals from '@temporalio/workflow/lib/worker-interface';
 import { WorkflowInfo } from '@temporalio/workflow';
-import { IllegalStateError } from '@temporalio/common';
+import { defaultDataConverter, errorToFailure, IllegalStateError } from '@temporalio/common';
 import { partition } from '../utils';
 import { Workflow, WorkflowCreator, WorkflowCreateOptions } from './interface';
 import { SinkCall } from '@temporalio/workflow/lib/sinks';
@@ -97,6 +97,8 @@ type WorkflowModule = typeof internals;
  * A Workflow implementation using Node.js' built-in `vm` module
  */
 export class VMWorkflow implements Workflow {
+  unhandledRejection: unknown;
+
   constructor(
     public readonly info: WorkflowInfo,
     protected context: vm.Context | undefined,
@@ -166,7 +168,23 @@ export class VMWorkflow implements Workflow {
       await new Promise((resolve) => process.nextTick(resolve));
     }
     const completion = this.workflowModule.concludeActivation();
+    // Give unhandledRejection handler a chance to process.
+    // Apparently nextTick does not get it triggered so we use setTimeout here.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    if (this.unhandledRejection) {
+      return coresdk.workflow_completion.WFActivationCompletion.encodeDelimited({
+        runId: activation.runId,
+        failed: { failure: await errorToFailure(this.unhandledRejection, defaultDataConverter) },
+      }).finish();
+    }
     return coresdk.workflow_completion.WFActivationCompletion.encodeDelimited(completion).finish();
+  }
+
+  /**
+   * If called (by an external unhandledRejection handler), activations will fail with provided error.
+   */
+  public setUnhandledRejection(err: unknown): void {
+    this.unhandledRejection = err;
   }
 
   /**

--- a/packages/worker/src/workflow/vm.ts
+++ b/packages/worker/src/workflow/vm.ts
@@ -31,7 +31,7 @@ export class VMWorkflowCreator implements WorkflowCreator {
         get(_: any, fn: string) {
           return (...args: any[]) => {
             context.args = args;
-            return vm.runInContext(`lib.api.${fn}(...globalThis.args)`, context, {
+            return vm.runInContext(`__TEMPORAL__.api.${fn}(...globalThis.args)`, context, {
               timeout: isolateExecutionTimeoutMs,
               displayErrors: true,
             });

--- a/packages/worker/src/workflow/workflow-worker-thread.ts
+++ b/packages/worker/src/workflow/workflow-worker-thread.ts
@@ -29,7 +29,7 @@ process.on('unhandledRejection', (err, promise) => {
   // Get the runId associated with the vm context.
   // See for reference https://github.com/patriksimek/vm2/issues/32
   const ctor = promise.constructor.constructor;
-  const runId = ctor('return __TEMPORAL__.runId')();
+  const runId = ctor('return globalThis.__TEMPORAL__?.runId')();
   if (runId !== undefined) {
     const workflow = workflowByRunId.get(runId);
     if (workflow !== undefined) {

--- a/packages/worker/src/workflow/workflow-worker-thread.ts
+++ b/packages/worker/src/workflow/workflow-worker-thread.ts
@@ -39,7 +39,7 @@ process.on('unhandledRejection', (err, promise) => {
   }
   // The user's logger is not accessible in this thread,
   // dump the error information to stderr and abort.
-  console.error('Unhandled rejection', err);
+  console.error('Unhandled rejection', { runId }, err);
   process.exit(1);
 });
 

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -111,6 +111,10 @@ export function overrideGlobals(): void {
  * Sets required internal state and instantiates the workflow and interceptors.
  */
 export async function initRuntime({ info, randomnessSeed, now, patches }: WorkflowCreateOptions): Promise<void> {
+  // Set the runId globally on the context so it can be retrieved in the case
+  // of an unhandled promise rejection.
+  (globalThis as any).__TEMPORAL__.runId = info.runId;
+
   // Globals are overridden while building the isolate before loading user code.
   // For some reason the `WeakRef` mock is not restored properly when creating an isolate from snapshot in node 14 (at least on ubuntu), override again.
   (globalThis as any).WeakRef = function () {


### PR DESCRIPTION
This PR makes the best effort to associate unhandled rejections from workflow code to a specific runId.
It also makes the unhandled rejection behavior consistent between node 14 and 16 and propagates failure back to the user.
Previously, in node 16 the process would crash and in node 14 we would incorrectly ignore rejections leading to unexpected workflow behavior (see the correct behavior in the added tests).