### PR TITLE
feat(workflow): List registered queries in error response when a quer…

### DIFF
--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -611,6 +611,9 @@ export class WorkflowClient {
         },
       });
     } catch (err) {
+      if (isServerErrorResponse(err) && err.code === grpcStatus.INVALID_ARGUMENT) {
+        throw new QueryNotRegisteredError(err.message, err.code);
+      }
       this.rethrowGrpcError(err, input.workflowExecution, 'Failed to query Workflow');
     }
     if (response.queryRejected) {
@@ -935,6 +938,13 @@ export class QueryRejectedError extends Error {
   public readonly name: string = 'QueryRejectedError';
   constructor(public readonly status: temporal.api.enums.v1.WorkflowExecutionStatus) {
     super('Query rejected');
+  }
+}
+
+export class QueryNotRegisteredError extends Error {
+  public readonly name: string = 'QueryNotRegisteredError';
+  constructor(message: string, public readonly code: grpcStatus) {
+    super(message);
   }
 }
 

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -612,7 +612,7 @@ export class WorkflowClient {
       });
     } catch (err) {
       if (isServerErrorResponse(err) && err.code === grpcStatus.INVALID_ARGUMENT) {
-        throw new QueryNotRegisteredError(err.message, err.code);
+        throw new QueryNotRegisteredError(err.message.replace(/^3 INVALID_ARGUMENT: /, ''), err.code);
       }
       this.rethrowGrpcError(err, input.workflowExecution, 'Failed to query Workflow');
     }

--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -402,8 +402,7 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
     await workflow.result();
     await t.throwsAsync(workflow.query('not found'), {
       instanceOf: QueryNotRegisteredError,
-      message:
-        '3 INVALID_ARGUMENT: Workflow did not register a handler for not found. Registered queries: [__stack_trace isBlocked]',
+      message: 'Workflow did not register a handler for not found. Registered queries: [__stack_trace isBlocked]',
     });
   });
 

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -212,8 +212,11 @@ export class Activator implements ActivationHandler {
   protected queryWorkflowNextHandler({ queryName, args }: QueryInput): Promise<unknown> {
     const fn = state.queryHandlers.get(queryName);
     if (fn === undefined) {
+      const knownQueryTypes = [...state.queryHandlers.keys()].join(' ');
       // Fail the query
-      throw new ReferenceError(`Workflow did not register a handler for ${queryName}`);
+      throw new ReferenceError(
+        `Workflow did not register a handler for ${queryName}. Registered queries: [${knownQueryTypes}]`
+      );
     }
     try {
       const ret = fn(...args);


### PR DESCRIPTION
…y is not found

This is required by the UI to display available queries.
Eventually we should implement a `__get_handlers` internal query but this will do for now.