### PR TITLE
fix: Prevent ending a worker span twice

### DIFF
--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1126,7 +1126,7 @@ export class Worker {
                     const completion = await this.workflowCodecRunner.encodeCompletion(unencodedCompletion);
                     this.log.trace('Completed activation', workflowLogAttributes(state.info));
 
-                    span.setAttribute('close', close).end();
+                    span.setAttribute('close', close);
                     return { state, output: { close, completion, parentSpan } };
                   } catch (err) {
                     if (err instanceof errors.UnexpectedError) {


### PR DESCRIPTION
## What was changed
Remove a call to `end()` the `workflow.process` span in a worker.

## Why?
Since this span is coming from an `instrument` call, it will be guaranteed to end once the function given to instrument ends, so we should not call `end`.

Ending a span twice results in some logging that is undesirable in production scenarios ([see otel](https://github.com/open-telemetry/opentelemetry-js/blob/cfda625e83a164c9e19745392879c32aedcfe76f/packages/opentelemetry-sdk-trace-base/src/Span.ts#L239)).

## Checklist
Closes #781