### PR TITLE
fix: Help protobufjs find 'long' in Yarn PnP (#810)

### DIFF
--- a/packages/proto/protos/root.js
+++ b/packages/proto/protos/root.js
@@ -1,3 +1,9 @@
+// Workaround an issue that prevents protobufjs from loading 'long' in Yarn 3 PnP
+// https://github.com/protobufjs/protobuf.js/issues/1745#issuecomment-1200319399
+const $protobuf = require('protobufjs/light');
+$protobuf.util.Long = require('long');
+$protobuf.configure();
+
 const { patchProtobufRoot } = require('../lib/patch-protobuf-root');
 const unpatchedRoot = require('./json-module');
 module.exports = patchProtobufRoot(unpatchedRoot);

--- a/packages/testing/scripts/compile-proto.mjs
+++ b/packages/testing/scripts/compile-proto.mjs
@@ -47,6 +47,20 @@ async function compileProtos(protoPath, jsOutputFile, dtsOutputFile, ...args) {
   ];
   await promisify(pbjs.main)(pbjsArgs);
 
+  // Workaround an issue that prevents protobufjs from loading 'long' in Yarn 3 PnP
+  // https://github.com/protobufjs/protobuf.js/issues/1745#issuecomment-1200319399
+  const pbjsOutput = readFileSync(jsOutputFile, 'utf8');
+  writeFileSync(
+    jsOutputFile,
+    pbjsOutput.replace(
+      /(require\("protobufjs\/minimal"\);)$/m,
+      `$1
+       $protobuf.util.Long = require('long');
+       $protobuf.configure();
+    `
+    )
+  );
+
   console.log(`Creating protobuf TS definitions from ${protoPath}`);
   await promisify(pbts.main)(['--out', dtsOutputFile, jsOutputFile]);
 


### PR DESCRIPTION
## What was changed

Forcibly inject `long` into `protobufs` objects.

Reference: https://github.com/protobufjs/protobuf.js/issues/1745#issuecomment-1200319399

## Why?
`protobufjs/light` delegates loading of `long` to the `@protobufjs/inquire` package. Now, `@protobufjs/inquire` itself does not declare a dependency on long in its `package.json`.

This pattern works in most environment, thanks to the way traditional package managers lay out their `node_modules` directory, but is forbidden by Yarn 3 and PNPM, though the extend to which they goes in applying that restriction depend on various configuration item... Yarn 3's PnP is essentially the strictest of all.

In practice, that means that in some environement, `protobufjs` fails to load `long`. It fallbacks to create number objects that are very similar to the objects created by `long`, but without any method on them. This in turn cause an error message such as `TypeError: (seconds || long_1.default.UZERO).mul is not a function`.

## Checklist
1. Closes #810

2. How was this tested:
Verdaccio build on the hello world sample, reconfigured for Yarn 3 PnP.