### PR TITLE
fix: Build `nyc-test-coverage` package, fixes #839

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@temporalio/interceptors-opentelemetry": "file:packages/interceptors-opentelemetry",
         "@temporalio/internal-non-workflow-common": "file:packages/internal-non-workflow-common",
         "@temporalio/internal-workflow-common": "file:packages/internal-workflow-common",
+        "@temporalio/nyc-test-coverage": "file:packages/nyc-test-coverage",
         "@temporalio/proto": "file:packages/proto",
         "@temporalio/test": "file:packages/test",
         "@temporalio/testing": "file:packages/testing",
@@ -3522,6 +3523,10 @@
       "resolved": "packages/internal-workflow-common",
       "link": true
     },
+    "node_modules/@temporalio/nyc-test-coverage": {
+      "resolved": "packages/nyc-test-coverage",
+      "link": true
+    },
     "node_modules/@temporalio/proto": {
       "resolved": "packages/proto",
       "link": true
@@ -3678,6 +3683,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+      "dev": true
     },
     "node_modules/@types/json-buffer": {
       "version": "3.0.0",
@@ -8629,6 +8640,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-worker": {
@@ -14764,6 +14783,18 @@
         "node": ">=14.0.0"
       }
     },
+    "packages/nyc-test-coverage": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@temporalio/worker": "file:../worker",
+        "@temporalio/workflow": "file:../workflow",
+        "istanbul-lib-coverage": "^3.2.0"
+      },
+      "devDependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.4"
+      }
+    },
     "packages/proto": {
       "name": "@temporalio/proto",
       "version": "1.1.0",
@@ -17674,6 +17705,15 @@
         "ms": "^2.1.3"
       }
     },
+    "@temporalio/nyc-test-coverage": {
+      "version": "file:packages/nyc-test-coverage",
+      "requires": {
+        "@temporalio/worker": "file:../worker",
+        "@temporalio/workflow": "file:../workflow",
+        "@types/istanbul-lib-coverage": "^2.0.4",
+        "istanbul-lib-coverage": "^3.2.0"
+      }
+    },
     "@temporalio/proto": {
       "version": "file:packages/proto",
       "requires": {
@@ -17905,6 +17945,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+      "dev": true
     },
     "@types/json-buffer": {
       "version": "3.0.0",
@@ -21679,6 +21725,11 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
+    },
+    "istanbul-lib-coverage": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw=="
     },
     "jest-worker": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@temporalio/testing": "file:packages/testing",
     "@temporalio/worker": "file:packages/worker",
     "@temporalio/workflow": "file:packages/workflow",
+    "@temporalio/nyc-test-coverage": "file:packages/nyc-test-coverage",
     "temporalio": "file:packages/meta"
   },
   "devDependencies": {

--- a/packages/nyc-test-coverage/package.json
+++ b/packages/nyc-test-coverage/package.json
@@ -20,6 +20,9 @@
     "lib",
     "src"
   ],
+  "scripts": {
+    "build": "tsc --build"
+  },
   "dependencies": {
     "@temporalio/worker": "file:../worker",
     "@temporalio/workflow": "file:../workflow",

--- a/packages/nyc-test-coverage/package.json
+++ b/packages/nyc-test-coverage/package.json
@@ -2,16 +2,24 @@
   "name": "@temporalio/nyc-test-coverage",
   "version": "1.1.0",
   "description": "Temporal.io SDK code coverage integration",
-  "main": "lib/index.js",
-  "types": "./lib/index.d.ts",
   "keywords": [
     "temporal",
     "workflow",
     "testing",
     "coverage"
   ],
-  "author": "Temporal Technologies Inc. <sdk@temporal.io>",
+  "homepage": "https://github.com/temporalio/sdk-typescript/tree/main/packages/testing",
+  "bugs": {
+    "url": "https://github.com/temporalio/sdk-typescript/issues"
+  },
   "license": "MIT",
+  "author": "Temporal Technologies Inc. <sdk@temporal.io>",
+  "main": "lib/index.js",
+  "types": "./lib/index.d.ts",
+  "files": [
+    "lib",
+    "src"
+  ],
   "dependencies": {
     "@temporalio/worker": "file:../worker",
     "@temporalio/workflow": "file:../workflow",
@@ -20,14 +28,6 @@
   "devDependencies": {
     "@types/istanbul-lib-coverage": "^2.0.4"
   },
-  "bugs": {
-    "url": "https://github.com/temporalio/sdk-typescript/issues"
-  },
-  "homepage": "https://github.com/temporalio/sdk-typescript/tree/main/packages/testing",
-  "files": [
-    "lib",
-    "src"
-  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/nyc-test-coverage/package.json
+++ b/packages/nyc-test-coverage/package.json
@@ -8,9 +8,6 @@
     "testing",
     "coverage"
   ],
-  "scripts": {
-    "build": "tsc --build"
-  },
   "homepage": "https://github.com/temporalio/sdk-typescript/tree/main/packages/testing",
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"

--- a/packages/nyc-test-coverage/package.json
+++ b/packages/nyc-test-coverage/package.json
@@ -8,6 +8,9 @@
     "testing",
     "coverage"
   ],
+  "scripts": {
+    "build": "tsc --build"
+  },
   "homepage": "https://github.com/temporalio/sdk-typescript/tree/main/packages/testing",
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"
@@ -20,9 +23,6 @@
     "lib",
     "src"
   ],
-  "scripts": {
-    "build": "tsc --build"
-  },
   "dependencies": {
     "@temporalio/worker": "file:../worker",
     "@temporalio/workflow": "file:../workflow",

--- a/packages/nyc-test-coverage/tsconfig.json
+++ b/packages/nyc-test-coverage/tsconfig.json
@@ -4,6 +4,13 @@
     "outDir": "./lib",
     "rootDir": "./src"
   },
-  "references": [{ "path": "../worker" }, { "path": "../workflow" }],
+  "references": [
+    { "path": "../workflow" },
+    { "path": "../activity" },
+    { "path": "../common" },
+    { "path": "../internal-workflow-common" },
+    { "path": "../internal-non-workflow-common" },
+    { "path": "../proto" }
+  ],
   "include": ["./src/**/*.ts"]
 }

--- a/packages/nyc-test-coverage/tsconfig.json
+++ b/packages/nyc-test-coverage/tsconfig.json
@@ -4,13 +4,6 @@
     "outDir": "./lib",
     "rootDir": "./src"
   },
-  "references": [
-    { "path": "../workflow" },
-    { "path": "../activity" },
-    { "path": "../common" },
-    { "path": "../internal-workflow-common" },
-    { "path": "../internal-non-workflow-common" },
-    { "path": "../proto" }
-  ],
+  "references": [{ "path": "../worker" }, { "path": "../workflow" }],
   "include": ["./src/**/*.ts"]
 }

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -16,7 +16,8 @@
     { "path": "../interceptors-opentelemetry" },
     { "path": "../testing" },
     { "path": "../worker" },
-    { "path": "../workflow" }
+    { "path": "../workflow" },
+    { "path": "../nyc-test-coverage" }
   ],
   "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
#839

When I added `    "build": "tsc --build",` to nyc package.json, I got this:

![image](https://user-images.githubusercontent.com/251288/186064596-45f0fc9a-4fb9-4d07-b03d-93ace92df7e1.png)

hence adding to `/test/tsconfig.json` instead.