### PR TITLE
fix:(worker) use total_available_size to calculate maxCachedWorkflows

### DIFF
--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -2,6 +2,7 @@ import { DataConverter, LoadedDataConverter } from '@temporalio/common';
 import { loadDataConverter } from '@temporalio/internal-non-workflow-common';
 import { msToNumber } from '@temporalio/internal-workflow-common';
 import os from 'os';
+import v8 from 'v8';
 import { ActivityInboundLogInterceptor } from './activity-log-interceptor';
 import { NativeConnection } from './connection';
 import { WorkerInterceptors } from './interceptors';
@@ -172,7 +173,7 @@ export interface WorkerOptions {
    * You should be able to fit about 500 Workflows per GB of memory dependening on your Workflow bundle size.
    * For the SDK test Workflows, we managed to fit 750 Workflows per GB.
    *
-   * @default `max(os.totalmem() / 1GiB - 1, 1) * 200`
+   * @default `max(v8.getHeapStatistics().total_available_size / 1GiB - 1, 1) * 200`
    */
   maxCachedWorkflows?: number;
 
@@ -411,7 +412,7 @@ export function addDefaultWorkerOptions(options: WorkerOptions): WorkerOptionsWi
     // 4294967295ms is the maximum allowed time
     isolateExecutionTimeout: debugMode ? '4294967295ms' : '5s',
     workflowThreadPoolSize: 8,
-    maxCachedWorkflows: maxCachedWorkflows ?? Math.max(os.totalmem() / GiB - 1, 1) * 200,
+    maxCachedWorkflows: maxCachedWorkflows ?? Math.max(v8.getHeapStatistics().total_available_size / GiB - 1, 1) * 200,
     enableSDKTracing: false,
     debugMode: debugMode ?? false,
     interceptors: appendDefaultInterceptors({}),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Calculate default maxCachedWorkflows by `v8.getHeapStatistics()` instead of `os.totalmem()`

## Why?
When running in container, the os.totalmem() will get the host machine memory not container resource setting (which is in [cgroup](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/))

## issue
#762 