### PR TITLE
refactor: Make SearchAttributesValue an array

### DIFF
--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,4 +1,4 @@
-import type { SearchAttributeValue } from '@temporalio/internal-workflow-common';
+import type { SearchAttributes } from '@temporalio/internal-workflow-common';
 import { temporal } from '@temporalio/proto';
 import type * as grpc from '@grpc/grpc-js';
 
@@ -35,7 +35,7 @@ export interface WorkflowExecutionDescription {
   executionTime?: Date;
   closeTime?: Date;
   memo?: Record<string, unknown>;
-  searchAttributes: Record<string, SearchAttributeValue[]>;
+  searchAttributes: SearchAttributes;
   parentExecution?: Required<temporal.api.common.v1.IWorkflowExecution>;
   raw: DescribeWorkflowExecutionResponse;
 }

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -27,7 +27,7 @@ import {
   optionalTsToDate,
   QueryDefinition,
   Replace,
-  SearchAttributeValue,
+  SearchAttributes,
   SignalDefinition,
   tsToDate,
   WithWorkflowArgs,
@@ -861,7 +861,7 @@ export class WorkflowClient {
           searchAttributes: mapFromPayloads(
             searchAttributePayloadConverter,
             raw.workflowExecutionInfo!.searchAttributes?.indexedFields ?? {}
-          ) as Record<string, SearchAttributeValue[]>,
+          ) as SearchAttributes,
           parentExecution: raw.workflowExecutionInfo?.parentExecution
             ? {
                 workflowId: raw.workflowExecutionInfo.parentExecution.workflowId!,

--- a/packages/internal-workflow-common/src/interfaces.ts
+++ b/packages/internal-workflow-common/src/interfaces.ts
@@ -41,4 +41,5 @@ export type WorkflowResultType<W extends Workflow> = ReturnType<W> extends Promi
  *
  * Dates are serialized as ISO strings.
  */
-export type SearchAttributeValue = string | number | boolean | Date;
+export type SearchAttributes = Record<string, SearchAttributeValue>;
+export type SearchAttributeValue = string[] | number[] | boolean[] | Date[];

--- a/packages/internal-workflow-common/src/workflow-options.ts
+++ b/packages/internal-workflow-common/src/workflow-options.ts
@@ -1,5 +1,5 @@
 import type { coresdk, google } from '@temporalio/proto';
-import { SearchAttributeValue, Workflow } from './interfaces';
+import { SearchAttributes, Workflow } from './interfaces';
 import { RetryPolicy } from './retry-policy';
 import { msOptionalToTs } from './time';
 import { checkExtends, Replace } from './type-helpers';
@@ -58,7 +58,7 @@ export interface BaseWorkflowOptions {
    *
    * Values are always converted using {@link JsonPayloadConverter}, even when a custom data converter is provided.
    */
-  searchAttributes?: Record<string, SearchAttributeValue[]>;
+  searchAttributes?: SearchAttributes;
 }
 
 export type WithWorkflowArgs<W extends Workflow, T> = T &

--- a/packages/test/src/workflows/return-search-attributes.ts
+++ b/packages/test/src/workflows/return-search-attributes.ts
@@ -1,6 +1,6 @@
-import { SearchAttributeValue, workflowInfo } from '@temporalio/workflow';
+import { SearchAttributes, workflowInfo } from '@temporalio/workflow';
 
-export async function returnSearchAttributes(): Promise<Record<string, SearchAttributeValue[]> | undefined> {
+export async function returnSearchAttributes(): Promise<SearchAttributes | undefined> {
   const sa = workflowInfo().searchAttributes!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
   const datetime = (sa.CustomDatetimeField as Array<Date>)[0];
   return {

--- a/packages/test/src/workflows/upsert-and-read-search-attributes.ts
+++ b/packages/test/src/workflows/upsert-and-read-search-attributes.ts
@@ -1,8 +1,6 @@
-import { SearchAttributeValue, upsertSearchAttributes, workflowInfo } from '@temporalio/workflow';
+import { SearchAttributes, upsertSearchAttributes, workflowInfo } from '@temporalio/workflow';
 
-export async function upsertAndReadSearchAttributes(
-  msSinceEpoch: number
-): Promise<Record<string, SearchAttributeValue[]> | undefined> {
+export async function upsertAndReadSearchAttributes(msSinceEpoch: number): Promise<SearchAttributes | undefined> {
   upsertSearchAttributes({
     CustomIntField: [123],
     CustomBoolField: [true],

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -30,7 +30,7 @@ import {
 import {
   optionalTsToDate,
   optionalTsToMs,
-  SearchAttributeValue,
+  SearchAttributes,
   tsToMs,
   decompileRetryPolicy,
 } from '@temporalio/internal-workflow-common';
@@ -975,7 +975,7 @@ export class Worker {
                         searchAttributes: mapFromPayloads(
                           searchAttributePayloadConverter,
                           searchAttributes?.indexedFields
-                        ) as Record<string, SearchAttributeValue[]> | undefined,
+                        ) as SearchAttributes | undefined,
                         memo: await decodeMapFromPayloads(this.options.loadedDataConverter, memo?.fields),
                         parent: convertToParentWorkflowType(parentWorkflowInfo),
                         lastResult: await decodeFromPayloadsAtIndex(

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1,5 +1,5 @@
 import { RetryPolicy, TemporalFailure } from '@temporalio/common';
-import { checkExtends, CommonWorkflowOptions, SearchAttributeValue } from '@temporalio/internal-workflow-common';
+import { checkExtends, CommonWorkflowOptions, SearchAttributes } from '@temporalio/internal-workflow-common';
 import type { coresdk } from '@temporalio/proto';
 
 /**
@@ -25,7 +25,7 @@ export interface WorkflowInfo {
   /**
    * Indexed information attached to the Workflow Execution
    */
-  searchAttributes?: Record<string, SearchAttributeValue[]>;
+  searchAttributes?: SearchAttributes;
 
   /**
    * Non-indexed information attached to the Workflow Execution

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -11,7 +11,7 @@ import {
   msToNumber,
   msToTs,
   QueryDefinition,
-  SearchAttributeValue,
+  SearchAttributes,
   SignalDefinition,
   tsToMs,
   WithWorkflowArgs,
@@ -1163,14 +1163,14 @@ export function setHandler<Ret, Args extends any[], T extends SignalDefinition<A
  *
  * @param searchAttributes The Record to merge. Use a value of `[]` to clear a Search Attribute.
  */
-export function upsertSearchAttributes(searchAttributes: Record<string, SearchAttributeValue[]>): void {
+export function upsertSearchAttributes(searchAttributes: SearchAttributes): void {
   if (!state.info) {
     throw new IllegalStateError('`state.info` should be defined');
   }
 
   const mergedSearchAttributes = { ...state.info.searchAttributes, ...searchAttributes };
   if (!mergedSearchAttributes) {
-    throw new Error('searchAttributes must be a non-null Record<string, SearchAttributeValue[]>');
+    throw new Error('searchAttributes must be a non-null SearchAttributes');
   }
 
   state.pushCommand({


### PR DESCRIPTION
To prevent mixed-type array at type level. Keeping runtime check for JS users.

Background: https://github.com/temporalio/sdk-python/pull/43#discussion_r894771799

Not labeling as breaking, since it can be included in the same release as SA feature.