### PR TITLE
feat(workflow)!: Make random workflow errors retryable

### DIFF
--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -114,8 +114,8 @@ export class ApplicationFailure extends TemporalFailure {
    * @param details optional details about the failure. They are serialized using the same approach
    *     as arguments and results.
    */
-  public static retryable(message: string | undefined, type: string, ...details: unknown[]): ApplicationFailure {
-    return new this(message, type, false, details);
+  public static retryable(message: string | undefined, type?: string, ...details: unknown[]): ApplicationFailure {
+    return new this(message, type ?? 'Error', false, details);
   }
 
   /**
@@ -129,8 +129,8 @@ export class ApplicationFailure extends TemporalFailure {
    * @param details optional details about the failure. They are serialized using the same approach
    *     as arguments and results.
    */
-  public static nonRetryable(message: string | undefined, type: string, ...details: unknown[]): ApplicationFailure {
-    return new this(message, type, true, details);
+  public static nonRetryable(message: string | undefined, type?: string, ...details: unknown[]): ApplicationFailure {
+    return new this(message, type ?? 'Error', true, details);
   }
 }
 

--- a/packages/test/src/test-integration.ts
+++ b/packages/test/src/test-integration.ts
@@ -247,7 +247,8 @@ if (RUN_INTEGRATION_TESTS) {
     t.is(
       cleanStackTrace(err.cause.cause.stack),
       dedent`
-        Error: failure
+        ApplicationFailure: failure
+            at Function.nonRetryable
             at throwAsync
       `
     );
@@ -728,10 +729,8 @@ if (RUN_INTEGRATION_TESTS) {
         }
         t.is(wftFailedEvent.workflowTaskFailedEventAttributes?.failure?.message, 'Error: unhandled rejection');
       },
-      { minTimeout: 300, factor: 1, maxRetryTime: 10000 }
+      { minTimeout: 300, factor: 1, retries: 100 }
     );
     await handle.terminate();
   });
-
-  test.todo('default retryPolicy is filled in ActivityInfo');
 }

--- a/packages/test/src/test-interceptors.ts
+++ b/packages/test/src/test-interceptors.ts
@@ -201,7 +201,8 @@ if (RUN_INTEGRATION_TESTS) {
     t.is(
       cleanStackTrace(err.cause.stack),
       dedent`
-      Error: Expected anything other than 1
+      ApplicationFailure: Expected anything other than 1
+          at Function.nonRetryable
           at Object.continueAsNew
           at next
           at eval

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -243,7 +243,7 @@ function makeFailWorkflowExecution(
 ): coresdk.workflow_commands.IWorkflowCommand {
   return {
     failWorkflowExecution: {
-      failure: { message, stackTrace, applicationFailureInfo: { type, nonRetryable: false }, source: 'TypeScriptSDK' },
+      failure: { message, stackTrace, applicationFailureInfo: { type, nonRetryable: true }, source: 'TypeScriptSDK' },
     },
   };
 }
@@ -363,7 +363,8 @@ test('throwAsync', async (t) => {
       makeFailWorkflowExecution(
         'failure',
         dedent`
-        Error: failure
+        ApplicationFailure: failure
+            at Function.nonRetryable
             at throwAsync
         `
       ),
@@ -663,7 +664,8 @@ test('interruptableWorkflow', async (t) => {
           // The stack trace is weird here and might confuse users, it might be a JS limitation
           // since the Error stack trace is generated in the constructor.
           dedent`
-          Error: just because
+          ApplicationFailure: just because
+              at Function.nonRetryable
               at eval
           `,
           'Error'
@@ -688,7 +690,8 @@ test('failSignalWorkflow', async (t) => {
         makeFailWorkflowExecution(
           'Signal failed',
           dedent`
-          Error: Signal failed
+          ApplicationFailure: Signal failed
+              at Function.nonRetryable
               at eval
           `,
           'Error'
@@ -717,7 +720,8 @@ test('asyncFailSignalWorkflow', async (t) => {
         makeFailWorkflowExecution(
           'Signal failed',
           dedent`
-          Error: Signal failed
+          ApplicationFailure: Signal failed
+              at Function.nonRetryable
               at eval
               at runNextTicks
               at listOnTimeout
@@ -1465,7 +1469,7 @@ test('resolve activity with failure - http', async (t) => {
     );
   }
 
-  const failure = ApplicationFailure.retryable('Connection timeout', 'MockError');
+  const failure = ApplicationFailure.nonRetryable('Connection timeout', 'MockError');
   failure.stack = failure.stack?.split('\n')[0];
 
   {
@@ -1657,7 +1661,8 @@ test('tryToContinueAfterCompletion', async (t) => {
         makeFailWorkflowExecution(
           'fail before continue',
           dedent`
-          Error: fail before continue
+          ApplicationFailure: fail before continue
+              at Function.nonRetryable
               at tryToContinueAfterCompletion
         `
         ),

--- a/packages/test/src/workflows/async-fail-signal.ts
+++ b/packages/test/src/workflows/async-fail-signal.ts
@@ -1,10 +1,10 @@
-import { setHandler, sleep } from '@temporalio/workflow';
+import { setHandler, sleep, ApplicationFailure } from '@temporalio/workflow';
 import { failSignal } from './definitions';
 
 export async function asyncFailSignalWorkflow(): Promise<void> {
   setHandler(failSignal, async () => {
     await sleep(100);
-    throw new Error('Signal failed');
+    throw ApplicationFailure.nonRetryable('Signal failed');
   });
   // Don't complete to allow Workflow to be interrupted by fail() signal
   await sleep(100000);

--- a/packages/test/src/workflows/fail-signal.ts
+++ b/packages/test/src/workflows/fail-signal.ts
@@ -1,9 +1,9 @@
-import { setHandler, sleep } from '@temporalio/workflow';
+import { setHandler, sleep, ApplicationFailure } from '@temporalio/workflow';
 import { failSignal } from './definitions';
 
 export async function failSignalWorkflow(): Promise<void> {
   setHandler(failSignal, () => {
-    throw new Error('Signal failed');
+    throw ApplicationFailure.nonRetryable('Signal failed');
   });
   // Don't complete to allow Workflow to be interrupted by fail() signal
   await sleep(100000);

--- a/packages/test/src/workflows/interceptor-example.ts
+++ b/packages/test/src/workflows/interceptor-example.ts
@@ -7,6 +7,7 @@ import {
   defineSignal,
   defineQuery,
   setHandler,
+  ApplicationFailure,
 } from '@temporalio/workflow';
 import { echo } from './configured-activities';
 
@@ -31,7 +32,7 @@ export async function interceptorExample(): Promise<string> {
     throw new Error('timer did not fail');
   } catch (err) {
     if (!(err instanceof InvalidTimerDurationError)) {
-      throw new Error('timer failed with wrong error type');
+      throw ApplicationFailure.nonRetryable('timer failed with wrong error type');
     }
   }
   await sleep(2);
@@ -82,7 +83,7 @@ export const interceptors = (): WorkflowInterceptors => ({
       async continueAsNew(input, next) {
         // Used to test interception of continue-as-new-to-different-workflow
         if (input.args[0] === 1) {
-          throw new InvalidTimerDurationError('Expected anything other than 1');
+          throw ApplicationFailure.nonRetryable('Expected anything other than 1', 'InvalidTimerDurationError');
         }
         return next(input);
       },

--- a/packages/test/src/workflows/interrupt-signal.ts
+++ b/packages/test/src/workflows/interrupt-signal.ts
@@ -1,12 +1,12 @@
 // @@@SNIPSTART typescript-workflow-signal-implementation
-import { defineSignal, setHandler } from '@temporalio/workflow';
+import { defineSignal, setHandler, ApplicationFailure } from '@temporalio/workflow';
 
 export const interruptSignal = defineSignal<[string]>('interrupt');
 
 export async function interruptableWorkflow(): Promise<void> {
   // When this Promise is rejected Workflow execution will fail
   await new Promise<never>((_resolve, reject) => {
-    setHandler(interruptSignal, (reason) => reject(new Error(reason)));
+    setHandler(interruptSignal, (reason) => reject(ApplicationFailure.nonRetryable(reason)));
   });
 }
 // @@@SNIPEND

--- a/packages/test/src/workflows/throw-async.ts
+++ b/packages/test/src/workflows/throw-async.ts
@@ -1,3 +1,5 @@
+import { ApplicationFailure } from '@temporalio/workflow';
+
 export async function throwAsync(): Promise<void> {
-  throw new Error('failure');
+  throw ApplicationFailure.nonRetryable('failure');
 }

--- a/packages/test/src/workflows/try-to-continue-after-completion.ts
+++ b/packages/test/src/workflows/try-to-continue-after-completion.ts
@@ -1,4 +1,4 @@
-import { continueAsNew } from '@temporalio/workflow';
+import { continueAsNew, ApplicationFailure } from '@temporalio/workflow';
 
 /**
  * Verifies that Workflow does not generate any more commands after it is considered complete
@@ -7,6 +7,6 @@ export async function tryToContinueAfterCompletion(): Promise<void> {
   await Promise.race([
     // Note that continueAsNew only throws after microtasks and as a result, looses the race
     continueAsNew<typeof tryToContinueAfterCompletion>(),
-    Promise.reject(new Error('fail before continue')),
+    Promise.reject(ApplicationFailure.nonRetryable('fail before continue')),
   ]);
 }

--- a/packages/test/src/workflows/workflow-cancellation-scenarios.ts
+++ b/packages/test/src/workflows/workflow-cancellation-scenarios.ts
@@ -1,4 +1,4 @@
-import { CancellationScope, CancelledFailure, sleep } from '@temporalio/workflow';
+import { ApplicationFailure, CancellationScope, CancelledFailure, sleep } from '@temporalio/workflow';
 
 export type WorkflowCancellationScenarioOutcome = 'complete' | 'cancel' | 'fail';
 export type WorkflowCancellationScenarioTiming = 'immediately' | 'after-cleanup';
@@ -22,7 +22,7 @@ export async function workflowCancellationScenarios(
       case 'complete':
         return;
       case 'fail':
-        throw new Error('Expected failure');
+        throw ApplicationFailure.nonRetryable('Expected failure');
     }
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Before this change throwing an error in a Workflow
would cause the Workflow execution to fail. After the change only the
Workflow task fails on random errors.
To fail the Workflow exection throw `ApplicationFailure.nonRetryable`.
To make other error types non retryable use the
`WorkflowInboundCallsInterceptor` `execute` and `handleSignal` methods
to catch errors thrown from the Workflow and convert them to non
retryable failures, e.g:

```ts
class WorkflowErrorInterceptor implements WorkflowInboundCallsInterceptor {
  async execute(input: WorkflowExecuteInput, next: Next<WorkflowInboundCallsInterceptor, 'execute'>): Promise<unknown> {
    try {
      return await next(input);
    } catch (err) {
      if (err instanceof MySpecialNonRetryableError) {
        throw ApplicationFailure.nonRetryable(err.message, 'MySpecialNonRetryableError');
      }
      throw err;
    }
  }
}
```

NOTE: Propagated Activity and child Workflow failures are considered non
retryable and will fail the workflow execution.