### PR TITLE
chore: Add more build artifacts for debugging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           RUN_INTEGRATION_TESTS: ${{ startsWith(matrix.os, 'ubuntu') }}
 
       - uses: actions/upload-artifact@v3
-        if: ${{ cancelled() || failure() }}
+        if: ${{ failure() }}
         with:
           name: npm-logs
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,14 @@ jobs:
           # TODO: Run integration tests on MacOS / Windows probably using temporalite
           RUN_INTEGRATION_TESTS: ${{ startsWith(matrix.os, 'ubuntu') }}
 
+      - uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: npm-logs
+          path: |
+            ~/.npm/_logs/
+            C:\npm\cache\_logs\
+
       # Do docs stuff (only on one host)
       - name: Build docs
         if: ${{ matrix.docsTarget }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           RUN_INTEGRATION_TESTS: ${{ startsWith(matrix.os, 'ubuntu') }}
 
       - uses: actions/upload-artifact@v3
-        if: ${{ always() }}
+        if: ${{ cancelled() || failure() }}
         with:
           name: npm-logs
           path: |

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -54,11 +54,10 @@ jobs:
       - run: mkdir -p $TEMPORAL_TESTING_LOG_DIR/tails
       - run: mkdir -p $TEMPORAL_TESTING_MEM_LOG_DIR
       - run: 'timeout ${{ inputs.test-timeout-minutes }}m npm run ${{ inputs.test-type }}'
-      # Tail the logs and upload as artifact on cancel or failure
       - run: for f in $TEMPORAL_TESTING_LOG_DIR/*.log; do tail -20000 $f > $TEMPORAL_TESTING_LOG_DIR/tails/$(basename $f); done
-        if: ${{ cancelled() || failure() }}
+        if: ${{ always() }}
       - uses: actions/upload-artifact@v3
-        if: ${{ cancelled() || failure() }}
+        if: ${{ always() }}
         with:
           name: worker-logs
           path: ${{ env.TEMPORAL_TESTING_LOG_DIR }}/tails


### PR DESCRIPTION
- add npm logs for https://github.com/temporalio/sdk-typescript/issues/496#issuecomment-1166099476
- always upload nightly worker logs, so we have green output to compare to