### PR TITLE
fix(client): Only require `signalArgs` when needed

### DIFF
--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -409,15 +409,15 @@ export class WorkflowClient {
   }
 
   /**
-   * Sends a signal to a running Workflow or starts a new one if not already running and immediately signals it.
-   * Useful when you're unsure of the Workflows' run state.
+   * Sends a Signal to a running Workflow or starts a new one if not already running and immediately Signals it.
+   * Useful when you're unsure whether the Workflow has been started.
    *
-   * @returns a WorkflowHandle to the started Workflow
+   * @returns a {@link WorkflowHandle} to the started Workflow
    */
-  public async signalWithStart<T extends Workflow, SA extends any[] = []>(
-    workflowTypeOrFunc: string | T,
-    options: WithWorkflowArgs<T, WorkflowSignalWithStartOptions<SA>>
-  ): Promise<WorkflowHandleWithSignaledRunId<T>> {
+  public async signalWithStart<WorkflowFn extends Workflow, SignalArgs extends any[] = []>(
+    workflowTypeOrFunc: string | WorkflowFn,
+    options: WithWorkflowArgs<WorkflowFn, WorkflowSignalWithStartOptions<SignalArgs>>
+  ): Promise<WorkflowHandleWithSignaledRunId<WorkflowFn>> {
     const { workflowId } = options;
     const interceptors = (this.options.interceptors.calls ?? []).map((ctor) => ctor({ workflowId }));
     const runId = await this._signalWithStart(workflowTypeOrFunc, options, interceptors);
@@ -430,7 +430,7 @@ export class WorkflowClient {
       runIdForResult: runId,
       interceptors,
       followRuns: options.followRuns ?? true,
-    }) as WorkflowHandleWithSignaledRunId<T>; // Cast is safe because we know we add the signaledRunId below
+    }) as WorkflowHandleWithSignaledRunId<WorkflowFn>; // Cast is safe because we know we add the signaledRunId below
     (handle as any) /* readonly */.signaledRunId = runId;
     return handle;
   }

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -377,7 +377,7 @@ export class WorkflowClient {
       headers: {},
       workflowType,
       signalName: typeof signal === 'string' ? signal : signal.name,
-      signalArgs,
+      signalArgs: signalArgs ?? [],
     });
   }
 

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -37,15 +37,26 @@ export interface WorkflowOptions extends CommonWorkflowOptions {
   followRuns?: boolean;
 }
 
-export interface WorkflowSignalWithStartOptions<SA extends any[] = []> extends WorkflowOptions {
+export type WorkflowSignalWithStartOptions<SignalArgs extends any[] = []> = SignalArgs extends []
+  ? WorkflowSignalWithStartOptionsWithoutArgs
+  : WorkflowSignalWithStartOptionsWithArgs<SignalArgs>;
+
+export interface WorkflowSignalWithStartOptionsWithoutArgs extends WorkflowOptions {
   /**
    * SignalDefinition or name of signal
    */
-  signal: SignalDefinition<SA> | string;
+  signal: SignalDefinition | string;
+}
+
+export interface WorkflowSignalWithStartOptionsWithArgs<SignalArgs extends any[]> extends WorkflowOptions {
+  /**
+   * SignalDefinition or name of signal
+   */
+  signal: SignalDefinition<SignalArgs> | string;
   /**
    * Arguments to invoke the signal handler with
    */
-  signalArgs: SA;
+  signalArgs: SignalArgs;
 }
 
 // export interface WorkflowOptionsWithDefaults<T extends Workflow> extends CommonWorkflowOptionsWithDefaults<T> {

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -37,9 +37,9 @@ export interface WorkflowOptions extends CommonWorkflowOptions {
   followRuns?: boolean;
 }
 
-export type WorkflowSignalWithStartOptions<SignalArgs extends any[] = []> = SignalArgs extends []
-  ? WorkflowSignalWithStartOptionsWithoutArgs
-  : WorkflowSignalWithStartOptionsWithArgs<SignalArgs>;
+export type WorkflowSignalWithStartOptions<SignalArgs extends any[] = []> = SignalArgs extends [any, ...any[]]
+  ? WorkflowSignalWithStartOptionsWithArgs<SignalArgs>
+  : WorkflowSignalWithStartOptionsWithoutArgs;
 
 export interface WorkflowSignalWithStartOptionsWithoutArgs extends WorkflowOptions {
   /**

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -39,13 +39,18 @@ export interface WorkflowOptions extends CommonWorkflowOptions {
 
 export type WorkflowSignalWithStartOptions<SignalArgs extends any[] = []> = SignalArgs extends [any, ...any[]]
   ? WorkflowSignalWithStartOptionsWithArgs<SignalArgs>
-  : WorkflowSignalWithStartOptionsWithoutArgs;
+  : WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs>;
 
-export interface WorkflowSignalWithStartOptionsWithoutArgs extends WorkflowOptions {
+export interface WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs extends any[]> extends WorkflowOptions {
   /**
    * SignalDefinition or name of signal
    */
   signal: SignalDefinition | string;
+
+  /**
+   * Arguments to invoke the signal handler with
+   */
+  signalArgs?: SignalArgs;
 }
 
 export interface WorkflowSignalWithStartOptionsWithArgs<SignalArgs extends any[]> extends WorkflowOptions {
@@ -53,6 +58,7 @@ export interface WorkflowSignalWithStartOptionsWithArgs<SignalArgs extends any[]
    * SignalDefinition or name of signal
    */
   signal: SignalDefinition<SignalArgs> | string;
+
   /**
    * Arguments to invoke the signal handler with
    */

--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -1090,7 +1090,6 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
       taskQueue: 'test',
       workflowId,
       signal: 'unblock',
-      signalArgs: [],
     });
     const handleFromGet = client.getHandle(workflowId);
     await t.throwsAsync(handleFromGet.result(), { message: /.*/ });


### PR DESCRIPTION
when calling `signalWithStart` 