### PR TITLE
feat(worker): support exporting a workflow bootstrapper

### DIFF
--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -158,10 +158,10 @@ export class WorkflowCodeBundler {
       // Bundle all Workflows and interceptor modules for lazy evaluation
       api.overrideGlobals();
       api.setImportFuncs({
-        importWorkflows: () => {
+        importWorkflows: async () => {
           let workflows = await import(/* webpackMode: "eager" */ ${JSON.stringify(this.workflowsPath)});
-          if (workflows.default && typeof workflows.default === 'function) {
-            workflows = workflows.default();
+          if (workflows.default && typeof workflows.default === 'function') {
+            return workflows.default();
           }
           return workflows;
         },

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -159,7 +159,11 @@ export class WorkflowCodeBundler {
       api.overrideGlobals();
       api.setImportFuncs({
         importWorkflows: () => {
-          return import(/* webpackMode: "eager" */ ${JSON.stringify(this.workflowsPath)});
+          let workflows = await import(/* webpackMode: "eager" */ ${JSON.stringify(this.workflowsPath)});
+          if (workflows.default && typeof workflows.default === 'function) {
+            workflows = workflows.default();
+          }
+          return workflows;
         },
         importInterceptors: () => {
           return Promise.all([


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

If the module in `workflowsPath` has a `default` export, and it's a function, the results of running that function will be returned from `importWorkflows` (and it can be async! so you can run all sorts of lifecycle hooks 'n what-not). We hope this will enable additional use-cases, such as deeper NestJS integration.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Part of #483 

2. How was this tested:

It isn't yet! I'll start with testing locally through linking, but any pointers here would be greatly appreciated.

3. Any docs updates needed?

Yes! Extensively! WIP!

- [x] Validate locally
- [ ] Write tests
- [ ] Discuss documentation