### PR TITLE
fix(workflow): Fix ContinueAsNew error message and name

### DIFF
--- a/packages/interceptors-opentelemetry/src/client/index.ts
+++ b/packages/interceptors-opentelemetry/src/client/index.ts
@@ -30,15 +30,15 @@ export class OpenTelemetryWorkflowClientCallsInterceptor implements WorkflowClie
   }
 
   async start(input: WorkflowStartInput, next: Next<WorkflowClientCallsInterceptor, 'start'>): Promise<string> {
-    return await instrument(
-      this.tracer,
-      `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}${input.workflowType}`,
-      async (span) => {
+    return await instrument({
+      tracer: this.tracer,
+      spanName: `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}${input.workflowType}`,
+      fn: async (span) => {
         const headers = await headersWithContext(input.headers);
         const runId = await next({ ...input, headers });
         span.setAttribute(RUN_ID_ATTR_KEY, runId);
         return runId;
-      }
-    );
+      },
+    });
   }
 }

--- a/packages/interceptors-opentelemetry/src/instrumentation.ts
+++ b/packages/interceptors-opentelemetry/src/instrumentation.ts
@@ -4,33 +4,49 @@
  */
 import * as otel from '@opentelemetry/api';
 
-async function wrapWithSpan<T>(span: otel.Span, fn: (span: otel.Span) => Promise<T>): Promise<T> {
+async function wrapWithSpan<T>(
+  span: otel.Span,
+  fn: (span: otel.Span) => Promise<T>,
+  acceptableErrors?: (err: unknown) => boolean
+): Promise<T> {
   try {
     const ret = await fn(span);
     span.setStatus({ code: otel.SpanStatusCode.OK });
     return ret;
   } catch (err: any) {
-    span.setStatus({ code: otel.SpanStatusCode.ERROR });
-    span.recordException(err);
+    if (acceptableErrors === undefined || !acceptableErrors(err)) {
+      span.setStatus({ code: otel.SpanStatusCode.ERROR });
+      span.recordException(err);
+    } else {
+      span.setStatus({ code: otel.SpanStatusCode.OK });
+    }
     throw err;
   } finally {
     span.end();
   }
 }
 
+export interface InstrumentOptions<T> {
+  tracer: otel.Tracer;
+  spanName: string;
+  fn: (span: otel.Span) => Promise<T>;
+  context?: otel.Context;
+  acceptableErrors?: (err: unknown) => boolean;
+}
 /**
  * Wraps `fn` in a span which ends when function returns or throws
  */
-export async function instrument<T>(
-  tracer: otel.Tracer,
-  name: string,
-  fn: (span: otel.Span) => Promise<T>,
-  context?: otel.Context
-): Promise<T> {
+export async function instrument<T>({
+  tracer,
+  spanName,
+  fn,
+  context,
+  acceptableErrors,
+}: InstrumentOptions<T>): Promise<T> {
   if (context) {
     return await otel.context.with(context, async () => {
-      return await tracer.startActiveSpan(name, async (span) => await wrapWithSpan(span, fn));
+      return await tracer.startActiveSpan(spanName, async (span) => await wrapWithSpan(span, fn, acceptableErrors));
     });
   }
-  return await tracer.startActiveSpan(name, async (span) => await wrapWithSpan(span, fn));
+  return await tracer.startActiveSpan(spanName, async (span) => await wrapWithSpan(span, fn, acceptableErrors));
 }

--- a/packages/interceptors-opentelemetry/src/worker/index.ts
+++ b/packages/interceptors-opentelemetry/src/worker/index.ts
@@ -37,7 +37,7 @@ export class OpenTelemetryActivityInboundInterceptor implements ActivityInboundC
   async execute(input: ActivityExecuteInput, next: Next<ActivityInboundCallsInterceptor, 'execute'>): Promise<unknown> {
     const context = await extractContextFromHeaders(input.headers);
     const spanName = `${SpanName.ACTIVITY_EXECUTE}${SPAN_DELIMITER}${this.ctx.info.activityType}`;
-    return await instrument(this.tracer, spanName, () => next(input), context);
+    return await instrument({ tracer: this.tracer, spanName, fn: () => next(input), context });
   }
 }
 

--- a/packages/interceptors-opentelemetry/src/workflow/index.ts
+++ b/packages/interceptors-opentelemetry/src/workflow/index.ts
@@ -10,6 +10,7 @@ import {
   WorkflowExecuteInput,
   workflowInfo,
   ContinueAsNewInput,
+  ContinueAsNew,
   WorkflowInternalsInterceptor,
 } from '@temporalio/workflow';
 import { extractContextFromHeaders, headersWithContext } from '@temporalio/common/lib/otel';
@@ -51,8 +52,13 @@ export class OpenTelemetryInboundInterceptor implements WorkflowInboundCallsInte
     next: Next<WorkflowInboundCallsInterceptor, 'execute'>
   ): Promise<unknown> {
     const context = await extractContextFromHeaders(input.headers);
-    const spanName = `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}${workflowInfo().workflowType}`;
-    return await instrument(this.tracer, spanName, () => next(input), context);
+    return await instrument({
+      tracer: this.tracer,
+      spanName: `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}${workflowInfo().workflowType}`,
+      fn: () => next(input),
+      context,
+      acceptableErrors: (err) => err instanceof ContinueAsNew,
+    });
   }
 }
 
@@ -68,51 +74,52 @@ export class OpenTelemetryOutboundInterceptor implements WorkflowOutboundCallsIn
     input: ActivityInput,
     next: Next<WorkflowOutboundCallsInterceptor, 'scheduleActivity'>
   ): Promise<unknown> {
-    return await instrument(
-      this.tracer,
-      `${SpanName.ACTIVITY_START}${SPAN_DELIMITER}${input.activityType}`,
-      async () => {
+    return await instrument({
+      tracer: this.tracer,
+      spanName: `${SpanName.ACTIVITY_START}${SPAN_DELIMITER}${input.activityType}`,
+      fn: async () => {
         const headers = await headersWithContext(input.headers);
         return next({
           ...input,
           headers,
         });
-      }
-    );
+      },
+    });
   }
 
   public async startChildWorkflowExecution(
     input: StartChildWorkflowExecutionInput,
     next: Next<WorkflowOutboundCallsInterceptor, 'startChildWorkflowExecution'>
   ): Promise<[Promise<string>, Promise<unknown>]> {
-    return await instrument(
-      this.tracer,
-      `${SpanName.CHILD_WORKFLOW_START}${SPAN_DELIMITER}${input.workflowType}`,
-      async () => {
+    return await instrument({
+      tracer: this.tracer,
+      spanName: `${SpanName.CHILD_WORKFLOW_START}${SPAN_DELIMITER}${input.workflowType}`,
+      fn: async () => {
         const headers = await headersWithContext(input.headers);
         return next({
           ...input,
           headers,
         });
-      }
-    );
+      },
+    });
   }
 
   public async continueAsNew(
     input: ContinueAsNewInput,
     next: Next<WorkflowOutboundCallsInterceptor, 'continueAsNew'>
   ): Promise<never> {
-    return await instrument(
-      this.tracer,
-      `${SpanName.CONTINUE_AS_NEW}${SPAN_DELIMITER}${input.options.workflowType}`,
-      async () => {
+    return await instrument({
+      tracer: this.tracer,
+      spanName: `${SpanName.CONTINUE_AS_NEW}${SPAN_DELIMITER}${input.options.workflowType}`,
+      fn: async () => {
         const headers = await headersWithContext(input.headers);
         return next({
           ...input,
           headers,
         });
-      }
-    );
+      },
+      acceptableErrors: (err) => err instanceof ContinueAsNew,
+    });
   }
 }
 

--- a/packages/test/src/test-otel.ts
+++ b/packages/test/src/test-otel.ts
@@ -20,6 +20,7 @@ import { OpenTelemetrySinks, SpanName, SPAN_DELIMITER } from '@temporalio/interc
 import * as activities from './activities';
 import * as workflows from './workflows';
 import { RUN_INTEGRATION_TESTS } from './helpers';
+import { SpanStatusCode } from '@opentelemetry/api';
 
 if (RUN_INTEGRATION_TESTS) {
   test.serial('Otel interceptor spans are connected and complete', async (t) => {
@@ -80,12 +81,14 @@ if (RUN_INTEGRATION_TESTS) {
         parentSpanId === originalSpan?.spanContext().spanId
     );
     t.true(firstExecuteSpan !== undefined);
+    t.true(firstExecuteSpan!.status.code === SpanStatusCode.OK);
     const continueAsNewSpan = spans.find(
       ({ name, parentSpanId }) =>
         name === `${SpanName.CONTINUE_AS_NEW}${SPAN_DELIMITER}smorgasbord` &&
         parentSpanId === firstExecuteSpan?.spanContext().spanId
     );
     t.true(continueAsNewSpan !== undefined);
+    t.true(continueAsNewSpan!.status.code === SpanStatusCode.OK);
     const parentExecuteSpan = spans.find(
       ({ name, parentSpanId }) =>
         name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}smorgasbord` &&

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -79,6 +79,7 @@ export {
   ContinueAsNewOptions,
   ParentClosePolicy,
   WorkflowInfo,
+  ContinueAsNew,
 } from './interfaces';
 export * from './errors';
 export * from './workflow';

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -41,10 +41,10 @@ export interface WorkflowInfo {
  * Not an actual error, used by the Workflow runtime to abort execution when {@link continueAsNew} is called
  */
 export class ContinueAsNew extends Error {
-  public readonly type = 'ContinueAsNew';
+  public readonly name = 'ContinueAsNew';
 
   constructor(public readonly command: coresdk.workflow_commands.IContinueAsNewWorkflowExecution) {
-    super();
+    super('Workflow continued as new');
   }
 }
 


### PR DESCRIPTION
Also do not set an error on the otel span when the interceptor catches `ContinueAsNew`.

Closes #397 