### PR TITLE
fix: Export and hide `errorMessage` and `errorCode`

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -3,23 +3,22 @@
  *
  * @module
  */
-export { Headers, Next } from './interceptors';
-
 export * from './activity-options';
 export * from './converter/data-converter';
 export * from './converter/failure-converter';
 export * from './converter/payload-codec';
 export * from './converter/payload-converter';
 export * from './converter/types';
+export * from './deprecated-time';
 export * from './errors';
 export * from './failure';
-export * from './failure';
+export { Headers, Next } from './interceptors';
 export * from './interfaces';
 export * from './retry-policy';
 export { Timestamp } from './time';
-export * from './workflow-options';
+export { errorCode, errorMessage } from './type-helpers';
 export * from './workflow-handle';
-export * from './deprecated-time';
+export * from './workflow-options';
 
 import * as encoding from './encoding';
 

--- a/packages/common/src/type-helpers.ts
+++ b/packages/common/src/type-helpers.ts
@@ -34,6 +34,8 @@ export function hasOwnProperties<X extends Record<string, unknown>, Y extends Pr
 
 /**
  * Get `error.message` (or `undefined` if not present)
+ *
+ * @hidden
  */
 export function errorMessage(error: unknown): string | undefined {
   if (typeof error === 'string') {
@@ -50,6 +52,8 @@ interface ErrorWithCode {
 }
 /**
  * Get `error.code` (or `undefined` if not present)
+ *
+ * @hidden
  */
 export function errorCode(error: unknown): string | undefined {
   if (


### PR DESCRIPTION
These used to be re-exported from `@temporalio/common`, but were moved in: https://github.com/temporalio/sdk-typescript/pull/881/files#diff-b3f127f417ba115081f7791c1ab78f6a143a3287346c90fdfacc22ddf281ebed