### PR TITLE
feat: Remove proto usage from workflow runtime

### DIFF
--- a/packages/common/src/activity-options.ts
+++ b/packages/common/src/activity-options.ts
@@ -1,7 +1,16 @@
-import { coresdk } from '@temporalio/proto/lib/coresdk';
+import type { coresdk } from '@temporalio/proto/lib/coresdk';
 import { RetryOptions } from './interfaces';
+import { checkExtends } from './type-helpers';
 
-export const ActivityCancellationType = coresdk.workflow_commands.ActivityCancellationType;
+// Avoid importing the proto implementation to reduce workflow bundle size
+// Copied from coresdk.workflow_commands.ActivityCancellationType
+export enum ActivityCancellationType {
+  TRY_CANCEL = 0,
+  WAIT_CANCELLATION_COMPLETED = 1,
+  ABANDON = 2,
+}
+
+checkExtends<coresdk.workflow_commands.ActivityCancellationType, ActivityCancellationType>();
 
 /**
  * Options for remote activity invocation - will be processed from a task queue.

--- a/packages/common/src/converter/types.ts
+++ b/packages/common/src/converter/types.ts
@@ -1,4 +1,4 @@
-import * as iface from '@temporalio/proto/lib/coresdk';
+import type * as iface from '@temporalio/proto/lib/coresdk';
 import { TextEncoder, TextDecoder } from '../encoding';
 
 export type Payload = iface.coresdk.common.IPayload;

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -1,12 +1,36 @@
-import { temporal } from '@temporalio/proto/lib/coresdk';
+import type { temporal } from '@temporalio/proto/lib/coresdk';
 import { DataConverter, arrayFromPayloads } from './converter/data-converter';
+import { checkExtends } from './type-helpers';
 
 export const FAILURE_SOURCE = 'TypeScriptSDK';
 export type ProtoFailure = temporal.api.failure.v1.IFailure;
-export type TimeoutType = temporal.api.enums.v1.TimeoutType;
-export const TimeoutType = temporal.api.enums.v1.TimeoutType;
-export type RetryState = temporal.api.enums.v1.RetryState;
-export const RetryState = temporal.api.enums.v1.RetryState;
+// Avoid importing the proto implementation to reduce workflow bundle size
+// Copied from temporal.api.enums.v1.TimeoutType
+export enum TimeoutType {
+  TIMEOUT_TYPE_UNSPECIFIED = 0,
+  TIMEOUT_TYPE_START_TO_CLOSE = 1,
+  TIMEOUT_TYPE_SCHEDULE_TO_START = 2,
+  TIMEOUT_TYPE_SCHEDULE_TO_CLOSE = 3,
+  TIMEOUT_TYPE_HEARTBEAT = 4,
+}
+
+checkExtends<temporal.api.enums.v1.TimeoutType, TimeoutType>();
+
+// Avoid importing the proto implementation to reduce workflow bundle size
+// Copied from temporal.api.enums.v1.RetryState
+export enum RetryState {
+  RETRY_STATE_UNSPECIFIED = 0,
+  RETRY_STATE_IN_PROGRESS = 1,
+  RETRY_STATE_NON_RETRYABLE_FAILURE = 2,
+  RETRY_STATE_TIMEOUT = 3,
+  RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED = 4,
+  RETRY_STATE_RETRY_POLICY_NOT_SET = 5,
+  RETRY_STATE_INTERNAL_SERVER_ERROR = 6,
+  RETRY_STATE_CANCEL_REQUESTED = 7,
+}
+
+checkExtends<temporal.api.enums.v1.RetryState, RetryState>();
+
 export type WorkflowExecution = temporal.api.common.v1.IWorkflowExecution;
 
 /**

--- a/packages/common/src/interceptors.ts
+++ b/packages/common/src/interceptors.ts
@@ -1,4 +1,4 @@
-import { coresdk } from '@temporalio/proto/lib/coresdk';
+import type { coresdk } from '@temporalio/proto/lib/coresdk';
 import { AnyFunc, OmitLastParam } from './type-helpers';
 
 /**

--- a/packages/common/src/time.ts
+++ b/packages/common/src/time.ts
@@ -1,6 +1,6 @@
 import Long from 'long';
 import ms from 'ms';
-import * as iface from '@temporalio/proto/lib/coresdk';
+import type * as iface from '@temporalio/proto/lib/coresdk';
 import { ValueError } from './errors';
 
 // NOTE: these are the same interface in JS

--- a/packages/common/src/type-helpers.ts
+++ b/packages/common/src/type-helpers.ts
@@ -4,3 +4,8 @@ export type AnyFunc = (...args: any[]) => any;
 export type OmitLast<T> = T extends [...infer REST, any] ? REST : never;
 /** F with all arguments but the last */
 export type OmitLastParam<F extends AnyFunc> = (...args: OmitLast<Parameters<F>>) => ReturnType<F>;
+
+/** Verify that an type _Copy extends _Orig */
+export function checkExtends<_Orig, _Copy extends _Orig>(): void {
+  // noop, just type check
+}

--- a/packages/common/src/workflow-options.ts
+++ b/packages/common/src/workflow-options.ts
@@ -1,9 +1,19 @@
-import { coresdk, google } from '@temporalio/proto/lib/coresdk';
+import type { coresdk, google } from '@temporalio/proto/lib/coresdk';
 import { Workflow } from './interfaces';
 import { msToTs } from './time';
+import { checkExtends } from './type-helpers';
 
-export type WorkflowIdReusePolicy = coresdk.common.WorkflowIdReusePolicy;
-export const WorkflowIdReusePolicy = coresdk.common.WorkflowIdReusePolicy;
+// Avoid importing the proto implementation to reduce workflow bundle size
+// Copied from coresdk.common.WorkflowIdReusePolicy
+export enum WorkflowIdReusePolicy {
+  WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED = 0,
+  WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE = 1,
+  WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY = 2,
+  WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE = 3,
+}
+
+checkExtends<coresdk.common.WorkflowIdReusePolicy, WorkflowIdReusePolicy>();
+
 export type RetryPolicy = coresdk.common.IRetryPolicy;
 
 export interface BaseWorkflowOptions {

--- a/packages/worker/src/workflow/vm.ts
+++ b/packages/worker/src/workflow/vm.ts
@@ -155,15 +155,18 @@ export class VMWorkflow implements Workflow {
       if (jobs.length === 0) {
         continue;
       }
-      const arr = coresdk.workflow_activation.WFActivation.encodeDelimited({ ...activation, jobs }).finish();
-      const { numBlockedConditions } = await this.workflowModule.activate(arr, batchIndex++);
+      const { numBlockedConditions } = await this.workflowModule.activate(
+        coresdk.workflow_activation.WFActivation.fromObject({ ...activation, jobs }),
+        batchIndex++
+      );
       if (numBlockedConditions > 0) {
         await this.tryUnblockConditions();
       }
       // Wait for microtasks to be processed
       await new Promise((resolve) => process.nextTick(resolve));
     }
-    return this.workflowModule.concludeActivation();
+    const completion = this.workflowModule.concludeActivation();
+    return coresdk.workflow_completion.WFActivationCompletion.encodeDelimited(completion).finish();
   }
 
   /**

--- a/packages/workflow/src/interceptors.ts
+++ b/packages/workflow/src/interceptors.ts
@@ -7,7 +7,7 @@
  */
 
 import { ActivityOptions, WorkflowExecution, Headers, Next } from '@temporalio/common';
-import { coresdk } from '@temporalio/proto/lib/coresdk';
+import type { coresdk } from '@temporalio/proto/lib/coresdk';
 import { ChildWorkflowOptionsWithDefaults, ContinueAsNewOptions } from './interfaces';
 
 export { Next, Headers };

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1,5 +1,6 @@
-import { coresdk } from '@temporalio/proto/lib/coresdk';
+import type { coresdk } from '@temporalio/proto/lib/coresdk';
 import { CommonWorkflowOptions } from '@temporalio/common';
+import { checkExtends } from '@temporalio/common/lib/type-helpers';
 
 /**
  * Workflow execution information
@@ -79,10 +80,23 @@ export interface ContinueAsNewOptions {
   searchAttributes?: Record<string, any>;
 }
 
-export type ChildWorkflowCancellationType = coresdk.child_workflow.ChildWorkflowCancellationType;
-export const ChildWorkflowCancellationType = coresdk.child_workflow.ChildWorkflowCancellationType;
-export type ParentClosePolicy = coresdk.child_workflow.ParentClosePolicy;
-export const ParentClosePolicy = coresdk.child_workflow.ParentClosePolicy;
+export enum ChildWorkflowCancellationType {
+  ABANDON = 0,
+  TRY_CANCEL = 1,
+  WAIT_CANCELLATION_COMPLETED = 2,
+  WAIT_CANCELLATION_REQUESTED = 3,
+}
+
+checkExtends<coresdk.child_workflow.ChildWorkflowCancellationType, ChildWorkflowCancellationType>();
+
+export enum ParentClosePolicy {
+  PARENT_CLOSE_POLICY_UNSPECIFIED = 0,
+  PARENT_CLOSE_POLICY_TERMINATE = 1,
+  PARENT_CLOSE_POLICY_ABANDON = 2,
+  PARENT_CLOSE_POLICY_REQUEST_CANCEL = 3,
+}
+
+checkExtends<coresdk.child_workflow.ParentClosePolicy, ParentClosePolicy>();
 
 export interface ChildWorkflowOptions extends CommonWorkflowOptions {
   /**


### PR DESCRIPTION
This is now possible because we're using vm instead of isolated-vm.

- Greatly reduce workflow bundle size - our test bundle size went down from 2.77MB to 0.73MB
- Step 1 in supporting custom data converters
