### PR TITLE
feat(worker): Add `runUntil` method

### DIFF
--- a/packages/test/src/test-custom-payload-codec.ts
+++ b/packages/test/src/test-custom-payload-codec.ts
@@ -56,7 +56,7 @@ if (RUN_INTEGRATION_TESTS) {
       sinks,
     });
     const client = new WorkflowClient({ dataConverter });
-    const runAndShutdown = async () => {
+    await worker.runUntil(async () => {
       const result = await client.execute(twoStrings, {
         args: ['arg1', 'arg2'],
         workflowId: uuid4(),
@@ -64,9 +64,7 @@ if (RUN_INTEGRATION_TESTS) {
       });
 
       t.is(result, 'encoded'); // workflow retval encoded by worker
-      worker.shutdown();
-    };
-    await Promise.all([worker.run(), runAndShutdown()]);
+    });
     t.is(logs[0], 'encodedencoded'); // workflow args encoded by client
   });
 
@@ -91,7 +89,7 @@ if (RUN_INTEGRATION_TESTS) {
       sinks,
     });
     const client = new WorkflowClient({ dataConverter });
-    const runAndShutdown = async () => {
+    await worker.runUntil(async () => {
       const result = await client.execute(twoStrings, {
         args: ['arg1', 'arg2'],
         workflowId: uuid4(),
@@ -99,9 +97,7 @@ if (RUN_INTEGRATION_TESTS) {
       });
 
       t.is(result, 'decoded'); // workflow retval decoded by client
-      worker.shutdown();
-    };
-    await Promise.all([worker.run(), runAndShutdown()]);
+    });
     t.is(logs[0], 'decodeddecoded'); // workflow args decoded by worker
   });
 
@@ -128,14 +124,12 @@ if (RUN_INTEGRATION_TESTS) {
       sinks,
     });
     const client = new WorkflowClient({ dataConverter });
-    const runAndShutdown = async () => {
+    await worker.runUntil(async () => {
       await client.execute(twoStringsActivity, {
         workflowId: uuid4(),
         taskQueue,
       });
-      worker.shutdown();
-    };
-    await Promise.all([worker.run(), runAndShutdown()]);
+    });
     t.is(workflowLogs[0], 'encoded'); // activity retval encoded by worker
     t.is(activityLogs[0], 'Activityencodedencoded'); // activity args encoded by worker
   });
@@ -163,14 +157,12 @@ if (RUN_INTEGRATION_TESTS) {
       sinks,
     });
     const client = new WorkflowClient({ dataConverter });
-    const runAndShutdown = async () => {
+    await worker.runUntil(async () => {
       await client.execute(twoStringsActivity, {
         workflowId: uuid4(),
         taskQueue,
       });
-      worker.shutdown();
-    };
-    await Promise.all([worker.run(), runAndShutdown()]);
+    });
     t.is(workflowLogs[0], 'decoded'); // activity retval decoded by worker
     t.is(activityLogs[0], 'Activitydecodeddecoded'); // activity args decoded by worker
   });
@@ -212,7 +204,7 @@ if (RUN_INTEGRATION_TESTS) {
       sinks,
     });
     const client = new WorkflowClient({ dataConverter });
-    const runAndShutdown = async () => {
+    await worker.runUntil(async () => {
       const result = await client.execute(twoStrings, {
         args: ['arg1', 'arg2'],
         workflowId: uuid4(),
@@ -220,9 +212,7 @@ if (RUN_INTEGRATION_TESTS) {
       });
 
       t.is(result, 'encoded'); // workflow retval encoded by worker
-      worker.shutdown();
-    };
-    await Promise.all([worker.run(), runAndShutdown()]);
+    });
     t.is(logs[0], 'encodedencoded'); // workflow args encoded by client
   });
 
@@ -264,7 +254,7 @@ if (RUN_INTEGRATION_TESTS) {
       sinks,
     });
     const client = new WorkflowClient({ dataConverter });
-    const runAndShutdown = async () => {
+    await worker.runUntil(async () => {
       const result = await client.execute(twoStrings, {
         args: ['arg1', 'arg2'],
         workflowId: uuid4(),
@@ -272,9 +262,7 @@ if (RUN_INTEGRATION_TESTS) {
       });
 
       t.is(result, 'decoded'); // workflow retval decoded by client
-      worker.shutdown();
-    };
-    await Promise.all([worker.run(), runAndShutdown()]);
+    });
     t.is(logs[0], 'decodeddecoded'); // workflow args decoded by worker
   });
 }

--- a/packages/test/src/test-otel.ts
+++ b/packages/test/src/test-otel.ts
@@ -69,12 +69,7 @@ if (RUN_INTEGRATION_TESTS) {
         calls: [() => new OpenTelemetryWorkflowClientCallsInterceptor()],
       },
     });
-    await Promise.all([
-      client
-        .execute(workflows.smorgasbord, { taskQueue: 'test-otel', workflowId: uuid4() })
-        .finally(() => worker.shutdown()),
-      worker.run(),
-    ]);
+    await worker.runUntil(client.execute(workflows.smorgasbord, { taskQueue: 'test-otel', workflowId: uuid4() }));
     await otel.shutdown();
     const originalSpan = spans.find(({ name }) => name === `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}smorgasbord`);
     t.true(originalSpan !== undefined);
@@ -183,12 +178,7 @@ if (RUN_INTEGRATION_TESTS) {
         calls: [() => new OpenTelemetryWorkflowClientCallsInterceptor()],
       },
     });
-    await Promise.all([
-      client
-        .execute(workflows.cancelFakeProgress, { taskQueue: 'test-otel', workflowId: uuid4() })
-        .finally(() => worker.shutdown()),
-      worker.run(),
-    ]);
+    worker.runUntil(client.execute(workflows.cancelFakeProgress, { taskQueue: 'test-otel', workflowId: uuid4() }));
     // Allow some time to ensure spans are flushed out to collector
     await new Promise((resolve) => setTimeout(resolve, 5000));
     t.pass();

--- a/packages/test/src/test-payload-converter.ts
+++ b/packages/test/src/test-payload-converter.ts
@@ -206,7 +206,6 @@ if (RUN_INTEGRATION_TESTS) {
         await expectedErrorWasThrown;
       } finally {
         await handle.terminate();
-        worker.shutdown();
       }
     });
     t.pass();

--- a/packages/test/src/test-payload-converter.ts
+++ b/packages/test/src/test-payload-converter.ts
@@ -201,17 +201,14 @@ if (RUN_INTEGRATION_TESTS) {
       taskQueue,
     });
 
-    await Promise.all([
-      worker.run(),
-      (async () => {
-        try {
-          await expectedErrorWasThrown;
-        } finally {
-          await handle.terminate();
-          worker.shutdown();
-        }
-      })(),
-    ]);
+    await worker.runUntil(async () => {
+      try {
+        await expectedErrorWasThrown;
+      } finally {
+        await handle.terminate();
+        worker.shutdown();
+      }
+    });
     t.pass();
   });
 }

--- a/packages/test/src/test-signals-are-always-delivered.ts
+++ b/packages/test/src/test-signals-are-always-delivered.ts
@@ -41,13 +41,7 @@ if (RUN_INTEGRATION_TESTS) {
       sinks,
     });
 
-    await worker.runUntil(async () => {
-      try {
-        await wf.result();
-      } finally {
-        worker.shutdown();
-      }
-    });
+    await worker.runUntil(wf.result());
 
     // Workflow completes if it got the signal
     t.pass();

--- a/packages/test/src/test-signals-are-always-delivered.ts
+++ b/packages/test/src/test-signals-are-always-delivered.ts
@@ -41,16 +41,13 @@ if (RUN_INTEGRATION_TESTS) {
       sinks,
     });
 
-    await Promise.all([
-      worker.run(),
-      (async () => {
-        try {
-          await wf.result();
-        } finally {
-          worker.shutdown();
-        }
-      })(),
-    ]);
+    await worker.runUntil(async () => {
+      try {
+        await wf.result();
+      } finally {
+        worker.shutdown();
+      }
+    });
 
     // Workflow completes if it got the signal
     t.pass();

--- a/packages/test/src/test-worker-debug-mode.ts
+++ b/packages/test/src/test-worker-debug-mode.ts
@@ -12,14 +12,12 @@ if (RUN_INTEGRATION_TESTS) {
     const taskQueue = 'debug-mode';
     const worker = await Worker.create({ ...defaultOptions, taskQueue, debugMode: true });
     const client = new WorkflowClient();
-    const runAndShutdown = async () => {
-      const result = await client.execute(successString, {
+    const result = await worker.runUntil(
+      client.execute(successString, {
         workflowId: uuid4(),
         taskQueue,
-      });
-      t.is(result, 'success');
-      worker.shutdown();
-    };
-    await Promise.all([worker.run(), runAndShutdown()]);
+      })
+    );
+    t.is(result, 'success');
   });
 }

--- a/packages/test/src/test-worker-from-bundle.ts
+++ b/packages/test/src/test-worker-from-bundle.ts
@@ -31,16 +31,7 @@ if (RUN_INTEGRATION_TESTS) {
       workflowBundle,
     });
     const client = new WorkflowClient();
-    await Promise.all([
-      worker.run(),
-      (async () => {
-        try {
-          await client.execute(successString, { taskQueue, workflowId: uuid4() });
-        } finally {
-          worker.shutdown();
-        }
-      })(),
-    ]);
+    await worker.runUntil(client.execute(successString, { taskQueue, workflowId: uuid4() }));
     t.pass();
   });
 
@@ -60,16 +51,7 @@ if (RUN_INTEGRATION_TESTS) {
     });
     const client = new WorkflowClient();
     try {
-      await Promise.all([
-        worker.run(),
-        (async () => {
-          try {
-            await client.execute(successString, { taskQueue, workflowId: uuid4() });
-          } finally {
-            worker.shutdown();
-          }
-        })(),
-      ]);
+      await worker.runUntil(client.execute(successString, { taskQueue, workflowId: uuid4() }));
     } finally {
       await unlink(codePath);
     }
@@ -87,16 +69,7 @@ if (RUN_INTEGRATION_TESTS) {
       workflowBundle,
     });
     const client = new WorkflowClient();
-    await Promise.all([
-      worker.run(),
-      (async () => {
-        try {
-          await client.execute(issue516, { taskQueue, workflowId: uuid4() });
-        } finally {
-          worker.shutdown();
-        }
-      })(),
-    ]);
+    await worker.runUntil(client.execute(issue516, { taskQueue, workflowId: uuid4() }));
     t.pass();
   });
 

--- a/packages/test/src/test-worker-heartbeats.ts
+++ b/packages/test/src/test-worker-heartbeats.ts
@@ -7,10 +7,10 @@ import { isolateFreeWorker, Worker } from './mock-native-worker';
 
 async function runActivity(worker: Worker, callback?: (completion: coresdk.ActivityTaskCompletion) => void) {
   const taskToken = Buffer.from(uuid4());
-  const completion = await worker.runUntil(() =>
-    worker.native.runActivityTask({ taskToken, start: { activityType: 'rapidHeartbeater' } })
-  );
-  callback?.(completion);
+  await worker.runUntil(async () => {
+    const completion = await worker.native.runActivityTask({ taskToken, start: { activityType: 'rapidHeartbeater' } });
+    callback?.(completion);
+  });
 }
 
 test('Worker stores last heartbeat if flushing is in progress', async (t) => {

--- a/packages/test/src/test-worker-heartbeats.ts
+++ b/packages/test/src/test-worker-heartbeats.ts
@@ -7,11 +7,10 @@ import { isolateFreeWorker, Worker } from './mock-native-worker';
 
 async function runActivity(worker: Worker, callback?: (completion: coresdk.ActivityTaskCompletion) => void) {
   const taskToken = Buffer.from(uuid4());
-  const p = worker.run();
-  const completion = await worker.native.runActivityTask({ taskToken, start: { activityType: 'rapidHeartbeater' } });
+  const completion = await worker.runUntil(() =>
+    worker.native.runActivityTask({ taskToken, start: { activityType: 'rapidHeartbeater' } })
+  );
   callback?.(completion);
-  worker.shutdown();
-  await p;
 }
 
 test('Worker stores last heartbeat if flushing is in progress', async (t) => {

--- a/packages/test/src/test-worker-no-activities.ts
+++ b/packages/test/src/test-worker-no-activities.ts
@@ -12,14 +12,12 @@ if (RUN_INTEGRATION_TESTS) {
     const { activities, taskQueue, ...rest } = defaultOptions;
     const worker = await Worker.create({ taskQueue: 'only-workflows', ...rest });
     const client = new WorkflowClient();
-    const runAndShutdown = async () => {
-      const result = await client.execute(successString, {
+    const result = await worker.runUntil(
+      client.execute(successString, {
         workflowId: uuid4(),
         taskQueue: 'only-workflows',
-      });
-      t.is(result, 'success');
-      worker.shutdown();
-    };
-    await Promise.all([worker.run(), runAndShutdown()]);
+      })
+    );
+    t.is(result, 'success');
   });
 }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1493,6 +1493,29 @@ export class Worker {
   }
 
   /**
+   * {@link run | Run} the Worker until `fnOrPromise` completes.
+   *
+   * @returns the result of `fnOrPromise`
+   *
+   * Throws on fatal Worker errors.
+   */
+  async runUntil<R>(fnOrPromise: Promise<R> | (() => Promise<R>)): Promise<R> {
+    const runAndShutdown = async () => {
+      try {
+        if (typeof fnOrPromise === 'function') {
+          return await fnOrPromise();
+        } else {
+          return await fnOrPromise;
+        }
+      } finally {
+        this.shutdown();
+      }
+    };
+    const [_, ret] = await Promise.all([this.run(), runAndShutdown()]);
+    return ret;
+  }
+
+  /**
    * Start polling on tasks, completes after graceful shutdown.
    * Throws on a fatal error or failure to shutdown gracefully.
    * @see {@link errors}

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -124,8 +124,12 @@ export class WorkflowCodeBundler {
       // Bundle all Workflows and interceptor modules for lazy evaluation
       api.overrideGlobals();
       api.setImportFuncs({
-        importWorkflows: () => {
-          return import(/* webpackMode: "eager" */ ${JSON.stringify(this.workflowsPath)});
+        importWorkflows: async () => {
+          const mod = await import(/* webpackMode: "eager" */ ${JSON.stringify(this.workflowsPath)});
+          if (typeof mod.default === 'function') {
+            return mod.default();
+          }
+          return mod;
         },
         importInterceptors: () => {
           return Promise.all([

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -124,12 +124,8 @@ export class WorkflowCodeBundler {
       // Bundle all Workflows and interceptor modules for lazy evaluation
       api.overrideGlobals();
       api.setImportFuncs({
-        importWorkflows: async () => {
-          const mod = await import(/* webpackMode: "eager" */ ${JSON.stringify(this.workflowsPath)});
-          if (typeof mod.default === 'function') {
-            return mod.default();
-          }
-          return mod;
+        importWorkflows: () => {
+          return import(/* webpackMode: "eager" */ ${JSON.stringify(this.workflowsPath)});
         },
         importInterceptors: () => {
           return Promise.all([


### PR DESCRIPTION
Useful helper especially in tests.

Usage:

```ts
const worker = await Worker.create(opts);

// Wait on an async function
await worker.runUntil(async () => {
  client.execute(someWorkflow, wopts);
});

// -- OR --

// Wait on a promise
await worker.runUntil(client.execute(someWorkflow, wopts));
```