### PR TITLE
fix!: Improve failure details, fixes #462

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,13 +31,20 @@ See [sdk-structure.md](./docs/sdk-structure.md)
   npm ci
   ```
   This may take a few minutes, as it involves downloading and compiling Rust dependencies.
-  You should now be able to successfully do `npm run build`. If this fails, resetting your environment may help:
+- You should now be able to build:
+  ```sh
+  npm run build
+  ```
+
+If building fails, resetting your environment may help:
 
 ```
 npx lerna clean -y && npm ci
 ```
 
-To update your environment, run `git submodule update` to update to the latest version of the Core SDK, followed by `npm run build` to recompile.
+If `npm ci` fails in `@temporalio/core-bridge` on the command `node ./scripts/build.js`, you may need to do `rustup update`.
+
+To update to the latest version of the Core SDK, run `git submodule update` followed by `npm run build` to recompile.
 
 > For cross compilation on MacOS follow [these instructions](https://github.com/temporalio/sdk-typescript/blob/main/docs/building.md) (only required for publishing packages).
 

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -338,13 +338,13 @@ export async function errorToFailure(err: unknown, dataConverter: DataConverter)
     };
   }
 
-  const stackTrace = `A non-Error value was thrown from your code. We recommend throwing Error objects so that we can provide a stack trace.`;
+  const recommendation = ` [A non-Error value was thrown from your code. We recommend throwing Error objects so that we can provide a stack trace.]`;
 
   if (typeof err === 'string') {
-    return { ...base, stackTrace, message: err };
+    return { ...base, message: err + recommendation };
   }
 
-  return { ...base, stackTrace, message: JSON.stringify(err) };
+  return { ...base, message: JSON.stringify(err) + recommendation };
 }
 
 /**

--- a/packages/common/src/type-helpers.ts
+++ b/packages/common/src/type-helpers.ts
@@ -13,3 +13,14 @@ export function checkExtends<_Orig, _Copy extends _Orig>(): void {
 export type Replace<Base, New> = Omit<Base, keyof New> & New;
 
 export type MakeOptional<Base, Keys extends keyof Base> = Omit<Base, Keys> & Partial<Pick<Base, Keys>>;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function hasOwnProperties<X extends Record<string, unknown>, Y extends PropertyKey>(
+  record: X,
+  props: Y[]
+): record is X & Record<Y, unknown> {
+  return props.every((prop) => prop in record);
+}

--- a/packages/test/src/test-integration.ts
+++ b/packages/test/src/test-integration.ts
@@ -748,7 +748,7 @@ if (RUN_INTEGRATION_TESTS) {
     await handle.terminate();
   });
 
-  test('throwObject includes message and our stackTrace recommendation', async (t) => {
+  test('throwObject includes message with our recommendation', async (t) => {
     const { client } = t.context;
     const workflowId = uuid4();
     const handle = await client.start(workflows.throwObject, {
@@ -770,10 +770,9 @@ if (RUN_INTEGRATION_TESTS) {
           t.fail();
           return;
         }
-        t.is(failure.message, '{"plainObject":true}');
         t.is(
-          failure.stackTrace,
-          'A non-Error value was thrown from your code. We recommend throwing Error objects so that we can provide a stack trace.'
+          failure.message,
+          '{"plainObject":true} [A non-Error value was thrown from your code. We recommend throwing Error objects so that we can provide a stack trace.]'
         );
       },
       { minTimeout: 300, factor: 1, retries: 100 }

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -39,6 +39,7 @@ export * from './signal-target';
 // The reason it is redefined is for completeness of the snippet.
 export { unblockOrCancel, isBlockedQuery } from './unblock-or-cancel';
 export * from './throw-async';
+export * from './throw-object';
 export * from './args-and-return';
 export * from './activity-failure';
 export * from './activity-failures';

--- a/packages/test/src/workflows/throw-object.ts
+++ b/packages/test/src/workflows/throw-object.ts
@@ -1,0 +1,3 @@
+export async function throwObject(): Promise<void> {
+  throw { plainObject: true };
+}

--- a/packages/test/src/workflows/unhandled-rejection.ts
+++ b/packages/test/src/workflows/unhandled-rejection.ts
@@ -16,7 +16,10 @@ export async function throwUnhandledRejection({ crashWorker }: { crashWorker: bo
       const Promise = globalThis.constructor.constructor('return Promise')();
       Promise.reject(new Error('error to crash the worker'));
     } else {
-      throw new Error('unhandled rejection');
+      const cause = new Error('root failure');
+      const e: any = new Error('unhandled rejection');
+      e.cause = cause;
+      throw e;
     }
   })();
 


### PR DESCRIPTION
Implements all I suggested in #462  except for more specific `source`, which I think would require passing more info to `errorToFailure`. I'd like to get to that later.

This change could be breaking: if a user is checking whether `failure.message === 'Error: orig message'`, it won't catch the new `failure.message = 'orig message'`. I think the old behavior that added the `Error: ` was unintentional—at the end of `errorToFailure`, the `instanceof Error` failed because the Error was coming from the vm, so `String(err)` was used.