### PR TITLE
fix(worker)!: Mark activity errors retryable

### DIFF
--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -79,7 +79,7 @@ export class ServerFailure extends TemporalFailure {
  * Any unhandled exception which doesn't extend {@link TemporalFailure} is converted to an
  * instance of this class before being returned to a caller.
  *
- * The {@link type} property is used by {@link io.temporal.common.RetryOptions} to determine if
+ * The {@link type} property is used by {@link temporal.common.RetryOptions} to determine if
  * an instance of this exception is non retryable. Another way to avoid retrying an exception of
  * this type is by setting {@link nonRetryable} flag to `true`.
  *

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -477,7 +477,7 @@ export class Worker {
                               message: `Activity function ${activityType} is not registered on this Worker, available activities: ${JSON.stringify(
                                 Object.keys(this.options.activities ?? {})
                               )}`,
-                              applicationFailureInfo: { type: 'NotFoundError', nonRetryable: true },
+                              applicationFailureInfo: { type: 'NotFoundError', nonRetryable: false },
                             },
                           },
                         },
@@ -499,7 +499,7 @@ export class Worker {
                               )}`,
                               applicationFailureInfo: {
                                 type: err instanceof Error ? err.name : undefined,
-                                nonRetryable: true,
+                                nonRetryable: false,
                               },
                             },
                           },


### PR DESCRIPTION
Before this fix, the ApplicationFailures returned by the Worker in these
two circumstances were not retryable:

- Activity not found
- Failed to parse Activity args

Closes #521
