### PR TITLE
feat(client): Minor connection improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7473,6 +7473,7 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash._reinterpolate": {
@@ -12181,7 +12182,7 @@
       "version": "0.19.0-rc.1",
       "license": "MIT",
       "dependencies": {
-        "@grpc/grpc-js": "^1.3.7",
+        "@grpc/grpc-js": "^1.5.7",
         "@temporalio/common": "file:../common",
         "@temporalio/internal-non-workflow-common": "file:../internal-non-workflow-common",
         "@temporalio/internal-workflow-common": "file:../internal-workflow-common",
@@ -12354,8 +12355,7 @@
       "license": "MIT",
       "dependencies": {
         "@temporalio/common": "file:../common",
-        "@temporalio/internal-workflow-common": "file:../internal-workflow-common",
-        "lodash": "^4.17.21"
+        "@temporalio/internal-workflow-common": "file:../internal-workflow-common"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.178"
@@ -14292,7 +14292,7 @@
     "@temporalio/client": {
       "version": "file:packages/client",
       "requires": {
-        "@grpc/grpc-js": "^1.3.7",
+        "@grpc/grpc-js": "^1.5.7",
         "@temporalio/common": "file:../common",
         "@temporalio/internal-non-workflow-common": "file:../internal-non-workflow-common",
         "@temporalio/internal-workflow-common": "file:../internal-workflow-common",
@@ -14413,8 +14413,7 @@
       "requires": {
         "@temporalio/common": "file:../common",
         "@temporalio/internal-workflow-common": "file:../internal-workflow-common",
-        "@types/lodash": "^4.14.178",
-        "lodash": "^4.17.21"
+        "@types/lodash": "^4.14.178"
       }
     },
     "@temporalio/internal-workflow-common": {
@@ -17639,7 +17638,8 @@
       }
     },
     "lodash": {
-      "version": "4.17.21"
+      "version": "4.17.21",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,7 +13,7 @@
   "author": "Roey Berman <roey@temporal.io>",
   "license": "MIT",
   "dependencies": {
-    "@grpc/grpc-js": "^1.3.7",
+    "@grpc/grpc-js": "^1.5.7",
     "@temporalio/common": "file:../common",
     "@temporalio/internal-non-workflow-common": "file:../internal-non-workflow-common",
     "@temporalio/internal-workflow-common": "file:../internal-workflow-common",

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -38,9 +38,9 @@ export interface ConnectionOptions {
   /**
    * GRPC Channel arguments
    *
-   * @see options {@link https://grpc.github.io/grpc/core/group__grpc__arg__keys.html | here}
+   * @see option descriptions {@link https://grpc.github.io/grpc/core/group__grpc__arg__keys.html | here}
    */
-  channelArgs?: Record<string, any>;
+  channelArgs?: grpc.ChannelOptions;
 
   /**
    * Grpc interceptors which will be applied to every RPC call performed by this connection. By
@@ -110,7 +110,12 @@ function normalizeGRPCConfig(options?: ConnectionOptions): ConnectionOptions {
       ),
       channelArgs: {
         ...rest.channelArgs,
-        ...(tls.serverNameOverride ? { 'grpc.ssl_target_name_override': tls.serverNameOverride } : undefined),
+        ...(tls.serverNameOverride
+          ? {
+              'grpc.ssl_target_name_override': tls.serverNameOverride,
+              'grpc.default_authority': tls.serverNameOverride,
+            }
+          : undefined),
       },
     };
   } else {

--- a/packages/client/src/grpc-retry.ts
+++ b/packages/client/src/grpc-retry.ts
@@ -41,12 +41,12 @@ const retryableCodes = new Set([
   grpc.status.OUT_OF_RANGE,
 ]);
 
-function isRetryableError(status: StatusObject): boolean {
+export function isRetryableError(status: StatusObject): boolean {
   return retryableCodes.has(status.code);
 }
 
-// Return backoff amount in ms
-function backOffAmount(attempt: number): number {
+/** Return backoff amount in ms */
+export function backOffAmount(attempt: number): number {
   return 2 ** attempt * 20;
 }
 
@@ -62,7 +62,7 @@ export function makeGrpcRetryInterceptor(retryOptions: GrpcRetryOptions): Interc
     let savedReceiveMessage: any;
     let savedMessageNext: any;
     const requester = new RequesterBuilder()
-      .withStart(function (metadata, listener, next) {
+      .withStart(function (metadata, _listener, next) {
         savedMetadata = metadata;
         const newListener = new ListenerBuilder()
           .withOnReceiveMessage((message, next) => {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -26,6 +26,7 @@ export { RetryPolicy } from '@temporalio/internal-workflow-common';
 export * from './async-completion-client';
 export * from './connection';
 export * from './errors';
+export * from './grpc-retry';
 export * from './interceptors';
 export * from './types';
 export * from './workflow-client';


### PR DESCRIPTION
- Upgrade grpc-js dependency to ^1.5.7
- Export `*` from `grpc-retry`
- Use more exact type for `ConnectionOptions.channelArgs`
- Set `grpc.default_authority` channel arg if `serverNameOverride` is
  provided (closes #455)