### PR TITLE
chore(worker): Update swc-loader options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -438,6 +438,38 @@
         "cosmiconfig": ">=6"
       }
     },
+    "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader/node_modules/ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -12672,38 +12704,6 @@
         "code-block-writer": "^11.0.0"
       }
     },
-    "node_modules/ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-      "dev": true,
-      "dependencies": {
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.7"
-      }
-    },
-    "node_modules/ts-node/node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
-    },
     "node_modules/ts-prune": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/ts-prune/-/ts-prune-0.10.3.tgz",
@@ -13583,6 +13583,7 @@
       }
     },
     "packages/activity": {
+      "name": "@temporalio/activity",
       "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
@@ -13592,6 +13593,7 @@
       }
     },
     "packages/client": {
+      "name": "@temporalio/client",
       "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
@@ -13614,6 +13616,7 @@
       }
     },
     "packages/common": {
+      "name": "@temporalio/common",
       "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
@@ -13626,6 +13629,7 @@
       }
     },
     "packages/core-bridge": {
+      "name": "@temporalio/core-bridge",
       "version": "0.20.2",
       "hasInstallScript": true,
       "license": "MIT",
@@ -13638,6 +13642,7 @@
       }
     },
     "packages/create-project": {
+      "name": "@temporalio/create",
       "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
@@ -13722,6 +13727,7 @@
       }
     },
     "packages/interceptors-opentelemetry": {
+      "name": "@temporalio/interceptors-opentelemetry",
       "version": "0.20.2",
       "license": "MIT",
       "dependencies": {
@@ -13736,6 +13742,7 @@
       }
     },
     "packages/internal-non-workflow-common": {
+      "name": "@temporalio/internal-non-workflow-common",
       "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
@@ -13747,6 +13754,7 @@
       }
     },
     "packages/internal-workflow-common": {
+      "name": "@temporalio/internal-workflow-common",
       "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
@@ -13756,6 +13764,7 @@
       }
     },
     "packages/meta": {
+      "name": "temporalio",
       "version": "0.20.2",
       "license": "MIT",
       "dependencies": {
@@ -13771,6 +13780,7 @@
       }
     },
     "packages/proto": {
+      "name": "@temporalio/proto",
       "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
@@ -13783,6 +13793,7 @@
       }
     },
     "packages/test": {
+      "name": "@temporalio/test",
       "version": "0.20.2",
       "license": "MIT",
       "dependencies": {
@@ -13804,6 +13815,7 @@
       }
     },
     "packages/testing": {
+      "name": "@temporalio/testing",
       "version": "0.20.2",
       "hasInstallScript": true,
       "license": "MIT",
@@ -13924,6 +13936,7 @@
       }
     },
     "packages/worker": {
+      "name": "@temporalio/worker",
       "version": "0.20.2",
       "license": "MIT",
       "dependencies": {
@@ -13965,6 +13978,7 @@
       }
     },
     "packages/workflow": {
+      "name": "@temporalio/workflow",
       "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
@@ -14256,6 +14270,28 @@
         "make-error": "^1",
         "ts-node": "^9",
         "tslib": "^2"
+      },
+      "dependencies": {
+        "arg": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+          "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+          "dev": true
+        },
+        "ts-node": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+          "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+          "dev": true,
+          "requires": {
+            "arg": "^4.1.0",
+            "create-require": "^1.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.17",
+            "yn": "3.1.1"
+          }
+        }
       }
     },
     "@eslint/eslintrc": {
@@ -23943,28 +23979,6 @@
       "requires": {
         "@ts-morph/common": "~0.12.3",
         "code-block-writer": "^11.0.0"
-      }
-    },
-    "ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-      "dev": true,
-      "requires": {
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      },
-      "dependencies": {
-        "arg": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-          "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-          "dev": true
-        }
       }
     },
     "ts-prune": {

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -69,6 +69,7 @@ export * from './sleep';
 export * from './sleep-invalid-duration';
 export * from './smorgasbord';
 export * from './success-string';
+export * from './swc';
 export * from './tasks-and-microtasks';
 export * from './throw-async';
 export * from './throw-object';

--- a/packages/test/src/workflows/swc.ts
+++ b/packages/test/src/workflows/swc.ts
@@ -1,0 +1,24 @@
+// eslint-disable-next-line @typescript-eslint/ban-types
+function sealed(constructor: Function) {
+  Object.seal(constructor);
+  Object.seal(constructor.prototype);
+}
+
+function decorate() {
+  console.log('decorate(): factory evaluated');
+  return function (_target: any, _propertyKey: string, _descriptor: PropertyDescriptor) {
+    console.log('decorate(): called');
+  };
+}
+
+@sealed
+class ExampleClass {
+  @decorate()
+  method() {
+    return 'hi';
+  }
+}
+
+export async function swc(): Promise<void> {
+  new ExampleClass().method();
+}

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "./lib",
     "rootDir": "./src",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "experimentalDecorators": true,
   },
   "references": [
     { "path": "../internal-workflow-common" },

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -228,8 +228,6 @@ export class WorkflowCodeBundler {
                   // match tsc defaults
                   parser: {
                     syntax: 'typescript',
-                    jsx: true,
-                    tsx: true,
                     decorators: true,
                   },
                 },

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -225,6 +225,13 @@ export class WorkflowCodeBundler {
               options: {
                 jsc: {
                   target: 'es2017',
+                  // match tsc defaults
+                  parser: {
+                    syntax: 'typescript',
+                    jsx: true,
+                    tsx: true,
+                    decorators: true,
+                  },
                 },
               },
             },

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -54,7 +54,13 @@ function cleanProtoGeneratedFiles() {
 function cleanCompiledRustFiles() {
   const bridgeDir = resolve(packagesPath, 'core-bridge');
   console.log('Cleaning compiled rust files');
-  rmSync(resolve(bridgeDir, 'releases'), { recursive: true });
+  try {
+    rmSync(resolve(bridgeDir, 'releases'), { recursive: true });
+  } catch (e) {
+    if (e?.code !== 'ENOENT') {
+      throw e;
+    }
+  }
   spawnSync('cargo', ['clean'], { cwd: bridgeDir, stdio: 'inherit' });
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Original intent was to update `swc-loader` options to better match what we used to have (`ts-loader`). Didn't find much to do, and I think [original reported issue](https://temporalio.slack.com/archives/C01DKSMU94L/p1650267315905719?thread_ts=1649977054.551749&cid=C01DKSMU94L) was a red herring.

`swc` defaults, with my comments on whether they're defaults in `ts-loader`:

```ts
{
  "jsc": {
    "parser": {
      "syntax": "ecmascript",  // we're only using on .ts files, so safe to change to typescript
      "tsx": false, // default true, but needs to be .tsx file, which we haven't been supporting (`test: /\.ts$/,`)
      "dynamicImport": false, // true if target is 2020, which by default it isn't
      "privateMethod": false, // didn't find in tsc options https://www.typescriptlang.org/tsconfig
      "functionBind": false, // didn't find
      "exportDefaultFrom": false, // didn't find
      "exportNamespaceFrom": false, // didn't find
      "decorators": false, // not enabled by default, but we can enable just in case someone wants to use them. think doesn't hurt?
      "decoratorsBeforeExport": false, // two ways of decorating exports, leaving default
      "topLevelAwait": false, // didn't find
      "importMeta": false, // didn't find
      "preserveAllComments": false // enabled by default, but don't think it's necessary or helpful in our case? would be if people were looking at the bundle
    },
  }
}
```

## Checklist
<!--- add/delete as needed --->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Just made sure it doesn't break our test bundle with `node packages/test/lib/run-a-worker.js`.