### PR TITLE
feat: Support Jest mock Activity functions

### DIFF
--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -681,7 +681,7 @@ export class Worker {
 
                     const { activityType } = info;
                     const fn = this.options.activities?.[activityType];
-                    if (!(fn instanceof Function)) {
+                    if (typeof fn !== 'function') {
                       output = {
                         type: 'result',
                         result: {


### PR DESCRIPTION
Because Jest messes up with imports and modules get re-evaluated in different contexts, our Activity function check doesn't work when the function is a mock `jest.fn()`.

https://temporalio.slack.com/archives/C01DKSMU94L/p1655374964331519