### PR TITLE
Bunch of small stuff

### DIFF
--- a/packages/client/src/grpc-retry.ts
+++ b/packages/client/src/grpc-retry.ts
@@ -1,6 +1,9 @@
 import { InterceptingCall, Interceptor, ListenerBuilder, RequesterBuilder, StatusObject } from '@grpc/grpc-js';
 import * as grpc from '@grpc/grpc-js';
 
+/**
+ * @experimental
+ */
 export interface GrpcRetryOptions {
   /**
    * A function which accepts the current retry attempt (starts at 1) and returns the millisecond
@@ -16,6 +19,8 @@ export interface GrpcRetryOptions {
 
 /**
  * Options for the backoff formula: `factor ^ attempt * initialIntervalMs(status) * jitter(maxJitter)`
+ *
+ * @experimental
  */
 export interface BackoffOptions {
   /**
@@ -74,6 +79,8 @@ function withDefaultBackoffOptions({
 
 /**
  * Generates the default retry behavior based on given backoff options
+ *
+ * @experimental
  */
 export function defaultGrpcRetryOptions(options: Partial<BackoffOptions> = {}): GrpcRetryOptions {
   const { maxAttempts, factor, maxJitter, initialIntervalMs, maxIntervalMs } = withDefaultBackoffOptions(options);
@@ -125,6 +132,8 @@ function defaultInitialIntervalMs({ code }: StatusObject) {
  * Returns a GRPC interceptor that will perform automatic retries for some types of failed calls
  *
  * @param retryOptions Options for the retry interceptor
+ *
+ * @experimental
  */
 export function makeGrpcRetryInterceptor(retryOptions: GrpcRetryOptions): Interceptor {
   return (options, nextCall) => {

--- a/packages/common/src/converter/failure-converter.ts
+++ b/packages/common/src/converter/failure-converter.ts
@@ -190,9 +190,6 @@ export class DefaultFailureConverter implements FailureConverter {
   }
 
   failureToError(failure: ProtoFailure): TemporalFailure {
-    const err = this.failureToErrorInner(failure);
-    err.stack = failure.stackTrace ?? '';
-    err.failure = failure;
     if (failure.encodedAttributes) {
       const attrs = this.options.payloadConverter.fromPayload<DefaultEncodedFailureAttributes>(
         failure.encodedAttributes
@@ -200,14 +197,19 @@ export class DefaultFailureConverter implements FailureConverter {
       // Don't apply encodedAttributes unless they conform to an expected schema
       if (typeof attrs === 'object' && attrs !== null) {
         const { message, stack_trace } = attrs;
+        // Avoid mutating the argument
+        failure = { ...failure };
         if (typeof message === 'string') {
-          err.message = message;
+          failure.message = message;
         }
         if (typeof stack_trace === 'string') {
-          err.stack = stack_trace;
+          failure.stackTrace = stack_trace;
         }
       }
     }
+    const err = this.failureToErrorInner(failure);
+    err.stack = failure.stackTrace ?? '';
+    err.failure = failure;
     return err;
   }
 

--- a/packages/core-bridge/Cargo.lock
+++ b/packages/core-bridge/Cargo.lock
@@ -431,16 +431,6 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
-dependencies = [
- "cfg-if",
- "num_cpus",
-]
-
-[[package]]
-name = "dashmap"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8858831f7781322e539ea39e72449c46b059638250c14344fec8d0aa6e539c"
@@ -747,11 +737,12 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19775995ee20209163239355bc3ad2f33f83da35d9ef72dea26e5af753552c87"
+checksum = "de1b4626e87b9eb1d603ed23067ba1e29ec1d0b35325a2b96c3fe1cf20871f56"
 dependencies = [
- "dashmap 5.2.0",
+ "cfg-if",
+ "dashmap",
  "futures",
  "futures-timer",
  "no-std-compat",
@@ -777,7 +768,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util",
  "tracing",
 ]
 
@@ -794,15 +785,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -1027,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
@@ -1306,54 +1288,93 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
 dependencies = [
- "async-trait",
- "crossbeam-channel",
- "dashmap 4.0.2",
- "fnv",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "js-sys",
- "lazy_static",
- "percent-encoding",
- "pin-project",
- "rand",
- "thiserror",
- "tokio",
- "tokio-stream",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1a6ca9de4c8b00aa7f1a153bd76cb263287155cec642680d79d98706f3d28a"
+checksum = "d1c928609d087790fc936a1067bdc310ae702bdf3b090c3f281b713622c8bbde"
 dependencies = [
  "async-trait",
  "futures",
  "futures-util",
  "http",
- "opentelemetry 0.17.0",
- "prost 0.9.0",
+ "opentelemetry 0.18.0",
+ "opentelemetry-proto",
+ "prost",
  "thiserror",
  "tokio",
- "tonic 0.6.2",
- "tonic-build 0.6.2",
+ "tonic",
 ]
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9328977e479cebe12ce0d3fcecdaea4721d234895a9440c5b5dfd113f0594ac6"
+checksum = "06c3d833835a53cf91331d2cfb27e9121f5a95261f31f08a1f79ab31688b8da8"
 dependencies = [
- "opentelemetry 0.17.0",
+ "opentelemetry 0.18.0",
  "prometheus",
  "protobuf",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61a2f56df5574508dd86aaca016c917489e589ece4141df1b5e349af8d66c28"
+dependencies = [
+ "futures",
+ "futures-util",
+ "opentelemetry 0.18.0",
+ "prost",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
+dependencies = [
+ "fnv",
+ "futures-channel",
+ "futures-util",
+ "indexmap",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "dashmap",
+ "fnv",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry_api",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -1465,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -1553,42 +1574,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
-dependencies = [
- "bytes",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
 dependencies = [
  "bytes",
- "prost-derive 0.11.0",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
-dependencies = [
- "bytes",
- "heck 0.3.3",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost 0.9.0",
- "prost-types 0.9.0",
- "regex",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -1598,30 +1589,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
 dependencies = [
  "bytes",
- "heck 0.4.0",
+ "heck",
  "itertools",
  "lazy_static",
  "log",
  "multimap",
  "petgraph",
- "prost 0.11.0",
- "prost-types 0.11.1",
+ "prost",
+ "prost-types",
  "regex",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1639,22 +1617,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
-dependencies = [
- "bytes",
- "prost 0.9.0",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
 dependencies = [
  "bytes",
- "prost 0.11.0",
+ "prost",
 ]
 
 [[package]]
@@ -1801,7 +1769,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
- "tokio-util 0.7.1",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2180,13 +2148,13 @@ dependencies = [
  "futures-retry",
  "http",
  "once_cell",
- "opentelemetry 0.17.0",
+ "opentelemetry 0.18.0",
  "parking_lot 0.12.0",
- "prost-types 0.11.1",
+ "prost-types",
  "temporal-sdk-core-protos",
  "thiserror",
  "tokio",
- "tonic 0.8.1",
+ "tonic",
  "tower",
  "tracing",
  "url",
@@ -2203,7 +2171,7 @@ dependencies = [
  "async-trait",
  "base64",
  "crossbeam",
- "dashmap 5.2.0",
+ "dashmap",
  "derive_builder",
  "derive_more",
  "enum_dispatch",
@@ -2220,13 +2188,13 @@ dependencies = [
  "mockall",
  "nix",
  "once_cell",
- "opentelemetry 0.17.0",
+ "opentelemetry 0.18.0",
  "opentelemetry-otlp",
  "opentelemetry-prometheus",
  "parking_lot 0.12.0",
  "prometheus",
- "prost 0.11.0",
- "prost-types 0.11.1",
+ "prost",
+ "prost-types",
  "rand",
  "reqwest",
  "ringbuf",
@@ -2242,10 +2210,9 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.1",
- "tonic 0.6.2",
- "tonic 0.8.1",
- "tonic-build 0.8.0",
+ "tokio-util",
+ "tonic",
+ "tonic-build",
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",
@@ -2263,12 +2230,12 @@ dependencies = [
  "async-trait",
  "derive_builder",
  "log",
- "opentelemetry 0.17.0",
- "prost-types 0.11.1",
+ "opentelemetry 0.18.0",
+ "prost-types",
  "temporal-client",
  "temporal-sdk-core-protos",
  "thiserror",
- "tonic 0.8.1",
+ "tonic",
 ]
 
 [[package]]
@@ -2278,14 +2245,14 @@ dependencies = [
  "anyhow",
  "base64",
  "derive_more",
- "prost 0.11.0",
- "prost-types 0.11.1",
+ "prost",
+ "prost-types",
  "rand",
  "serde",
  "serde_json",
  "thiserror",
- "tonic 0.8.1",
- "tonic-build 0.8.0",
+ "tonic",
+ "tonic-build",
  "uuid",
 ]
 
@@ -2299,8 +2266,8 @@ dependencies = [
  "once_cell",
  "opentelemetry 0.16.0",
  "parking_lot 0.12.0",
- "prost 0.11.0",
- "prost-types 0.11.1",
+ "prost",
+ "prost-types",
  "temporal-client",
  "temporal-sdk-core",
  "tokio",
@@ -2440,20 +2407,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
@@ -2464,37 +2417,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "tonic"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
-dependencies = [
- "async-stream",
- "async-trait",
- "base64",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.9.0",
- "prost-derive 0.9.0",
- "tokio",
- "tokio-stream",
- "tokio-util 0.6.9",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -2517,31 +2439,19 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.11.0",
- "prost-derive 0.11.0",
+ "prost",
+ "prost-derive",
  "rustls-native-certs",
  "rustls-pemfile",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-util 0.7.1",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
  "tracing-futures",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
-dependencies = [
- "proc-macro2",
- "prost-build 0.9.0",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2552,7 +2462,7 @@ checksum = "2fbcd2800e34e743b9ae795867d5f77b535d3a3be69fd731e39145719752df8c"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.11.1",
+ "prost-build",
  "quote",
  "syn",
 ]
@@ -2571,7 +2481,7 @@ dependencies = [
  "rand",
  "slab",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2610,9 +2520,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
  "log",
@@ -2623,9 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.20"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2634,11 +2544,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.26"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "valuable",
 ]
 
@@ -2654,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
  "log",
@@ -2665,11 +2575,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f9378e96a9361190ae297e7f3a8ff644aacd2897f244b1ff81f381669196fa6"
+checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
 dependencies = [
- "opentelemetry 0.17.0",
+ "once_cell",
+ "opentelemetry 0.18.0",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -2721,12 +2632,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-xid"

--- a/packages/core-bridge/index.d.ts
+++ b/packages/core-bridge/index.d.ts
@@ -111,7 +111,14 @@ export interface PrometheusMetricsExporter {
 /**
  * Metrics exporters supported by Core
  */
-export type MetricsExporter = PrometheusMetricsExporter | OtelCollectorExporter;
+export type MetricsExporter = {
+  /**
+   * Type of aggregation temporality for metric export.
+   *
+   * See the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/ce50e4634efcba8da445cc23523243cb893905cb/specification/metrics/datamodel.md#temporality) for more information.
+   */
+  temporality?: 'cumulative' | 'delta';
+} & (PrometheusMetricsExporter | OtelCollectorExporter);
 
 /**
  * Trace exporters supported by Core

--- a/packages/proto/scripts/compile-proto.js
+++ b/packages/proto/scripts/compile-proto.js
@@ -63,16 +63,6 @@ async function compileProtos(dtsOutputFile, ...args) {
   } finally {
     await rm(tempFile);
   }
-
-  // Fix issue where Long is not found in TS definitions (https://github.com/protobufjs/protobuf.js/issues/1533)
-  const pbtsOutput = readFileSync(dtsOutputFile, 'utf8');
-  writeFileSync(
-    dtsOutputFile,
-    dedent`
-  import Long from "long";
-  ${pbtsOutput}
-  `
-  );
 }
 
 async function main() {

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -1516,7 +1516,23 @@ test('logAndTimeout', async (t) => {
     message: 'Script execution timed out after 100ms',
   });
   const calls = await workflow.getAndResetSinkCalls();
-  t.deepEqual(calls, [{ ifaceName: 'logger', fnName: 'info', args: ['logging before getting stuck'] }]);
+  t.deepEqual(calls, [
+    {
+      ifaceName: 'defaultWorkerLogger',
+      fnName: 'debug',
+      args: [
+        'Workflow started',
+        {
+          namespace: 'default',
+          runId: 'beforeEach hook for logAndTimeout',
+          taskQueue: 'test',
+          workflowId: 'test-workflowId',
+          workflowType: 'logAndTimeout',
+        },
+      ],
+    },
+    { ifaceName: 'logger', fnName: 'info', args: ['logging before getting stuck'] },
+  ]);
 });
 
 test('continueAsNewSameWorkflow', async (t) => {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -33,6 +33,7 @@ export {
   appendDefaultInterceptors,
   CompiledWorkerOptions,
   defaultSinks,
+  defaultWorflowInterceptorModules,
   ReplayWorkerOptions,
   WorkerOptions,
   WorkflowBundle,

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -432,6 +432,8 @@ export function defaultSinks(logger = Runtime.instance().logger): InjectedSinks<
   };
 }
 
+export const defaultWorflowInterceptorModules = [require.resolve('./workflow-log-interceptor')];
+
 /**
  * Appends the default Worker logging interceptors to given interceptor arrays.
  *
@@ -443,7 +445,7 @@ export function appendDefaultInterceptors(
 ): WorkerInterceptors {
   return {
     activityInbound: [...(interceptors.activityInbound ?? []), (ctx) => new ActivityInboundLogInterceptor(ctx, logger)],
-    workflowModules: [...(interceptors.workflowModules ?? []), require.resolve('./workflow-log-interceptor')],
+    workflowModules: [...(interceptors.workflowModules ?? []), ...defaultWorflowInterceptorModules],
   };
 }
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -71,6 +71,7 @@ import {
   ReplayWorkerOptions,
   WorkflowBundle,
   WorkerOptions,
+  defaultWorflowInterceptorModules,
 } from './worker-options';
 import { WorkflowCodecRunner } from './workflow-codec-runner';
 import { WorkflowCodeBundler } from './workflow/bundler';
@@ -543,7 +544,9 @@ export class Worker {
       if (compiledOptions.bundlerOptions) {
         logger.warn('Ignoring WorkerOptions.bundlerOptions because WorkerOptions.workflowBundle is set');
       }
-      if (compiledOptions.interceptors?.workflowModules) {
+      const modules = compiledOptions.interceptors?.workflowModules;
+      // Warn if user tries to customize the default set of workflow interceptor modules
+      if (modules && new Set([...modules, ...defaultWorflowInterceptorModules]).size !== modules.length) {
         logger.warn(
           'Ignoring WorkerOptions.interceptors.workflowModules because WorkerOptions.workflowBundle is set.\n' +
             'To use workflow interceptors with a workflowBundle, pass them in the call to bundleWorkflowCode.'

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -7,6 +7,7 @@ import util from 'util';
 import webpack from 'webpack';
 import { DefaultLogger, Logger } from '../logger';
 import { toMB } from '../utils';
+import { defaultWorflowInterceptorModules } from '../worker-options';
 
 export const allowedBuiltinModules = ['assert'];
 export const disallowedBuiltinModules = builtinModules.filter((module) => !allowedBuiltinModules.includes(module));
@@ -65,7 +66,7 @@ export class WorkflowCodeBundler {
     this.workflowsPath = workflowsPath;
     this.payloadConverterPath = payloadConverterPath;
     this.failureConverterPath = failureConverterPath;
-    this.workflowInterceptorModules = workflowInterceptorModules ?? [];
+    this.workflowInterceptorModules = workflowInterceptorModules ?? defaultWorflowInterceptorModules;
     this.ignoreModules = ignoreModules ?? [];
     this.webpackConfigHook = webpackConfigHook ?? ((config) => config);
   }
@@ -308,9 +309,12 @@ export interface BundleOptions {
    */
   workflowsPath: string;
   /**
-   * List of modules to import Workflow interceptors from
+   * List of modules to import Workflow interceptors from.
    *
    * Modules should export an `interceptors` variable of type {@link WorkflowInterceptorsFactory}.
+   *
+   * By default, {@link WorkflowInboundLogInterceptor} is installed. If you wish to customize the interceptors while
+   * keeping the defaults, add {@link defaultWorflowInterceptorModules} to the provided array.
    */
   workflowInterceptorModules?: string[];
   /**


### PR DESCRIPTION
[Fix double import of long in generated proto TS files](https://github.com/temporalio/sdk-typescript/commit/4c4b0d9609ec892227163a93f3751ed593bb362d)
 
[Fix bundler with default workflow interceptors](https://github.com/temporalio/sdk-typescript/commit/179c05ab6220910c590e653129f873fff3225ebc)

[Label grpc-retry API as experimental](https://github.com/temporalio/sdk-typescript/commit/cf77e2346a30ce5d6c35aba023a5091a7c9fb6a6)

[Upgrade core, add support for OTEL metric temporality](https://github.com/temporalio/sdk-typescript/commit/882f13aaf2b70b358ea62ea02dd3c427bfc10682)

[Limit eager activity requests to 3](https://github.com/temporalio/sdk-typescript/commit/2658bad3e228637884a21bfe37648ce69ce34c07)

[Make the failure-converter code symmetric](https://github.com/temporalio/sdk-typescript/commit/cca751ce3458957f9d5159f96c86d618f068aad7)

- Closes #829 
- Closes #884