### PR TITLE
fix: Do not patch global object in otel runtime if not in workflow context

### DIFF
--- a/packages/interceptors-opentelemetry/src/workflow/runtime.ts
+++ b/packages/interceptors-opentelemetry/src/workflow/runtime.ts
@@ -2,12 +2,17 @@
  * Sets global variables required for importing opentelemetry in isolate
  * @module
  */
+import { inWorkflowContext } from '@temporalio/workflow';
 
-// Required by opentelemetry (pretend to be a browser)
-(globalThis as any).performance = {
-  timeOrigin: Date.now(),
-  now() {
-    return Date.now() - this.timeOrigin;
-  },
-};
-(globalThis as any).window = globalThis;
+if (inWorkflowContext()) {
+  // Required by opentelemetry (pretend to be a browser)
+  Object.assign(globalThis, {
+    performance: {
+      timeOrigin: Date.now(),
+      now() {
+        return Date.now() - this.timeOrigin;
+      },
+    },
+    window: globalThis,
+  });
+}

--- a/packages/test/src/test-otel.ts
+++ b/packages/test/src/test-otel.ts
@@ -185,4 +185,9 @@ if (RUN_INTEGRATION_TESTS) {
     await new Promise((resolve) => setTimeout(resolve, 5000));
     t.pass();
   });
+
+  test('Otel workflow module does not patch node window object', (t) => {
+    // Importing the otel workflow modules above should patch globalThis
+    t.falsy((globalThis as any).window);
+  });
 }

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -771,6 +771,24 @@ export function workflowInfo(): WorkflowInfo {
 }
 
 /**
+ * Returns whether or not code is executing in workflow context
+ */
+export function inWorkflowContext(): boolean {
+  try {
+    workflowInfo();
+    return true;
+  } catch (err: any) {
+    // Use string comparison in case multiple versions of @temporalio/common are
+    // installed in which case an instanceof check would fail.
+    if (err.name === 'IllegalStateError') {
+      return false;
+    } else {
+      throw err;
+    }
+  }
+}
+
+/**
  * Get a reference to Sinks for exporting data out of the Workflow.
  *
  * These Sinks **must** be registered with the Worker in order for this


### PR DESCRIPTION
Closes #620 