### PR TITLE
feat(common): Improve ApplicationFailure arguments; add create

### DIFF
--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -139,8 +139,8 @@ export class ApplicationFailure extends TemporalFailure {
    * @param details Optional details about the failure. Serialized by the Worker's {@link PayloadConverter}.
    */
   public static retryable(
-    message?: string | undefined | null,
-    type?: string | undefined | null,
+    message?: string | null,
+    type?: string | null,
     ...details: unknown[]
   ): ApplicationFailure {
     return new this(message, type ?? 'Error', false, details);

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -126,7 +126,7 @@ export class ApplicationFailure extends TemporalFailure {
    * By default, will be retryable (unless its `type` is included in {@link RetryPolicy.nonRetryableErrorTypes}).
    */
   public static create(options: ApplicationFailureOptions): ApplicationFailure {
-    const { message, type, nonRetryable = false, details, cause } = options ?? {};
+    const { message, type, nonRetryable = false, details, cause } = options;
     return new this(message, type, nonRetryable, details, cause);
   }
 

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -138,11 +138,7 @@ export class ApplicationFailure extends TemporalFailure {
    * @param type Optional error type (used by {@link RetryPolicy.nonRetryableErrorTypes})
    * @param details Optional details about the failure. Serialized by the Worker's {@link PayloadConverter}.
    */
-  public static retryable(
-    message?: string | null,
-    type?: string | null,
-    ...details: unknown[]
-  ): ApplicationFailure {
+  public static retryable(message?: string | null, type?: string | null, ...details: unknown[]): ApplicationFailure {
     return new this(message, type ?? 'Error', false, details);
   }
 
@@ -156,11 +152,7 @@ export class ApplicationFailure extends TemporalFailure {
    * @param type Optional error type
    * @param details Optional details about the failure. Serialized by the Worker's {@link PayloadConverter}.
    */
-  public static nonRetryable(
-    message?: string | null,
-    type?: string | null,
-    ...details: unknown[]
-  ): ApplicationFailure {
+  public static nonRetryable(message?: string | null, type?: string | null, ...details: unknown[]): ApplicationFailure {
     return new this(message, type ?? 'Error', true, details);
   }
 }

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -109,6 +109,11 @@ export class ApplicationFailure extends TemporalFailure {
     super(message, cause);
   }
 
+  /**
+   * Create a new `ApplicationFailure`.
+   *
+   * By default, will be retryable (unless its `type` is included in {@link RetryPolicy.nonRetryableErrorTypes}).
+   */
   public static create(options?: ApplicationFailureOptions): ApplicationFailure {
     const { message, type, nonRetryable = false, details, cause } = options ?? {};
     return new this(message, type, nonRetryable, details, cause);

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -157,8 +157,8 @@ export class ApplicationFailure extends TemporalFailure {
    * @param details Optional details about the failure. Serialized by the Worker's {@link PayloadConverter}.
    */
   public static nonRetryable(
-    message?: string | undefined | null,
-    type?: string | undefined | null,
+    message?: string | null,
+    type?: string | null,
     ...details: unknown[]
   ): ApplicationFailure {
     return new this(message, type ?? 'Error', true, details);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Fixes #752
```ts
ApplicationFailure.create({ cause })
```
- Makes fields optional and allows them to be `undefined | null`, so you can do:

```ts
new ApplicationFailure()
new ApplicationFailure(null, null, null, null, cause)
new ApplicationFailure(undefined, undefined, undefined, undefined, cause)
ApplicationFailure.retryable()
ApplicationFailure.retryable(null, null, ...details)
```

## Why?
<!-- Tell your future self why have you made these changes -->

DX

