### PR TITLE
docs: Fix order in publishing script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,14 +133,8 @@ git-cliff --tag 0.18.0 v0.17.2..HEAD | pbcopy
 
 We're [working on automating](https://github.com/temporalio/sdk-typescript/pull/395) the rest of the process:
 
-- Download the artifacts from [GitHub Actions](https://github.com/temporalio/sdk-typescript/actions)
-- Decompress and copy:
-
-```sh
-for f in ~/Downloads/packages-*.zip; do mkdir "$HOME/Downloads/$(basename -s .zip $f)"; (cd "$HOME/Downloads/$(basename -s .zip $f)" && unzip $f && tar -xvzf @temporalio/core-bridge/core-bridge-*.tgz package/releases/ && cp -r package/releases/* ~/gh/release-sdk-typescript/packages/core-bridge/releases/); done
-```
-
 - Log in to npm as `temporal-sdk-team`
+- Download the artifacts from [GitHub Actions](https://github.com/temporalio/sdk-typescript/actions)
 - Publish:
 
 ```sh
@@ -150,6 +144,8 @@ set -euo pipefail
 git clean -fdx
 npm ci
 npm run build
+
+for f in ~/Downloads/packages-*.zip; do mkdir "$HOME/Downloads/$(basename -s .zip $f)"; (cd "$HOME/Downloads/$(basename -s .zip $f)" && unzip $f && tar -xvzf @temporalio/core-bridge/core-bridge-*.tgz package/releases/ && cp -r package/releases/* ~/gh/release-sdk-typescript/packages/core-bridge/releases/); done
 
 # we don't build for aarch64-linux in CI, so we build for it now
 export CC_aarch64_unknown_linux_gnu=aarch64-unknown-linux-gnu-gcc


### PR DESCRIPTION
Decompressing/copying before `git clean` resulted in no `packages/core-bridge/releases/` directory.