### PR TITLE
Resolve ts-loader

### DIFF
--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -112,7 +112,7 @@ export class WorkflowCodeBundler {
         rules: [
           {
             test: /\.ts$/,
-            loader: 'ts-loader',
+            loader: require.resolve('ts-loader'),
             exclude: /node_modules/,
           },
         ],


### PR DESCRIPTION
so its found in a yarn workspaces monorepo

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Wrapped `ts-loader` in a call to `require.resolve()`

## Why?
So its correctly located in a `yarn workspaces` monorepo

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
I edited the published source code to make this change and re-ran the sample app I was working in.

3. Any docs updates needed?
N/A
