### PR TITLE
fix(activity): Fix Activity resolved as cancelled in unsupported situations

### DIFF
--- a/packages/test/src/test-worker-activities.ts
+++ b/packages/test/src/test-worker-activities.ts
@@ -245,7 +245,9 @@ test('Worker cancels activities after shutdown', async (t) => {
       }),
     };
   });
+  // Worker has been shutdown, wait for activity to complete
   const { result } = await promise;
+
   // The result is failed because an activity shouldn't be resolved as cancelled
   // unless cancellation was requested.
   t.truthy(result?.failed);

--- a/packages/test/src/test-worker-heartbeats.ts
+++ b/packages/test/src/test-worker-heartbeats.ts
@@ -106,8 +106,6 @@ test('Worker ignores last heartbeat if activity succeeds', async (t) => {
 });
 
 test('Activity gets cancelled if heartbeat fails', async (t) => {
-  const codecErr = new Error('Refuse to encode data for test');
-
   const worker = isolateFreeWorker({
     taskQueue: 'unused',
     dataConverter: {
@@ -116,7 +114,7 @@ test('Activity gets cancelled if heartbeat fails', async (t) => {
           // Fail to encode heartbeat details.
           // data will be undefined when this method gets the activity result for completion.
           if (p[0].data !== undefined) {
-            throw codecErr;
+            throw new Error('Refuse to encode data for test');
           }
           return p;
         },
@@ -138,7 +136,7 @@ test('Activity gets cancelled if heartbeat fails', async (t) => {
     heartbeatsSeen.push(details);
   };
   await runActivity(worker, (completion) => {
-    t.is(completion.result?.failed?.failure?.message, codecErr.toString());
+    t.is(completion.result?.failed?.failure?.message, 'HEARTBEAT_DETAILS_CONVERSION_FAILED');
   });
   t.deepEqual(heartbeatsSeen, []);
 });

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -716,7 +716,7 @@ export class Worker {
                     const reason = task.cancel?.reason;
                     if (reason === undefined || reason === null) {
                       // Special case of Lang side cancellation during shutdown (see `activity.shutdown.evict` above)
-                      activity.cancel('WORKER SHUTDOWN' as CancelReason);
+                      activity.cancel('WORKER_SHUTDOWN');
                     } else {
                       activity.cancel(coresdk.activity_task.ActivityCancelReason[reason] as CancelReason);
                     }


### PR DESCRIPTION
Discovered in nightly tests: https://github.com/temporalio/sdk-typescript/runs/6312107494

Symptom was this fatal error:

```
[TransportError: Unhandled grpc error when completing activity: Status { code: InvalidArgument, message: "Failure must have ApplicationFailureInfo.", metadata: MetadataMap { headers: {"content-type": "application/grpc"} }, source: None }]
```
