### PR TITLE
Defaulted WorkflowHandle T generics to Workflow

### DIFF
--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -67,7 +67,7 @@ import { Connection, WorkflowService } from './connection';
  * await handle.result(); // throws WorkflowExecutionCancelledError
  * ```
  */
-export interface WorkflowHandle<T extends Workflow> extends BaseWorkflowHandle<T> {
+export interface WorkflowHandle<T extends Workflow = Workflow> extends BaseWorkflowHandle<T> {
   /**
    * Query a running or completed Workflow.
    *
@@ -106,7 +106,7 @@ export interface WorkflowHandle<T extends Workflow> extends BaseWorkflowHandle<T
  * This interface is exactly the same as {@link WorkflowHandle} except it
  * includes the `originalRunId` returned after starting a new Workflow.
  */
-export interface WorkflowHandleWithRunId<T extends Workflow> extends WorkflowHandle<T> {
+export interface WorkflowHandleWithRunId<T extends Workflow = Workflow> extends WorkflowHandle<T> {
   /**
    * The runId of the initial run of the bound Workflow
    */
@@ -195,7 +195,7 @@ export interface WorkflowResultOptions {
 /**
  * Options for starting a Workflow
  */
-export type WorkflowStartOptions<T extends Workflow> = WithWorkflowArgs<T, WorkflowOptions>;
+export type WorkflowStartOptions<T extends Workflow = Workflow> = WithWorkflowArgs<T, WorkflowOptions>;
 
 /**
  * Client for starting Workflow executions and creating Workflow handles


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added `T extends Workflow = Workflow` defaults for `WorkflowHandle` & co.

## Why?
This way workflow handle type declarations don't need to pass around their workflow type.

## Checklist
1. Closes #418