### PR TITLE
Fix: Make sure signal handlers can be cleared

### DIFF
--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -978,18 +978,4 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
       await client.getHandle(workflowId).terminate();
     }
   });
-
-  test('signal handlers can be cleared', async (t) => {
-    const { client } = t.context;
-    const workflow = await client.start(workflows.signalHandlersCanBeCleared, {
-      taskQueue: 'test',
-      workflowId: uuid4(),
-    });
-
-    await workflow.signal(workflows.unblockSignal);
-    await workflow.signal(workflows.unblockSignal);
-    await workflow.signal(workflows.unblockSignal);
-
-    t.is(await workflow.result(), 111);
-  });
 }

--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -978,4 +978,18 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
       await client.getHandle(workflowId).terminate();
     }
   });
+
+  test('signal handlers can be cleared', async (t) => {
+    const { client } = t.context;
+    const workflow = await client.start(workflows.signalHandlersCanBeCleared, {
+      taskQueue: 'test',
+      workflowId: uuid4(),
+    });
+
+    await workflow.signal(workflows.unblockSignal);
+    await workflow.signal(workflows.unblockSignal);
+    await workflow.signal(workflows.unblockSignal);
+
+    t.is(await workflow.result(), 111);
+  });
 }

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -63,6 +63,7 @@ export * from './shared-promise-scopes';
 export * from './shield-awaited-in-root-scope';
 export * from './shield-in-shield';
 export * from './signal-target';
+export * from './signal-handlers-clear';
 export * from './signals-are-always-processed';
 export * from './sinks';
 export * from './sleep';

--- a/packages/test/src/workflows/signal-handlers-clear.ts
+++ b/packages/test/src/workflows/signal-handlers-clear.ts
@@ -1,0 +1,39 @@
+/**
+ * Workflow used by integration-tests.ts: signal handlers can be cleared
+ *
+ * @module
+ */
+
+import { setHandler, sleep } from '@temporalio/workflow';
+import { unblockSignal } from './definitions';
+
+export async function signalHandlersCanBeCleared(): Promise<number> {
+  let counter = 0;
+
+  // Give time for signals to be received and buffered BEFORE the handler is configured. See issue #612 for details.
+  await sleep('20ms');
+
+  // Each handler below should catch a single occurence of the unblock signal.
+  // sleep() between each to make sure that any pending microtask has been run before the next handler is set
+  // If everything went ok, counter should equals 111 at the end.
+
+  setHandler(unblockSignal, () => {
+    counter += 1;
+    setHandler(unblockSignal, undefined);
+  });
+
+  await sleep('1ms');
+
+  setHandler(unblockSignal, () => {
+    counter += 10;
+    setHandler(unblockSignal, undefined);
+  });
+
+  await sleep('1ms');
+
+  setHandler(unblockSignal, () => {
+    counter += 100;
+  });
+
+  return counter;
+}

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1080,16 +1080,16 @@ export type Handler<
  */
 export function setHandler<Ret, Args extends any[], T extends SignalDefinition<Args> | QueryDefinition<Ret, Args>>(
   def: T,
-  handler: Handler<Ret, Args, T>
+  handler: Handler<Ret, Args, T> | undefined
 ): void {
   if (def.type === 'signal') {
     state.signalHandlers.set(def.name, handler as any);
     const bufferedSignals = state.bufferedSignals.get(def.name);
-    if (bufferedSignals !== undefined) {
+    if (bufferedSignals !== undefined && handler !== undefined) {
+      state.bufferedSignals.delete(def.name);
       for (const signal of bufferedSignals) {
         state.activator.signalWorkflow(signal);
       }
-      state.bufferedSignals.delete(def.name);
     }
   } else if (def.type === 'query') {
     state.queryHandlers.set(def.name, handler as any);


### PR DESCRIPTION
## What was changed

1. Fixed a heap overflow issue in `setHandler(signal, handler)` when handler is `undefined` and there are buffered signals for that signal name.

2. Changed the signature of `setHandler(...)` to indicate that `handler` can be `undefined` (in order to clear up previously configured handler for that signal name).

## Why?

Refer to #612 for discussion.

## Checklist

1. Closes #612 

2. **How was this tested?** I added appropriate integration test

3. **Any docs updates needed?** No doc that I know of that should be updated, but it could be useful to add a sample demonstrating this use case (for example based on examples in #612 or code in unit test).
