### PR TITLE
fix(workflow)!: Make breakpoints work inside workflow isolate context

### DIFF
--- a/packages/test/src/test-bundler.ts
+++ b/packages/test/src/test-bundler.ts
@@ -37,14 +37,13 @@ if (RUN_INTEGRATION_TESTS) {
 
   test('Worker can be created from bundle path', async (t) => {
     const taskQueue = `${t.title}-${uuid4()}`;
-    const { code, sourceMap } = await bundleWorkflowCode({
+    const { code } = await bundleWorkflowCode({
       workflowsPath: require.resolve('./workflows'),
     });
     const uid = uuid4();
     const codePath = pathJoin(os.tmpdir(), `workflow-bundle-${uid}.js`);
-    const sourceMapPath = pathJoin(os.tmpdir(), `workflow-bundle-${uid}.map.js`);
-    await Promise.all([writeFile(codePath, code), writeFile(sourceMapPath, sourceMap)]);
-    const workflowBundle = { codePath, sourceMapPath };
+    await writeFile(codePath, code);
+    const workflowBundle = { codePath };
     const worker = await Worker.create({
       taskQueue,
       workflowBundle,

--- a/packages/test/src/test-local-activities.ts
+++ b/packages/test/src/test-local-activities.ts
@@ -1,6 +1,6 @@
 import { ApplicationFailure, defaultPayloadConverter, WorkflowClient, WorkflowFailedError } from '@temporalio/client';
 import { temporal } from '@temporalio/proto';
-import { bundleWorkflowCode, Worker, WorkflowBundleWithSourceMap } from '@temporalio/worker';
+import { bundleWorkflowCode, Worker, WorkflowBundle } from '@temporalio/worker';
 import { isCancellation } from '@temporalio/workflow';
 import anyTest, { TestInterface } from 'ava';
 import { firstValueFrom, Subject } from 'rxjs';
@@ -10,7 +10,7 @@ import { RUN_INTEGRATION_TESTS } from './helpers';
 import * as workflows from './workflows/local-activity-testers';
 
 interface Context {
-  workflowBundle: WorkflowBundleWithSourceMap;
+  workflowBundle: WorkflowBundle;
   taskQueue: string;
   client: WorkflowClient;
   getWorker: () => Promise<Worker>;

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -10,6 +10,7 @@ import { msToTs } from '@temporalio/internal-workflow-common';
 import { coresdk } from '@temporalio/proto';
 import { WorkflowCodeBundler } from '@temporalio/worker/lib/workflow/bundler';
 import { VMWorkflow, VMWorkflowCreator } from '@temporalio/worker/lib/workflow/vm';
+import { parseWorkflowCode } from '@temporalio/worker/lib/worker';
 import { WorkflowInfo } from '@temporalio/workflow';
 import anyTest, { ExecutionContext, TestInterface } from 'ava';
 import dedent from 'dedent';
@@ -46,8 +47,8 @@ const test = anyTest as TestInterface<Context>;
 test.before(async (t) => {
   const workflowsPath = path.join(__dirname, 'workflows');
   const bundler = new WorkflowCodeBundler({ workflowsPath });
-  const { code, sourceMap } = await bundler.createBundle();
-  t.context.workflowCreator = await TestVMWorkflowCreator.create(code, sourceMap, 100);
+  const workflowBundle = parseWorkflowCode((await bundler.createBundle()).code);
+  t.context.workflowCreator = await TestVMWorkflowCreator.create(workflowBundle, 100);
 });
 
 test.after.always(async (t) => {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -34,7 +34,7 @@ export {
   ReplayWorkerOptions,
   WorkerOptions,
   WorkflowBundleOption,
-  WorkflowBundlePathWithSourceMap,
+  WorkflowBundlePath,
 } from './worker-options';
 export { WorkflowInboundLogInterceptor, workflowLogAttributes } from './workflow-log-interceptor';
-export { BundleOptions, bundleWorkflowCode, WorkflowBundleWithSourceMap } from './workflow/bundler';
+export { BundleOptions, bundleWorkflowCode, WorkflowBundle } from './workflow/bundler';

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -9,26 +9,25 @@ import { Runtime } from './runtime';
 import { InjectedSinks } from './sinks';
 import { GiB } from './utils';
 import { LoggerSinks } from './workflow-log-interceptor';
-import { WorkflowBundleWithSourceMap } from './workflow/bundler';
+import { WorkflowBundle } from './workflow/bundler';
 import * as v8 from 'v8';
 import * as os from 'os';
 
 export type { WebpackConfiguration };
 
-export interface WorkflowBundlePathWithSourceMap {
+export interface WorkflowBundlePath {
   codePath: string;
-  sourceMapPath: string;
 }
-export type WorkflowBundleOption = WorkflowBundleWithSourceMap | WorkflowBundlePathWithSourceMap;
+export type WorkflowBundleOption = WorkflowBundle | WorkflowBundlePath;
 
-export function isCodeBundleOption(bundleOpt: WorkflowBundleOption): bundleOpt is WorkflowBundleWithSourceMap {
+export function isCodeBundleOption(bundleOpt: WorkflowBundleOption): bundleOpt is WorkflowBundle {
   const opt = bundleOpt as any; // Cast to access properties without TS complaining
-  return typeof opt.code === 'string' && typeof opt.sourceMap === 'string';
+  return typeof opt.code === 'string';
 }
 
-export function isPathBundleOption(bundleOpt: WorkflowBundleOption): bundleOpt is WorkflowBundlePathWithSourceMap {
+export function isPathBundleOption(bundleOpt: WorkflowBundleOption): bundleOpt is WorkflowBundlePath {
   const opt = bundleOpt as any; // Cast to access properties without TS complaining
-  return typeof opt.codePath === 'string' && opt.sourceMapPath;
+  return typeof opt.codePath === 'string';
 }
 
 /**

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1671,8 +1671,6 @@ export function parseWorkflowCode(code: string, codePath?: string): WorkflowBund
   }
 
   // Preloading the script makes breakpoints significantly more reliable and more responsive
-  // Keep these objects from GC long enough for debugger to complete parsing the source map and reporting locations
-  // to the node process. Otherwise, the debugger risks source mapping resolution errors, meaning breakings wont work.
   let script: vm.Script | undefined = new vm.Script(code, { filename });
   let context: any = vm.createContext({});
   try {
@@ -1680,6 +1678,9 @@ export function parseWorkflowCode(code: string, codePath?: string): WorkflowBund
   } catch (e) {
     // Context has not been properly configured, so eventual errors are possible. Just ignore at this point
   }
+
+  // Keep these objects from GC long enough for debugger to complete parsing the source map and reporting locations
+  // to the node process. Otherwise, the debugger risks source mapping resolution errors, meaning breakpoints wont work.
   setTimeout(() => {
     script = undefined;
     context = undefined;

--- a/packages/worker/src/workflow/threaded-vm.ts
+++ b/packages/worker/src/workflow/threaded-vm.ts
@@ -13,6 +13,7 @@ import { coresdk } from '@temporalio/proto';
 import { IllegalStateError, SinkCall } from '@temporalio/workflow';
 import { Worker as NodeWorker } from 'worker_threads';
 import { UnexpectedError } from '../errors';
+import { WorkflowBundleWithSourceMap } from '../worker';
 import { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interface';
 import { WorkerThreadInput, WorkerThreadRequest } from './workflow-worker-thread/input';
 import { WorkerThreadOutput, WorkerThreadResponse } from './workflow-worker-thread/output';
@@ -118,8 +119,7 @@ export class WorkerThreadClient {
 }
 
 export interface ThreadedVMWorkflowCreatorOptions {
-  code: string;
-  sourceMap: string;
+  workflowBundle: WorkflowBundleWithSourceMap;
   threadPoolSize: number;
   isolateExecutionTimeoutMs: number;
 }
@@ -137,15 +137,14 @@ export class ThreadedVMWorkflowCreator implements WorkflowCreator {
    */
   static async create({
     threadPoolSize,
-    code,
-    sourceMap,
+    workflowBundle,
     isolateExecutionTimeoutMs,
   }: ThreadedVMWorkflowCreatorOptions): Promise<ThreadedVMWorkflowCreator> {
     const workerThreadClients = Array(threadPoolSize)
       .fill(0)
       .map(() => new WorkerThreadClient(new NodeWorker(require.resolve('./workflow-worker-thread'))));
     await Promise.all(
-      workerThreadClients.map((client) => client.send({ type: 'init', code, sourceMap, isolateExecutionTimeoutMs }))
+      workerThreadClients.map((client) => client.send({ type: 'init', workflowBundle, isolateExecutionTimeoutMs }))
     );
     return new this(workerThreadClients);
   }

--- a/packages/worker/src/workflow/workflow-worker-thread.ts
+++ b/packages/worker/src/workflow/workflow-worker-thread.ts
@@ -30,7 +30,7 @@ setUnhandledRejectionHandler();
 async function handleRequest({ requestId, input }: WorkerThreadRequest): Promise<WorkerThreadResponse> {
   switch (input.type) {
     case 'init':
-      workflowCreator = await VMWorkflowCreator.create(input.code, input.sourceMap, input.isolateExecutionTimeoutMs);
+      workflowCreator = await VMWorkflowCreator.create(input.workflowBundle, input.isolateExecutionTimeoutMs);
       return ok(requestId);
     case 'destroy':
       await workflowCreator?.destroy();

--- a/packages/worker/src/workflow/workflow-worker-thread/input.ts
+++ b/packages/worker/src/workflow/workflow-worker-thread/input.ts
@@ -1,3 +1,4 @@
+import { WorkflowBundleWithSourceMap } from '../../worker';
 import { WorkflowCreateOptions } from '../interface';
 
 /**
@@ -6,8 +7,7 @@ import { WorkflowCreateOptions } from '../interface';
 export interface Init {
   type: 'init';
   isolateExecutionTimeoutMs: number;
-  code: string;
-  sourceMap: string;
+  workflowBundle: WorkflowBundleWithSourceMap;
 }
 
 /**


### PR DESCRIPTION
## Objective
Makes it possible to actually use breakpoints in workflow code.

## What was changed
- Use inline source maps
- Set script filename to be an absolute path, matching the original filename stored in the source map
- Make sure different workflow bundles get different filename
- Preload and cache the script object

## Checklist
1. Closes #795
2. How was this tested:
- Breakpoints during tests execution (vscode)
- Verdaccio build on local examples (vscode)
- Verdaccio build on local examples (chrome's debugger)

## Other notes
- Chrome's debugger don't know much about nodejs worker threads. It however works properly when running a worker in single thread mode (ie. `debugMode = true`)