### PR TITLE
Fix error details being dropped when returning core errors

### DIFF
--- a/packages/core-bridge/src/errors.rs
+++ b/packages/core-bridge/src/errors.rs
@@ -20,14 +20,14 @@ pub trait CustomError {
     where
         C: Context<'a>;
 
-    fn from_string<'a, C>(&self, cx: &mut C, message: String) -> JsResult<'a, JsObject>
+    fn from_string<'a, C>(&self, cx: &mut C, message: impl Into<String>) -> JsResult<'a, JsObject>
     where
         C: Context<'a>;
 
     fn from_error<'a, C, E>(&self, cx: &mut C, err: E) -> JsResult<'a, JsObject>
     where
         C: Context<'a>,
-        E: std::fmt::Display;
+        E: std::error::Error;
 }
 
 // Implement `CustomError` for ALL errors in a `OnceCell`. This only needs to be
@@ -46,20 +46,20 @@ impl CustomError for OnceCell<Root<JsFunction>> {
         error.construct(cx, args)
     }
 
-    fn from_string<'a, C>(&self, cx: &mut C, message: String) -> JsResult<'a, JsObject>
+    fn from_string<'a, C>(&self, cx: &mut C, message: impl Into<String>) -> JsResult<'a, JsObject>
     where
         C: Context<'a>,
     {
-        let args = vec![cx.string(message).upcast()];
+        let args = vec![cx.string(message.into()).upcast()];
         self.construct(cx, args)
     }
 
     fn from_error<'a, C, E>(&self, cx: &mut C, err: E) -> JsResult<'a, JsObject>
     where
         C: Context<'a>,
-        E: std::fmt::Display,
+        E: std::error::Error,
     {
-        self.from_string(cx, format!("{}", err))
+        self.from_string(cx, format!("{:?}", err))
     }
 }
 

--- a/packages/test/src/test-native-connection.ts
+++ b/packages/test/src/test-native-connection.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { IllegalStateError, NativeConnection, Worker } from '@temporalio/worker';
+import { IllegalStateError, NativeConnection, TransportError, Worker } from '@temporalio/worker';
 import { RUN_INTEGRATION_TESTS } from './helpers';
 
 test('NativeConnection.connect() throws meaningful error when passed invalid address', async (t) => {
@@ -18,6 +18,13 @@ test('NativeConnection.connect() throws meaningful error when passed invalid cli
 });
 
 if (RUN_INTEGRATION_TESTS) {
+  test('NativeConnection errors have detail', async (t) => {
+    await t.throwsAsync(() => NativeConnection.connect({ address: 'localhost:1' }), {
+      instanceOf: TransportError,
+      message: /.*Connection refused.*/,
+    });
+  });
+
   test('NativeConnection.close() throws when called a second time', async (t) => {
     const conn = await NativeConnection.connect();
     await conn.close();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixed error reporting to use debug instead of display formatting, which was hiding detail. Also cleaned up error conversion code.

## Why?
Detail good.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
