### PR TITLE
fix: Use JsonPayloadConverter for search attributes

### DIFF
--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -2,9 +2,11 @@ import { status as grpcStatus } from '@grpc/grpc-js';
 import {
   CancelledFailure,
   DataConverter,
-  defaultDataConverter,
   LoadedDataConverter,
+  mapFromPayloads,
+  mapToPayloads,
   RetryState,
+  searchAttributePayloadConverter,
   TerminatedFailure,
   TimeoutFailure,
   TimeoutType,
@@ -612,7 +614,7 @@ export class WorkflowClient {
           : undefined,
         searchAttributes: options.searchAttributes
           ? {
-              indexedFields: await encodeMapToPayloads(defaultDataConverter, options.searchAttributes),
+              indexedFields: mapToPayloads(searchAttributePayloadConverter, options.searchAttributes),
             }
           : undefined,
         cronSchedule: options.cronSchedule,
@@ -651,7 +653,7 @@ export class WorkflowClient {
       memo: opts.memo ? { fields: await encodeMapToPayloads(this.options.loadedDataConverter, opts.memo) } : undefined,
       searchAttributes: opts.searchAttributes
         ? {
-            indexedFields: await encodeMapToPayloads(defaultDataConverter, opts.searchAttributes),
+            indexedFields: mapToPayloads(searchAttributePayloadConverter, opts.searchAttributes),
           }
         : undefined,
       cronSchedule: opts.cronSchedule,
@@ -787,8 +789,8 @@ export class WorkflowClient {
             this.client.options.loadedDataConverter,
             raw.workflowExecutionInfo!.memo?.fields
           ),
-          searchAttributes: await decodeMapFromPayloads(
-            defaultDataConverter,
+          searchAttributes: mapFromPayloads(
+            searchAttributePayloadConverter,
             raw.workflowExecutionInfo!.searchAttributes?.indexedFields
           ),
           parentExecution: raw.workflowExecutionInfo!.parentExecution

--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -139,6 +139,21 @@ export function arrayFromPayloads(converter: PayloadConverter, payloads?: Payloa
   return payloads.map((payload: Payload) => converter.fromPayload(payload));
 }
 
+export function mapFromPayloads<K extends string>(
+  converter: PayloadConverter,
+  map?: Record<K, Payload> | null | undefined
+): Record<K, unknown> | null | undefined {
+  if (map === undefined || map === null) return map;
+  return Object.fromEntries(
+    Object.entries(map).map(([k, payload]): [K, unknown] => {
+      const value = converter.fromPayload(payload as Payload);
+      return [k as K, value];
+    })
+  ) as Record<K, unknown>;
+}
+
+export const searchAttributePayloadConverter = new JsonPayloadConverter();
+
 export class DefaultPayloadConverter extends CompositePayloadConverter {
   // Match the order used in other SDKs, but exclude Protobuf converters so that the code, including
   // `proto3-json-serializer`, doesn't take space in Workflow bundles that don't use Protobufs. To use Protobufs, use

--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -142,8 +142,8 @@ export function arrayFromPayloads(converter: PayloadConverter, payloads?: Payloa
 export function mapFromPayloads<K extends string>(
   converter: PayloadConverter,
   map?: Record<K, Payload> | null | undefined
-): Record<K, unknown> | null | undefined {
-  if (map === undefined || map === null) return map;
+): Record<K, unknown> | undefined {
+  if (map === undefined || map === null) return undefined;
   return Object.fromEntries(
     Object.entries(map).map(([k, payload]): [K, unknown] => {
       const value = converter.fromPayload(payload as Payload);

--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -14,6 +14,7 @@ import {
   Payload,
   PayloadCodec,
   RetryState,
+  searchAttributePayloadConverter,
   TerminatedFailure,
   TimeoutFailure,
   TimeoutType,
@@ -574,7 +575,7 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
       'BinaryChecksums',
     ]);
 
-    const checksums = defaultPayloadConverter.fromPayload(
+    const checksums = searchAttributePayloadConverter.fromPayload(
       execution.raw.workflowExecutionInfo!.searchAttributes!.indexedFields!.BinaryChecksums!
     );
     t.true(checksums instanceof Array && checksums.length === 1);
@@ -612,7 +613,7 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
     );
     t.deepEqual(await fromPayload(execution.raw.workflowExecutionInfo!.memo!.fields!.a!), 'b');
     t.deepEqual(
-      await defaultPayloadConverter.fromPayload(
+      await searchAttributePayloadConverter.fromPayload(
         execution.raw.workflowExecutionInfo!.searchAttributes!.indexedFields!.CustomIntField!
       ),
       3

--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -613,7 +613,7 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
     );
     t.deepEqual(await fromPayload(execution.raw.workflowExecutionInfo!.memo!.fields!.a!), 'b');
     t.deepEqual(
-      await searchAttributePayloadConverter.fromPayload(
+      searchAttributePayloadConverter.fromPayload(
         execution.raw.workflowExecutionInfo!.searchAttributes!.indexedFields!.CustomIntField!
       ),
       3

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1,4 +1,4 @@
-import { defaultPayloadConverter, mapToPayloads, toPayloads } from '@temporalio/common';
+import { mapToPayloads, searchAttributePayloadConverter, toPayloads } from '@temporalio/common';
 import {
   ActivityFunction,
   ActivityInterface,
@@ -251,7 +251,7 @@ async function startChildWorkflowExecutionNextHandler({
         parentClosePolicy: options.parentClosePolicy,
         cronSchedule: options.cronSchedule,
         searchAttributes: options.searchAttributes
-          ? mapToPayloads(defaultPayloadConverter, options.searchAttributes)
+          ? mapToPayloads(searchAttributePayloadConverter, options.searchAttributes)
           : undefined,
         memo: options.memo && mapToPayloads(state.payloadConverter, options.memo),
       },


### PR DESCRIPTION
Temporal doesn't support Null or Binary Payloads for search attributes.