### PR TITLE
fix(workflow-bundler): Enable resolution of modules in Webpack based on Node's regular algorithm

### DIFF
--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -78,7 +78,7 @@ export class WorkflowCodeBundler {
 
       // Bundle all Workflows and interceptor modules for lazy evaluation
       api.overrideGlobals();
-      api.setImportFuncs({ 
+      api.setImportFuncs({
         importWorkflows: () => {
           return import(/* webpackMode: "eager" */ ${JSON.stringify(this.workflowsPath)});
         },
@@ -105,7 +105,10 @@ export class WorkflowCodeBundler {
   protected async bundle(filesystem: typeof unionfs.ufs, entry: string, distDir: string): Promise<void> {
     const compiler = webpack({
       resolve: {
-        modules: this.nodeModulesPaths,
+        modules: [
+          ...this.nodeModulesPaths,
+          ...(!this.nodeModulesPaths.includes('node_modules') ? ['node_modules'] : []),
+        ],
         extensions: ['.ts', '.js'],
       },
       module: {


### PR DESCRIPTION
Fix #489

## What was changed
Append the string `node_module` to Webpack's configuration `resolve.modules` (unless it is already included in provided `nodeModulesPaths`).

## Why?
If `resolve.modules` contains only absolute paths, then webpack will only look at those exact directories for requested modules (ie. it will _not_ behave in a way similar to how Node resolve dependencies). See [Webpack's documentation](https://webpack.js.org/configuration/resolve/#resolvemodules) about this.

It so happens that the `resolveNodeModulesPaths(...)` function, used by the workflow bundler to calculate the default value of `resolve.modules` when none has been provided by the user, indeed returns a single absolute path. It can also be expected that, even if a user was to explicitly provide a path using the `nodeModulesPaths`, he would probably not know that he has to include `node_modules` in it.

Hence, the workflow bundler currently only resolve modules that come from that single, determined `node_modules`, but fails to resolve modules from other, related `node_modules`. This may cause various errors when the workflow code is being bundled, including "Module not found" errors or resolving a dependency to the wrong version. This is notably visible when dependencies has been installed using `npm i --production`, but may also happen for many other reasons.

See #489 for a detailed explanation of such a case.

## Checklist
1. Closes 489

2. How was this tested:
Before applying this change, I reached to the hello-world example (see discussion in #489) and installed dependencies using `npm i --production`. Then, I built the example (`npm run build`) and ran it (`node lib/worker.js`). At this point, I would get an error about module `ms` being missing.

After applying this change and building the Temporal's TS SDK, I reached to the hello-world example, and linked `@temporalio/worker` to the one I has built. Then, I built the example and ran it. No more error.

3. Any docs updates needed?
It might no longer be useful to recommend that dependencies of workers not be installed with `npm i --production` (that is, it could be possible to revert [temporalio/documentation#930](https://github.com/temporalio/documentation/pull/930).