### PR TITLE
refactor(workflow)!: Move TaskInfo to WorkflowInfo

### DIFF
--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -681,6 +681,8 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
       searchAttributes: {},
       workflowType: 'returnWorkflowInfo',
       workflowId,
+      historyLength: 3,
+      unsafe: { isReplaying: false },
     });
   });
 

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -100,6 +100,8 @@ if (RUN_INTEGRATION_TESTS) {
       memo: undefined,
       parent: undefined,
       searchAttributes: {},
+      historyLength: 3,
+      unsafe: { isReplaying: false },
     };
 
     t.deepEqual(recordedCalls, [

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -91,12 +91,12 @@ async function createWorkflow(
       taskTimeoutMs: 1000,
       taskQueue: 'test',
       searchAttributes: {},
+      historyLength: 3,
+      unsafe: { isReplaying: false },
     },
     randomnessSeed: Long.fromInt(1337).toBytes(),
     now: startTime,
     patches: [],
-    isReplaying: false,
-    historyLength: 3,
   })) as VMWorkflow;
   return workflow;
 }

--- a/packages/test/src/workflows/log-sink-tester.ts
+++ b/packages/test/src/workflows/log-sink-tester.ts
@@ -13,13 +13,17 @@ const { logger } = wf.proxySinks<LoggerSinks>();
 
 export async function logSinkTester(): Promise<void> {
   logger.info(
-    `Workflow execution started, replaying: ${wf.taskInfo().unsafe.isReplaying}, hl: ${wf.taskInfo().historyLength}`
+    `Workflow execution started, replaying: ${wf.workflowInfo().unsafe.isReplaying}, hl: ${
+      wf.workflowInfo().historyLength
+    }`
   );
   // We rely on the test to run with max cached workflows of 1.
   // Executing this child will flush the current workflow from the cache
   // causing replay or the first sink call.
   await wf.executeChild(successString);
   logger.info(
-    `Workflow execution completed, replaying: ${wf.taskInfo().unsafe.isReplaying}, hl: ${wf.taskInfo().historyLength}`
+    `Workflow execution completed, replaying: ${wf.workflowInfo().unsafe.isReplaying}, hl: ${
+      wf.workflowInfo().historyLength
+    }`
   );
 }

--- a/packages/worker/src/workflow/vm.ts
+++ b/packages/worker/src/workflow/vm.ts
@@ -76,7 +76,7 @@ export class VMWorkflowCreator implements WorkflowCreator {
    */
   async createWorkflow(options: WorkflowCreateOptions): Promise<Workflow> {
     const context = await this.getContext();
-    const activationContext = { isReplaying: options.isReplaying };
+    const activationContext = { isReplaying: options.info.unsafe.isReplaying };
     this.injectConsole(context, options.info, activationContext);
     const { hasSeparateMicrotaskQueue, isolateExecutionTimeoutMs } = this;
     const workflowModule: WorkflowModule = new Proxy(

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -24,6 +24,8 @@ export interface WorkflowInfo {
 
   /**
    * Indexed information attached to the Workflow Execution
+   *
+   * This value may change during the lifetime of an Execution.
    */
   searchAttributes: SearchAttributes;
 
@@ -48,6 +50,15 @@ export interface WorkflowInfo {
    * Failure from the previous Run (present when this Run is a retry, or the last Run of a Cron Workflow failed)
    */
   lastFailure?: TemporalFailure;
+
+  /**
+   * Length of Workflow history up until the current Workflow Task.
+   *
+   * This value changes during the lifetime of an Execution.
+   *
+   * You may safely use this information to decide when to {@link continueAsNew}.
+   */
+  historyLength: number;
 
   /**
    * Task queue this Workflow is executing on
@@ -114,6 +125,17 @@ export interface WorkflowInfo {
    * Milliseconds between Cron Runs
    */
   cronScheduleToScheduleInterval?: number;
+
+  unsafe: UnsafeWorkflowInfo;
+}
+
+/**
+ * Unsafe information about the current Workflow Execution.
+ *
+ * Never rely on this information in Workflow logic as it will cause non-deterministic behavior.
+ */
+export interface UnsafeWorkflowInfo {
+  isReplaying: boolean;
 }
 
 export interface ParentWorkflowInfo {

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -477,16 +477,6 @@ export class State {
   public info?: WorkflowInfo;
 
   /**
-   * Whether a Workflow is replaying history or processing new events
-   */
-  isReplaying?: boolean;
-
-  /**
-   * ID of last WorkflowTaskStarted event
-   */
-  historyLength?: number;
-
-  /**
    * A deterministic RNG, used by the isolate's overridden Math.random
    */
   public random: RNG = function () {

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -22,8 +22,6 @@ export interface WorkflowCreateOptions {
   randomnessSeed: number[];
   now: number;
   patches: string[];
-  isReplaying: boolean;
-  historyLength: number;
 }
 
 export interface ImportFunctions {
@@ -108,14 +106,7 @@ export function overrideGlobals(): void {
  *
  * Sets required internal state and instantiates the workflow and interceptors.
  */
-export async function initRuntime({
-  info,
-  randomnessSeed,
-  now,
-  patches,
-  isReplaying,
-  historyLength,
-}: WorkflowCreateOptions): Promise<void> {
+export async function initRuntime({ info, randomnessSeed, now, patches }: WorkflowCreateOptions): Promise<void> {
   const global = globalThis as any;
   // Set the runId globally on the context so it can be retrieved in the case
   // of an unhandled promise rejection.
@@ -129,9 +120,8 @@ export async function initRuntime({
   state.info = info;
   state.now = now;
   state.random = alea(randomnessSeed);
-  state.historyLength = historyLength;
 
-  if (isReplaying) {
+  if (info.unsafe.isReplaying) {
     for (const patch of patches) {
       state.knownPresentPatches.add(patch);
     }
@@ -193,8 +183,8 @@ export function activate(activation: coresdk.workflow_activation.WorkflowActivat
       if (activation.historyLength == null) {
         throw new TypeError('Got activation with no historyLength');
       }
-      state.isReplaying = activation.isReplaying ?? false;
-      state.historyLength = activation.historyLength;
+      state.info.unsafe.isReplaying = activation.isReplaying ?? false;
+      state.info.historyLength = activation.historyLength;
     }
 
     // Cast from the interface to the class which has the `variant` attribute.


### PR DESCRIPTION
We want Tasks to be as much of an implementation detail as possible so that normally devs don't have to know/think about them. 

Added note to `workflowInfo()` about recommended usage due to the fact that fields change (and which fields change will also change).