### PR TITLE
feat: Accept IHistory for history replay

### DIFF
--- a/packages/test/src/test-replay.ts
+++ b/packages/test/src/test-replay.ts
@@ -1,4 +1,5 @@
-import { DefaultLogger, ReplayCore, Core, Worker } from '@temporalio/worker';
+import { DefaultLogger, Core, Worker } from '@temporalio/worker';
+import { ReplayCore } from '@temporalio/worker/lib/core';
 import anyTest, { TestInterface } from 'ava';
 import { temporal } from '@temporalio/proto';
 const History = temporal.api.history.v1.History;

--- a/packages/worker/src/core.ts
+++ b/packages/worker/src/core.ts
@@ -17,7 +17,8 @@ import * as errors from './errors';
 import { temporal } from '@temporalio/proto';
 import { byteArrayToBuffer } from './utils';
 import { MakeOptional } from '@temporalio/common/src/type-helpers';
-import History = temporal.api.history.v1.History;
+
+export type History = temporal.api.history.v1.IHistory;
 
 export type TelemetryOptions = MakeOptional<RequiredTelemetryOptions, 'logForwardingLevel'>;
 
@@ -282,6 +283,8 @@ export class Core {
 /**
  * An alternate version of Core which creates core instances that use mocks
  * rather than an actual server to replay histories.
+ *
+ * Intentionally not exported since Core will soon be deprecated.
  */
 export class ReplayCore extends Core {
   protected static _statics: CoreStatics<ReplayCore> = new CoreStatics((opts, cb) =>
@@ -294,7 +297,7 @@ export class ReplayCore extends Core {
     const worker = await promisify(native.newReplayWorker)(
       this.native,
       options,
-      byteArrayToBuffer(History.encodeDelimited(history).finish())
+      byteArrayToBuffer(temporal.api.history.v1.History.encodeDelimited(history).finish())
     );
     this.registeredWorkers.add(worker);
     return worker;

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -11,7 +11,7 @@
 export { State, Worker, DataConverter, defaultDataConverter, errors } from './worker';
 export { WorkerOptions, CompiledWorkerOptions } from './worker-options';
 export { ServerOptions, TLSConfig } from './server-options';
-export { Core, CompiledCoreOptions, CoreOptions, TelemetryOptions, ReplayCore } from './core';
+export { Core, CompiledCoreOptions, CoreOptions, TelemetryOptions, History } from './core';
 export * from './logger';
 export * from './sinks';
 export * from './interceptors';

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -46,7 +46,7 @@ import { Logger } from './logger';
 import * as errors from './errors';
 import { childSpan, getTracer, instrument } from './tracing';
 import { ActivityExecuteInput } from './interceptors';
-import { Core, ReplayCore } from './core';
+import { Core, ReplayCore, History } from './core';
 import { ThreadedVMWorkflowCreator } from './workflow/threaded-vm';
 import { DeterminismViolationError, SinkCall, WorkflowInfo } from '@temporalio/workflow';
 import {
@@ -60,7 +60,6 @@ import {
 } from './worker-options';
 import { VMWorkflowCreator } from './workflow/vm';
 import IWorkflowActivationJob = coresdk.workflow_activation.IWorkflowActivationJob;
-import History = temporal.api.history.v1.History;
 import EvictionReason = coresdk.workflow_activation.RemoveFromCache.EvictionReason;
 import IRemoveFromCache = coresdk.workflow_activation.IRemoveFromCache;
 


### PR DESCRIPTION
The `getWorkflowExecutionHistory` grpc call returns `GetWorkflowExecutionHistoryResponse` with a `history: IHistory` attribute. We should support this use case.
                                                                                                            