### PR TITLE
chore: Improve integration test for failure converter

### DIFF
--- a/packages/common/src/converter/failure-converter.ts
+++ b/packages/common/src/converter/failure-converter.ts
@@ -169,6 +169,7 @@ export class DefaultFailureConverter implements FailureConverter {
         throw new TypeError('Missing activityType?.name on activityFailureInfo');
       }
       return new ActivityFailure(
+        failure.message ?? undefined,
         failure.activityFailureInfo.activityType.name,
         failure.activityFailureInfo.activityId ?? undefined,
         failure.activityFailureInfo.retryState ?? RetryState.RETRY_STATE_UNSPECIFIED,

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -232,13 +232,14 @@ export class ActivityFailure extends TemporalFailure {
   public readonly name: string = 'ActivityFailure';
 
   public constructor(
+    message: string | undefined,
     public readonly activityType: string,
     public readonly activityId: string | undefined,
     public readonly retryState: RetryState,
     public readonly identity: string | undefined,
     cause?: Error
   ) {
-    super('Activity execution failed', cause);
+    super(message, cause);
   }
 }
 

--- a/packages/test/src/test-failure-converter.ts
+++ b/packages/test/src/test-failure-converter.ts
@@ -6,14 +6,22 @@ import {
   DataConverter,
   DefaultEncodedFailureAttributes,
 } from '@temporalio/common';
+import { proxyActivities } from '@temporalio/workflow';
 import { WorkflowFailedError } from '@temporalio/client';
 import { decodeFromPayloadsAtIndex } from '@temporalio/common/lib/internal-non-workflow';
 import { test, bundlerOptions, ByteSkewerPayloadCodec, Worker } from './helpers';
 
 export const failureConverter = new DefaultFailureConverter({ encodeCommonAttributes: true });
 
-export async function workflow(): Promise<never> {
-  throw ApplicationFailure.create({ message: 'error message' });
+class Activities {
+  public raise = async () => {
+    throw ApplicationFailure.nonRetryable('error message');
+  };
+}
+
+export async function workflow(): Promise<void> {
+  const activities = proxyActivities<Activities>({ startToCloseTimeout: '1m' });
+  await activities.raise();
 }
 
 test('Client and Worker use provided failureConverter', async (t) => {
@@ -24,15 +32,10 @@ test('Client and Worker use provided failureConverter', async (t) => {
   };
   const env = await TestWorkflowEnvironment.createLocal({ client: { dataConverter } });
   try {
-    const info = await env.connection.workflowService.getSystemInfo({});
-    if (!info.capabilities?.encodedFailureAttributes) {
-      t.pass('Skipped test for lack of encodedFailureAttributes capability');
-      return;
-    }
-
     const taskQueue = 'test';
     const worker = await Worker.create({
       connection: env.nativeConnection,
+      activities: new Activities(),
       workflowsPath: __filename,
       taskQueue,
       dataConverter,
@@ -42,19 +45,37 @@ test('Client and Worker use provided failureConverter', async (t) => {
     // Run the workflow, expect error with message and stack trace
     const handle = await env.client.workflow.start(workflow, { taskQueue, workflowId: randomUUID() });
     const err = (await worker.runUntil(t.throwsAsync(handle.result()))) as WorkflowFailedError;
-    t.is(err.cause?.message, 'error message');
-    t.true(err.cause?.stack?.startsWith('ApplicationFailure: error message\n'));
+    t.is(err.cause?.message, 'Activity task failed');
+    t.is(err.cause?.cause?.message, 'error message');
+    t.true(err.cause?.cause?.stack?.includes('ApplicationFailure: error message\n'));
 
     // Verify failure was indeed encoded
     const { events } = await handle.fetchHistory();
-    const payload = events?.[events.length - 1].workflowExecutionFailedEventAttributes?.failure?.encodedAttributes;
-    const attrs = await decodeFromPayloadsAtIndex<DefaultEncodedFailureAttributes>(
-      env.client.options.loadedDataConverter,
-      0,
-      payload ? [payload] : undefined
-    );
-    t.is(attrs.message, 'error message');
-    t.true(attrs.stack_trace.startsWith('ApplicationFailure: error message\n'));
+    const { failure } = events?.[events.length - 1].workflowExecutionFailedEventAttributes ?? {};
+    {
+      const payload = failure?.encodedAttributes;
+      const attrs = await decodeFromPayloadsAtIndex<DefaultEncodedFailureAttributes>(
+        env.client.options.loadedDataConverter,
+        0,
+        payload ? [payload] : undefined
+      );
+      t.is(failure?.message, 'Encoded failure');
+      t.is(failure?.stackTrace, '');
+      t.is(attrs.message, 'Activity task failed');
+      t.is(attrs.stack_trace, '');
+    }
+    {
+      const payload = failure?.cause?.encodedAttributes;
+      const attrs = await decodeFromPayloadsAtIndex<DefaultEncodedFailureAttributes>(
+        env.client.options.loadedDataConverter,
+        0,
+        payload ? [payload] : undefined
+      );
+      t.is(failure?.cause?.message, 'Encoded failure');
+      t.is(failure?.stackTrace, '');
+      t.is(attrs.message, 'error message');
+      t.true(attrs.stack_trace.includes('ApplicationFailure: error message\n'));
+    }
   } finally {
     await env.teardown();
   }


### PR DESCRIPTION
Test that failure details aren't leaked if chained from activity to workflow.
Also fix error message of `ActivityFailure`.