### PR TITLE
fix: Add reason to cancelation tasks in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
           name: packages-${{ matrix.target }}
           path: /tmp/registry/storage
         if: ${{ matrix.server != 'cloud' || env.TEMPORAL_CLIENT_CERT != '' }}
-      - run: node scripts/init-from-verdaccio.js --registry-dir /tmp/registry --sample https://github.com/temporalio/samples-typescript/tree/next/${{ matrix.sample }}
+      - run: node scripts/init-from-verdaccio.js --registry-dir /tmp/registry --sample https://github.com/temporalio/samples-typescript/tree/main/${{ matrix.sample }}
         if: ${{ matrix.server != 'cloud' || env.TEMPORAL_CLIENT_CERT != '' }}
       - name: Get Temporal docker-compose.yml
         run: wget https://raw.githubusercontent.com/temporalio/docker-compose/v1.13.0/docker-compose.yml

--- a/packages/test/src/test-worker-activities.ts
+++ b/packages/test/src/test-worker-activities.ts
@@ -107,10 +107,12 @@ test('Worker cancels activity and reports cancellation', async (t) => {
     });
     const completion = await worker.native.runActivityTask({
       taskToken,
-      cancel: {},
+      cancel: {
+        reason: coresdk.activity_task.ActivityCancelReason.CANCELLED,
+      },
     });
     compareCompletion(t, completion.result, {
-      cancelled: { failure: { source: 'TypeScriptSDK', message: '', canceledFailureInfo: {} } },
+      cancelled: { failure: { source: 'TypeScriptSDK', message: 'CANCELLED', canceledFailureInfo: {} } },
     });
   });
 });
@@ -131,7 +133,9 @@ test('Activity Context AbortSignal cancels a fetch request', async (t) => {
       });
       const completion = await worker.native.runActivityTask({
         taskToken,
-        cancel: {},
+        cancel: {
+          reason: coresdk.activity_task.ActivityCancelReason.CANCELLED,
+        },
       });
       compareCompletion(t, completion.result, {
         cancelled: { failure: { source: 'TypeScriptSDK', canceledFailureInfo: {} } },

--- a/packages/test/src/test-worker-lifecycle.ts
+++ b/packages/test/src/test-worker-lifecycle.ts
@@ -2,10 +2,10 @@
  * Test the various states of a Worker.
  * Most tests use a mocked core, some tests run serially because they emit signals to the process
  */
-import test from 'ava';
 import { Worker } from '@temporalio/worker';
-import { isolateFreeWorker, defaultOptions } from './mock-native-worker';
+import test from 'ava';
 import { RUN_INTEGRATION_TESTS } from './helpers';
+import { defaultOptions, isolateFreeWorker } from './mock-native-worker';
 
 if (RUN_INTEGRATION_TESTS) {
   test.serial('run shuts down gracefully', async (t) => {


### PR DESCRIPTION
Without a `cancel.reason`, the test hangs after:

![image](https://user-images.githubusercontent.com/251288/157917432-85739720-de1d-45ab-9baa-e33585b85e78.png)

Just confirming: even though the proto says reason is optional, it should always be there, and worker should throw & fail when it's not?