### PR TITLE
fix: Avoid using dynamic import in /testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7431,7 +7431,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
       "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -14808,17 +14807,6 @@
         "unzipper": "^0.10.11"
       }
     },
-    "packages/testing/node_modules/get-port": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
-      "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/worker": {
       "name": "@temporalio/worker",
       "version": "1.0.1",
@@ -17626,12 +17614,6 @@
         "protobufjs": "^7.0.0",
         "tar-stream": "^2.2.0",
         "unzipper": "^0.10.11"
-      },
-      "dependencies": {
-        "get-port": {
-          "version": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
-          "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw=="
-        }
       }
     },
     "@temporalio/worker": {
@@ -20776,8 +20758,7 @@
     "get-port": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-      "dev": true
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
     },
     "get-stream": {
       "version": "6.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14572,7 +14572,7 @@
     },
     "packages/activity": {
       "name": "@temporalio/activity",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@temporalio/common": "file:../common",
@@ -14582,7 +14582,7 @@
     },
     "packages/client": {
       "name": "@temporalio/client",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.6.7",
@@ -14597,7 +14597,7 @@
     },
     "packages/common": {
       "name": "@temporalio/common",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.0.3",
@@ -14609,7 +14609,7 @@
     },
     "packages/core-bridge": {
       "name": "@temporalio/core-bridge",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -14704,7 +14704,7 @@
     },
     "packages/interceptors-opentelemetry": {
       "name": "@temporalio/interceptors-opentelemetry",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -14719,7 +14719,7 @@
     },
     "packages/internal-non-workflow-common": {
       "name": "@temporalio/internal-non-workflow-common",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.0.3",
@@ -14729,7 +14729,7 @@
     },
     "packages/internal-workflow-common": {
       "name": "@temporalio/internal-workflow-common",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@temporalio/proto": "file:../proto",
@@ -14739,7 +14739,7 @@
     },
     "packages/meta": {
       "name": "temporalio",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@temporalio/activity": "file:../activity",
@@ -14757,7 +14757,7 @@
     },
     "packages/proto": {
       "name": "@temporalio/proto",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/long": "^4.0.2",
@@ -14767,7 +14767,7 @@
     },
     "packages/test": {
       "name": "@temporalio/test",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.29.2",
@@ -14789,7 +14789,7 @@
     },
     "packages/testing": {
       "name": "@temporalio/testing",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -14800,7 +14800,7 @@
         "@temporalio/worker": "file:../worker",
         "@types/long": "^4.0.2",
         "abort-controller": "^3.0.0",
-        "get-port": "^6.1.2",
+        "get-port": "^5.0.0",
         "got": "^12.1.0",
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
@@ -14821,7 +14821,7 @@
     },
     "packages/worker": {
       "name": "@temporalio/worker",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -14861,7 +14861,7 @@
     },
     "packages/workflow": {
       "name": "@temporalio/workflow",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@temporalio/common": "file:../common",
@@ -17620,7 +17620,7 @@
         "@temporalio/worker": "file:../worker",
         "@types/long": "^4.0.2",
         "abort-controller": "^3.0.0",
-        "get-port": "^6.1.2",
+        "get-port": "^5.0.0",
         "got": "^12.1.0",
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
@@ -17629,8 +17629,7 @@
       },
       "dependencies": {
         "get-port": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
+          "version": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
           "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw=="
         }
       }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -24,7 +24,7 @@
     "@temporalio/worker": "file:../worker",
     "@types/long": "^4.0.2",
     "abort-controller": "^3.0.0",
-    "get-port": "^6.1.2",
+    "get-port": "^5.0.0",
     "got": "^12.1.0",
     "long": "^5.2.0",
     "protobufjs": "^7.0.0",

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -24,7 +24,7 @@ import { AbortController } from 'abort-controller';
 import { ChildProcess, spawn, StdioOptions } from 'child_process';
 import events from 'events';
 import { kill, waitOnChild } from './child-process';
-import type getPortType from 'get-port';
+import getPort from 'get-port';
 import { Connection, TestService } from './test-service-client';
 
 const TEST_SERVER_EXECUTABLE_NAME = os.platform() === 'win32' ? 'test-server.exe' : 'test-server';
@@ -161,10 +161,6 @@ function addDefaults({
   };
 }
 
-// TS transforms `import` statements into `require`s, this is a workaround until
-// tsconfig module nodenext is stable.
-const _importDynamic = new Function('modulePath', 'return import(modulePath)');
-
 /**
  * An execution environment for running Workflow integration tests.
  *
@@ -209,8 +205,6 @@ export class TestWorkflowEnvironment {
    * Create a new test environment
    */
   static async create(opts?: TestWorkflowEnvironmentOptions): Promise<TestWorkflowEnvironment> {
-    // No, we're not going to compile this to ESM for one dependency
-    const getPort = (await _importDynamic('get-port')).default as typeof getPortType;
     const port = await getPort();
 
     const { testServerSpawner, logger } = addDefaults(opts ?? {});


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Removes use of dynamic import by downgrading to pre-ESM-only version of `get-port`.

## Why?

<!-- Tell your future self why have you made these changes -->

So that users don't have to support dynamic imports in their test build system.
