### PR TITLE
fix: Various improvements and fixes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,8 @@ name: Nightly Tests
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '00 19 * * *'
+    - cron: '00 08 * * *'
+    # (1 AM PST)
 
 jobs:
   nightly:

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   TEMPORAL_TESTING_LOG_DIR: /tmp/worker-logs
+  TEMPORAL_TESTING_MEM_LOG_DIR: /tmp/worker-mem-logs
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -51,15 +52,21 @@ jobs:
       # end:docker-compose
 
       - run: mkdir -p $TEMPORAL_TESTING_LOG_DIR/tails
+      - run: mkdir -p $TEMPORAL_TESTING_MEM_LOG_DIR
       - run: 'timeout ${{ inputs.test-timeout-minutes }}m npm run ${{ inputs.test-type }}'
       # Tail the logs and upload as artifact on cancel or failure
       - run: for f in $TEMPORAL_TESTING_LOG_DIR/*.log; do tail -20000 $f > $TEMPORAL_TESTING_LOG_DIR/tails/$(basename $f); done
         if: ${{ cancelled() || failure() }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ cancelled() || failure() }}
         with:
           name: worker-logs
           path: ${{ env.TEMPORAL_TESTING_LOG_DIR }}/tails
+      - uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: worker-mem-logs
+          path: ${{ env.TEMPORAL_TESTING_MEM_LOG_DIR }}
 
       # TODO: set up alerting
       # TODO: record test durations and other metrics like memory usage / cache utilization / CPU

--- a/packages/test/src/load/all-scenarios.ts
+++ b/packages/test/src/load/all-scenarios.ts
@@ -12,16 +12,17 @@ type Args = EvaluatedArgs<AllInOneArgSpec>;
 
 const TEMPORAL_TESTING_SERVER_URL = process.env.TEMPORAL_TESTING_SERVER_URL;
 const TEMPORAL_TESTING_LOG_DIR = process.env.TEMPORAL_TESTING_LOG_DIR;
+const TEMPORAL_TESTING_MEM_LOG_DIR = process.env.TEMPORAL_TESTING_MEM_LOG_DIR;
 
 // Use the default unless provided
 const baseArgs: Args = {
   ...(TEMPORAL_TESTING_SERVER_URL ? { '--server-address': TEMPORAL_TESTING_SERVER_URL } : undefined),
+  '--status-port': 6666,
 };
 
 const smallCacheArgs: Args = {
   '--max-cached-wfs': 3,
   '--max-concurrent-wft-executions': 3,
-  '--status-port': 6666,
 };
 
 export const activityCancellation10kIters: Args = {
@@ -82,6 +83,9 @@ export function runScenarios(scenarios: Record<string, Args>): void {
         '--log-file': path.join(TEMPORAL_TESTING_LOG_DIR, `${name}.log`),
         '--log-level': 'DEBUG',
       };
+    }
+    if (TEMPORAL_TESTING_MEM_LOG_DIR) {
+      config['--worker-memory-log-file'] = path.join(TEMPORAL_TESTING_MEM_LOG_DIR, `${name}.log`);
     }
     console.log('*'.repeat(120));
     console.log('Running test scenario:', name, { config });

--- a/packages/test/src/load/args.ts
+++ b/packages/test/src/load/args.ts
@@ -28,6 +28,7 @@ export interface StarterArgSpec extends Spec {
   '--concurrent-wf-clients': typeof Number;
   '--server-address': typeof String;
   '--worker-pid': typeof Number;
+  '--worker-memory-log-file': typeof String;
   '--do-query': typeof String;
   '--initial-query-delay-ms': typeof Number;
   '--query-interval-ms': typeof Number;
@@ -43,6 +44,7 @@ export const starterArgSpec: StarterArgSpec = {
   '--concurrent-wf-clients': Number,
   '--server-address': String,
   '--worker-pid': Number,
+  '--worker-memory-log-file': String,
   '--do-query': String,
   '--initial-query-delay-ms': Number,
   '--query-interval-ms': Number,

--- a/packages/test/src/load/starter.ts
+++ b/packages/test/src/load/starter.ts
@@ -1,5 +1,6 @@
 import arg from 'arg';
 import os from 'os';
+import fs from 'fs';
 import pidusage from 'pidusage';
 import * as grpc from '@grpc/grpc-js';
 import { v4 as uuid4 } from 'uuid';
@@ -73,12 +74,18 @@ interface RunWorkflowOptions {
   concurrency: number;
   minWFPS: number;
   workerPid?: number;
+  workerMemoryLogFile?: string;
   queryingOptions?: QueryingOptions;
 }
 
 async function runWorkflows(options: RunWorkflowOptions): Promise<void> {
-  const { workflowName, stopCondition, concurrency, workerPid, minWFPS } = options;
+  const { workflowName, stopCondition, concurrency, workerPid, workerMemoryLogFile, minWFPS } = options;
   let observable: Observable<any>;
+  let recordMemUsage = (_mem: number) => undefined;
+  if (workerMemoryLogFile) {
+    const stream = fs.createWriteStream('/tmp/worker-mem.log');
+    recordMemUsage = (mem) => void stream.write(`${mem}\n`);
+  }
 
   if (stopCondition instanceof NumberOfWorkflows) {
     observable = range(0, stopCondition.num).pipe(
@@ -89,6 +96,7 @@ async function runWorkflows(options: RunWorkflowOptions): Promise<void> {
         let resourceString = '';
         if (workerResources) {
           resourceString = `CPU ${workerResources.cpu.toFixed(0)}%, MEM ${toMB(workerResources.memory)}MB`;
+          recordMemUsage(workerResources?.memory);
         }
         process.stderr.write(
           `\rWFs complete (${numComplete}/${stopCondition.num}) -- WFs/s curr ${wfsPerSecond} (acc ${overallWfsPerSecond}) -- ${resourceString}  `
@@ -111,6 +119,7 @@ async function runWorkflows(options: RunWorkflowOptions): Promise<void> {
         let resourceString = '';
         if (workerResources) {
           resourceString = `CPU ${workerResources.cpu.toFixed(0)}%, MEM ${toMB(workerResources.memory)}MB`;
+          recordMemUsage(workerResources?.memory);
         }
         const secondsLeft = Math.max(Math.floor(stopCondition.seconds - totalTime), 0);
         process.stderr.write(
@@ -180,6 +189,7 @@ async function main() {
   const namespace = getRequired(args, '--ns');
   const taskQueue = getRequired(args, '--task-queue');
   const workerPid = args['--worker-pid'];
+  const workerMemoryLogFile = args['--worker-memory-log-file'];
 
   const connection = new Connection({ address: serverAddress });
   const client = new WorkflowClient(connection.service, { namespace });
@@ -197,6 +207,7 @@ async function main() {
     concurrency: concurrentWFClients,
     minWFPS,
     workerPid,
+    workerMemoryLogFile,
     queryingOptions,
   });
 }

--- a/packages/test/src/payload-converters/payload-converter.ts
+++ b/packages/test/src/payload-converters/payload-converter.ts
@@ -1,13 +1,4 @@
 import { defaultPayloadConverter } from '@temporalio/common';
 import { WrappedPayloadConverter } from '@temporalio/common/lib/converter/wrapped-payload-converter';
-import { DefaultPayloadConverterWithProtobufs } from '@temporalio/common/lib/protobufs';
-import root, { foo } from '../../protos/root';
-
-// Used in tests
-export const messageInstance = foo.bar.ProtoActivityInput.create({ name: 'Proto', age: 1 });
-
-export const payloadConverter = new WrappedPayloadConverter(
-  new DefaultPayloadConverterWithProtobufs({ protobufRoot: root })
-);
 
 export const wrappedDefaultPayloadConverter = new WrappedPayloadConverter(defaultPayloadConverter);

--- a/packages/test/src/payload-converters/proto-payload-converter.ts
+++ b/packages/test/src/payload-converters/proto-payload-converter.ts
@@ -1,0 +1,7 @@
+import { DefaultPayloadConverterWithProtobufs } from '@temporalio/common/lib/protobufs';
+import root, { foo } from '../../protos/root';
+
+// Used in tests
+export const messageInstance = foo.bar.ProtoActivityInput.create({ name: 'Proto', age: 1 });
+
+export const payloadConverter = new DefaultPayloadConverterWithProtobufs({ protobufRoot: root });

--- a/packages/test/src/test-payload-converter.ts
+++ b/packages/test/src/test-payload-converter.ts
@@ -25,8 +25,8 @@ import { v4 as uuid4 } from 'uuid';
 import root from '../protos/root';
 import { RUN_INTEGRATION_TESTS } from './helpers';
 import { defaultOptions } from './mock-native-worker';
-import { messageInstance } from './payload-converters/payload-converter';
-import { protobufWorkflow } from './workflows';
+import { messageInstance } from './payload-converters/proto-payload-converter';
+import { protobufWorkflow } from './workflows/protobufs';
 
 test('UndefinedPayloadConverter converts from undefined only', (t) => {
   const converter = new UndefinedPayloadConverter();
@@ -189,12 +189,13 @@ if (RUN_INTEGRATION_TESTS) {
     const taskQueue = 'test-data-converter';
     const worker = await Worker.create({
       ...defaultOptions,
+      workflowsPath: require.resolve('./workflows/protobufs'),
       taskQueue,
       enableSDKTracing: true,
     });
     const connection = new Connection();
     const client = new WorkflowClient(connection.service, {
-      dataConverter: { payloadConverterPath: require.resolve('./payload-converters/payload-converter') },
+      dataConverter: { payloadConverterPath: require.resolve('./payload-converters/proto-payload-converter') },
     });
     const runPromise = worker.run();
     client.execute(protobufWorkflow, {

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -8,12 +8,6 @@ import { defaultOptions } from './mock-native-worker';
 import { RUN_INTEGRATION_TESTS } from './helpers';
 import * as workflows from './workflows';
 
-interface RecordedCall {
-  info: WorkflowInfo;
-  counter: number;
-  fn: string;
-}
-
 class DependencyError extends Error {
   constructor(public readonly ifaceName: string, public readonly fnName: string) {
     super(`${ifaceName}.${fnName}`);
@@ -30,9 +24,16 @@ if (RUN_INTEGRATION_TESTS) {
     });
   });
 
-  test('Worker injects sinks', async (t) => {
+  // Must be serial because it uses the global Runtime to check for error messages
+  test.serial('Worker injects sinks', async (t) => {
+    interface RecordedCall {
+      info: WorkflowInfo;
+      counter: number;
+      fn: string;
+    }
+
     const recordedCalls: RecordedCall[] = [];
-    const taskQueue = 'test-sinks';
+    const taskQueue = `${__filename}-${t.title}`;
     const thrownErrors = Array<DependencyError>();
     const sinks: InjectedSinks<workflows.TestSinks> = {
       success: {
@@ -109,5 +110,78 @@ if (RUN_INTEGRATION_TESTS) {
     );
   });
 
-  test.todo('Sink functions are called during replay if callDuringReplay is set');
+  test('Sink functions are not called during replay if callDuringReplay is unset', async (t) => {
+    const recordedMessages = Array<string>();
+    const taskQueue = `${__filename}-${t.title}`;
+    const sinks: InjectedSinks<workflows.LoggerSinks> = {
+      logger: {
+        info: {
+          async fn(_info, message) {
+            recordedMessages.push(message);
+          },
+        },
+      },
+    };
+
+    const worker = await Worker.create({
+      ...defaultOptions,
+      taskQueue,
+      sinks,
+      maxCachedWorkflows: 1,
+      maxConcurrentWorkflowTaskExecutions: 1,
+    });
+    const conn = new WorkflowClient();
+    await Promise.all([
+      (async () => {
+        try {
+          await conn.execute(workflows.logSinkTester, { taskQueue, workflowId: uuid4() });
+        } finally {
+          worker.shutdown();
+        }
+      })(),
+      worker.run(),
+    ]);
+
+    t.deepEqual(recordedMessages, ['Workflow execution started', 'Workflow execution completed']);
+  });
+
+  test('Sink functions are called during replay if callDuringReplay is set', async (t) => {
+    const recordedMessages = Array<string>();
+    const taskQueue = `${__filename}-${t.title}`;
+    const sinks: InjectedSinks<workflows.LoggerSinks> = {
+      logger: {
+        info: {
+          async fn(_info, message) {
+            recordedMessages.push(message);
+          },
+          callDuringReplay: true,
+        },
+      },
+    };
+
+    const worker = await Worker.create({
+      ...defaultOptions,
+      taskQueue,
+      sinks,
+      maxCachedWorkflows: 1,
+      maxConcurrentWorkflowTaskExecutions: 1,
+    });
+    const conn = new WorkflowClient();
+    await Promise.all([
+      (async () => {
+        try {
+          await conn.execute(workflows.logSinkTester, { taskQueue, workflowId: uuid4() });
+        } finally {
+          worker.shutdown();
+        }
+      })(),
+      worker.run(),
+    ]);
+
+    t.deepEqual(recordedMessages, [
+      'Workflow execution started',
+      'Workflow execution started',
+      'Workflow execution completed',
+    ]);
+  });
 }

--- a/packages/test/src/workflows/args-and-return.ts
+++ b/packages/test/src/workflows/args-and-return.ts
@@ -1,10 +1,4 @@
-function str(a: Uint8Array): string {
-  let out = '';
-  for (const c of a) {
-    out += String.fromCharCode(c);
-  }
-  return out;
-}
+import { str } from '@temporalio/common';
 
 export async function argsAndReturn(greeting: string, _skip: undefined, arr: ArrayBuffer): Promise<string> {
   const name = str(new Uint8Array(arr));

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -55,7 +55,6 @@ export * from './patched-top-level';
 export * from './promise-all';
 export * from './promise-race';
 export * from './promise-then-promise';
-export * from './protobufs';
 export * from './race';
 export * from './random';
 export * from './reject-promise';

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -45,6 +45,7 @@ export { internalsInterceptorExample } from './internals-interceptor-example';
 export * from './interrupt-signal';
 export * from './invalid-or-failed-queries';
 export * from './log-before-timing-out';
+export * from './log-sink-tester';
 export * from './long-history-generator';
 export * from './multiple-activities-single-timeout';
 export * from './nested-cancellation';

--- a/packages/test/src/workflows/log-sink-tester.ts
+++ b/packages/test/src/workflows/log-sink-tester.ts
@@ -1,0 +1,19 @@
+/**
+ * Workflow used in test-sinks.ts to verify sink replay behavior
+ * @module
+ */
+
+import * as wf from '@temporalio/workflow';
+import { LoggerSinks } from './definitions';
+import { successString } from './success-string';
+
+const { logger } = wf.proxySinks<LoggerSinks>();
+
+export async function logSinkTester(): Promise<void> {
+  logger.info('Workflow execution started');
+  // We rely on the test to run with max cached workflows of 1.
+  // Executing this child will flush the current workflow from the cache
+  // causing replay or the first sink call.
+  await wf.executeChild(successString);
+  logger.info('Workflow execution completed');
+}

--- a/packages/testing/src/child-process.ts
+++ b/packages/testing/src/child-process.ts
@@ -43,4 +43,18 @@ export async function kill(child: ChildProcess, signal: NodeJS.Signals = 'SIGINT
   }
 }
 
+export async function killIfExists(
+  child: ChildProcess,
+  signal: NodeJS.Signals = 'SIGINT',
+  opts?: WaitOptions
+): Promise<void> {
+  try {
+    await kill(child, signal, opts);
+  } catch (err: any) {
+    if (err.code !== 'ESRCH') {
+      throw err;
+    }
+  }
+}
+
 export const shell = process.platform === 'win32';

--- a/packages/worker/src/activity.ts
+++ b/packages/worker/src/activity.ts
@@ -78,7 +78,10 @@ export class Activity {
           // expects activity to only fail with ApplicationFailure
           return {
             failed: {
-              failure: ApplicationFailure.retryable(this.cancelReason, 'CancelledFailure'),
+              failure: await encodeErrorToFailure(
+                this.dataConverter,
+                ApplicationFailure.retryable(this.cancelReason, 'CancelledFailure')
+              ),
             },
           };
         } else if (this.cancelReason) {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -980,7 +980,7 @@ export class Worker {
                     // Fatal error means we cannot call into this workflow again unfortunately
                     if (!isFatalError) {
                       const externalCalls = await state.workflow.getAndResetSinkCalls();
-                      await this.processSinkCalls(externalCalls, state.info);
+                      await this.processSinkCalls(externalCalls, state.info, activation.isReplaying);
                     }
                   }
                 });
@@ -1031,7 +1031,7 @@ export class Worker {
    * This function does not throw, it will log in case of missing sinks
    * or failed sink function invocations.
    */
-  protected async processSinkCalls(externalCalls: SinkCall[], info: WorkflowInfo): Promise<void> {
+  protected async processSinkCalls(externalCalls: SinkCall[], info: WorkflowInfo, isReplaying: boolean): Promise<void> {
     const { sinks } = this.options;
     await Promise.all(
       externalCalls.map(async ({ ifaceName, fnName, args }) => {
@@ -1041,7 +1041,7 @@ export class Worker {
             ifaceName,
             fnName,
           });
-        } else if (dep.callDuringReplay || !info.isReplaying) {
+        } else if (dep.callDuringReplay || !isReplaying) {
           try {
             await dep.fn(info, ...args);
           } catch (error) {


### PR DESCRIPTION
- Record memory usage in stress tests
- Run nightly at night (PST)
- Don't block runtime loop when creating new client
- Don't include proto converter in test workflows `index.ts` - cuts the test bundle size by half
- Fix inflight activity tracking
- Expose `WorkerStatus.numHeartbeatingActivities`
- Handle ShutdownError by name - closes #614 
- Fix TS initiated activity cancellation not creating a proper `ApplicationFailure`
- Closes #667 