### PR TITLE
fix(worker): Remove unnecessary `ReplayWorkerOptions`

### DIFF
--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -340,6 +340,11 @@ export interface ReplayWorkerOptions
     | 'maxHeartbeatThrottleInterval'
     | 'defaultHeartbeatThrottleInterval'
     | 'debugMode'
+    | 'enableNonLocalActivities'
+    | 'maxActivitiesPerSecond'
+    | 'maxTaskQueueActivitiesPerSecond'
+    | 'stickyQueueScheduleToStartTimeout'
+    | 'maxCachedWorkflows'
   > {
   /**
    *  A name for this replay worker. It will be combined with a short random ID to form a unique

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -546,7 +546,7 @@ export class Worker {
     if (compiledOptions.workflowsPath) {
       if (compiledOptions.workflowBundle) {
         throw new ValueError(
-          'You cannot set both WorkerOptions.workflowsPath and .workflowBundle: only one can be used.'
+          'You cannot set both WorkerOptions.workflowsPath and .workflowBundle: only one can be used'
         );
       }
 
@@ -563,9 +563,7 @@ export class Worker {
       return bundle;
     } else if (compiledOptions.workflowBundle) {
       if (compiledOptions.bundlerOptions) {
-        throw new ValueError(
-          `You cannot set both WorkerOptions.workflowBundle and .bundlerOptions: if you're providing the bundle, bundlerOptions are not used.`
-        );
+        throw new ValueError(`You cannot set both WorkerOptions.workflowBundle and .bundlerOptions`);
       }
 
       if (isCodeBundleOption(compiledOptions.workflowBundle)) {


### PR DESCRIPTION
Added the ones @cretz suggested as well as `stickyQueueScheduleToStartTimeout` and `maxCachedWorkflows`