### PR TITLE
fix: Use error constructor name as `applicationFailureInfo.type`

### DIFF
--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -366,7 +366,7 @@ export function ensureTemporalFailure(err: unknown): TemporalFailure {
   if (err instanceof TemporalFailure) {
     return err;
   } else if (err instanceof Error) {
-    const name = err.constructor?.name || err.name;
+    const name = err.constructor?.name ?? err.name;
     const failure = new ApplicationFailure(err.message, name, false);
     failure.stack = err.stack;
     return failure;

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -366,7 +366,8 @@ export function ensureTemporalFailure(err: unknown): TemporalFailure {
   if (err instanceof TemporalFailure) {
     return err;
   } else if (err instanceof Error) {
-    const failure = new ApplicationFailure(err.message, err.name, false);
+    const name = err.constructor?.name || err.name;
+    const failure = new ApplicationFailure(err.message, name, false);
     failure.stack = err.stack;
     return failure;
   } else {

--- a/packages/test/src/activities/failure-tester.ts
+++ b/packages/test/src/activities/failure-tester.ts
@@ -8,9 +8,12 @@ class RetryableError extends Error {
   public readonly name = 'RetryableError';
 }
 
+class CustomError extends Error {}
+
 type ErrorType =
   | 'NonRetryableError'
   | 'RetryableError'
+  | 'CustomError'
   | 'NonRetryableApplicationFailureWithNonRetryableFlag'
   | 'NonRetryableApplicationFailureWithRetryableFlag'
   | 'RetryableApplicationFailureWithRetryableFlag'
@@ -23,6 +26,8 @@ export async function throwSpecificError(type: ErrorType, message: string): Prom
       throw new NonRetryableError(message);
     case 'RetryableError':
       throw new RetryableError(message);
+    case 'CustomError':
+      throw new CustomError(message);
     case 'NonRetryableApplicationFailureWithRetryableFlag':
       throw ApplicationFailure.retryable(message, 'NonRetryableError');
     case 'NonRetryableApplicationFailureWithNonRetryableFlag':

--- a/packages/test/src/workflows/activity-failures.ts
+++ b/packages/test/src/workflows/activity-failures.ts
@@ -66,6 +66,11 @@ export async function activityFailures(): Promise<void> {
     assertApplicationFailure(err.cause, 'NonRetryableError', false, '2');
   }
   {
+    const err = await assertThrows(throwSpecificError('CustomError', '2'), ActivityFailure);
+    assertRetryState(err, RetryState.RETRY_STATE_NON_RETRYABLE_FAILURE);
+    assertApplicationFailure(err.cause, 'CustomError', false, '2');
+  }
+  {
     const err = await assertThrows(
       throwSpecificError('RetryableApplicationFailureWithRetryableFlag', '3'),
       ActivityFailure

--- a/packages/test/src/workflows/activity-failures.ts
+++ b/packages/test/src/workflows/activity-failures.ts
@@ -29,7 +29,7 @@ async function assertThrows<T extends Error>(p: Promise<any>, ctor: new (...args
     }
     return err;
   }
-  throw new Error('Expected activity to throw');
+  throw ApplicationFailure.nonRetryable('Expected activity to throw');
 }
 
 export function assertApplicationFailure(
@@ -42,7 +42,7 @@ export function assertApplicationFailure(
     throw new Error(`Expected ApplicationFailure, got ${err}`);
   }
   if (err.type !== type || err.nonRetryable != nonRetryable || err.message !== originalMessage) {
-    throw new Error(
+    throw ApplicationFailure.nonRetryable(
       `Expected ${type} with nonRetryable=${nonRetryable} originalMessage=${originalMessage}, got ${err}`
     );
   }
@@ -50,7 +50,7 @@ export function assertApplicationFailure(
 
 function assertRetryState(err: ActivityFailure, retryState: RetryState) {
   if (err.retryState !== retryState) {
-    throw new Error(`Expected retryState to be ${retryState}, got ${err.retryState}`);
+    throw ApplicationFailure.nonRetryable(`Expected retryState to be ${retryState}, got ${err.retryState}`);
   }
 }
 
@@ -67,7 +67,7 @@ export async function activityFailures(): Promise<void> {
   }
   {
     const err = await assertThrows(throwSpecificError('CustomError', '2'), ActivityFailure);
-    assertRetryState(err, RetryState.RETRY_STATE_NON_RETRYABLE_FAILURE);
+    assertRetryState(err, RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED);
     assertApplicationFailure(err.cause, 'CustomError', false, '2');
   }
   {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Use `err.constructor.name` instead of `err.name` by default, since `.name` is still 'Error' for classes that extend Error.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes #637

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
