### PR TITLE
Improve regex for extracting source map

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
 
   # Runs the sdk features repo tests with this repo's current SDK code
   sdk-features-tests:
-    uses: temporalio/sdk-features/.github/workflows/typescript.yaml@protoc
+    uses: temporalio/sdk-features/.github/workflows/typescript.yaml@main
     with:
       typescript-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       typescript-repo-ref: ${{github.event.pull_request.head.ref}}

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1659,7 +1659,7 @@ export interface WorkflowBundleWithSourceMapAndFilename {
 }
 
 export function parseWorkflowCode(code: string, codePath?: string): WorkflowBundleWithSourceMapAndFilename {
-  const sourceMappingUrlDataRegex = /\s*\n[/][/][#]\s+sourceMappingURL=data:(?:[^,]*;)base64,([0-9A-Za-z+/=]+)\s*$/;
+  const sourceMappingUrlDataRegex = /^\/\/#\s+sourceMappingURL=data:(?:[^,]*;)base64,([0-9A-Za-z+/=]+)$/m;
   const sourceMapMatcher = code.match(sourceMappingUrlDataRegex);
   if (!sourceMapMatcher) throw new Error("Can't extract inlined source map from the provided Workflow Bundle");
 


### PR DESCRIPTION
User complained in slack that the previous regex was causing `RangeError: Maximum call stack size exceeded`.

I tried a couple alternatives, the chosen one and splitting the lines first, ran 10,000 iterations and got these results:

- Split first: 12.371s
- New regex: 4.797s
- Original regex: 36.535s
