### PR TITLE
fix: Make docs /api page show all namespaces

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -125,20 +125,6 @@ module.exports = {
         watch,
       },
     ],
-    [
-      'docusaurus-plugin-typedoc',
-      {
-        id: 'teesting-docs',
-        entryPoints: ['../testing/src/index-for-docs.ts'],
-        tsconfig: '../testing/tsconfig.json',
-        excludePrivate: true,
-        excludeProtected: true,
-        hideGenerator: true,
-        disableSources: true,
-        readme: 'none',
-        watch,
-      },
-    ],
     ...(watch
       ? []
       : [

--- a/packages/meta/src/index.ts
+++ b/packages/meta/src/index.ts
@@ -5,3 +5,4 @@ export * as common from '@temporalio/common';
 export * as protobufs from '@temporalio/common/lib/protobufs';
 export * as workflow from '@temporalio/workflow';
 export * as activity from '@temporalio/activity';
+export * as testing from '@temporalio/testing';


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Currently https://typescript.temporal.io/api/ only has testing namespace:

![image](https://user-images.githubusercontent.com/1620265/174488232-064c3287-31a1-4657-aa4d-248691a285a5.png)

This is because we're using two instances of docusaurus-plugin-typedoc without using their [pattern for multiple instances](https://github.com/tgreyuk/typedoc-plugin-markdown/tree/master/packages/docusaurus-plugin-typedoc#multi-instance). I don't see why we don't just have one instance and pull in `testing`?

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
