### PR TITLE
fix(worker): avoid a race in shutdown hooks

### DIFF
--- a/packages/test/src/test-worker-lifecycle.ts
+++ b/packages/test/src/test-worker-lifecycle.ts
@@ -5,14 +5,60 @@
  * @module
  */
 import { Worker } from '@temporalio/worker';
+import { Runtime } from '@temporalio/worker';
 import test from 'ava';
 import { RUN_INTEGRATION_TESTS } from './helpers';
 import { defaultOptions, isolateFreeWorker } from './mock-native-worker';
 
 if (RUN_INTEGRATION_TESTS) {
   test.serial('Worker shuts down gracefully', async (t) => {
-    const worker = await Worker.create({
-      ...defaultOptions,
+    try {
+      const worker = await Worker.create({
+        ...defaultOptions,
+        shutdownGraceTime: '500ms',
+        taskQueue: 'shutdown-test',
+      });
+      t.is(worker.getState(), 'INITIALIZED');
+      const p = worker.run();
+      t.is(worker.getState(), 'RUNNING');
+      process.emit('SIGINT', 'SIGINT');
+      // Shutdown callback is enqueued as a microtask
+      await new Promise((resolve) => process.nextTick(resolve));
+      t.is(worker.getState(), 'STOPPING');
+      await p;
+      t.is(worker.getState(), 'STOPPED');
+      await t.throwsAsync(worker.run(), { message: 'Poller was already started' });
+    } finally {
+      // Make sure Runtime is reset after this test
+      if (Runtime._instance) await Runtime._instance.shutdown();
+      Runtime.instance();
+    }
+  });
+
+  test.serial('Worker shuts down gracefully if interrupted before running', async (t) => {
+    try {
+      const worker = await Worker.create({
+        ...defaultOptions,
+        shutdownGraceTime: '500ms',
+        taskQueue: 'shutdown-test',
+      });
+      t.is(worker.getState(), 'INITIALIZED');
+      process.emit('SIGINT', 'SIGINT');
+      const p = worker.run();
+      t.is(worker.getState(), 'STOPPING');
+      await p;
+      t.is(worker.getState(), 'STOPPED');
+    } finally {
+      // Make sure Runtime is reset after this test
+      if (Runtime._instance) await Runtime._instance.shutdown();
+      Runtime.instance();
+    }
+  });
+}
+
+test.serial('Mocked run shuts down gracefully', async (t) => {
+  try {
+    const worker = isolateFreeWorker({
       shutdownGraceTime: '500ms',
       taskQueue: 'shutdown-test',
     });
@@ -20,30 +66,37 @@ if (RUN_INTEGRATION_TESTS) {
     const p = worker.run();
     t.is(worker.getState(), 'RUNNING');
     process.emit('SIGINT', 'SIGINT');
-    // Shutdown callback is enqueued as a microtask
-    await new Promise((resolve) => process.nextTick(resolve));
-    t.is(worker.getState(), 'STOPPING');
     await p;
     t.is(worker.getState(), 'STOPPED');
     await t.throwsAsync(worker.run(), { message: 'Poller was already started' });
-  });
-}
-
-test.serial('Mocked run shuts down gracefully', async (t) => {
-  const worker = isolateFreeWorker({
-    shutdownGraceTime: '500ms',
-    taskQueue: 'shutdown-test',
-  });
-  t.is(worker.getState(), 'INITIALIZED');
-  const p = worker.run();
-  t.is(worker.getState(), 'RUNNING');
-  process.emit('SIGINT', 'SIGINT');
-  await p;
-  t.is(worker.getState(), 'STOPPED');
-  await t.throwsAsync(worker.run(), { message: 'Poller was already started' });
+  } finally {
+    // Make sure Runtime is reset after this test
+    if (Runtime._instance) await Runtime._instance.shutdown();
+    Runtime.instance();
+  }
 });
 
-test('Mocked run throws if not shut down gracefully', async (t) => {
+test.serial('Mocked run shuts down gracefully if interrupted before running', async (t) => {
+  try {
+    const worker = isolateFreeWorker({
+      shutdownGraceTime: '500ms',
+      taskQueue: 'shutdown-test',
+    });
+    worker.native.initiateShutdown = () => new Promise(() => undefined);
+    t.is(worker.getState(), 'INITIALIZED');
+    process.emit('SIGINT', 'SIGINT');
+    const p = worker.run();
+    t.is(worker.getState(), 'STOPPING');
+    await p;
+    t.is(worker.getState(), 'STOPPED');
+  } finally {
+    // Make sure Runtime is reset after this test
+    if (Runtime._instance) await Runtime._instance.shutdown();
+    Runtime.instance();
+  }
+});
+
+test.serial('Mocked run throws if not shut down gracefully', async (t) => {
   const worker = isolateFreeWorker({
     shutdownGraceTime: '5ms',
     taskQueue: 'shutdown-test',

--- a/packages/test/src/test-worker-lifecycle.ts
+++ b/packages/test/src/test-worker-lifecycle.ts
@@ -12,47 +12,35 @@ import { defaultOptions, isolateFreeWorker } from './mock-native-worker';
 
 if (RUN_INTEGRATION_TESTS) {
   test.serial('Worker shuts down gracefully', async (t) => {
-    try {
-      const worker = await Worker.create({
-        ...defaultOptions,
-        shutdownGraceTime: '500ms',
-        taskQueue: 'shutdown-test',
-      });
-      t.is(worker.getState(), 'INITIALIZED');
-      const p = worker.run();
-      t.is(worker.getState(), 'RUNNING');
-      process.emit('SIGINT', 'SIGINT');
-      // Shutdown callback is enqueued as a microtask
-      await new Promise((resolve) => process.nextTick(resolve));
-      t.is(worker.getState(), 'STOPPING');
-      await p;
-      t.is(worker.getState(), 'STOPPED');
-      await t.throwsAsync(worker.run(), { message: 'Poller was already started' });
-    } finally {
-      // Make sure Runtime is reset after this test
-      if (Runtime._instance) await Runtime._instance.shutdown();
-      Runtime.instance();
-    }
+    const worker = await Worker.create({
+      ...defaultOptions,
+      shutdownGraceTime: '500ms',
+      taskQueue: 'shutdown-test',
+    });
+    t.is(worker.getState(), 'INITIALIZED');
+    const p = worker.run();
+    t.is(worker.getState(), 'RUNNING');
+    process.emit('SIGINT', 'SIGINT');
+    // Shutdown callback is enqueued as a microtask
+    await new Promise((resolve) => process.nextTick(resolve));
+    t.is(worker.getState(), 'STOPPING');
+    await p;
+    t.is(worker.getState(), 'STOPPED');
+    await t.throwsAsync(worker.run(), { message: 'Poller was already started' });
   });
 
   test.serial('Worker shuts down gracefully if interrupted before running', async (t) => {
-    try {
-      const worker = await Worker.create({
-        ...defaultOptions,
-        shutdownGraceTime: '500ms',
-        taskQueue: 'shutdown-test',
-      });
-      t.is(worker.getState(), 'INITIALIZED');
-      process.emit('SIGINT', 'SIGINT');
-      const p = worker.run();
-      t.is(worker.getState(), 'STOPPING');
-      await p;
-      t.is(worker.getState(), 'STOPPED');
-    } finally {
-      // Make sure Runtime is reset after this test
-      if (Runtime._instance) await Runtime._instance.shutdown();
-      Runtime.instance();
-    }
+    const worker = await Worker.create({
+      ...defaultOptions,
+      shutdownGraceTime: '500ms',
+      taskQueue: 'shutdown-test',
+    });
+    t.is(worker.getState(), 'INITIALIZED');
+    process.emit('SIGINT', 'SIGINT');
+    const p = worker.run();
+    t.is(worker.getState(), 'RUNNING');
+    await p;
+    t.is(worker.getState(), 'STOPPED');
   });
 }
 
@@ -70,9 +58,7 @@ test.serial('Mocked run shuts down gracefully', async (t) => {
     t.is(worker.getState(), 'STOPPED');
     await t.throwsAsync(worker.run(), { message: 'Poller was already started' });
   } finally {
-    // Make sure Runtime is reset after this test
     if (Runtime._instance) await Runtime._instance.shutdown();
-    Runtime.instance();
   }
 });
 
@@ -82,17 +68,15 @@ test.serial('Mocked run shuts down gracefully if interrupted before running', as
       shutdownGraceTime: '500ms',
       taskQueue: 'shutdown-test',
     });
-    worker.native.initiateShutdown = () => new Promise(() => undefined);
+    // worker.native.initiateShutdown = () => new Promise(() => undefined);
     t.is(worker.getState(), 'INITIALIZED');
     process.emit('SIGINT', 'SIGINT');
     const p = worker.run();
-    t.is(worker.getState(), 'STOPPING');
+    t.is(worker.getState(), 'RUNNING');
     await p;
     t.is(worker.getState(), 'STOPPED');
   } finally {
-    // Make sure Runtime is reset after this test
     if (Runtime._instance) await Runtime._instance.shutdown();
-    Runtime.instance();
   }
 });
 

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -378,7 +378,11 @@ export class Runtime {
   /**
    * Used by Workers to register for shutdown signals
    *
+   * Returns false if a shutdown has already been requested. In that case, the Worker should
+   * immediately initiate its shutdown.
+   *
    * Hidden in the docs because it is only meant to be used internally by the Worker.
+   * @returns true if callback was registered, or false if shutdown has already been requested
    * @hidden
    */
   public registerShutdownSignalCallback(callback: () => void): boolean {

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -101,7 +101,7 @@ export class Runtime {
   protected readonly logPollPromise: Promise<void>;
   public readonly logger: Logger;
   protected readonly shutdownSignalCallbacks = new Set<() => void>();
-  protected state: 'running' | 'shuttingdown' = 'running';
+  protected state: 'RUNNING' | 'SHUTTING_DOWN' = 'RUNNING';
 
   static _instance?: Runtime;
   static instantiator?: 'install' | 'instance';
@@ -382,7 +382,7 @@ export class Runtime {
    * @hidden
    */
   public registerShutdownSignalCallback(callback: () => void): void {
-    if (this.state === 'running') {
+    if (this.state === 'RUNNING') {
       this.shutdownSignalCallbacks.add(callback);
     } else {
       queueMicrotask(callback);
@@ -421,7 +421,7 @@ export class Runtime {
    * Bound to `this` for use with `process.on` and `process.off`
    */
   protected startShutdownSequence = (): void => {
-    this.state = 'shuttingdown';
+    this.state = 'SHUTTING_DOWN';
     this.teardownShutdownHook();
     for (const callback of this.shutdownSignalCallbacks) {
       queueMicrotask(callback); // Run later

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -378,19 +378,14 @@ export class Runtime {
   /**
    * Used by Workers to register for shutdown signals
    *
-   * Returns false if a shutdown has already been requested. In that case, the Worker should
-   * immediately initiate its shutdown.
-   *
    * Hidden in the docs because it is only meant to be used internally by the Worker.
-   * @returns true if callback was registered, or false if shutdown has already been requested
    * @hidden
    */
-  public registerShutdownSignalCallback(callback: () => void): boolean {
+  public registerShutdownSignalCallback(callback: () => void): void {
     if (this.state === 'running') {
       this.shutdownSignalCallbacks.add(callback);
-      return true;
     } else {
-      return false;
+      queueMicrotask(callback);
     }
   }
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1596,16 +1596,10 @@ export class Worker {
     }
     this.state = 'RUNNING';
 
-    try {
-      const shutdownCallback = () => this.shutdown();
-      if (!Runtime.instance().registerShutdownSignalCallback(shutdownCallback)) {
-        // Shutdown has already been requested
-        this.shutdown();
-        await this.nativeWorker.finalizeShutdown();
-        this.state = 'STOPPED';
-        return;
-      }
+    const shutdownCallback = () => this.shutdown();
+    Runtime.instance().registerShutdownSignalCallback(shutdownCallback);
 
+    try {
       try {
         await lastValueFrom(
           merge(


### PR DESCRIPTION
## What was changed
In `Runtime`, deny adding more shutdown hooks once a shutdown signal has been received.

## Why?
Avoid a race situation where a process might be sent a shutdown signal, but some worker has not yet registered its shutdown hook, causing the worker to never terminate.

## Checklist
1. Closes #909 