### PR TITLE
fix: Delay checking for __coverage__ until helpers run because __coverage__ is undefined when Jest starts

### DIFF
--- a/packages/nyc-test-coverage/src/index.ts
+++ b/packages/nyc-test-coverage/src/index.ts
@@ -5,12 +5,14 @@ import libCoverage from 'istanbul-lib-coverage';
 // Pull `webpack.Configuration` type without needing to import Webpack
 type WebpackConfigType = ReturnType<NonNullable<BundleOptions['webpackConfigHook']>>;
 
-// Check if running through nyc or some other Istanbul-based tool.
-// If not, any `workflowCoverage()` tools are a no-op.
-const hasCoverageGlobal = '__coverage__' in global;
-
 export class WorkflowCoverage {
   coverageMap = libCoverage.createCoverageMap();
+
+  // Check if running through nyc or some other Istanbul-based tool.
+  // If not, any `workflowCoverage()` tools are a no-op.
+  hasCoverageGlobal() {
+    return '__coverage__' in global;
+  }
 
   /**
    * Add all necessary coverage-specific logic to Worker config:
@@ -23,7 +25,7 @@ export class WorkflowCoverage {
       throw new TypeError('Cannot automatically instrument coverage without specifying `workflowsPath`');
     }
 
-    if (!hasCoverageGlobal) {
+    if (!this.hasCoverageGlobal()) {
       return workerOptions;
     }
 
@@ -67,7 +69,7 @@ export class WorkflowCoverage {
       throw new TypeError('Cannot automatically instrument coverage without specifying `workflowsPath`');
     }
 
-    if (!hasCoverageGlobal) {
+    if (!this.hasCoverageGlobal()) {
       return bundleOptions;
     }
 
@@ -101,7 +103,7 @@ export class WorkflowCoverage {
       );
     }
 
-    if (!hasCoverageGlobal) {
+    if (!this.hasCoverageGlobal()) {
       return workerOptions;
     }
 
@@ -142,7 +144,7 @@ export class WorkflowCoverage {
    * code using istanbul-instrumenter-loader
    */
   addInstrumenterRule(workflowsPath: string, config: WebpackConfigType): WebpackConfigType {
-    if (!hasCoverageGlobal) {
+    if (!this.hasCoverageGlobal()) {
       return config;
     }
 
@@ -169,7 +171,7 @@ export class WorkflowCoverage {
    * map data `global.__coverage__`.
    */
   mergeIntoGlobalCoverage(): void {
-    if (!hasCoverageGlobal) {
+    if (!this.hasCoverageGlobal()) {
       return;
     }
 

--- a/packages/nyc-test-coverage/src/index.ts
+++ b/packages/nyc-test-coverage/src/index.ts
@@ -10,7 +10,7 @@ export class WorkflowCoverage {
 
   // Check if running through nyc or some other Istanbul-based tool.
   // If not, any `workflowCoverage()` tools are a no-op.
-  hasCoverageGlobal() {
+  private hasCoverageGlobal() {
     return '__coverage__' in global;
   }
 


### PR DESCRIPTION
Re: temporalio/temporal-pendulum#21

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Don't check for `__coverage__` when the module loads, but when the `augment()` methods run.

## Why?
<!-- Tell your future self why have you made these changes -->

Jest quirks: `__coverage__` isn't set when the module first loads.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
