### PR TITLE
test: Test ABANDONED child timer can be fast-forwarded

### DIFF
--- a/packages/test/src/workflows/testenv-test-workflows.ts
+++ b/packages/test/src/workflows/testenv-test-workflows.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert';
-import { sleep, proxyActivities, defineSignal, setHandler } from '@temporalio/workflow';
+import { sleep, proxyActivities, defineSignal, setHandler, startChild, ParentClosePolicy } from '@temporalio/workflow';
 
 // Export sleep to be invoked as a workflow
 export { sleep };
@@ -31,4 +31,12 @@ export async function waitOnSignalWithTimeout(): Promise<void> {
 
 export async function assertFromWorkflow(x: number): Promise<void> {
   assert.strictEqual(x, 7);
+}
+
+export async function asyncChildStarter(childWorkflowId: string): Promise<void> {
+  await startChild(sleep, {
+    args: ['1 day'],
+    workflowId: childWorkflowId,
+    parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON,
+  });
 }

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -24,7 +24,7 @@ import {
 } from '@temporalio/client';
 import { ActivityFunction, CancelledFailure } from '@temporalio/common';
 import { msToTs, tsToMs } from '@temporalio/common/lib/time';
-import { NativeConnection, Runtime } from '@temporalio/worker';
+import { NativeConnection, Runtime, appendDefaultInterceptors } from '@temporalio/worker';
 import {
   EphemeralServer,
   EphemeralServerConfig,


### PR DESCRIPTION
Tried to reproduce an issue reported in community slack and failed, might as well leave this test for reference.