### PR TITLE
fix: Update `proto3-json-serializer` to `^1.0.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14602,7 +14602,7 @@
         "@opentelemetry/api": "^1.0.3",
         "@temporalio/internal-workflow-common": "file:../internal-workflow-common",
         "@temporalio/proto": "file:../proto",
-        "proto3-json-serializer": "^1.0.2",
+        "proto3-json-serializer": "^1.0.3",
         "protobufjs": "^7.0.0"
       }
     },
@@ -17468,7 +17468,7 @@
         "@opentelemetry/api": "^1.0.3",
         "@temporalio/internal-workflow-common": "file:../internal-workflow-common",
         "@temporalio/proto": "file:../proto",
-        "proto3-json-serializer": "^1.0.2",
+        "proto3-json-serializer": "^1.0.3",
         "protobufjs": "^7.0.0"
       }
     },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,7 +15,7 @@
     "@opentelemetry/api": "^1.0.3",
     "@temporalio/internal-workflow-common": "file:../internal-workflow-common",
     "@temporalio/proto": "file:../proto",
-    "proto3-json-serializer": "^1.0.2",
+    "proto3-json-serializer": "^1.0.3",
     "protobufjs": "^7.0.0"
   },
   "bugs": {


### PR DESCRIPTION
So that multiple versions of protobufjs aren't installed (1.0.2 used v6). Hopefully avoids this issue https://community.temporal.io/t/worker-error-with-mul-is-not-a-function/5573/13