### PR TITLE
fix: Upgrade Core to receive recent fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Breaking changes marked with a :boom:
 - [`workflow`] Fix startChild options type ([#447](https://github.com/temporalio/sdk-typescript/pull/447))
 - [`workflow`] Fix error when timer is cancelled and immediately fired in the same activation ([#466](https://github.com/temporalio/sdk-typescript/pull/466))
 
+- Upgrade Core to receive recent fixes ([#475](https://github.com/temporalio/sdk-typescript/pull/475))
+  - Replay mock client wasn't allowing completes ([sdk-core#269](https://github.com/temporalio/sdk-core/pull/269))
+  - Fix heartbeats not flushing on activity completion ([sdk-core#266](https://github.com/temporalio/sdk-core/pull/266))
+
 ### Features
 
 - Replay history from files ([#449](https://github.com/temporalio/sdk-typescript/pull/449))

--- a/packages/core-bridge/Cargo.lock
+++ b/packages/core-bridge/Cargo.lock
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]


### PR DESCRIPTION
- Replay mock client wasn't allowing completes ([#269](https://github.com/temporalio/sdk-core/pull/269))
- Fix heartbeats not flushing on activity completion ([#266](https://github.com/temporalio/sdk-core/pull/266))
