### PR TITLE
test: Fix activity heartbeat timeout crashing nightly

### DIFF
--- a/packages/test/src/workflows/cancel-fake-progress.ts
+++ b/packages/test/src/workflows/cancel-fake-progress.ts
@@ -11,7 +11,6 @@ import type * as activities from '../activities';
 
 const { fakeProgress } = proxyActivities<typeof activities>({
   startToCloseTimeout: '200s',
-  heartbeatTimeout: '3s',
   cancellationType: ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
 });
 

--- a/packages/test/src/workflows/long-history-generator.ts
+++ b/packages/test/src/workflows/long-history-generator.ts
@@ -6,7 +6,7 @@ const { echo } = wf.proxyActivities<typeof activities>({ startToCloseTimeout: '1
 /**
  * Simple workflow that generates a lot of sequential activities for testing long histories
  */
-export async function longHistoryGenerator(numIterations = 200, pauseAfterCompletion = true): Promise<void> {
+export async function longHistoryGenerator(numIterations = 200, pauseAfterCompletion = false): Promise<void> {
   let i = 0;
   wf.setHandler(wf.defineQuery('iteration'), () => i);
 


### PR DESCRIPTION
Fixes this flake:

```
Starter encountered error WorkflowFailedError: Workflow execution failed
2022-05-05T19:38:26.9393036Z     at WorkflowClient.result (/home/runner/_work/sdk-typescript/sdk-typescript/packages/client/lib/workflow-client.js:205:23)
2022-05-05T19:38:26.9394301Z     at runMicrotasks (<anonymous>)
2022-05-05T19:38:26.9395092Z     at processTicksAndRejections (node:internal/process/task_queues:96:5)
2022-05-05T19:38:26.9395783Z     at async Promise.all (index 0)
2022-05-05T19:38:26.9397052Z     at async runWorkflow (/home/runner/_work/sdk-typescript/sdk-typescript/packages/test/lib/load/starter.js:73:5) {
2022-05-05T19:38:26.9397944Z   cause: [TemporalFailure: Activity execution failed] {
2022-05-05T19:38:26.9398714Z     cause: [TimeoutFailure: activity Heartbeat timeout] {
2022-05-05T19:38:26.9399242Z       cause: undefined,
2022-05-05T19:38:26.9399828Z       lastHeartbeatDetails: undefined,
2022-05-05T19:38:26.9400362Z       timeoutType: 4,
2022-05-05T19:38:26.9400876Z       failure: [Object]
2022-05-05T19:38:26.9401254Z     },
2022-05-05T19:38:26.9402066Z     activityType: 'fakeProgress',
2022-05-05T19:38:26.9402676Z     activityId: '1',
2022-05-05T19:38:26.9403099Z     retryState: 7,
2022-05-05T19:38:26.9403654Z     identity: '',
2022-05-05T19:38:26.9404066Z     failure: {
2022-05-05T19:38:26.9404793Z       message: 'Activity task timed out',
2022-05-05T19:38:26.9405333Z       cause: [Object],
2022-05-05T19:38:26.9405883Z       activityFailureInfo: [ActivityFailureInfo],
2022-05-05T19:38:26.9406563Z       applicationFailureInfo: undefined,
2022-05-05T19:38:26.9407196Z       timeoutFailureInfo: undefined,
2022-05-05T19:38:26.9407787Z       canceledFailureInfo: undefined,
2022-05-05T19:38:26.9408405Z       resetWorkflowFailureInfo: undefined
2022-05-05T19:38:26.9408894Z     }
2022-05-05T19:38:26.9409265Z   },
2022-05-05T19:38:26.9409657Z   retryState: 5
2022-05-05T19:38:26.9409976Z }
```