### PR TITLE
feat(client)!: Make client gRPC retry more configurable

### DIFF
--- a/packages/test/src/test-client-connection.ts
+++ b/packages/test/src/test-client-connection.ts
@@ -3,26 +3,30 @@ import util from 'util';
 import path from 'path';
 import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
-import { Connection } from '@temporalio/client';
+import { Connection, defaultGrpcRetryOptions, makeGrpcRetryInterceptor } from '@temporalio/client';
 import pkg from '@temporalio/client/lib/pkg';
 import { temporal, grpc as grpcProto } from '@temporalio/proto';
 
-test('withMetadata / withDeadline set the CallContext for RPC call', async (t) => {
-  const packageDefinition = protoLoader.loadSync(
-    path.resolve(
-      __dirname,
-      '../../core-bridge/sdk-core/protos/api_upstream/temporal/api/workflowservice/v1/service.proto'
-    ),
-    { includeDirs: [path.resolve(__dirname, '../../core-bridge/sdk-core/protos/api_upstream')] }
-  );
-  const protoDescriptor = grpc.loadPackageDefinition(packageDefinition) as any;
+const workflowServicePackageDefinition = protoLoader.loadSync(
+  path.resolve(
+    __dirname,
+    '../../core-bridge/sdk-core/protos/api_upstream/temporal/api/workflowservice/v1/service.proto'
+  ),
+  { includeDirs: [path.resolve(__dirname, '../../core-bridge/sdk-core/protos/api_upstream')] }
+);
+const workflowServiceProtoDescriptor = grpc.loadPackageDefinition(workflowServicePackageDefinition) as any;
 
+async function bindLocalhost(server: grpc.Server): Promise<number> {
+  return await util.promisify(server.bindAsync.bind(server))('127.0.0.1:0', grpc.ServerCredentials.createInsecure());
+}
+
+test('withMetadata / withDeadline set the CallContext for RPC call', async (t) => {
   const server = new grpc.Server();
   let gotTestHeaders = false;
   let gotDeadline = false;
   const deadline = Date.now() + 10000;
 
-  server.addService(protoDescriptor.temporal.api.workflowservice.v1.WorkflowService.service, {
+  server.addService(workflowServiceProtoDescriptor.temporal.api.workflowservice.v1.WorkflowService.service, {
     registerNamespace(
       call: grpc.ServerUnaryCall<
         temporal.api.workflowservice.v1.IRegisterNamespaceRequest,
@@ -52,10 +56,7 @@ test('withMetadata / withDeadline set the CallContext for RPC call', async (t) =
       callback(null, {});
     },
   });
-  const port = await util.promisify(server.bindAsync.bind(server))(
-    '127.0.0.1:0',
-    grpc.ServerCredentials.createInsecure()
-  );
+  const port = await bindLocalhost(server);
   server.start();
   const conn = await Connection.connect({ address: `127.0.0.1:${port}`, metadata: { staticKey: 'set' } });
   await conn.withMetadata({ test: 'true' }, () =>
@@ -88,12 +89,75 @@ test('healthService works', async (t) => {
       );
     },
   });
-  const port = await util.promisify(server.bindAsync.bind(server))(
-    '127.0.0.1:0',
-    grpc.ServerCredentials.createInsecure()
-  );
+  const port = await bindLocalhost(server);
   server.start();
   const conn = await Connection.connect({ address: `127.0.0.1:${port}` });
   const response = await conn.healthService.check({});
   t.is(response.status, grpcProto.health.v1.HealthCheckResponse.ServingStatus.SERVING);
+});
+
+test('grpc retry passes request and headers on retry, propagates responses', async (t) => {
+  let attempt = 0;
+  let successAttempt = 3;
+
+  const meta = Array<string>();
+  const namespaces = Array<string>();
+
+  const server = new grpc.Server();
+
+  server.addService(workflowServiceProtoDescriptor.temporal.api.workflowservice.v1.WorkflowService.service, {
+    describeWorkflowExecution(
+      call: grpc.ServerUnaryCall<
+        temporal.api.workflowservice.v1.IDescribeWorkflowExecutionRequest,
+        temporal.api.workflowservice.v1.IDescribeWorkflowExecutionResponse
+      >,
+      callback: grpc.sendUnaryData<temporal.api.workflowservice.v1.IRegisterNamespaceResponse>
+    ) {
+      const { namespace } = call.request;
+      if (typeof namespace === 'string') {
+        namespaces.push(namespace);
+      }
+      const [aValue] = call.metadata.get('a');
+      if (typeof aValue === 'string') {
+        meta.push(aValue);
+      }
+
+      attempt++;
+      if (attempt < successAttempt) {
+        callback({ code: grpc.status.UNKNOWN });
+        return;
+      }
+      const response: temporal.api.workflowservice.v1.IDescribeWorkflowExecutionResponse = {
+        workflowExecutionInfo: { execution: { workflowId: 'test' } },
+      };
+      callback(null, response);
+    },
+  });
+  const port = await bindLocalhost(server);
+  server.start();
+
+  // Default interceptor config with backoff factor of 1 to speed things up
+  const interceptor = makeGrpcRetryInterceptor(defaultGrpcRetryOptions({ factor: 1 }));
+  const conn = await Connection.connect({
+    address: `127.0.0.1:${port}`,
+    metadata: { a: 'bc' },
+    interceptors: [interceptor],
+  });
+  const response = await conn.workflowService.describeWorkflowExecution({ namespace: 'a' });
+  // Check that response is sent correctly
+  t.is(response.workflowExecutionInfo?.execution?.workflowId, 'test');
+  t.is(attempt, 3);
+  // Check that request is sent correctly in each attempt
+  t.deepEqual(namespaces, ['a', 'a', 'a']);
+  // Check that metadata is sent correctly in each attempt
+  t.deepEqual(meta, ['bc', 'bc', 'bc']);
+
+  // Reset and rerun expecting error in the response
+  attempt = 0;
+  successAttempt = 11; // never
+
+  await t.throwsAsync(() => conn.workflowService.describeWorkflowExecution({ namespace: 'a' }), {
+    message: '2 UNKNOWN: Unknown Error',
+  });
+  t.is(attempt, 10);
 });


### PR DESCRIPTION
Also backs off more on RESOURCE_EXHAUSTED errors (https://github.com/temporalio/sdk-features/issues/96)

Technically a breaking change but affects only really advanced options.