### PR TITLE
fix!: Use firstExecutionRunId instead of originalRunId

### DIFF
--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -129,13 +129,13 @@ export interface WorkflowHandle<T extends Workflow = Workflow> extends BaseWorkf
 
 /**
  * This interface is exactly the same as {@link WorkflowHandle} except it
- * includes the `originalRunId` returned after starting a new Workflow.
+ * includes the `firstExecutionRunId` returned after starting a new Workflow.
  */
 export interface WorkflowHandleWithRunId<T extends Workflow = Workflow> extends WorkflowHandle<T> {
   /**
    * The runId of the initial run of the bound Workflow
    */
-  readonly originalRunId: string;
+  readonly firstExecutionRunId: string;
 }
 
 export interface WorkflowClientOptions {
@@ -340,8 +340,8 @@ export class WorkflowClient {
       runIdForResult: runId,
       interceptors,
       followRuns: options.followRuns ?? true,
-    }) as WorkflowHandleWithRunId<T>; // Cast is safe because we know we add the originalRunId below
-    (handle as any) /* readonly */.originalRunId = runId;
+    }) as WorkflowHandleWithRunId<T>; // Cast is safe because we know we add the firstExecutionRunId below
+    (handle as any) /* readonly */.firstExecutionRunId = runId;
     return handle;
   }
 
@@ -367,8 +367,8 @@ export class WorkflowClient {
       runIdForResult: runId,
       interceptors,
       followRuns: options.followRuns ?? true,
-    }) as WorkflowHandleWithRunId<T>; // Cast is safe because we know we add the originalRunId below
-    (handle as any) /* readonly */.originalRunId = runId;
+    }) as WorkflowHandleWithRunId<T>; // Cast is safe because we know we add the firstExecutionRunId below
+    (handle as any) /* readonly */.firstExecutionRunId = runId;
     return handle;
   }
 

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -140,16 +140,16 @@ export interface WorkflowHandleWithFirstExecutionRunId<T extends Workflow = Work
 
 /**
  * This interface is exactly the same as {@link WorkflowHandle} except it
- * includes the `originalRunId` returned from `signalWithStart`.
+ * includes the `signaledRunId` returned from `signalWithStart`.
  */
-export interface WorkflowHandleWithOriginalRunId<T extends Workflow = Workflow> extends WorkflowHandle<T> {
+export interface WorkflowHandleWithSignaledRunId<T extends Workflow = Workflow> extends WorkflowHandle<T> {
   /**
    * The Run Id of the bound Workflow at the time of {@link WorkflowClient.signalWithStart}.
    *
-   * Since `signalWithStart` may have signaled an existing Workflow Chain, `originalRunId` might not be the
+   * Since `signalWithStart` may have signaled an existing Workflow Chain, `signaledRunId` might not be the
    * `firstExecutionRunId`.
    */
-  readonly originalRunId: string;
+  readonly signaledRunId: string;
 }
 
 export interface WorkflowClientOptions {
@@ -368,7 +368,7 @@ export class WorkflowClient {
   public async signalWithStart<T extends Workflow, SA extends any[] = []>(
     workflowTypeOrFunc: string | T,
     options: WithWorkflowArgs<T, WorkflowSignalWithStartOptions<SA>>
-  ): Promise<WorkflowHandleWithOriginalRunId<T>> {
+  ): Promise<WorkflowHandleWithSignaledRunId<T>> {
     const { workflowId } = options;
     const interceptors = (this.options.interceptors.calls ?? []).map((ctor) => ctor({ workflowId }));
     const runId = await this._signalWithStart(workflowTypeOrFunc, options, interceptors);
@@ -381,8 +381,8 @@ export class WorkflowClient {
       runIdForResult: runId,
       interceptors,
       followRuns: options.followRuns ?? true,
-    }) as WorkflowHandleWithOriginalRunId<T>; // Cast is safe because we know we add the originalRunId below
-    (handle as any) /* readonly */.originalRunId = runId;
+    }) as WorkflowHandleWithSignaledRunId<T>; // Cast is safe because we know we add the signaledRunId below
+    (handle as any) /* readonly */.signaledRunId = runId;
     return handle;
   }
 

--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -740,7 +740,7 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
       t.is(err.cause.message, 'interrupted from signalWithStart');
     }
     // Test returned runId
-    const workflow = client.getHandle<typeof workflows.interruptableWorkflow>(ogWF.workflowId, ogWF.originalRunId);
+    const workflow = client.getHandle<typeof workflows.interruptableWorkflow>(ogWF.workflowId, ogWF.signaledRunId);
     {
       const err: WorkflowFailedError = await t.throwsAsync(workflow.result(), {
         instanceOf: WorkflowFailedError,

--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -740,10 +740,7 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
       t.is(err.cause.message, 'interrupted from signalWithStart');
     }
     // Test returned runId
-    const workflow = client.getHandle<typeof workflows.interruptableWorkflow>(
-      ogWF.workflowId,
-      ogWF.firstExecutionRunId
-    );
+    const workflow = client.getHandle<typeof workflows.interruptableWorkflow>(ogWF.workflowId, ogWF.originalRunId);
     {
       const err: WorkflowFailedError = await t.throwsAsync(workflow.result(), {
         instanceOf: WorkflowFailedError,

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -82,7 +82,7 @@ if (RUN_INTEGRATION_TESTS) {
       namespace: 'default',
       taskQueue,
       workflowId: wf.workflowId,
-      runId: wf.originalRunId,
+      runId: wf.firstExecutionRunId,
       workflowType: 'sinksWorkflow',
       isReplaying: false,
     };

--- a/packages/test/src/workflows/child-workflow-cancel.ts
+++ b/packages/test/src/workflows/child-workflow-cancel.ts
@@ -41,7 +41,7 @@ export async function childWorkflowCancel(): Promise<void> {
   // Cancellation of external workflow
   try {
     const child = await startChild(signalTarget, {});
-    const external = getExternalWorkflowHandle(child.workflowId, child.originalRunId);
+    const external = getExternalWorkflowHandle(child.workflowId, child.firstExecutionRunId);
     await external.cancel();
     await child.result();
     throw new Error('ChildWorkflow was not cancelled');

--- a/packages/test/src/workflows/child-workflow-invoke.ts
+++ b/packages/test/src/workflows/child-workflow-invoke.ts
@@ -14,5 +14,5 @@ export async function childWorkflowInvoke(): Promise<{
 }> {
   const child = await startChild(successString, {});
   const execResult = await executeChild(successString, {});
-  return { workflowId: child.workflowId, runId: child.originalRunId, result: await child.result(), execResult };
+  return { workflowId: child.workflowId, runId: child.firstExecutionRunId, result: await child.result(), execResult };
 }

--- a/packages/test/src/workflows/child-workflow-signals.ts
+++ b/packages/test/src/workflows/child-workflow-signals.ts
@@ -53,7 +53,7 @@ export async function childWorkflowSignals(): Promise<void> {
   {
     // Happy path
     const child = await startChild(signalTarget, {});
-    const external = getExternalWorkflowHandle(child.workflowId, child.originalRunId);
+    const external = getExternalWorkflowHandle(child.workflowId, child.firstExecutionRunId);
     // Args are transferred correctly
     await external.signal(argsTestSignal, 123, 'kid');
     await external.signal(unblockSignal);
@@ -62,7 +62,7 @@ export async function childWorkflowSignals(): Promise<void> {
   {
     // Cancel signal
     const child = await startChild(signalTarget, {});
-    const external = getExternalWorkflowHandle(child.workflowId, child.originalRunId);
+    const external = getExternalWorkflowHandle(child.workflowId, child.firstExecutionRunId);
 
     try {
       await CancellationScope.cancellable(async () => {

--- a/packages/test/src/workflows/child-workflow-termination.ts
+++ b/packages/test/src/workflows/child-workflow-termination.ts
@@ -14,6 +14,6 @@ export async function childWorkflowTermination(): Promise<void> {
   setHandler(childExecutionQuery, () => workflowExecution);
 
   const child = await startChild(unblockOrCancel, {});
-  workflowExecution = { workflowId: child.workflowId, runId: child.originalRunId };
+  workflowExecution = { workflowId: child.workflowId, runId: child.firstExecutionRunId };
   await child.result();
 }

--- a/packages/workflow/src/workflow-handle.ts
+++ b/packages/workflow/src/workflow-handle.ts
@@ -59,5 +59,5 @@ export interface ChildWorkflowHandle<T extends Workflow> extends BaseWorkflowHan
   /**
    * The runId of the initial run of the bound Workflow
    */
-  readonly originalRunId: string;
+  readonly firstExecutionRunId: string;
 }

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -676,11 +676,11 @@ export async function startChild<T extends Workflow>(
     headers: {},
     workflowType,
   });
-  const originalRunId = await started;
+  const firstExecutionRunId = await started;
 
   return {
     workflowId: optionsWithDefaults.workflowId,
-    originalRunId,
+    firstExecutionRunId,
     result(): Promise<WorkflowResultType<T>> {
       return completed as any;
     },


### PR DESCRIPTION
`originalRunId` is a concept related to resetting workflows. None of the instances of `originalRunId` I found in the SDK seem to do with resetting, so I changed them all to `firstExecutionRunId`.