### PR TITLE
test: Actually fail stress test when child fails

### DIFF
--- a/packages/test/src/load/all-scenarios.ts
+++ b/packages/test/src/load/all-scenarios.ts
@@ -87,9 +87,16 @@ export function runScenarios(scenarios: Record<string, Args>): void {
     console.log('Running test scenario:', name, { config });
     console.log('*'.repeat(120));
 
-    spawnSync('node', [require.resolve('./all-in-one'), ...Object.entries(config).flatMap(([k, v]) => [k, `${v}`])], {
-      stdio: 'inherit',
-    });
+    const { error, signal, status } = spawnSync(
+      'node',
+      [require.resolve('./all-in-one'), ...Object.entries(config).flatMap(([k, v]) => [k, `${v}`])],
+      {
+        stdio: 'inherit',
+      }
+    );
+    if (status !== 0) {
+      throw new Error(`Test failed with status: ${status}, signal: ${signal}, error: ${error?.message}`);
+    }
 
     console.log('*'.repeat(120));
     console.log('End test scenario:', name);


### PR DESCRIPTION
Not used to running `spawnSync`, luckily I caught it early