### PR TITLE
feat!(worker): Move shutdownSignals to RuntimeOptions

### DIFF
--- a/packages/test/src/test-local-activities.ts
+++ b/packages/test/src/test-local-activities.ts
@@ -36,8 +36,6 @@ test.beforeEach(async (t) => {
 
 async function defaultWorker(taskQueue: string) {
   return await Worker.create({
-    // Avoid creating too many signal handlers
-    shutdownSignals: [],
     taskQueue,
     workflowsPath: require.resolve('./workflows/local-activity-testers'),
     activities,

--- a/packages/test/src/test-worker-lifecycle.ts
+++ b/packages/test/src/test-worker-lifecycle.ts
@@ -1,6 +1,8 @@
 /**
  * Test the various states of a Worker.
  * Most tests use a mocked core, some tests run serially because they emit signals to the process
+ *
+ * @module
  */
 import { Worker } from '@temporalio/worker';
 import test from 'ava';
@@ -8,7 +10,7 @@ import { RUN_INTEGRATION_TESTS } from './helpers';
 import { defaultOptions, isolateFreeWorker } from './mock-native-worker';
 
 if (RUN_INTEGRATION_TESTS) {
-  test.serial('run shuts down gracefully', async (t) => {
+  test.serial('Worker shuts down gracefully', async (t) => {
     const worker = await Worker.create({
       ...defaultOptions,
       shutdownGraceTime: '500ms',
@@ -18,6 +20,8 @@ if (RUN_INTEGRATION_TESTS) {
     const p = worker.run();
     t.is(worker.getState(), 'RUNNING');
     process.emit('SIGINT', 'SIGINT');
+    // Shutdown callback is enqueued as a microtask
+    await new Promise((resolve) => process.nextTick(resolve));
     t.is(worker.getState(), 'STOPPING');
     await p;
     t.is(worker.getState(), 'STOPPED');
@@ -26,7 +30,7 @@ if (RUN_INTEGRATION_TESTS) {
 }
 
 test.serial('Mocked run shuts down gracefully', async (t) => {
-  const worker = await isolateFreeWorker({
+  const worker = isolateFreeWorker({
     shutdownGraceTime: '500ms',
     taskQueue: 'shutdown-test',
   });
@@ -34,14 +38,13 @@ test.serial('Mocked run shuts down gracefully', async (t) => {
   const p = worker.run();
   t.is(worker.getState(), 'RUNNING');
   process.emit('SIGINT', 'SIGINT');
-  t.is(worker.getState(), 'STOPPING');
   await p;
   t.is(worker.getState(), 'STOPPED');
   await t.throwsAsync(worker.run(), { message: 'Poller was already started' });
 });
 
 test('Mocked run throws if not shut down gracefully', async (t) => {
-  const worker = await isolateFreeWorker({
+  const worker = isolateFreeWorker({
     shutdownGraceTime: '5ms',
     taskQueue: 'shutdown-test',
   });

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -76,15 +76,6 @@ export interface WorkerOptions {
   shutdownGraceTime?: string | number;
 
   /**
-   * Automatically shut down worker on any of these signals.
-   * @default
-   * ```ts
-   * ['SIGINT', 'SIGTERM', 'SIGQUIT', 'SIGUSR2']
-   * ```
-   */
-  shutdownSignals?: NodeJS.Signals[];
-
-  /**
    * Provide a custom {@link DataConverter}.
    */
   dataConverter?: DataConverter;
@@ -226,7 +217,6 @@ export type WorkerOptionsWithDefaults = WorkerOptions &
       WorkerOptions,
       | 'namespace'
       | 'shutdownGraceTime'
-      | 'shutdownSignals'
       | 'maxConcurrentActivityTaskExecutions'
       | 'maxConcurrentWorkflowTaskExecutions'
       | 'maxConcurrentActivityTaskPolls'
@@ -306,7 +296,6 @@ export function addDefaultWorkerOptions(options: WorkerOptions): WorkerOptionsWi
   return {
     namespace: 'default',
     shutdownGraceTime: '5s',
-    shutdownSignals: ['SIGINT', 'SIGTERM', 'SIGQUIT', 'SIGUSR2'],
     maxConcurrentActivityTaskExecutions: 100,
     maxConcurrentWorkflowTaskExecutions: 100,
     maxConcurrentActivityTaskPolls: 5,


### PR DESCRIPTION
Makes more sense to put it on the singleton `Runtime` instead of a per-Worker