### PR TITLE
Hackily fix #614 by checking error names instead of instances

### DIFF
--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -210,7 +210,7 @@ export class Runtime {
       );
     } catch (error) {
       // Prevent unhandled rejection
-      if (error instanceof errors.ShutdownError) return;
+      if (error.name == 'ShutdownError') return;
       // Log using the original logger instead of buffering
       this.options.logger.warn('Error gathering forwarded logs from core', { error });
     } finally {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -577,7 +577,7 @@ export class Worker {
           try {
             yield await pollFn();
           } catch (err) {
-            if (err instanceof errors.ShutdownError) {
+            if (err.name == 'ShutdownError') {
               break;
             }
             throw err;


### PR DESCRIPTION


## What was changed

As discussed on the support slack, jest's re-requiring of stuff means there are multiple versions of the same error class floating around. The per-process one quacked by the native runtime no longer matches in the 2nd+ jest test run, making these instanceof checks fail. Instead, we just look at their names.

## Why?

Fix using jest test suites to test temporal workflows

## Checklist

1. Closes #614

2. How was this tested:

In repro repo here: https://github.com/airhorns/temporal-jest
