### PR TITLE
fix: Fix workflow retryable Application failure fails execution

### DIFF
--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -239,11 +239,12 @@ function makeCompleteWorkflowExecution(result?: coresdk.common.IPayload): coresd
 function makeFailWorkflowExecution(
   message: string,
   stackTrace: string,
-  type = 'Error'
+  type = 'Error',
+  nonRetryable = true
 ): coresdk.workflow_commands.IWorkflowCommand {
   return {
     failWorkflowExecution: {
-      failure: { message, stackTrace, applicationFailureInfo: { type, nonRetryable: true }, source: 'TypeScriptSDK' },
+      failure: { message, stackTrace, applicationFailureInfo: { type, nonRetryable }, source: 'TypeScriptSDK' },
     },
   };
 }
@@ -665,10 +666,11 @@ test('interruptableWorkflow', async (t) => {
           // since the Error stack trace is generated in the constructor.
           dedent`
           ApplicationFailure: just because
-              at Function.nonRetryable
+              at Function.retryable
               at eval
           `,
-          'Error'
+          'Error',
+          false
         ),
       ])
     );

--- a/packages/test/src/workflows/interrupt-signal.ts
+++ b/packages/test/src/workflows/interrupt-signal.ts
@@ -6,7 +6,7 @@ export const interruptSignal = defineSignal<[string]>('interrupt');
 export async function interruptableWorkflow(): Promise<void> {
   // When this Promise is rejected Workflow execution will fail
   await new Promise<never>((_resolve, reject) => {
-    setHandler(interruptSignal, (reason) => reject(ApplicationFailure.nonRetryable(reason)));
+    setHandler(interruptSignal, (reason) => reject(ApplicationFailure.retryable(reason)));
   });
 }
 // @@@SNIPEND

--- a/packages/test/src/workflows/throw-async.ts
+++ b/packages/test/src/workflows/throw-async.ts
@@ -1,5 +1,5 @@
 import { ApplicationFailure } from '@temporalio/workflow';
 
-export async function throwAsync(): Promise<void> {
-  throw ApplicationFailure.nonRetryable('failure');
+export async function throwAsync(variant: 'retryable' | 'nonRetryable' = 'nonRetryable'): Promise<void> {
+  throw ApplicationFailure[variant]('failure');
 }


### PR DESCRIPTION
Makes `ApplicationFailure.retryable` fail the workflow execution and not the task as intended, this was wrongly implemented in #429.