### PR TITLE
fix: Allow `RetryPolicy.maximumAttempts: Number.POSITIVE_INFINITY`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,10 +193,11 @@ npx lerna version patch # or major|minor|etc, or leave out to be prompted. eithe
 npx lerna publish from-git # add `--dist-tag next` for pre-release versions
 ```
 
-- Cleanup:
+- Cleanup after publishing:
 
 ```sh
 rm $HOME/Downloads/packages-*
+rm packages/core-bridge/releases/
 ```
 
 ## Updating the Java test server proto files

--- a/packages/internal-workflow-common/src/retry-policy.ts
+++ b/packages/internal-workflow-common/src/retry-policy.ts
@@ -24,8 +24,6 @@ export interface RetryPolicy {
    * Maximum number of attempts. When exceeded, retries stop (even if {@link ActivityOptions.scheduleToCloseTimeout}
    * hasn't been reached).
    *
-   * `0` means Infinity (same as default)
-   *
    * @default Infinity
    */
   maximumAttempts?: number;
@@ -53,11 +51,13 @@ export function compileRetryPolicy(retryPolicy: RetryPolicy): temporal.api.commo
     throw new ValueError('RetryPolicy.backoffCoefficient must be greater than 0');
   }
   if (retryPolicy.maximumAttempts != null) {
-    if (retryPolicy.maximumAttempts < 0) {
-      throw new ValueError('RetryPolicy.maximumAttempts must be nonnegative');
-    }
-
-    if (!Number.isInteger(retryPolicy.maximumAttempts)) {
+    if (retryPolicy.maximumAttempts === Number.POSITIVE_INFINITY) {
+      // drop field (Infinity is the default)
+      const { maximumAttempts: _, ...without } = retryPolicy;
+      retryPolicy = without;
+    } else if (retryPolicy.maximumAttempts <= 0) {
+      throw new ValueError('RetryPolicy.maximumAttempts must be a positive integer');
+    } else if (!Number.isInteger(retryPolicy.maximumAttempts)) {
       throw new ValueError('RetryPolicy.maximumAttempts must be an integer');
     }
   }

--- a/packages/internal-workflow-common/src/retry-policy.ts
+++ b/packages/internal-workflow-common/src/retry-policy.ts
@@ -21,8 +21,11 @@ export interface RetryPolicy {
    */
   initialInterval?: string | number;
   /**
-   * Maximum number of attempts. When exceeded the retries stop even if not expired yet.
-   * @minimum 1
+   * Maximum number of attempts. When exceeded, retries stop (even if {@link ActivityOptions.scheduleToCloseTimeout}
+   * hasn't been reached).
+   *
+   * `0` means Infinity (same as default)
+   *
    * @default Infinity
    */
   maximumAttempts?: number;
@@ -50,8 +53,8 @@ export function compileRetryPolicy(retryPolicy: RetryPolicy): temporal.api.commo
     throw new ValueError('RetryPolicy.backoffCoefficient must be greater than 0');
   }
   if (retryPolicy.maximumAttempts != null) {
-    if (retryPolicy.maximumAttempts <= 0) {
-      throw new ValueError('RetryPolicy.maximumAttempts must be greater than 0');
+    if (retryPolicy.maximumAttempts < 0) {
+      throw new ValueError('RetryPolicy.maximumAttempts must be nonnegative');
     }
 
     if (!Number.isInteger(retryPolicy.maximumAttempts)) {

--- a/packages/test/src/test-retry-policy.ts
+++ b/packages/test/src/test-retry-policy.ts
@@ -35,10 +35,10 @@ test('compileRetryPolicy validates backoffCoefficient is greater than 0', (t) =>
   });
 });
 
-test('compileRetryPolicy validates maximumAttempts nonnegative', (t) => {
+test('compileRetryPolicy validates maximumAttempts is positive', (t) => {
   t.throws(() => compileRetryPolicy({ maximumAttempts: -1 }), {
     instanceOf: ValueError,
-    message: 'RetryPolicy.maximumAttempts must be nonnegative',
+    message: 'RetryPolicy.maximumAttempts must be a positive integer',
   });
 });
 
@@ -49,11 +49,8 @@ test('compileRetryPolicy validates maximumAttempts is an integer', (t) => {
   });
 });
 
-test('compileRetryPolicy validates maximumAttempts is not POSITIVE_INFINITY', (t) => {
-  t.throws(() => compileRetryPolicy({ maximumAttempts: Number.POSITIVE_INFINITY }), {
-    instanceOf: ValueError,
-    message: 'RetryPolicy.maximumAttempts must be an integer',
-  });
+test('compileRetryPolicy drops maximumAttempts when POSITIVE_INFINITY', (t) => {
+  t.deepEqual(compileRetryPolicy({ maximumAttempts: Number.POSITIVE_INFINITY }), compileRetryPolicy({}));
 });
 
 test('compileRetryPolicy defaults initialInterval to 1 second', (t) => {

--- a/packages/test/src/test-retry-policy.ts
+++ b/packages/test/src/test-retry-policy.ts
@@ -35,10 +35,10 @@ test('compileRetryPolicy validates backoffCoefficient is greater than 0', (t) =>
   });
 });
 
-test('compileRetryPolicy validates maximumAttempts greater than 0', (t) => {
-  t.throws(() => compileRetryPolicy({ maximumAttempts: 0 }), {
+test('compileRetryPolicy validates maximumAttempts nonnegative', (t) => {
+  t.throws(() => compileRetryPolicy({ maximumAttempts: -1 }), {
     instanceOf: ValueError,
-    message: 'RetryPolicy.maximumAttempts must be greater than 0',
+    message: 'RetryPolicy.maximumAttempts must be nonnegative',
   });
 });
 


### PR DESCRIPTION
Edit: Allow user to provide `maximumAttempts: Number.POSITIVE_INFINITY` and drop it, since it's the default.

---

In the changelog we suggest using 0 for Infinity, but are currently throwing when 0 is passed. 

![image](https://user-images.githubusercontent.com/251288/181361482-a0bc4051-0246-44d3-8721-bd6f26ce07ed.png)
