### PR TITLE
feat: Allow for multiple DataConverter.payloadCodecs

### DIFF
--- a/docs/data-converter.md
+++ b/docs/data-converter.md
@@ -23,12 +23,12 @@ function workflowInclusiveInstanceOf(instance: unknown, type: Function): boolean
 
 ## Decision
 
-Given the possibility of switching or adding other isolation methods in future, we opted to convert to/from Payloads inside the vm (`PayloadConverter`). We also added another transformer layer called `PayloadCodec` that runs outside the vm, can use node async APIs (like `zlib.gzip` for compression or `crypto.scrypt` for encryption), and operates on Payloads. A `DataConverter` is a `PayloadConverter` and a `PayloadCodec`:
+Given the possibility of switching or adding other isolation methods in future, we opted to convert to/from Payloads inside the vm (`PayloadConverter`). We also added another transformer layer called `PayloadCodec` that runs outside the vm, can use node async APIs (like `zlib.gzip` for compression or `crypto.scrypt` for encryption), and operates on Payloads. A `DataConverter` is a `PayloadConverter` and zero or more `PayloadCodec`s:
 
 ```ts
 export interface DataConverter {
   payloadConverterPath?: string;
-  payloadCodec?: PayloadCodec;
+  payloadCodecs?: PayloadCodec[];
 }
 
 export interface PayloadConverter {

--- a/packages/common/src/converter/data-converter.ts
+++ b/packages/common/src/converter/data-converter.ts
@@ -1,4 +1,4 @@
-import { defaultPayloadCodec, PayloadCodec } from './payload-codec';
+import { PayloadCodec } from './payload-codec';
 import { defaultPayloadConverter, PayloadConverter } from './payload-converter';
 
 /**
@@ -34,9 +34,13 @@ export interface DataConverter {
   payloadConverterPath?: string;
 
   /**
-   * A {@link PayloadCodec} instance. The default codec is a no-op.
+   * An array of {@link PayloadCodec} instances.
+   *
+   * Payloads are encoded in the order of the array and decoded in the opposite order. For example, if you have a
+   * compression codec and an encryption codec, then you want data to be encoded with the compression codec first, so
+   * you'd do `payloadCodecs: [compressionCodec, encryptionCodec]`.
    */
-  payloadCodec?: PayloadCodec;
+  payloadCodecs?: PayloadCodec[];
 }
 
 /**
@@ -44,10 +48,10 @@ export interface DataConverter {
  */
 export interface LoadedDataConverter {
   payloadConverter: PayloadConverter;
-  payloadCodec: PayloadCodec;
+  payloadCodecs: PayloadCodec[];
 }
 
 export const defaultDataConverter: LoadedDataConverter = {
   payloadConverter: defaultPayloadConverter,
-  payloadCodec: defaultPayloadCodec,
+  payloadCodecs: [],
 };

--- a/packages/common/src/converter/payload-codec.ts
+++ b/packages/common/src/converter/payload-codec.ts
@@ -20,11 +20,3 @@ export interface PayloadCodec {
    */
   decode(payloads: Payload[]): Promise<Payload[]>;
 }
-
-/**
- * No-op implementation of {@link PayloadCodec}.
- */
-export const defaultPayloadCodec = {
-  encode: async (payloads: Payload[]): Promise<Payload[]> => payloads,
-  decode: async (payloads: Payload[]): Promise<Payload[]> => payloads,
-};

--- a/packages/internal-non-workflow-common/src/codec-helpers.ts
+++ b/packages/internal-non-workflow-common/src/codec-helpers.ts
@@ -14,9 +14,21 @@ import {
 } from '@temporalio/common';
 import { DecodedPayload, DecodedProtoFailure, EncodedPayload, EncodedProtoFailure } from './codec-types';
 
-export interface TypecheckedPayloadCodec {
-  encode(payloads: Payload[]): Promise<EncodedPayload[]>;
-  decode(payloads: Payload[]): Promise<DecodedPayload[]>;
+/**
+ * Decode through each codec, starting with the last codec.
+ */
+export async function decode(codecs: PayloadCodec[], payloads: Payload[]): Promise<DecodedPayload[]> {
+  for (let i = codecs.length - 1; i >= 0; i--) {
+    payloads = await codecs[i].decode(payloads);
+  }
+  return payloads as DecodedPayload[];
+}
+
+export async function encode(codecs: PayloadCodec[], payloads: Payload[]): Promise<EncodedPayload[]> {
+  for (let i = 0; i < codecs.length; i++) {
+    payloads = await codecs[i].encode(payloads);
+  }
+  return payloads as EncodedPayload[];
 }
 
 /**
@@ -27,8 +39,8 @@ export async function decodeFromPayloadsAtIndex<T>(
   index: number,
   payloads?: Payload[] | null
 ): Promise<T> {
-  const { payloadConverter, payloadCodec } = converter;
-  return fromPayloadsAtIndex(payloadConverter, index, payloads ? await payloadCodec.decode(payloads) : payloads);
+  const { payloadConverter, payloadCodecs } = converter;
+  return fromPayloadsAtIndex(payloadConverter, index, payloads ? await decode(payloadCodecs, payloads) : payloads);
 }
 
 /**
@@ -38,10 +50,10 @@ export async function decodeArrayFromPayloads(
   converter: LoadedDataConverter,
   payloads?: Payload[] | null
 ): Promise<unknown[]> {
-  const { payloadConverter, payloadCodec } = converter;
+  const { payloadConverter, payloadCodecs } = converter;
   let decodedPayloads = payloads;
   if (payloads) {
-    decodedPayloads = await payloadCodec.decode(payloads);
+    decodedPayloads = await decode(payloadCodecs, payloads);
   }
   return arrayFromPayloads(payloadConverter, decodedPayloads);
 }
@@ -53,78 +65,78 @@ export async function decodeOptionalFailureToOptionalError(
   converter: LoadedDataConverter,
   failure: ProtoFailure | undefined | null
 ): Promise<TemporalFailure | undefined> {
-  const { payloadConverter, payloadCodec } = converter;
-  return failure ? failureToError(await decodeFailure(payloadCodec, failure), payloadConverter) : undefined;
+  const { payloadConverter, payloadCodecs } = converter;
+  return failure ? failureToError(await decodeFailure(payloadCodecs, failure), payloadConverter) : undefined;
 }
 
 /** Run {@link PayloadCodec.encode} on `payloads` */
 export async function encodeOptional(
-  codec: PayloadCodec,
+  codecs: PayloadCodec[],
   payloads: Payload[] | null | undefined
 ): Promise<EncodedPayload[] | null | undefined> {
   if (payloads === null) return null;
   if (payloads === undefined) return undefined;
-  return (await codec.encode(payloads)) as EncodedPayload[];
+  return (await encode(codecs, payloads)) as EncodedPayload[];
 }
 
 /** Run {@link PayloadCodec.decode} on `payloads` */
 export async function decodeOptional(
-  codec: PayloadCodec,
+  codecs: PayloadCodec[],
   payloads: Payload[] | null | undefined
 ): Promise<DecodedPayload[] | null | undefined> {
   if (payloads === null) return null;
   if (payloads === undefined) return undefined;
-  return (await codec.decode(payloads)) as DecodedPayload[];
+  return (await decode(codecs, payloads)) as DecodedPayload[];
 }
 
-async function encodeSingle(codec: PayloadCodec, payload: Payload): Promise<EncodedPayload> {
-  const encodedPayloads = await codec.encode([payload]);
+async function encodeSingle(codecs: PayloadCodec[], payload: Payload): Promise<EncodedPayload> {
+  const encodedPayloads = await encode(codecs, [payload]);
   return encodedPayloads[0] as EncodedPayload;
 }
 
 /** Run {@link PayloadCodec.encode} on a single Payload */
 export async function encodeOptionalSingle(
-  codec: PayloadCodec,
+  codecs: PayloadCodec[],
   payload: Payload | null | undefined
 ): Promise<EncodedPayload | null | undefined> {
   if (payload === null) return null;
   if (payload === undefined) return undefined;
-  return await encodeSingle(codec, payload);
+  return await encodeSingle(codecs, payload);
 }
 
-async function decodeSingle(codec: PayloadCodec, payload: Payload): Promise<DecodedPayload> {
-  const decodedPayloads = await codec.decode([payload]);
+async function decodeSingle(codecs: PayloadCodec[], payload: Payload): Promise<DecodedPayload> {
+  const decodedPayloads = await decode(codecs, [payload]);
   return decodedPayloads[0] as DecodedPayload;
 }
 
 export async function decodeOptionalMap(
-  codec: PayloadCodec,
+  codecs: PayloadCodec[],
   payloads: Record<string, Payload> | null | undefined
 ): Promise<Record<string, DecodedPayload> | null | undefined> {
   if (payloads === null) return null;
   if (payloads === undefined) return undefined;
   return Object.fromEntries(
-    await Promise.all(Object.entries(payloads).map(async ([k, v]) => [k, await codec.decode([v])]))
+    await Promise.all(Object.entries(payloads).map(async ([k, v]) => [k, await decode(codecs, [v])]))
   );
 }
 
 /** Run {@link PayloadCodec.decode} on a single Payload */
 export async function decodeOptionalSingle(
-  codec: PayloadCodec,
+  codecs: PayloadCodec[],
   payload: Payload | null | undefined
 ): Promise<DecodedPayload | null | undefined> {
   if (payload === null) return null;
   if (payload === undefined) return undefined;
 
-  return await decodeSingle(codec, payload);
+  return await decodeSingle(codecs, payload);
 }
 
 /**
  * Run {@link PayloadConverter.toPayload} on value, and then encode it.
  */
 export async function encodeToPayload(converter: LoadedDataConverter, value: unknown): Promise<Payload> {
-  const { payloadConverter, payloadCodec } = converter;
-  return await encodeSingle(payloadCodec, toPayload(payloadConverter, value));
+  const { payloadConverter, payloadCodecs } = converter;
+  return await encodeSingle(payloadCodecs, toPayload(payloadConverter, value));
 }
 
 /**
@@ -134,12 +146,12 @@ export async function encodeToPayloads(
   converter: LoadedDataConverter,
   ...values: unknown[]
 ): Promise<Payload[] | undefined> {
-  const { payloadConverter, payloadCodec } = converter;
+  const { payloadConverter, payloadCodecs } = converter;
   if (values.length === 0) {
     return undefined;
   }
   const payloads = toPayloads(payloadConverter, ...values);
-  return payloads ? await payloadCodec.encode(payloads) : undefined;
+  return payloads ? await encode(payloadCodecs, payloads) : undefined;
 }
 
 /**
@@ -150,11 +162,11 @@ export async function decodeMapFromPayloads<K extends string>(
   map: Record<K, Payload> | null | undefined
 ): Promise<Record<K, unknown> | undefined> {
   if (!map) return undefined;
-  const { payloadConverter, payloadCodec } = converter;
+  const { payloadConverter, payloadCodecs } = converter;
   return Object.fromEntries(
     await Promise.all(
       Object.entries(map).map(async ([k, payload]): Promise<[K, unknown]> => {
-        const [decodedPayload] = await payloadCodec.decode([payload as Payload]);
+        const [decodedPayload] = await decode(payloadCodecs, [payload as Payload]);
         const value = payloadConverter.fromPayload(decodedPayload);
         return [k as K, value];
       })
@@ -164,7 +176,7 @@ export async function decodeMapFromPayloads<K extends string>(
 
 /** Run {@link PayloadCodec.encode} on all values in `map` */
 export async function encodeMap<K extends string>(
-  codec: PayloadCodec,
+  codecs: PayloadCodec[],
   map: Record<K, Payload> | null | undefined
 ): Promise<Record<K, EncodedPayload> | null | undefined> {
   if (map === null) return null;
@@ -172,7 +184,7 @@ export async function encodeMap<K extends string>(
   return Object.fromEntries(
     await Promise.all(
       Object.entries(map).map(async ([k, payload]): Promise<[K, EncodedPayload]> => {
-        return [k as K, await encodeSingle(codec, payload as Payload)];
+        return [k as K, await encodeSingle(codecs, payload as Payload)];
       })
     )
   ) as Record<K, EncodedPayload>;
@@ -185,13 +197,13 @@ export async function encodeMapToPayloads<K extends string>(
   converter: LoadedDataConverter,
   map: Record<K, unknown>
 ): Promise<Record<K, Payload>> {
-  const { payloadConverter, payloadCodec } = converter;
+  const { payloadConverter, payloadCodecs } = converter;
   return Object.fromEntries(
     await Promise.all(
       Object.entries(map).map(async ([k, v]): Promise<[K, Payload]> => {
         const payload = payloadConverter.toPayload(v);
         if (payload === undefined) throw new PayloadConverterError(`Failed to encode entry: ${k}: ${v}`);
-        const [encodedPayload] = await payloadCodec.encode([payload]);
+        const [encodedPayload] = await encode(payloadCodecs, [payload]);
         return [k as K, encodedPayload];
       })
     )
@@ -202,24 +214,23 @@ export async function encodeMapToPayloads<K extends string>(
  * Run {@link errorToFailure} on `error`, and then {@link encodeFailure}.
  */
 export async function encodeErrorToFailure(dataConverter: LoadedDataConverter, error: unknown): Promise<ProtoFailure> {
-  const { payloadConverter, payloadCodec } = dataConverter;
-  return await encodeFailure(payloadCodec, errorToFailure(error, payloadConverter));
+  const { payloadConverter, payloadCodecs } = dataConverter;
+  return await encodeFailure(payloadCodecs, errorToFailure(error, payloadConverter));
 }
 
 /**
  * Return a new {@link ProtoFailure} with `codec.encode()` run on all the {@link Payload}s.
  */
-export async function encodeFailure(_codec: PayloadCodec, failure: ProtoFailure): Promise<EncodedProtoFailure> {
-  const codec = _codec as TypecheckedPayloadCodec;
+export async function encodeFailure(codecs: PayloadCodec[], failure: ProtoFailure): Promise<EncodedProtoFailure> {
   return {
     ...failure,
-    cause: failure.cause ? await encodeFailure(codec, failure.cause) : null,
+    cause: failure.cause ? await encodeFailure(codecs, failure.cause) : null,
     applicationFailureInfo: failure.applicationFailureInfo
       ? {
           ...failure.applicationFailureInfo,
           details: failure.applicationFailureInfo.details
             ? {
-                payloads: await codec.encode(failure.applicationFailureInfo.details.payloads ?? []),
+                payloads: await encode(codecs, failure.applicationFailureInfo.details.payloads ?? []),
               }
             : undefined,
         }
@@ -229,7 +240,7 @@ export async function encodeFailure(_codec: PayloadCodec, failure: ProtoFailure)
           ...failure.timeoutFailureInfo,
           lastHeartbeatDetails: failure.timeoutFailureInfo.lastHeartbeatDetails
             ? {
-                payloads: await codec.encode(failure.timeoutFailureInfo.lastHeartbeatDetails.payloads ?? []),
+                payloads: await encode(codecs, failure.timeoutFailureInfo.lastHeartbeatDetails.payloads ?? []),
               }
             : undefined,
         }
@@ -239,7 +250,7 @@ export async function encodeFailure(_codec: PayloadCodec, failure: ProtoFailure)
           ...failure.canceledFailureInfo,
           details: failure.canceledFailureInfo.details
             ? {
-                payloads: await codec.encode(failure.canceledFailureInfo.details.payloads ?? []),
+                payloads: await encode(codecs, failure.canceledFailureInfo.details.payloads ?? []),
               }
             : undefined,
         }
@@ -249,7 +260,7 @@ export async function encodeFailure(_codec: PayloadCodec, failure: ProtoFailure)
           ...failure.resetWorkflowFailureInfo,
           lastHeartbeatDetails: failure.resetWorkflowFailureInfo.lastHeartbeatDetails
             ? {
-                payloads: await codec.encode(failure.resetWorkflowFailureInfo.lastHeartbeatDetails.payloads ?? []),
+                payloads: await encode(codecs, failure.resetWorkflowFailureInfo.lastHeartbeatDetails.payloads ?? []),
               }
             : undefined,
         }
@@ -261,40 +272,39 @@ export async function encodeFailure(_codec: PayloadCodec, failure: ProtoFailure)
  * Return a new {@link ProtoFailure} with `codec.encode()` run on all the {@link Payload}s.
  */
 export async function encodeOptionalFailure(
-  codec: PayloadCodec,
+  codecs: PayloadCodec[],
   failure: ProtoFailure | null | undefined
 ): Promise<EncodedProtoFailure | null | undefined> {
   if (failure === null) return null;
   if (failure === undefined) return undefined;
-  return await encodeFailure(codec, failure);
+  return await encodeFailure(codecs, failure);
 }
 
 /**
  * Return a new {@link ProtoFailure} with `codec.encode()` run on all the {@link Payload}s.
  */
 export async function decodeOptionalFailure(
-  codec: PayloadCodec,
+  codecs: PayloadCodec[],
   failure: ProtoFailure | null | undefined
 ): Promise<DecodedProtoFailure | null | undefined> {
   if (failure === null) return null;
   if (failure === undefined) return undefined;
-  return await decodeFailure(codec, failure);
+  return await decodeFailure(codecs, failure);
 }
 
 /**
  * Return a new {@link ProtoFailure} with `codec.decode()` run on all the {@link Payload}s.
  */
-export async function decodeFailure(_codec: PayloadCodec, failure: ProtoFailure): Promise<DecodedProtoFailure> {
-  const codec = _codec as TypecheckedPayloadCodec;
+export async function decodeFailure(codecs: PayloadCodec[], failure: ProtoFailure): Promise<DecodedProtoFailure> {
   return {
     ...failure,
-    cause: failure.cause ? await decodeFailure(codec, failure.cause) : null,
+    cause: failure.cause ? await decodeFailure(codecs, failure.cause) : null,
     applicationFailureInfo: failure.applicationFailureInfo
       ? {
           ...failure.applicationFailureInfo,
           details: failure.applicationFailureInfo.details
             ? {
-                payloads: await codec.decode(failure.applicationFailureInfo.details.payloads ?? []),
+                payloads: await decode(codecs, failure.applicationFailureInfo.details.payloads ?? []),
               }
             : undefined,
         }
@@ -304,7 +314,7 @@ export async function decodeFailure(_codec: PayloadCodec, failure: ProtoFailure)
           ...failure.timeoutFailureInfo,
           lastHeartbeatDetails: failure.timeoutFailureInfo.lastHeartbeatDetails
             ? {
-                payloads: await codec.decode(failure.timeoutFailureInfo.lastHeartbeatDetails.payloads ?? []),
+                payloads: await decode(codecs, failure.timeoutFailureInfo.lastHeartbeatDetails.payloads ?? []),
               }
             : undefined,
         }
@@ -314,7 +324,7 @@ export async function decodeFailure(_codec: PayloadCodec, failure: ProtoFailure)
           ...failure.canceledFailureInfo,
           details: failure.canceledFailureInfo.details
             ? {
-                payloads: await codec.decode(failure.canceledFailureInfo.details.payloads ?? []),
+                payloads: await decode(codecs, failure.canceledFailureInfo.details.payloads ?? []),
               }
             : undefined,
         }
@@ -324,7 +334,7 @@ export async function decodeFailure(_codec: PayloadCodec, failure: ProtoFailure)
           ...failure.resetWorkflowFailureInfo,
           lastHeartbeatDetails: failure.resetWorkflowFailureInfo.lastHeartbeatDetails
             ? {
-                payloads: await codec.decode(failure.resetWorkflowFailureInfo.lastHeartbeatDetails.payloads ?? []),
+                payloads: await decode(codecs, failure.resetWorkflowFailureInfo.lastHeartbeatDetails.payloads ?? []),
               }
             : undefined,
         }

--- a/packages/internal-non-workflow-common/src/data-converter-helpers.ts
+++ b/packages/internal-non-workflow-common/src/data-converter-helpers.ts
@@ -1,10 +1,4 @@
-import {
-  DataConverter,
-  defaultPayloadCodec,
-  defaultPayloadConverter,
-  LoadedDataConverter,
-  PayloadConverter,
-} from '@temporalio/common';
+import { DataConverter, defaultPayloadConverter, LoadedDataConverter, PayloadConverter } from '@temporalio/common';
 import { errorCode, hasOwnProperty, isRecord, ValueError } from '@temporalio/internal-workflow-common';
 
 const isValidPayloadConverter = (PayloadConverter: unknown): PayloadConverter is PayloadConverter =>
@@ -41,7 +35,7 @@ function requirePayloadConverter(path: string): PayloadConverter {
 /**
  * If {@link DataConverter.payloadConverterPath} is specified, `require()` it and validate that the module has a `payloadConverter` named export.
  * If not, use {@link defaultPayloadConverter}.
- * If {@link DataConverter.payloadCodec} is unspecified, use {@link defaultPayloadCodec}.
+ * If {@link DataConverter.payloadCodecs} is unspecified, use an empty array.
  */
 export function loadDataConverter(dataConverter?: DataConverter): LoadedDataConverter {
   let payloadConverter: PayloadConverter = defaultPayloadConverter;
@@ -50,6 +44,6 @@ export function loadDataConverter(dataConverter?: DataConverter): LoadedDataConv
   }
   return {
     payloadConverter,
-    payloadCodec: dataConverter?.payloadCodec ?? defaultPayloadCodec,
+    payloadCodecs: dataConverter?.payloadCodecs ?? [],
   };
 }

--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -9,7 +9,6 @@ import {
 } from '@temporalio/client';
 import {
   ChildWorkflowFailure,
-  defaultPayloadCodec,
   defaultPayloadConverter,
   Payload,
   PayloadCodec,
@@ -20,14 +19,14 @@ import {
   TimeoutType,
   WorkflowExecution,
 } from '@temporalio/common';
-import { decodeFromPayloadsAtIndex } from '@temporalio/internal-non-workflow-common';
+import { decode, decodeFromPayloadsAtIndex } from '@temporalio/internal-non-workflow-common';
 import {
   tsToMs,
   WorkflowExecutionAlreadyStartedError,
   WorkflowNotFoundError,
 } from '@temporalio/internal-workflow-common';
 import * as iface from '@temporalio/proto';
-import { Runtime, DefaultLogger, Worker } from '@temporalio/worker';
+import { DefaultLogger, Runtime, Worker } from '@temporalio/worker';
 import asyncRetry from 'async-retry';
 import anyTest, { Implementation, TestInterface } from 'ava';
 import dedent from 'dedent';
@@ -55,10 +54,10 @@ const namespace = 'default';
 
 export function runIntegrationTests(codec?: PayloadCodec): void {
   const test = (name: string, fn: Implementation<Context>) => _test(codec ? 'With codec—' + name : name, fn);
-  const dataConverter = { payloadCodec: codec ?? defaultPayloadCodec };
-  const loadedDataConverter = { payloadConverter: defaultPayloadConverter, payloadCodec: codec ?? defaultPayloadCodec };
+  const dataConverter = { payloadCodecs: codec ? [codec] : [] };
+  const loadedDataConverter = { payloadConverter: defaultPayloadConverter, payloadCodecs: codec ? [codec] : [] };
   async function fromPayload(payload: Payload) {
-    const [decodedPayload] = await dataConverter.payloadCodec.decode([payload]);
+    const [decodedPayload] = await decode(dataConverter.payloadCodecs, [payload]);
     return defaultPayloadConverter.fromPayload(decodedPayload);
   }
 

--- a/packages/test/src/test-worker-heartbeats.ts
+++ b/packages/test/src/test-worker-heartbeats.ts
@@ -1,9 +1,9 @@
-import test from 'ava';
-import { Subject, firstValueFrom } from 'rxjs';
-import { v4 as uuid4 } from 'uuid';
 import { Context } from '@temporalio/activity';
-import { isolateFreeWorker, Worker } from './mock-native-worker';
 import { coresdk } from '@temporalio/proto';
+import test from 'ava';
+import { firstValueFrom, Subject } from 'rxjs';
+import { v4 as uuid4 } from 'uuid';
+import { isolateFreeWorker, Worker } from './mock-native-worker';
 
 async function runActivity(worker: Worker, callback?: (completion: coresdk.ActivityTaskCompletion) => void) {
   const taskToken = Buffer.from(uuid4());
@@ -74,19 +74,21 @@ test('Worker ignores last heartbeat if activity succeeds', async (t) => {
   const worker = isolateFreeWorker({
     taskQueue: 'unused',
     dataConverter: {
-      payloadCodec: {
-        async encode(p) {
-          // Don't complete encoding heartbeat details until activity has completed.
-          // data will be undefined when this method gets the activity result for completion.
-          if (p[0].data !== undefined) {
-            await activityCompletePromise;
-          }
-          return p;
+      payloadCodecs: [
+        {
+          async encode(p) {
+            // Don't complete encoding heartbeat details until activity has completed.
+            // data will be undefined when this method gets the activity result for completion.
+            if (p[0].data !== undefined) {
+              await activityCompletePromise;
+            }
+            return p;
+          },
+          async decode(p) {
+            return p;
+          },
         },
-        async decode(p) {
-          return p;
-        },
-      },
+      ],
     },
     activities: {
       async rapidHeartbeater() {
@@ -109,19 +111,21 @@ test('Activity gets cancelled if heartbeat fails', async (t) => {
   const worker = isolateFreeWorker({
     taskQueue: 'unused',
     dataConverter: {
-      payloadCodec: {
-        async encode(p) {
-          // Fail to encode heartbeat details.
-          // data will be undefined when this method gets the activity result for completion.
-          if (p[0].data !== undefined) {
-            throw new Error('Refuse to encode data for test');
-          }
-          return p;
+      payloadCodecs: [
+        {
+          async encode(p) {
+            // Fail to encode heartbeat details.
+            // data will be undefined when this method gets the activity result for completion.
+            if (p[0].data !== undefined) {
+              throw new Error('Refuse to encode data for test');
+            }
+            return p;
+          },
+          async decode(p) {
+            return p;
+          },
         },
-        async decode(p) {
-          return p;
-        },
-      },
+      ],
     },
     activities: {
       async rapidHeartbeater() {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -448,7 +448,7 @@ export class Worker {
     protected readonly connection?: NativeConnection
   ) {
     this.tracer = getTracer(options.enableSDKTracing);
-    this.workflowCodecRunner = new WorkflowCodecRunner(options.loadedDataConverter.payloadCodec);
+    this.workflowCodecRunner = new WorkflowCodecRunner(options.loadedDataConverter.payloadCodecs);
   }
 
   /**


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

`DataConverter.payloadCodec` was changed to plural:

```ts
export interface DataConverter {
  ...
  payloadCodecs?: PayloadCodec[];
}
```

## Why?
<!-- Tell your future self why have you made these changes -->

So it's easier to provide multiple codecs (than the current solution, creating a CompositeCodec).

Wrote in a couple bugs that took a bit to track down! 


- Fixes: https://github.com/temporalio/sdk-typescript/issues/595