### PR TITLE
fix: Validate that RetryPolicy maximumAttempts is an integer

### DIFF
--- a/packages/internal-workflow-common/src/retry-policy.ts
+++ b/packages/internal-workflow-common/src/retry-policy.ts
@@ -49,8 +49,14 @@ export function compileRetryPolicy(retryPolicy: RetryPolicy): temporal.api.commo
   if (retryPolicy.backoffCoefficient != null && retryPolicy.backoffCoefficient <= 0) {
     throw new ValueError('RetryPolicy.backoffCoefficient must be greater than 0');
   }
-  if (retryPolicy.maximumAttempts != null && retryPolicy.maximumAttempts <= 0) {
-    throw new ValueError('RetryPolicy.maximumAttempts must be greater than 0');
+  if (retryPolicy.maximumAttempts != null) {
+    if (retryPolicy.maximumAttempts <= 0) {
+      throw new ValueError('RetryPolicy.maximumAttempts must be greater than 0');
+    }
+
+    if (!Number.isInteger(retryPolicy.maximumAttempts)) {
+      throw new ValueError('RetryPolicy.maximumAttempts must be an integer');
+    }
   }
   const maximumInterval = msOptionalToNumber(retryPolicy.maximumInterval);
   const initialInterval = msToNumber(retryPolicy.initialInterval ?? 1000);

--- a/packages/test/src/test-retry-policy.ts
+++ b/packages/test/src/test-retry-policy.ts
@@ -35,10 +35,17 @@ test('compileRetryPolicy validates backoffCoefficient is greater than 0', (t) =>
   });
 });
 
-test('compileRetryPolicy validates maximumAttempts is greater than 0', (t) => {
-  t.throws(() => compileRetryPolicy({ maximumAttempts: 0 }), {
+test('compileRetryPolicy validates maximumAttempts is an integer', (t) => {
+  t.throws(() => compileRetryPolicy({ maximumAttempts: 3.1415 }), {
     instanceOf: ValueError,
-    message: 'RetryPolicy.maximumAttempts must be greater than 0',
+    message: 'RetryPolicy.maximumAttempts must be an integer',
+  });
+});
+
+test('compileRetryPolicy validates maximumAttempts is not POSITIVE_INFINITY', (t) => {
+  t.throws(() => compileRetryPolicy({ maximumAttempts: Number.POSITIVE_INFINITY }), {
+    instanceOf: ValueError,
+    message: 'RetryPolicy.maximumAttempts must be an integer',
   });
 });
 

--- a/packages/test/src/test-retry-policy.ts
+++ b/packages/test/src/test-retry-policy.ts
@@ -35,6 +35,13 @@ test('compileRetryPolicy validates backoffCoefficient is greater than 0', (t) =>
   });
 });
 
+test('compileRetryPolicy validates maximumAttempts greater than 0', (t) => {
+  t.throws(() => compileRetryPolicy({ maximumAttempts: 0 }), {
+    instanceOf: ValueError,
+    message: 'RetryPolicy.maximumAttempts must be greater than 0',
+  });
+});
+
 test('compileRetryPolicy validates maximumAttempts is an integer', (t) => {
   t.throws(() => compileRetryPolicy({ maximumAttempts: 3.1415 }), {
     instanceOf: ValueError,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added a quick check that `maximumAttempts` is a number using [`Number.isInteger()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger). This check explicitly excludes numbers like 3.1415 and `Number.POSITIVE_INFINITY`.

## Why?
<!-- Tell your future self why have you made these changes -->

`maximumAttempts` should always be an integer, doesn't make much sense for it to have a decimal component. And `maximumAttempts = 0` is the preferred alternative for `maximumAttempts = Number.POSITIVE_INFINITY`

## Checklist
<!--- add/delete as needed --->

1. Closes #656

2. How was this tested:

Added a couple of test cases

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
