### PR TITLE
chore(test): Use GITHUB_TOKEN for higher rate limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
 name: Continuous Integration
+
 on: # rebuild any PRs and main branch changes
   pull_request:
   push:
     branches:
       - main
       - 'releases/*'
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build-and-test:
@@ -35,7 +39,6 @@ jobs:
       - run: npm run build
         env:
           BUILD_CORE_RELEASE: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # docker-compose
       - name: Checkout docker-compose repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - run: npm run build
         env:
           BUILD_CORE_RELEASE: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # docker-compose
       - name: Checkout docker-compose repo

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,5 @@
 name: Nightly Tests
+
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -32,6 +32,7 @@ jobs:
       - run: npm run build
         env:
           BUILD_CORE_RELEASE: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # docker-compose
       - name: Checkout docker-compose repo

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -1,4 +1,5 @@
 name: Stress tests
+
 on:
   workflow_call:
     inputs:
@@ -11,6 +12,7 @@ on:
 
 env:
   TEMPORAL_TESTING_LOG_DIR: /tmp/worker-logs
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   stress-test:
@@ -32,7 +34,6 @@ jobs:
       - run: npm run build
         env:
           BUILD_CORE_RELEASE: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # docker-compose
       - name: Checkout docker-compose repo

--- a/packages/testing/scripts/download-test-server.mjs
+++ b/packages/testing/scripts/download-test-server.mjs
@@ -26,7 +26,7 @@ const defaultHeaders = {
 
 const { GITHUB_TOKEN } = process.env;
 if (GITHUB_TOKEN) {
-  console.log(`Using GITHUB_TOKEN ${GITHUB_TOKEN}`);
+  console.log(`Using GITHUB_TOKEN`);
   defaultHeaders['Authorization'] = `Bearer ${GITHUB_TOKEN}`;
 }
 

--- a/packages/testing/scripts/download-test-server.mjs
+++ b/packages/testing/scripts/download-test-server.mjs
@@ -24,6 +24,20 @@ const defaultHeaders = {
   'User-Agent': '@temporalio/testing installer',
 };
 
+const { GITHUB_TOKEN } = process.env;
+if (GITHUB_TOKEN) {
+  console.log(`Using GITHUB_TOKEN ${GITHUB_TOKEN}`);
+  defaultHeaders['Authorization'] = `Bearer ${GITHUB_TOKEN}`;
+}
+
+const rateLimitResult = await got('https://api.github.com/rate_limit', {
+  headers: {
+    ...defaultHeaders,
+    Accept: 'application/vnd.github.v3+json',
+  },
+}).json();
+console.log(`Rate limit status: ${rateLimitResult?.rate?.remaining} requests remaining`);
+
 const latestReleaseRes = await got('https://api.github.com/repos/temporalio/sdk-java/releases/latest', {
   headers: {
     ...defaultHeaders,

--- a/packages/testing/scripts/download-test-server.mjs
+++ b/packages/testing/scripts/download-test-server.mjs
@@ -30,14 +30,6 @@ if (GITHUB_TOKEN) {
   defaultHeaders['Authorization'] = `Bearer ${GITHUB_TOKEN}`;
 }
 
-const rateLimitResult = await got('https://api.github.com/rate_limit', {
-  headers: {
-    ...defaultHeaders,
-    Accept: 'application/vnd.github.v3+json',
-  },
-}).json();
-console.log(`Rate limit status: ${rateLimitResult?.rate?.remaining} requests remaining`);
-
 const latestReleaseRes = await got('https://api.github.com/repos/temporalio/sdk-java/releases/latest', {
   headers: {
     ...defaultHeaders,


### PR DESCRIPTION
## Problem

CI is rate limited by Github REST API:

```
@temporalio/testing: > node ./scripts/download-test-server.mjs
@temporalio/testing: internal/process/esm_loader.js:74
@temporalio/testing:     internalBinding('errors').triggerUncaughtException(
@temporalio/testing:                               ^
@temporalio/testing: HTTPError: Response code 403 (rate limit exceeded)
```
[build-and-test (14, macos-latest)](https://github.com/temporalio/sdk-typescript/runs/6314570053?check_suite_focus=true#logs)

Currently on the default anonymous 60 requests per hour per IP address.

## Solution

Authenticate, to get 1k requests per hour per repo:

https://docs.github.com/en/rest/overview/resources-in-the-rest-api#requests-from-github-actions