### PR TITLE
make snipsync pull from samples-typescript

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -137,8 +137,8 @@ module.exports = {
                 },
                 {
                   owner: 'temporalio',
-                  repo: 'samples-typescript'
-                }
+                  repo: 'samples-typescript',
+                },
               ],
               targets: ['docs'],
               features: {

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -133,8 +133,12 @@ module.exports = {
             {
               origins: [
                 {
-                  files: ['../*/src/**/*.ts', '../create-project/samples/*.ts'],
+                  files: ['../*/src/**/*.ts', '../*/src/*.ts', '../create-project/samples/*.ts'],
                 },
+                {
+                  owner: 'temporalio',
+                  repo: 'samples-typescript'
+                }
               ],
               targets: ['docs'],
               features: {

--- a/packages/docs/package-lock.json
+++ b/packages/docs/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@temporalio/docs",
-      "version": "0.20.2",
+      "version": "0.21.1",
       "dependencies": {
         "@docusaurus/core": "^2.0.0-beta.18",
         "@docusaurus/preset-classic": "^2.0.0-beta.18",


### PR DESCRIPTION
Fix #544

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added samples-typescript as a source for snipsync. This way our docs can reference snippets from samples-typescript.

## Why?
<!-- Tell your future self why have you made these changes -->

There are a few places in the API docs where we want to use snippets from samples-typescript. There shouldn't be any problem with recursive dependencies since snipsync doesn't run `npm install` in the samples-typescript repo.

## Checklist
<!--- add/delete as needed --->

1. Closes #544

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Snippets now show up on my local:

![image](https://user-images.githubusercontent.com/1620265/165995861-35b431a0-ac5f-46ac-9e31-08139634cbdb.png)


3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
