### PR TITLE
feat(worker)!: Rename headers to metadata for `NativeConnection`

### DIFF
--- a/packages/core-bridge/index.d.ts
+++ b/packages/core-bridge/index.d.ts
@@ -42,6 +42,13 @@ export interface ClientOptions {
    * Optional retry options for server requests.
    */
   retry?: RetryOptions;
+
+  /**
+   * Optional mapping of gRPC metadata (HTTP headers) to send with each request to the server.
+   *
+   * Set statically at connection time, can be replaced later using {@link clientUpdateHeaders}.
+   */
+  metadata?: Record<string, string>;
 }
 
 /**

--- a/packages/core-bridge/src/lib.rs
+++ b/packages/core-bridge/src/lib.rs
@@ -576,13 +576,13 @@ fn client_new(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let callback = cx.argument::<JsFunction>(2)?;
 
     let client_options = opts.as_client_options(&mut cx)?;
-    let headers = match js_optional_getter!(&mut cx, &opts, "headers", JsObject) {
+    let headers = match js_optional_getter!(&mut cx, &opts, "metadata", JsObject) {
         None => None,
         Some(h) => Some(
             h.as_hash_map_of_string_to_string(&mut cx)
                 .map_err(|reason| {
                     cx.throw_type_error::<_, HashMap<String, String>>(format!(
-                        "Invalid headers: {}",
+                        "Invalid metadata: {}",
                         reason
                     ))
                     .unwrap_err()

--- a/packages/test/src/test-native-connection-headers.ts
+++ b/packages/test/src/test-native-connection-headers.ts
@@ -60,11 +60,11 @@ test('NativeConnection passes headers provided in options', async (t) => {
 
   const connection = await NativeConnection.connect({
     address: `127.0.0.1:${port}`,
-    headers: { initial: 'true' },
+    metadata: { initial: 'true' },
   });
   t.true(gotInitialHeader);
 
-  await connection.setHeaders({ update: 'true' });
+  await connection.setMetadata({ update: 'true' });
   // Create a worker so it starts polling for activities so we can check our mock server got the "update" header
   const worker = await Worker.create({
     connection,

--- a/packages/worker/src/connection-options.ts
+++ b/packages/worker/src/connection-options.ts
@@ -23,16 +23,16 @@ export interface NativeConnectionOptions {
   tls?: TLSConfig | boolean | null;
 
   /**
-   * HTTP headers to send with each gRPC request.
+   * Optional mapping of gRPC metadata (HTTP headers) to send with each request to the server.
    *
-   * Set statically at connection time, can be replaced later using {@link NativeConnection.setHeaders}.
+   * Set statically at connection time, can be replaced later using {@link NativeConnection.setMetadata}.
    */
-  headers?: Record<string, string>;
+  metadata?: Record<string, string>;
 }
 
-export type RequiredNativeConnectionOptions = Omit<Required<NativeConnectionOptions>, 'tls' | 'headers'> & {
+export type RequiredNativeConnectionOptions = Omit<Required<NativeConnectionOptions>, 'tls' | 'metadata'> & {
   tls?: NativeConnectionOptions['tls'];
-  headers?: NativeConnectionOptions['headers'];
+  metadata?: NativeConnectionOptions['metadata'];
   sdkVersion: string;
 };
 

--- a/packages/worker/src/connection.ts
+++ b/packages/worker/src/connection.ts
@@ -69,12 +69,12 @@ export class NativeConnection {
   }
 
   /**
-   * Set HTTP headers to be set in each gRPC request.
+   * Mapping of gRPC metadata (HTTP headers) to send with each request to the server.
    *
-   * Use {@link NativeConnectionOptions.headers} to set the initial headers for client creation.
+   * Use {@link NativeConnectionOptions.metadata} to set the initial metadata for client creation.
    */
-  async setHeaders(headers: Record<string, string>): Promise<void> {
-    await updateHeaders(this.nativeClient, headers);
+  async setMetadata(metadata: Record<string, string>): Promise<void> {
+    await updateHeaders(this.nativeClient, metadata);
   }
 }
 


### PR DESCRIPTION
To use the same term as `@temporalio/client.Connection`

BREAKING CHANGE:

- `NativeConnectionOptions.headers` was renamed to `NativeConnectionOptions.metadata`
- `NativeConnection.updateHeaders` was renamed to `NativeConnection.updateMetadata`