### PR TITLE
feat(core): Make Core portable

### DIFF
--- a/packages/core-bridge/common.js
+++ b/packages/core-bridge/common.js
@@ -1,0 +1,50 @@
+/**
+ * Shared code for scripts/build.js and index.js
+ *
+ * @module
+ */
+
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+// List of tested compile targets
+const targets = [
+  'x86_64-apple-darwin',
+  'aarch64-apple-darwin',
+  'x86_64-unknown-linux-gnu',
+  'aarch64-unknown-linux-gnu',
+  // TODO: this is not supported on macos
+  'x86_64-pc-windows-msvc',
+  'x86_64-pc-windows-gnu',
+];
+
+const archAlias = { x64: 'x86_64', arm64: 'aarch64' };
+const platformMapping = { darwin: 'apple-darwin', linux: 'unknown-linux-gnu', win32: 'pc-windows-msvc' };
+
+class PrebuildError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'PrebuildError';
+  }
+}
+
+function getPrebuiltPath() {
+  const arch = archAlias[os.arch()];
+  if (arch === undefined) {
+    throw new PrebuildError(`No prebuilt module for arch ${os.arch()}`);
+  }
+  const platform = platformMapping[os.platform()];
+  if (platform === undefined) {
+    throw new PrebuildError(`No prebuilt module for platform ${os.platform()}`);
+  }
+  const binary = path.resolve(__dirname, 'releases', `${arch}-${platform}`, 'index.node');
+  if (fs.existsSync(binary)) {
+    console.log('Found prebuilt bridge module', { binary });
+    return binary;
+  } else {
+    throw new PrebuildError(`No prebuilt module found at ${binary}`);
+  }
+}
+
+module.exports = { targets, archAlias, platformMapping, PrebuildError, getPrebuiltPath };

--- a/packages/core-bridge/index.js
+++ b/packages/core-bridge/index.js
@@ -1,0 +1,12 @@
+const { getPrebuiltPath, PrebuildError } = require('./common');
+
+try {
+  const prebuiltPath = getPrebuiltPath();
+  module.exports = require(prebuiltPath);
+} catch (err) {
+  if (err instanceof PrebuildError) {
+    module.exports = require('./default-build/index.node');
+  } else {
+    throw err;
+  }
+}

--- a/packages/core-bridge/package.json
+++ b/packages/core-bridge/package.json
@@ -36,6 +36,8 @@
     "sdk-core",
     "Cargo.toml",
     "Cargo.lock",
+    "index.js",
+    "common.js",
     "index.d.ts"
   ],
   "publishConfig": {

--- a/packages/core-bridge/scripts/build.js
+++ b/packages/core-bridge/scripts/build.js
@@ -1,26 +1,12 @@
 const path = require('path');
 const arg = require('arg');
-const os = require('os');
 const fs = require('fs');
 const which = require('which');
 const { spawnSync } = require('child_process');
 const { version } = require('../package.json');
+const { targets, getPrebuiltPath, PrebuildError } = require('../common');
 
 process.chdir(path.resolve(__dirname, '..'));
-
-// List of tested compile targets
-const targets = [
-  'x86_64-apple-darwin',
-  'aarch64-apple-darwin',
-  'x86_64-unknown-linux-gnu',
-  'aarch64-unknown-linux-gnu',
-  // TODO: this is not supported on macos
-  'x86_64-pc-windows-msvc',
-  'x86_64-pc-windows-gnu',
-];
-
-const archAlias = { x64: 'x86_64', arm64: 'aarch64' };
-const platformMapping = { darwin: 'apple-darwin', linux: 'unknown-linux-gnu', win32: 'pc-windows-gnu' };
 
 const args = arg({
   '--help': Boolean,
@@ -71,7 +57,7 @@ const buildRelease = args['--release'] || process.env.BUILD_CORE_RELEASE !== und
 function compile(target) {
   console.log('Compiling bridge', { target, buildRelease });
 
-  const out = target ? `releases/${target}/index.node` : 'index.node';
+  const out = target ? `releases/${target}/index.node` : 'default-build/index.node';
   try {
     fs.unlinkSync(out);
   } catch (err) {
@@ -103,35 +89,6 @@ function compile(target) {
   }
 }
 
-class PrebuildError extends Error {
-  constructor(message) {
-    super(message);
-    this.name = 'PrebuildError';
-  }
-}
-
-function usePrebuilt() {
-  const arch = archAlias[os.arch()];
-  if (arch === undefined) {
-    throw new PrebuildError(`No prebuilt module for arch ${os.arch()}`);
-  }
-  const platform = platformMapping[os.platform()];
-  if (platform === undefined) {
-    throw new PrebuildError(`No prebuilt module for platform ${os.platform()}`);
-  }
-  const source = path.resolve(__dirname, '../releases', `${arch}-${platform}`, 'index.node');
-  const target = path.resolve(__dirname, '..', 'index.node');
-  try {
-    fs.copyFileSync(source, target);
-    console.log('Copied prebuilt bridge module', { source, target });
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      throw new PrebuildError(`No prebuilt module found at ${source}`);
-    }
-    throw err;
-  }
-}
-
 if (requestedTargets.length > 0) {
   // NOTE: no forceBuild
   for (const target of requestedTargets) {
@@ -140,9 +97,10 @@ if (requestedTargets.length > 0) {
 } else {
   if (!forceBuild) {
     try {
-      usePrebuilt();
+      getPrebuiltPath();
     } catch (err) {
       if (err instanceof PrebuildError) {
+        console.warn(err.message);
         compile();
       } else {
         throw err;

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -59,14 +59,8 @@ function cleanCompiledRustFiles() {
   spawnSync('cargo', ['clean'], { cwd: bridgeDir, stdio: 'inherit' });
 }
 
-function cleanCompiledCppFiles() {
-  console.log('Cleaning compiled C++ files');
-  spawnSync('node-gyp', ['clean'], { cwd: workerDir, stdio: 'inherit' });
-}
-
 const { '--only': only } = arg({ '--only': [String] });
 const components = new Set(only === undefined || only.length === 0 ? ['ts', 'proto', 'rust', 'cpp'] : only);
 if (components.has('ts')) cleanTsGeneratedFiles();
 if (components.has('proto')) cleanProtoGeneratedFiles();
 if (components.has('rust')) cleanCompiledRustFiles();
-if (components.has('cpp')) cleanCompiledCppFiles();


### PR DESCRIPTION
- `core-bridge` can now be imported in a different OS than the one the SDK was installed in.
- Closes https://github.com/temporalio/sdk-typescript/issues/457