### PR TITLE
refactor!: Update activity and worker exports

### DIFF
--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -46,13 +46,14 @@
 import { msToNumber } from '@temporalio/internal-workflow-common';
 import { AbortSignal } from 'abort-controller';
 import { AsyncLocalStorage } from 'async_hooks';
-export { CancelledFailure } from '@temporalio/common';
+export { CancelledFailure, ApplicationFailure } from '@temporalio/common';
 export {
   ActivityFunction,
   ActivityInterface, // eslint-disable-line deprecation/deprecation
   UntypedActivities,
+  errorMessage,
+  errorCode,
 } from '@temporalio/internal-workflow-common';
-export * from '@temporalio/internal-workflow-common/lib/errors';
 
 /**
  * Throw this error from an Activity in order to make the Worker forget about this Activity.

--- a/packages/create-project/src/helpers/samples.ts
+++ b/packages/create-project/src/helpers/samples.ts
@@ -76,7 +76,13 @@ export async function checkForPackageJson({ username, name, branch, filePath }: 
 
   const fullUrl = contentsUrl + packagePath + `?ref=${branch}`;
 
-  if (!(await isUrlOk(fullUrl))) {
+  try {
+    const response = await got.head(fullUrl);
+    if (response.statusCode !== 200) {
+      throw response;
+    }
+  } catch (e) {
+    console.error(e);
     throw new Error(
       `Could not locate a package.json at ${chalk.red(
         `"${fullUrl}"`

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -53,7 +53,7 @@ module.exports = {
             },
             {
               label: 'Community Slack',
-              href: 'https://join.slack.com/t/temporalio/shared_invite/zt-onhti57l-J0bl~Tr7MqSUnIc1upjRkw',
+              href: 'https://temporal.io/slack',
             },
           ],
         },

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -40,7 +40,11 @@ module.exports = {
         {
           items: [
             {
-              label: 'NPM',
+              label: 'SDK Docs',
+              href: 'https://docs.temporal.io/typescript/introduction/',
+            },
+            {
+              label: 'npm',
               href: 'https://www.npmjs.com/package/temporalio',
             },
             {
@@ -48,21 +52,13 @@ module.exports = {
               href: 'https://community.temporal.io/',
             },
             {
-              label: 'Public Slack',
+              label: 'Community Slack',
               href: 'https://join.slack.com/t/temporalio/shared_invite/zt-onhti57l-J0bl~Tr7MqSUnIc1upjRkw',
-            },
-            {
-              label: 'Temporal Careers',
-              href: 'https://temporal.io/careers',
             },
           ],
         },
         {
           items: [
-            {
-              label: 'Temporal Documentation',
-              to: 'https://docs.temporal.io',
-            },
             {
               label: 'GitHub',
               href: 'https://github.com/temporalio/sdk-typescript',
@@ -74,6 +70,10 @@ module.exports = {
             {
               label: 'YouTube',
               href: 'https://www.youtube.com/channel/UCGovZyy8OfFPNlNV0i1fI1g',
+            },
+            {
+              label: 'Temporal Careers',
+              href: 'https://temporal.io/careers',
             },
           ],
         },

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -21,8 +21,10 @@ export {
   CompiledWorkerOptions,
   WorkerOptions,
   WorkflowBundleOption,
+  WorkflowBundlePathWithSourceMap,
   appendDefaultInterceptors,
   defaultSinks,
+  ReplayWorkerOptions,
 } from './worker-options';
 export { ActivityInboundLogInterceptor, activityLogAttributes } from './activity-log-interceptor';
 export { WorkflowInboundLogInterceptor, workflowLogAttributes } from './workflow-log-interceptor';


### PR DESCRIPTION
BREAKING CHANGE: If you were importing any of these from `@temporalio/activity`, instead import from `@temporalio/common`: `ValueError, PayloadConverterError, IllegalStateError, WorkflowExecutionAlreadyStartedError, WorkflowNotFoundError`