### PR TITLE
Update changelog for 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Breaking changes marked with a :boom:
   ([#902](https://github.com/temporalio/sdk-typescript/pull/902))
 - [`common`] Export and deprecate error helpers ([#901](https://github.com/temporalio/sdk-typescript/pull/901))
 
-  Fixes a breaking changed accidentally introduces in 1.4.0 where some rarely used utility functions were deleted.
+  Fixes a breaking change accidentally introduces in 1.4.0 where some rarely used utility functions were deleted.
 
 ### Miscellaneous Tasks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 Breaking changes marked with a :boom:
 
+## [1.4.1] - 2022-10-06
+
+### Bug Fixes
+
+- [`client`] Handle test server empty history when waiting for workflow result
+  ([#902](https://github.com/temporalio/sdk-typescript/pull/902))
+- [`common`] Export and deprecate error helpers ([#901](https://github.com/temporalio/sdk-typescript/pull/901))
+
+  Fixes a breaking changed accidentally introduces in 1.4.0 where some rarely used utility functions were deleted.
+
+### Miscellaneous Tasks
+
+- Improve regex for extracting source map ([#899](https://github.com/temporalio/sdk-typescript/pull/899))
+
+  Addresses reported issue by userr where regex caused `RangeError: Maximum call stack size exceeded` when parsing their
+  workflow bundle.
+
 ## [1.4.0] - 2022-09-28
 
 ### Features


### PR DESCRIPTION
I'm going to publish this version with `--exact`.
Rather not take anymore chances where we break our own internal packages like we did in 1.4.0.