### PR TITLE
chore: Upgrade ubuntu CI runner `18.04 -> 22.04`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,9 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-18.04
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             rustflags: '-C linker=aarch64-linux-gnu-gcc'
           - os: macos-latest
@@ -145,7 +145,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
       - name: Print libc version
         run: ldd --version
-        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
       - name: Install gcc-aarch64-linux-gnu
         run: sudo apt update && sudo apt install -y gcc-aarch64-linux-gnu
         if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}


### PR DESCRIPTION
18.04 is deprecated, and outages start today: https://github.com/actions/runner-images/issues/6002