### PR TITLE
feat(workflow-bundler): support excluding modules from workflows bundle

### DIFF
--- a/packages/test/src/mocks/workflows-with-node-dependencies/example/client.ts
+++ b/packages/test/src/mocks/workflows-with-node-dependencies/example/client.ts
@@ -1,0 +1,7 @@
+import dns from 'dns';
+
+export function exampleHeavyweightFunction(): void {
+  dns.resolve('localhost', () => {
+    /* ignore */
+  });
+}

--- a/packages/test/src/mocks/workflows-with-node-dependencies/example/index.ts
+++ b/packages/test/src/mocks/workflows-with-node-dependencies/example/index.ts
@@ -1,0 +1,2 @@
+export * from './client';
+export * from './models';

--- a/packages/test/src/mocks/workflows-with-node-dependencies/example/models.ts
+++ b/packages/test/src/mocks/workflows-with-node-dependencies/example/models.ts
@@ -1,0 +1,12 @@
+export interface ExampleModel {
+  someProperty: ExampleEnum;
+}
+
+export enum ExampleEnum {
+  success = 'succcess',
+  failure = 'failure',
+}
+
+export function extractProperty(obj: ExampleModel): ExampleEnum {
+  return obj.someProperty;
+}

--- a/packages/test/src/mocks/workflows-with-node-dependencies/issue-516.ts
+++ b/packages/test/src/mocks/workflows-with-node-dependencies/issue-516.ts
@@ -1,0 +1,7 @@
+import { ExampleModel, ExampleEnum, extractProperty } from './example/index';
+
+// Demonstrate issue #516
+export async function issue516(): Promise<string> {
+  const successModel: ExampleModel = { someProperty: ExampleEnum.success };
+  return extractProperty(successModel);
+}

--- a/packages/test/src/test-worker-from-bundle.ts
+++ b/packages/test/src/test-worker-from-bundle.ts
@@ -8,7 +8,7 @@ import { unlink, writeFile } from 'fs/promises';
 import os from 'os';
 import { v4 as uuid4 } from 'uuid';
 import { WorkflowClient } from '@temporalio/client';
-import { bundleWorkflowCode, Worker } from '@temporalio/worker';
+import { bundleWorkflowCode, DefaultLogger, LogEntry, Worker } from '@temporalio/worker';
 import { RUN_INTEGRATION_TESTS } from './helpers';
 import { successString } from './workflows';
 import { issue516 } from './mocks/workflows-with-node-dependencies/issue-516';
@@ -71,7 +71,7 @@ if (RUN_INTEGRATION_TESTS) {
     const taskQueue = `${t.title}-${uuid4()}`;
     const workflowBundle = await bundleWorkflowCode({
       workflowsPath: require.resolve('./mocks/workflows-with-node-dependencies/issue-516'),
-      // ignoreModules: ['dns'],
+      ignoreModules: ['dns'],
     });
     const worker = await Worker.create({
       taskQueue,
@@ -88,6 +88,25 @@ if (RUN_INTEGRATION_TESTS) {
         }
       })(),
     ]);
+    t.pass();
+  });
+
+  test('A warning is reported when workflow depends on a node built-in module', async (t) => {
+    const logs: LogEntry[] = [];
+    const logger = new DefaultLogger('WARN', (entry: LogEntry) => {
+      logs.push(entry);
+      console.warn(entry.message);
+    });
+
+    await bundleWorkflowCode({
+      workflowsPath: require.resolve('./mocks/workflows-with-node-dependencies/issue-516'),
+      logger,
+    });
+
+    t.true(
+      logs.some((entry) => entry.message.match(/'dns'/) && entry.message.match(/'BundleOptions.ignoreModules'/)),
+      "Bundler reported a warning message about package 'dns'"
+    );
     t.pass();
   });
 }


### PR DESCRIPTION
## What was changed

A property `ignoreModules` has been added to `bundleWorkflowCode(...)` argument (that is, inside `BundleOptions`). This property allow user to specify a list of modules to be excluded from the workflows bundle.

Also, all node built-in modules (except for `assert`, for which a stub has already been developed) are automatically ignored. A warning message is displayed at bundling time to inform users that these modules can't be used inside workflows.

## Why?

See #516 for rationale.

## Checklist
1. Closes #516

2. How was this tested:
Unit tests have been added

3. Any docs updates needed?
Yes, to be discussed.