### PR TITLE
feat!: Implement local activities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,11 @@
 .idea/
 node_modules/
 lib/
-workflow-lib/commonjs/
 *.tsbuildinfo
 build/
-commonjs/
-es2020/
 lerna*.log
 packages/test/protos/json-module.js
 packages/test/protos/root.d.ts
 packages/testing/test-server*
 packages/testing/generated-protos/
+packages/core-bridge/releases

--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -96,9 +96,11 @@ export interface Info {
    */
   scheduledTimestampMs: number;
   /**
-   * Timeout for this Activity from schedule to close in milliseconds
+   * Timeout for this Activity from schedule to close in milliseconds.
+   *
+   * Might be undefined for local activities.
    */
-  scheduleToCloseTimeoutMs: number;
+  scheduleToCloseTimeoutMs?: number;
   /**
    * Timeout for this Activity from start to close in milliseconds
    */

--- a/packages/internal-workflow-common/src/activity-options.ts
+++ b/packages/internal-workflow-common/src/activity-options.ts
@@ -85,7 +85,7 @@ Note that the Temporal Server doesn't detect Worker process failures directly. I
  */
 export interface LocalActivityOptions {
   /**
-   * RetryPolicy that define how activity is retried in case of failure. If this is not set, then the SDK-defined default activity retry policy will be used.
+   * RetryPolicy that defines how an activity is retried in case of failure. If this is not set, then the SDK-defined default activity retry policy will be used.
    * Note that local activities are always executed at least once, even if maximum attempts is set to 1 due to Workflow task retries.
    */
   retry?: RetryPolicy;

--- a/packages/internal-workflow-common/src/activity-options.ts
+++ b/packages/internal-workflow-common/src/activity-options.ts
@@ -13,8 +13,7 @@ export enum ActivityCancellationType {
 checkExtends<coresdk.workflow_commands.ActivityCancellationType, ActivityCancellationType>();
 
 /**
- * Options for remote activity invocation - will be processed from a task queue.
- * @see https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/activity/ActivityOptions.Builder.html
+ * Options for remote activity invocation
  */
 export interface ActivityOptions {
   /**
@@ -25,12 +24,6 @@ export interface ActivityOptions {
    * @default an incremental sequence number
    */
   activityId?: string;
-
-  /**
-   * Namespace to schedule this activity in.
-   * @default current worker namespace
-   */
-  namespace?: string;
 
   /**
    * Task queue name.
@@ -75,6 +68,80 @@ Note that the Temporal Server doesn't detect Worker process failures directly. I
    * @format {@link https://www.npmjs.com/package/ms | ms} formatted string or number of milliseconds
    */
   scheduleToCloseTimeout?: string | number;
+
+  /**
+   * Determines what the SDK does when the Activity is cancelled.
+   * - `TRY_CANCEL` - Initiate a cancellation request and immediately report cancellation to the workflow.
+   * - `WAIT_CANCELLATION_COMPLETED` - Wait for activity cancellation completion. Note that activity must heartbeat to receive a
+   *   cancellation notification. This can block the cancellation for a long time if activity doesn't
+   *   heartbeat or chooses to ignore the cancellation request.
+   * - `ABANDON` - Do not request cancellation of the activity and immediately report cancellation to the workflow.
+   */
+  cancellationType?: coresdk.workflow_commands.ActivityCancellationType;
+}
+
+/**
+ * Options for local activity invocation
+ */
+export interface LocalActivityOptions {
+  /**
+   * Identifier to use for tracking the activity in Workflow history.
+   * The `activityId` can be accessed by the activity function.
+   * Does not need to be unique.
+   *
+   * @default an incremental sequence number
+   */
+  activityId?: string;
+
+  /**
+   * RetryPolicy that define how activity is retried in case of failure. If this is not set, then the server-defined default activity retry policy will be used. To ensure zero retries, set maximum attempts to 1.
+   */
+  retry?: RetryPolicy;
+
+  /**
+   * Maximum time the local activity is allowed to execute after the task is dispatched. This
+   * timeout is always retryable.
+   *
+   * Either this option or {@link scheduleToCloseTimeout} is required.
+   * If set, this must be <= {@link scheduleToCloseTimeout}, otherwise, it will be clamped down.
+   *
+   * @format {@link https://www.npmjs.com/package/ms | ms} formatted string or number of milliseconds
+   */
+  startToCloseTimeout?: string | number;
+
+  /**
+   * Limits time the local activity can idle internally before being executed. That can happen if
+   * the worker is currently at max concurrent local activity executions. This timeout is always
+   * non retryable as all a retry would achieve is to put it back into the same queue. Defaults
+   * to {@link scheduleToCloseTimeout} if not specified and that is set. Must be <=
+   * {@link scheduleToCloseTimeout} when set, otherwise, it will be clamped down.
+   *
+   * @default unlimited
+   * @format {@link https://www.npmjs.com/package/ms | ms} formatted string or number of milliseconds
+   */
+  scheduleToStartTimeout?: string | number;
+
+  /**
+   * Indicates how long the caller is willing to wait for local activity completion. Limits how
+   * long retries will be attempted. When not specified defaults to the workflow execution
+   * timeout (which may be unset).
+   *
+   * Either this option or {@link startToCloseTimeout} is required.
+   *
+   * @default unlimited
+   * @format {@link https://www.npmjs.com/package/ms | ms} formatted string or number of milliseconds
+   */
+  scheduleToCloseTimeout?: string | number;
+
+  /**
+   * If the activity is retrying and backoff would exceed this value, lang will be told to
+   * schedule a timer and retry the activity after. Otherwise, backoff will happen internally in
+   * core.
+   *
+   * @default 1 minute
+   * @format {@link https://www.npmjs.com/package/ms | ms} formatted string or number of milliseconds
+   **/
+  localRetryThreshold?: string | number;
 
   /**
    * Determines what the SDK does when the Activity is cancelled.

--- a/packages/internal-workflow-common/src/activity-options.ts
+++ b/packages/internal-workflow-common/src/activity-options.ts
@@ -85,16 +85,8 @@ Note that the Temporal Server doesn't detect Worker process failures directly. I
  */
 export interface LocalActivityOptions {
   /**
-   * Identifier to use for tracking the activity in Workflow history.
-   * The `activityId` can be accessed by the activity function.
-   * Does not need to be unique.
-   *
-   * @default an incremental sequence number
-   */
-  activityId?: string;
-
-  /**
-   * RetryPolicy that define how activity is retried in case of failure. If this is not set, then the server-defined default activity retry policy will be used. To ensure zero retries, set maximum attempts to 1.
+   * RetryPolicy that define how activity is retried in case of failure. If this is not set, then the SDK-defined default activity retry policy will be used.
+   * Note that local activities are always executed at least once, even if maximum attempts is set to 1 due to Workflow task retries.
    */
   retry?: RetryPolicy;
 
@@ -134,9 +126,8 @@ export interface LocalActivityOptions {
   scheduleToCloseTimeout?: string | number;
 
   /**
-   * If the activity is retrying and backoff would exceed this value, lang will be told to
-   * schedule a timer and retry the activity after. Otherwise, backoff will happen internally in
-   * core.
+   * If the activity is retrying and backoff would exceed this value, a server side timer will be scheduled for the next attempt.
+   * Otherwise, backoff will happen internally in the SDK.
    *
    * @default 1 minute
    * @format {@link https://www.npmjs.com/package/ms | ms} formatted string or number of milliseconds

--- a/packages/test/src/test-local-activities.ts
+++ b/packages/test/src/test-local-activities.ts
@@ -3,7 +3,6 @@ import { Subject, firstValueFrom } from 'rxjs';
 import { v4 as uuid4 } from 'uuid';
 import { temporal } from '@temporalio/proto';
 import { Worker } from '@temporalio/worker';
-import * as activity from '@temporalio/activity';
 import { ApplicationFailure, defaultPayloadConverter, WorkflowClient, WorkflowFailedError } from '@temporalio/client';
 import { RUN_INTEGRATION_TESTS } from './helpers';
 import * as activities from './activities';

--- a/packages/test/src/test-local-activities.ts
+++ b/packages/test/src/test-local-activities.ts
@@ -1,0 +1,312 @@
+import anyTest, { TestInterface } from 'ava';
+import { Subject, firstValueFrom } from 'rxjs';
+import { v4 as uuid4 } from 'uuid';
+import { temporal } from '@temporalio/proto';
+import { Worker } from '@temporalio/worker';
+import * as activity from '@temporalio/activity';
+import { ApplicationFailure, defaultPayloadConverter, WorkflowClient, WorkflowFailedError } from '@temporalio/client';
+import { RUN_INTEGRATION_TESTS } from './helpers';
+import * as activities from './activities';
+import * as workflows from './workflows/local-activity-testers';
+import { isCancellation } from '@temporalio/workflow';
+
+interface Context {
+  taskQueue: string;
+  client: WorkflowClient;
+}
+
+const test = anyTest as TestInterface<Context>;
+
+export async function runWorker(worker: Worker, fn: () => Promise<any>): Promise<void> {
+  const promise = worker.run();
+  await fn();
+  worker.shutdown();
+  await promise;
+}
+
+test.beforeEach(async (t) => {
+  const title = t.title.replace('beforeEach hook for ', '');
+  const taskQueue = `test-local-activities-${title}`;
+  if (title.startsWith('[no-setup]')) {
+    t.context.taskQueue = taskQueue;
+    t.context.client = new WorkflowClient();
+    return;
+  }
+  t.context = { client: new WorkflowClient(), taskQueue };
+});
+
+async function defaultWorker(taskQueue: string) {
+  return await Worker.create({
+    // Avoid creating too many signal handlers
+    shutdownSignals: [],
+    taskQueue,
+    workflowsPath: require.resolve('./workflows/local-activity-testers'),
+    activities,
+  });
+}
+
+if (RUN_INTEGRATION_TESTS) {
+  test('Simple local activity works end to end', async (t) => {
+    const { client, taskQueue } = t.context;
+    const worker = await defaultWorker(taskQueue);
+    await runWorker(worker, async () => {
+      const res = await client.execute(workflows.runOneLocalActivity, {
+        workflowId: uuid4(),
+        taskQueue,
+        args: ['hello'],
+      });
+      t.is(res, 'hello');
+    });
+  });
+
+  test('Parallel local activities work end to end', async (t) => {
+    const { client, taskQueue } = t.context;
+    const worker = await defaultWorker(taskQueue);
+    await runWorker(worker, async () => {
+      const args = ['hey', 'ho', 'lets', 'go'];
+      const handle = await client.start(workflows.runParallelLocalActivities, {
+        workflowId: uuid4(),
+        taskQueue,
+        args,
+      });
+      const res = await handle.result();
+      t.deepEqual(res, args);
+
+      // Double check we have all local activity markers in history
+      const { history } = await client.service.getWorkflowExecutionHistory({
+        namespace: 'default',
+        execution: { workflowId: handle.workflowId },
+      });
+      const markers = history?.events?.filter(
+        (ev) => ev.eventType === temporal.api.enums.v1.EventType.EVENT_TYPE_MARKER_RECORDED
+      );
+      t.is(markers?.length, 4);
+    });
+  });
+
+  test('Local activity error is propagated properly to the Workflow', async (t) => {
+    const { client, taskQueue } = t.context;
+    const worker = await defaultWorker(taskQueue);
+    await runWorker(worker, async () => {
+      const err: WorkflowFailedError = await t.throwsAsync(
+        client.execute(workflows.throwAnErrorFromLocalActivity, {
+          workflowId: uuid4(),
+          taskQueue,
+          args: ['tesssst'],
+        }),
+        { instanceOf: WorkflowFailedError }
+      );
+      t.is(err.cause?.message, 'tesssst');
+    });
+  });
+
+  test('Local activity cancellation is propagated properly to the Workflow', async (t) => {
+    const { client, taskQueue } = t.context;
+    const worker = await defaultWorker(taskQueue);
+    await runWorker(worker, async () => {
+      const err: WorkflowFailedError = await t.throwsAsync(
+        client.execute(workflows.cancelALocalActivity, {
+          workflowId: uuid4(),
+          taskQueue,
+          workflowTaskTimeout: '3s',
+        }),
+        { instanceOf: WorkflowFailedError }
+      );
+      t.true(isCancellation(err.cause));
+      t.is(err.cause?.message, 'Activity cancelled');
+    });
+  });
+
+  test('Serial local activities (in the same task) work end to end', async (t) => {
+    const { client, taskQueue } = t.context;
+    const worker = await defaultWorker(taskQueue);
+    await runWorker(worker, async () => {
+      const handle = await client.start(workflows.runSerialLocalActivities, {
+        workflowId: uuid4(),
+        taskQueue,
+        workflowTaskTimeout: '3s',
+      });
+      await handle.result();
+      const { history } = await client.service.getWorkflowExecutionHistory({
+        namespace: 'default',
+        execution: { workflowId: handle.workflowId },
+      });
+      // WorkflowExecutionStarted
+      // WorkflowTaskScheduled
+      // WorkflowTaskStarted
+      // MarkerRecorded x 3
+      // WorkflowTaskCompleted
+      // WorkflowExecutionCompleted
+      t.is(history?.events?.length, 8);
+    });
+  });
+
+  test('Local activity does not retry if error is in nonRetryableErrorTypes', async (t) => {
+    const { client, taskQueue } = t.context;
+    const worker = await defaultWorker(taskQueue);
+    await runWorker(worker, async () => {
+      const err: WorkflowFailedError = await t.throwsAsync(
+        client.execute(workflows.throwAnExplicitNonRetryableErrorFromLocalActivity, {
+          workflowId: uuid4(),
+          taskQueue,
+          args: ['tesssst'],
+        }),
+        { instanceOf: WorkflowFailedError }
+      );
+      t.is(err.cause?.message, 'tesssst');
+    });
+  });
+
+  test('Local activity can retry once', async (t) => {
+    let attempts = 0;
+    const { taskQueue, client } = t.context;
+    const worker = await Worker.create({
+      taskQueue,
+      workflowsPath: require.resolve('./workflows/local-activity-testers'),
+      activities: {
+        // Reimplement here to track number of attempts
+        async throwAnError(_: unknown, message: string) {
+          attempts++;
+          throw new Error(message);
+        },
+      },
+    });
+
+    await runWorker(worker, async () => {
+      const err: WorkflowFailedError = await t.throwsAsync(
+        client.execute(workflows.throwARetryableErrorWithASingleRetry, {
+          workflowId: uuid4(),
+          taskQueue,
+          args: ['tesssst'],
+        }),
+        { instanceOf: WorkflowFailedError }
+      );
+      t.is(err.cause?.message, 'tesssst');
+    });
+    t.is(attempts, 2);
+  });
+
+  test('Local activity backs off with timer', async (t) => {
+    let attempts = 0;
+    const { client, taskQueue } = t.context;
+    const worker = await Worker.create({
+      taskQueue,
+      workflowsPath: require.resolve('./workflows/local-activity-testers'),
+      activities: {
+        // Reimplement here to track number of attempts
+        async succeedAfterFirstAttempt() {
+          attempts++;
+          if (attempts === 1) {
+            throw new Error('Retry me please');
+          }
+        },
+      },
+    });
+
+    await runWorker(worker, async () => {
+      const handle = await client.start(workflows.throwAnErrorWithBackoff, {
+        workflowId: uuid4(),
+        taskQueue,
+        workflowTaskTimeout: '3s',
+      });
+      await handle.result();
+      const { history } = await client.service.getWorkflowExecutionHistory({
+        namespace: 'default',
+        execution: { workflowId: handle.workflowId },
+      });
+      const timers = history?.events?.filter(
+        (ev) => ev.eventType === temporal.api.enums.v1.EventType.EVENT_TYPE_TIMER_FIRED
+      );
+      t.is(timers?.length, 1);
+
+      const markers = history?.events?.filter(
+        (ev) => ev.eventType === temporal.api.enums.v1.EventType.EVENT_TYPE_MARKER_RECORDED
+      );
+      t.is(markers?.length, 2);
+    });
+  });
+
+  test('Local activity can be intercepted', async (t) => {
+    const { client, taskQueue } = t.context;
+    const worker = await Worker.create({
+      taskQueue,
+      workflowsPath: require.resolve('./workflows/local-activity-testers'),
+      // Interceptors included with workflow implementations
+      interceptors: {
+        workflowModules: [require.resolve('./workflows/local-activity-testers')],
+        activityInbound: [
+          () => ({
+            async execute(input, next) {
+              t.is(defaultPayloadConverter.fromPayload(input.headers.secret), 'shhh');
+              return await next(input);
+            },
+          }),
+        ],
+      },
+      activities,
+    });
+    await runWorker(worker, async () => {
+      const res = await client.execute(workflows.runOneLocalActivity, {
+        workflowId: uuid4(),
+        taskQueue,
+        args: ['message'],
+      });
+      t.is(res, 'messagemessage');
+    });
+  });
+
+  // TODO: fix Core shutdown and reenable this test
+  test.skip('Worker shutdown while running a local activity completes after completion', async (t) => {
+    const { client, taskQueue } = t.context;
+    const subj = new Subject<void>();
+    const worker = await Worker.create({
+      taskQueue,
+      activities,
+      workflowsPath: require.resolve('./workflows/local-activity-testers'),
+      interceptors: {
+        workflowModules: [require.resolve('./workflows/local-activity-testers')],
+      },
+      sinks: {
+        test: {
+          timerFired: {
+            fn() {
+              subj.next();
+            },
+          },
+        },
+      },
+      // Just in case
+      shutdownGraceTime: '10s',
+    });
+    const handle = await client.start(workflows.cancelALocalActivity, {
+      workflowId: uuid4(),
+      taskQueue,
+      workflowTaskTimeout: '3s',
+    });
+    const p = worker.run();
+    await firstValueFrom(subj);
+    worker.shutdown();
+
+    const err: WorkflowFailedError = await t.throwsAsync(handle.result(), { instanceOf: WorkflowFailedError });
+    t.true(isCancellation(err.cause));
+    t.is(err.cause?.message, 'Activity cancelled');
+    console.log('Waiting for worker to complete shutdown');
+    await p;
+  });
+
+  test('Local activity fails if not registered on Worker', async (t) => {
+    const { client, taskQueue } = t.context;
+    const worker = await defaultWorker(taskQueue);
+    await runWorker(worker, async () => {
+      const err: WorkflowFailedError = await t.throwsAsync(
+        client.execute(workflows.runANonExisitingLocalActivity, {
+          workflowId: uuid4(),
+          taskQueue,
+        }),
+        { instanceOf: WorkflowFailedError }
+      );
+      t.true(err.cause instanceof ApplicationFailure && !err.cause.nonRetryable);
+      t.truthy(err.cause?.message?.startsWith('Activity function activityNotFound is not registered on this Worker'));
+    });
+  });
+}

--- a/packages/test/src/workflows/local-activity-testers.ts
+++ b/packages/test/src/workflows/local-activity-testers.ts
@@ -1,0 +1,97 @@
+/**
+ * Workflows used by `test-local-activities.ts`
+ * @module
+ */
+
+import * as wf from '@temporalio/workflow';
+import type * as activities from '../activities';
+
+const { echo, throwAnError, waitForCancellation } = wf.proxyLocalActivities<typeof activities>({
+  startToCloseTimeout: '1m',
+});
+
+export async function runOneLocalActivity(s: string): Promise<string> {
+  return await echo(s);
+}
+
+export async function runParallelLocalActivities(...ss: string[]): Promise<string[]> {
+  return await Promise.all(ss.map(echo));
+}
+
+export async function throwAnErrorFromLocalActivity(message: string): Promise<void> {
+  await throwAnError(true, message);
+}
+
+export async function throwAnExplicitNonRetryableErrorFromLocalActivity(message: string): Promise<void> {
+  const { throwAnError } = wf.proxyLocalActivities<typeof activities>({
+    startToCloseTimeout: '1m',
+    retry: { nonRetryableErrorTypes: ['Error'] },
+  });
+
+  await throwAnError(false, message);
+}
+
+export async function throwARetryableErrorWithASingleRetry(message: string): Promise<void> {
+  const { throwAnError } = wf.proxyLocalActivities<typeof activities>({
+    startToCloseTimeout: '1m',
+    retry: { maximumAttempts: 2 },
+  });
+
+  await throwAnError(false, message);
+}
+
+export async function cancelALocalActivity(): Promise<void> {
+  await wf.CancellationScope.cancellable(async () => {
+    const p = waitForCancellation();
+    await wf.sleep(1);
+    wf.CancellationScope.current().cancel();
+    await p;
+  });
+}
+
+export async function runSerialLocalActivities(): Promise<void> {
+  await echo('1');
+  await echo('2');
+  await echo('3');
+}
+
+export async function throwAnErrorWithBackoff(): Promise<void> {
+  const { succeedAfterFirstAttempt } = wf.proxyLocalActivities({
+    startToCloseTimeout: '1m',
+    localRetryThreshold: '1s',
+    retry: { maximumAttempts: 2, initialInterval: '2s' },
+  });
+
+  await succeedAfterFirstAttempt();
+}
+
+export async function runANonExisitingLocalActivity(): Promise<void> {
+  const { activityNotFound } = wf.proxyLocalActivities({
+    startToCloseTimeout: '1m',
+    retry: { maximumAttempts: 1 },
+  });
+
+  await activityNotFound();
+}
+
+export const interceptors: wf.WorkflowInterceptorsFactory = () => {
+  return {
+    outbound: [
+      {
+        async startTimer(input, next) {
+          const { test } = wf.proxySinks();
+          await next(input);
+          test.timerFired();
+        },
+        async scheduleLocalActivity(input, next) {
+          const secret = wf.defaultPayloadConverter.toPayload('shhh');
+          if (secret === undefined) {
+            throw new Error('Unexpected');
+          }
+          const output: any = await next({ ...input, headers: { secret } });
+          return output + output;
+        },
+      },
+    ],
+  };
+};

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -23,7 +23,7 @@ import {
   RUN_ID_ATTR_KEY,
   TASK_TOKEN_ATTR_KEY,
 } from '@temporalio/internal-non-workflow-common/lib/otel';
-import { tsToMs } from '@temporalio/internal-workflow-common';
+import { optionalTsToMs, tsToMs } from '@temporalio/internal-workflow-common';
 import { coresdk } from '@temporalio/proto';
 import { DeterminismViolationError, SinkCall, WorkflowInfo } from '@temporalio/workflow';
 import fs from 'fs/promises';
@@ -1411,6 +1411,6 @@ async function extractActivityInfo(
     workflowNamespace: start.workflowNamespace,
     scheduledTimestampMs: tsToMs(start.scheduledTime),
     startToCloseTimeoutMs: tsToMs(start.startToCloseTimeout),
-    scheduleToCloseTimeoutMs: tsToMs(start.scheduleToCloseTimeout),
+    scheduleToCloseTimeoutMs: optionalTsToMs(start.scheduleToCloseTimeout),
   };
 }

--- a/packages/workflow/src/interceptors.ts
+++ b/packages/workflow/src/interceptors.ts
@@ -7,7 +7,7 @@
  */
 
 import { WorkflowExecution } from '@temporalio/common';
-import { ActivityOptions, Headers, Next } from '@temporalio/internal-workflow-common';
+import { ActivityOptions, Headers, LocalActivityOptions, Next, Timestamp } from '@temporalio/internal-workflow-common';
 import type { coresdk } from '@temporalio/proto/lib/coresdk';
 import { ChildWorkflowOptionsWithDefaults, ContinueAsNewOptions } from './interfaces';
 
@@ -69,6 +69,17 @@ export interface ActivityInput {
   readonly seq: number;
 }
 
+/** Input for WorkflowOutboundCallsInterceptor.scheduleLocalActivity */
+export interface LocalActivityInput {
+  readonly activityType: string;
+  readonly args: unknown[];
+  readonly options: LocalActivityOptions;
+  readonly headers: Headers;
+  readonly seq: number;
+  readonly originalScheduleTime?: Timestamp;
+  readonly attempt: number;
+}
+
 /** Input for WorkflowOutboundCallsInterceptor.startChildWorkflowExecution */
 export interface StartChildWorkflowExecutionInput {
   readonly workflowType: string;
@@ -121,6 +132,13 @@ export interface WorkflowOutboundCallsInterceptor {
    * @return result of the activity execution
    */
   scheduleActivity?: (input: ActivityInput, next: Next<this, 'scheduleActivity'>) => Promise<unknown>;
+
+  /**
+   * Called when Workflow schedules a local Activity
+   *
+   * @return result of the activity execution
+   */
+  scheduleLocalActivity?: (input: LocalActivityInput, next: Next<this, 'scheduleLocalActivity'>) => Promise<unknown>;
 
   /**
    * Called when Workflow starts a timer

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -132,6 +132,11 @@ export function validateActivityOptions(options: ActivityOptions): void {
 const validateLocalActivityOptions = validateActivityOptions;
 
 /**
+ * Hooks up activity promise to current cancellation scope and completion callbacks.
+ *
+ * Returns `false` if the current scope is already cancelled.
+ */
+/**
  * Push a scheduleActivity command into state accumulator and register completion
  */
 async function scheduleActivityNextHandler({
@@ -225,7 +230,8 @@ async function scheduleLocalActivityNextHandler({
         seq,
         attempt,
         originalScheduleTime,
-        activityId: options.activityId ?? `${seq}`,
+        // Intentionally not exposing activityId as an option
+        activityId: `${seq}`,
         activityType,
         arguments: toPayloads(state.payloadConverter, ...args),
         retryPolicy: options.retry ? compileRetryPolicy(options.retry) : {},
@@ -273,10 +279,8 @@ export async function scheduleLocalActivity<R>(
     throw new TypeError('Got empty activity options');
   }
 
+  let attempt = 1;
   let originalScheduleTime = undefined;
-
-  // TODO: is the inital attempt 0 or 1?
-  let attempt = 0;
 
   for (;;) {
     const seq = state.nextSeqs.activity++;

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -6,9 +6,11 @@ import {
   compileRetryPolicy,
   composeInterceptors,
   IllegalStateError,
+  LocalActivityOptions,
   msOptionalToTs,
   msToNumber,
   msToTs,
+  tsToMs,
   QueryDefinition,
   SignalDefinition,
   WithWorkflowArgs,
@@ -17,7 +19,13 @@ import {
   WorkflowReturnType,
 } from '@temporalio/internal-workflow-common';
 import { CancellationScope, registerSleepImplementation } from './cancellation-scope';
-import { ActivityInput, SignalWorkflowInput, StartChildWorkflowExecutionInput, TimerInput } from './interceptors';
+import {
+  ActivityInput,
+  LocalActivityInput,
+  SignalWorkflowInput,
+  StartChildWorkflowExecutionInput,
+  TimerInput,
+} from './interceptors';
 import {
   ChildWorkflowCancellationType,
   ChildWorkflowOptions,
@@ -26,7 +34,7 @@ import {
   ContinueAsNewOptions,
   WorkflowInfo,
 } from './interfaces';
-import { state } from './internals';
+import { LocalActivityDoBackoff, state } from './internals';
 import { Sinks } from './sinks';
 import { ChildWorkflowHandle, ExternalWorkflowHandle } from './workflow-handle';
 
@@ -120,6 +128,9 @@ export function validateActivityOptions(options: ActivityOptions): void {
   }
 }
 
+// Use same validation we use for normal activities
+const validateLocalActivityOptions = validateActivityOptions;
+
 /**
  * Push a scheduleActivity command into state accumulator and register completion
  */
@@ -165,7 +176,63 @@ async function scheduleActivityNextHandler({
         scheduleToCloseTimeout: msOptionalToTs(options.scheduleToCloseTimeout),
         startToCloseTimeout: msOptionalToTs(options.startToCloseTimeout),
         scheduleToStartTimeout: msOptionalToTs(options.scheduleToStartTimeout),
-        namespace: options.namespace,
+        headers,
+        cancellationType: options.cancellationType,
+      },
+    });
+  });
+}
+
+/**
+ * Push a scheduleActivity command into state accumulator and register completion
+ */
+async function scheduleLocalActivityNextHandler({
+  options,
+  args,
+  headers,
+  seq,
+  activityType,
+  attempt,
+  originalScheduleTime,
+}: LocalActivityInput): Promise<unknown> {
+  validateLocalActivityOptions(options);
+
+  return new Promise((resolve, reject) => {
+    const scope = CancellationScope.current();
+    if (scope.consideredCancelled) {
+      scope.cancelRequested.catch(reject);
+      return;
+    }
+    if (scope.cancellable) {
+      scope.cancelRequested.catch(() => {
+        if (!state.completions.activity.has(seq)) {
+          return; // Already resolved
+        }
+        state.pushCommand({
+          requestCancelLocalActivity: {
+            seq,
+          },
+        });
+      });
+    }
+    state.completions.activity.set(seq, {
+      resolve,
+      reject,
+    });
+
+    state.pushCommand({
+      scheduleLocalActivity: {
+        seq,
+        attempt,
+        originalScheduleTime,
+        activityId: options.activityId ?? `${seq}`,
+        activityType,
+        arguments: toPayloads(state.payloadConverter, ...args),
+        retryPolicy: options.retry ? compileRetryPolicy(options.retry) : {},
+        scheduleToCloseTimeout: msOptionalToTs(options.scheduleToCloseTimeout),
+        startToCloseTimeout: msOptionalToTs(options.startToCloseTimeout),
+        scheduleToStartTimeout: msOptionalToTs(options.scheduleToStartTimeout),
+        localRetryThreshold: msOptionalToTs(options.localRetryThreshold),
         headers,
         cancellationType: options.cancellationType,
       },
@@ -191,6 +258,57 @@ export function scheduleActivity<R>(activityType: string, args: any[], options: 
     args,
     seq,
   }) as Promise<R>;
+}
+
+/**
+ * Schedule an activity and run outbound interceptors
+ * @hidden
+ */
+export async function scheduleLocalActivity<R>(
+  activityType: string,
+  args: any[],
+  options: LocalActivityOptions
+): Promise<R> {
+  if (options === undefined) {
+    throw new TypeError('Got empty activity options');
+  }
+
+  let originalScheduleTime = undefined;
+
+  // TODO: is the inital attempt 0 or 1?
+  let attempt = 0;
+
+  for (;;) {
+    const seq = state.nextSeqs.activity++;
+    const execute = composeInterceptors(
+      state.interceptors.outbound,
+      'scheduleLocalActivity',
+      scheduleLocalActivityNextHandler
+    );
+
+    try {
+      return (await execute({
+        activityType,
+        headers: {},
+        options,
+        args,
+        seq,
+        attempt,
+        originalScheduleTime,
+      })) as Promise<R>;
+    } catch (err) {
+      if (err instanceof LocalActivityDoBackoff) {
+        await sleep(tsToMs(err.backoff.backoffDuration));
+        if (typeof err.backoff.attempt !== 'number') {
+          throw new TypeError('Invalid backoff attempt type');
+        }
+        attempt = err.backoff.attempt;
+        originalScheduleTime = err.backoff.originalScheduleTime ?? undefined;
+      } else {
+        throw err;
+      }
+    }
+  }
 }
 
 async function startChildWorkflowExecutionNextHandler({
@@ -369,6 +487,39 @@ export function proxyActivities<A extends ActivityInterface>(options: ActivityOp
         }
         return (...args: unknown[]) => {
           return scheduleActivity(activityType, args, options);
+        };
+      },
+    }
+  ) as any;
+}
+
+/**
+ * Configure Local Activity functions with given {@link LocalActivityOptions}.
+ *
+ * This method may be called multiple times to setup Activities with different options.
+ *
+ * @return a [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy)
+ *         for which each attribute is a callable Activity function
+ *
+ * @typeparam A An {@link ActivityInterface} - mapping of name to function
+ *
+ * See {@link proxyActivities} for examples
+ */
+export function proxyLocalActivities<A extends ActivityInterface>(options: LocalActivityOptions): A {
+  if (options === undefined) {
+    throw new TypeError('options must be defined');
+  }
+  // Validate as early as possible for immediate user feedback
+  validateLocalActivityOptions(options);
+  return new Proxy(
+    {},
+    {
+      get(_, activityType) {
+        if (typeof activityType !== 'string') {
+          throw new TypeError(`Only strings are supported for Activity types, got: ${String(activityType)}`);
+        }
+        return (...args: unknown[]) => {
+          return scheduleLocalActivity(activityType, args, options);
         };
       },
     }


### PR DESCRIPTION
BREAKING CHANGE: ActivityOptions no longer takes a `namespace`