### PR TITLE
fix: Export more from client, workflow, and common

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -23,6 +23,7 @@ export {
   TimeoutFailure,
 } from '@temporalio/common';
 export { RetryPolicy } from '@temporalio/internal-workflow-common';
+export * from '@temporalio/internal-workflow-common/lib/interfaces';
 export * from './async-completion-client';
 export * from './connection';
 export * from './errors';

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -4,7 +4,7 @@ import {
   WithCompiledWorkflowDurationOptions,
 } from '@temporalio/internal-workflow-common';
 
-export { compileWorkflowOptions, WithCompiledWorkflowDurationOptions } from '@temporalio/internal-workflow-common';
+export * from '@temporalio/internal-workflow-common/lib/workflow-options';
 
 export interface CompiledWorkflowOptions extends WithCompiledWorkflowDurationOptions<WorkflowOptions> {
   args: unknown[];

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -3,10 +3,12 @@
  *
  * @module
  */
-export { ActivityFunction, ActivityInterface, Headers, Next, RetryPolicy } from '@temporalio/internal-workflow-common';
+export { Headers, Next, RetryPolicy } from '@temporalio/internal-workflow-common';
+export * from '@temporalio/internal-workflow-common/lib/activity-options';
 export * from '@temporalio/internal-workflow-common/lib/errors';
 export * from '@temporalio/internal-workflow-common/lib/interfaces';
 export * from '@temporalio/internal-workflow-common/lib/time';
+export * from '@temporalio/internal-workflow-common/lib/workflow-options';
 export * from './converter/data-converter';
 export * from './converter/payload-codec';
 export * from './converter/payload-converter';

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -71,20 +71,19 @@ export {
   IllegalStateError,
   RetryPolicy,
   ValueError,
-  Workflow,
-  WorkflowIdReusePolicy,
-  WorkflowResultType,
 } from '@temporalio/internal-workflow-common';
+export * from '@temporalio/internal-workflow-common/lib/interfaces';
+export * from '@temporalio/internal-workflow-common/lib/workflow-options';
 export { AsyncLocalStorage, CancellationScope, CancellationScopeOptions, ROOT_SCOPE } from './cancellation-scope';
 export * from './errors';
 export * from './interceptors';
 export {
   ChildWorkflowCancellationType,
   ChildWorkflowOptions,
+  ContinueAsNew,
   ContinueAsNewOptions,
   ParentClosePolicy,
   WorkflowInfo,
-  ContinueAsNew,
 } from './interfaces';
 export { Sink, SinkCall, SinkFunction, Sinks } from './sinks';
 export { Trigger } from './trigger';


### PR DESCRIPTION
Fixes #557

Alternatively, we could `export * from '@temporalio/common'` in client and workflow?