### PR TITLE
Update CHANGELOG for 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 Breaking changes marked with a :boom:
 
+## [1.4.4] - 2022-11-03
+
+### Bug Fixes
+
+- Don't request eager activities when worker started with no remote activities
+
+  Actual fix made in this Core SDK PR: https://github.com/temporalio/sdk-core/pull/429
+
 ## [1.4.3] - 2022-10-14
 
 ### Bug Fixes


### PR DESCRIPTION
The release will be made from the v1.4.4-release branch that points to `v1.4.3` + sdk-core commit that fixes the eager activity issue (see CHANGELOG).

I'll create another PR that will update core for the `main` branch to get some of the recent changes and this fix before we release `1.5.0`.