### PR TITLE
fix(workflow): Propagate scope cancellation while waiting on ExternalWorkflowHandle cancellation

### DIFF
--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -1803,3 +1803,25 @@ test('waitOnUser', async (t) => {
     compareCompletion(t, completion, makeSuccess());
   }
 });
+
+test('scopeCancelledWhileWaitingOnExternalWorkflowCancellation', async (t) => {
+  const { workflowType } = t.context;
+  {
+    const completion = await activate(t, makeStartWorkflow(workflowType));
+    compareCompletion(
+      t,
+      completion,
+      makeSuccess([
+        {
+          requestCancelExternalWorkflowExecution: {
+            seq: 1,
+            workflowExecution: { namespace: 'default', workflowId: 'irrelevant' },
+          },
+        },
+        {
+          completeWorkflowExecution: { result: defaultPayloadConverter.toPayload(undefined) },
+        },
+      ])
+    );
+  }
+});

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -1813,13 +1813,13 @@ test('scopeCancelledWhileWaitingOnExternalWorkflowCancellation', async (t) => {
       completion,
       makeSuccess([
         {
-          setPatchMarker: { deprecated: false, patchId: '__temporal_internal_connect_external_handle_cancel_to_scope' },
-        },
-        {
           requestCancelExternalWorkflowExecution: {
             seq: 1,
             workflowExecution: { namespace: 'default', workflowId: 'irrelevant' },
           },
+        },
+        {
+          setPatchMarker: { deprecated: false, patchId: '__temporal_internal_connect_external_handle_cancel_to_scope' },
         },
         {
           completeWorkflowExecution: { result: defaultPayloadConverter.toPayload(undefined) },

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -1813,6 +1813,9 @@ test('scopeCancelledWhileWaitingOnExternalWorkflowCancellation', async (t) => {
       completion,
       makeSuccess([
         {
+          setPatchMarker: { deprecated: false, patchId: '__temporal_internal_connect_external_handle_cancel_to_scope' },
+        },
+        {
           requestCancelExternalWorkflowExecution: {
             seq: 1,
             workflowExecution: { namespace: 'default', workflowId: 'irrelevant' },

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -61,6 +61,7 @@ export * from './random';
 export * from './reject-promise';
 export * from './run-activity-in-different-task-queue';
 export * from './set-timeout-after-microtasks';
+export * from './scope-cancelled-while-waiting-on-external-workflow-cancellation';
 export * from './shared-promise-scopes';
 export * from './shield-awaited-in-root-scope';
 export * from './shield-in-shield';

--- a/packages/test/src/workflows/scope-cancelled-while-waiting-on-external-workflow-cancellation.ts
+++ b/packages/test/src/workflows/scope-cancelled-while-waiting-on-external-workflow-cancellation.ts
@@ -1,0 +1,25 @@
+/**
+ * Tests that scope cancellation is propagated to the workflow while waiting on
+ * external workflow cancellation
+ *
+ * @module
+ */
+import { CancelledFailure } from '@temporalio/common';
+import { CancellationScope, getExternalWorkflowHandle } from '@temporalio/workflow';
+
+export async function scopeCancelledWhileWaitingOnExternalWorkflowCancellation(): Promise<void> {
+  try {
+    await CancellationScope.cancellable(async () => {
+      const handle = getExternalWorkflowHandle('irrelevant');
+      const promise = handle.cancel();
+      CancellationScope.current().cancel();
+      await promise;
+      throw new Error('External cancellation was not cancelled');
+    });
+    throw new Error('Expected CancellationScope to throw ChildWorkflowFailure');
+  } catch (err) {
+    if (!(err instanceof CancelledFailure)) {
+      throw err;
+    }
+  }
+}

--- a/packages/test/src/workflows/scope-cancelled-while-waiting-on-external-workflow-cancellation.ts
+++ b/packages/test/src/workflows/scope-cancelled-while-waiting-on-external-workflow-cancellation.ts
@@ -1,6 +1,10 @@
 /**
  * Tests that scope cancellation is propagated to the workflow while waiting on
- * external workflow cancellation
+ * external workflow cancellation (`await ExternalWorkflowHandle.cancel()`).
+ *
+ * This test was added along with the behavior fix where waiting for external
+ * workflow cancellation was the only framework generated promise that was not
+ * connected to a a cancellation scope.
  *
  * @module
  */
@@ -16,7 +20,7 @@ export async function scopeCancelledWhileWaitingOnExternalWorkflowCancellation()
       await promise;
       throw new Error('External cancellation was not cancelled');
     });
-    throw new Error('Expected CancellationScope to throw ChildWorkflowFailure');
+    throw new Error('Expected CancellationScope to throw CancelledFailure');
   } catch (err) {
     if (!(err instanceof CancelledFailure)) {
       throw err;

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -545,12 +545,15 @@ export function getExternalWorkflowHandle(workflowId: string, runId?: string): E
         if (state.info === undefined) {
           throw new IllegalStateError('Uninitialized workflow');
         }
-        const scope = CancellationScope.current();
-        if (scope.cancellable) {
-          scope.cancelRequested.catch(reject);
-        }
-        if (scope.consideredCancelled) {
-          return;
+        // TODO: deprecate this patch after "enough" time has passed
+        if (patched('__temporal_internal_connect_external_handle_cancel_to_scope')) {
+          const scope = CancellationScope.current();
+          if (scope.cancellable) {
+            scope.cancelRequested.catch(reject);
+          }
+          if (scope.consideredCancelled) {
+            return;
+          }
         }
 
         const seq = state.nextSeqs.cancelWorkflow++;

--- a/scripts/registry.js
+++ b/scripts/registry.js
@@ -53,6 +53,15 @@ class Registry {
           let contents;
           try {
             contents = await readFile(logPath, 'utf8');
+            // Sometimes (mostly in Windows) tail can miss updates.
+            // Use this workaround as a last resort to recover and avoid failing CI.
+            const found = contents
+              .split('\n')
+              .map(JSON.parse)
+              .find((parsed) => parsed.addr);
+            if (found) {
+              resolve();
+            }
           } catch (e) {
             contents = `Error ${e}`;
           }


### PR DESCRIPTION
Wrapped this functionality in a patch to avoid breaking history compatibility.
This patch should be deprecated in a few months and eventually deleted. 