### PR TITLE
feat: Delete search attributes with empty array values in describe() response

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           repository: temporalio/docker-compose
           path: docker-compose
-          ref: v1.17.5 # TODO: Upgrade to 1.18 - has a bug where search attributes are not deleted
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
 
       - name: Start Temporal Server

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -877,10 +877,14 @@ export class WorkflowClient {
           executionTime: optionalTsToDate(raw.workflowExecutionInfo!.executionTime),
           closeTime: optionalTsToDate(raw.workflowExecutionInfo!.closeTime),
           memo: await decodeMapFromPayloads(this.client.dataConverter, raw.workflowExecutionInfo!.memo?.fields),
-          searchAttributes: mapFromPayloads(
-            searchAttributePayloadConverter,
-            raw.workflowExecutionInfo!.searchAttributes?.indexedFields ?? {}
-          ) as SearchAttributes,
+          searchAttributes: Object.fromEntries(
+            Object.entries(
+              mapFromPayloads(
+                searchAttributePayloadConverter,
+                raw.workflowExecutionInfo!.searchAttributes?.indexedFields ?? {}
+              ) as SearchAttributes
+            ).filter(([_, v]) => v && v.length > 0) // Filter out empty arrays returned by pre 1.18 servers
+          ),
           parentExecution: raw.workflowExecutionInfo?.parentExecution
             ? {
                 workflowId: raw.workflowExecutionInfo.parentExecution.workflowId!,

--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -668,7 +668,6 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
     const { BinaryChecksums, ...rest } = searchAttributes;
     t.deepEqual(rest, {
       CustomBoolField: [true],
-      CustomIntField: [], // clear
       CustomKeywordField: ['durable code'],
       CustomTextField: ['is useful'],
       CustomDatetimeField: [date],


### PR DESCRIPTION
As of 1.18 the server deletes search attributes with empty array values, mimic that behavior when getting the `describe` response from older servers and update CI to use 1.18.