### PR TITLE
fix: Warn instead of throwing when getting `workflowBundle` with `workflowsPath` and `bundlerOptions`.

### DIFF
--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -114,8 +114,9 @@ export interface WorkerOptions {
    *
    * See https://docs.temporal.io/typescript/production-deploy#pre-build-code for more information.
    *
-   * When using this option, any Workflow interceptors provided in {@link interceptors} are not used. Instead, provide
-   * them via {@link BundleOptions.workflowInterceptorModules} when calling {@link bundleWorkflowCode}.
+   * When using this option, {@link workflowsPath}, {@link bundlerOptions} and any Workflow interceptors modules
+   * provided in * {@link interceptors} are not used. To use workflow interceptors, pass them via
+   * {@link BundleOptions.workflowInterceptorModules} when calling {@link bundleWorkflowCode}.
    */
   workflowBundle?: WorkflowBundleOption;
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -33,7 +33,6 @@ import {
   optionalTsToMs,
   SearchAttributes,
   tsToMs,
-  ValueError,
 } from '@temporalio/internal-workflow-common';
 import { coresdk, temporal } from '@temporalio/proto';
 import { DeterminismViolationError, SinkCall, WorkflowInfo } from '@temporalio/workflow';
@@ -544,7 +543,7 @@ export class Worker {
       }
       if (compiledOptions.interceptors?.workflowModules) {
         logger.warn(
-          'Ignoring compiledOptions.interceptors?.workflowModules because WorkerOptions.workflowBundle is set.\n' +
+          'Ignoring WorkerOptions.interceptors.workflowModules because WorkerOptions.workflowBundle is set.\n' +
             'To use workflow interceptors with a workflowBundle, pass them in the call to bundleWorkflowCode.'
         );
       }

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -7,6 +7,7 @@ import * as unionfs from 'unionfs';
 import util from 'util';
 import webpack from 'webpack';
 import { DefaultLogger, Logger } from '../logger';
+import { toMB } from '../utils';
 
 export const allowedBuiltinModules = ['assert'];
 export const disallowedBuiltinModules = builtinModules.filter((module) => !allowedBuiltinModules.includes(module));
@@ -104,11 +105,14 @@ export class WorkflowCodeBundler {
 
     this.genEntrypoint(vol, entrypointPath);
     const bundleFilePath = await this.bundle(ufs, memoryFs, entrypointPath, distDir);
+    const code = memoryFs.readFileSync(bundleFilePath, 'utf8') as string;
+
+    this.logger.info('Workflow bundle created', { size: `${toMB(code.length)}MB` });
 
     // Cast because the type definitions are inaccurate
     return {
-      sourceMap: 'deprecated: this is no longer in use',
-      code: memoryFs.readFileSync(bundleFilePath, 'utf8') as string,
+      sourceMap: 'deprecated: this is no longer in use\n',
+      code,
     };
   }
 


### PR DESCRIPTION
NOTE: We now prefer taking the bundle over workflowsPath which is the correct behavior and what users *should* expect.

Also warning that workflow interceptors are ignored when using a bundle.