### PR TITLE
fix(Worker): Throw error when importing a node built-in module from a Workflow

### DIFF
--- a/packages/test/src/test-worker-from-bundle.ts
+++ b/packages/test/src/test-worker-from-bundle.ts
@@ -98,23 +98,21 @@ if (RUN_INTEGRATION_TESTS) {
     t.pass();
   });
 
-  test('A warning is reported when workflow depends on a node built-in module', async (t) => {
+  test('An error is thrown when workflow depends on a node built-in module', async (t) => {
     const logs: LogEntry[] = [];
     const logger = new DefaultLogger('WARN', (entry: LogEntry) => {
       logs.push(entry);
       console.warn(entry.message);
     });
 
-    await bundleWorkflowCode({
-      workflowsPath: require.resolve('./mocks/workflows-with-node-dependencies/issue-516'),
-      logger,
-    });
-
-    t.true(
-      logs.some(
-        (entry) => entry.message.match(/'dns'/) && entry.message.match(/'WorkerOptions.bundlerOptions.ignoreModules'/)
-      ),
-      "Bundler reported a warning message about package 'dns'"
+    await t.throwsAsync(
+      bundleWorkflowCode({
+        workflowsPath: require.resolve('./mocks/workflows-with-node-dependencies/issue-516'),
+        logger,
+      }),
+      {
+        instanceOf: Error,
+      }
     );
   });
 }

--- a/packages/test/src/test-worker-from-bundle.ts
+++ b/packages/test/src/test-worker-from-bundle.ts
@@ -112,6 +112,7 @@ if (RUN_INTEGRATION_TESTS) {
       }),
       {
         instanceOf: Error,
+        message: /is importing the following built-in Node modules.*dns/,
       }
     );
   });

--- a/packages/test/src/test-worker-from-bundle.ts
+++ b/packages/test/src/test-worker-from-bundle.ts
@@ -112,7 +112,7 @@ if (RUN_INTEGRATION_TESTS) {
       }),
       {
         instanceOf: Error,
-        message: /is importing the following built-in Node modules.*dns/,
+        message: /is importing the following built-in Node modules.*dns/s,
       }
     );
   });

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -227,7 +227,22 @@ export class WorkflowCodeBundler {
                 )
               );
             }
-            this.reportProblematicModules(this.foundProblematicModules);
+
+            if (this.foundProblematicModules.size) {
+              const err = new Error(
+                `Your Workflow code (or a library used by your Workflow code) is importing the following built-in Node modules:\n` +
+                  Array.from(this.foundProblematicModules)
+                    .map((module) => `  - '${module}'\n`)
+                    .join('') +
+                  `Workflow code doesn't have access to built-in Node modules (in order to help enforce determinism). If you are certain ` +
+                  `these modules will not be used at runtime, then you may add their names to 'WorkerOptions.bundlerOptions.ignoreModules' in order to ` +
+                  `dismiss this warning. However, if your code execution actually depends on these modules, then you must change the code ` +
+                  `or remove the library.\n` +
+                  `See https://typescript.temporal.io/api/interfaces/worker.workeroptions/#bundleroptions for details.`
+              );
+
+              reject(err);
+            }
           }
           if (err) {
             reject(err);
@@ -239,22 +254,6 @@ export class WorkflowCodeBundler {
     } finally {
       await util.promisify(compiler.close).bind(compiler)();
     }
-  }
-
-  protected reportProblematicModules(foundProblematicModules: Set<string>): void {
-    if (!foundProblematicModules.size) return;
-
-    this.logger.warn(
-      `Your Workflow code (or a library used by your Workflow code) is importing the following built-in Node modules:\n` +
-        Array.from(foundProblematicModules)
-          .map((module) => `  - '${module}'\n`)
-          .join('') +
-        `Workflow code doesn't have access to built-in Node modules (in order to help enforce determinism). If you are certain ` +
-        `these modules will not be used at runtime, then you may add their names to 'WorkerOptions.bundlerOptions.ignoreModules' in order to ` +
-        `dismiss this warning. However, if your code execution actually depends on these modules, then you must change the code ` +
-        `or remove the library.\n` +
-        `See https://typescript.temporal.io/api/interfaces/worker.workeroptions/#bundleroptions for details.`
-    );
   }
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Instead of logging a warning, throw an error when importing a node built-in

## Why?

If you `import path from 'path'`, you get a warning, which is easy to miss in the log output. Then you end up with a hard-to-diagnose runtime error if you use `path.join()`:

```
  2022-06-07T18:54:11.935439Z  WARN temporal_sdk_core::worker: Failing workflow activation, run_id: "c9db39d3-851f-4386-bd8e-682b679e82cb", failure: Failure { failure: Some(Failure { message: "path__WEBPACK_IMPORTED_MODULE_1___default(...).join is not a function", source: "TypeScriptSDK", stack_trace: "TypeError: path__WEBPACK_IMPORTED_MODULE_1___default(...).join is not a function\n    at example (webpack-internal:///./src/workflows.ts:16:68)", cause: None, failure_info: None }) }
```

Right now, I'm thinking that throwing an error is better DX. What do you think?

## Checklist
<!--- add/delete as needed --->

1. Closes #685

2. How was this tested:
Added a test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
