### PR TITLE
fix: Recreate TransportErrors in initial connection to provide better stack traces

### DIFF
--- a/packages/worker/src/connection.ts
+++ b/packages/worker/src/connection.ts
@@ -3,6 +3,7 @@ import { IllegalStateError } from '@temporalio/common';
 import { Client, Worker, clientUpdateHeaders } from '@temporalio/core-bridge';
 import { NativeConnectionOptions } from './connection-options';
 import { Runtime } from './runtime';
+import { TransportError } from './errors';
 
 const updateHeaders = util.promisify(clientUpdateHeaders);
 
@@ -28,16 +29,30 @@ export class NativeConnection {
    * @deprecated use `connect` instead
    */
   static async create(options?: NativeConnectionOptions): Promise<NativeConnection> {
-    const client = await Runtime.instance().createNativeClient(options);
-    return new this(client);
+    try {
+      const client = await Runtime.instance().createNativeClient(options);
+      return new this(client);
+    } catch (err) {
+      if (err instanceof TransportError) {
+        throw new TransportError(err.message);
+      }
+      throw err;
+    }
   }
 
   /**
    * Eagerly connect to the Temporal server and return a NativeConnection instance
    */
   static async connect(options?: NativeConnectionOptions): Promise<NativeConnection> {
-    const client = await Runtime.instance().createNativeClient(options);
-    return new this(client);
+    try {
+      const client = await Runtime.instance().createNativeClient(options);
+      return new this(client);
+    } catch (err) {
+      if (err instanceof TransportError) {
+        throw new TransportError(err.message);
+      }
+      throw err;
+    }
   }
 
   /**


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Recreate and rethrow TransportErrors

## Why?
<!-- Tell your future self why have you made these changes -->

Better stack traces and debugging. I originally ran into this issue because when I'd start a worker without a Temporal server running, I'd get the `[TransportError: transport error]` error with no stack trace.

I originally took a look at #582, but I haven't been able to figure out enough about the core SDK to figure out how to improve the error message. However, adding [async stack traces](https://thecodebarbarian.com/async-stack-traces-in-node-js-12) is fairly easy as long as we're willing to create a new `TransportError` instance in our async function. With this change, if I start the hello-world sample without a Temporal server running, I get the below error (Node v16.14):

```
TransportError: transport error
    at Function.create (/home/val/Workspace/temporalio/samples-typescript/hello-world/node_modules/@temporalio/worker/src/connection.ts:24:4)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Function.create (/home/val/Workspace/temporalio/samples-typescript/hello-world/node_modules/@temporalio/worker/src/worker.ts:340:3)
    at async run (/home/val/Workspace/temporalio/samples-typescript/hello-world/src/worker.ts:9:18)
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
