### PR TITLE
fix(workflow): do encode memos on continueAsNew

### DIFF
--- a/packages/common/src/workflow-options.ts
+++ b/packages/common/src/workflow-options.ts
@@ -79,7 +79,7 @@ export interface BaseWorkflowOptions {
    * Specifies additional non-indexed information to attach to the Workflow Execution. The values can be anything that
    * is serializable by {@link DataConverter}.
    */
-  memo?: Record<string, any>;
+  memo?: Record<string, unknown>;
 
   /**
    * Specifies additional indexed information to attach to the Workflow Execution. More info:

--- a/packages/test/src/workflows/continue-as-new-to-different-workflow.ts
+++ b/packages/test/src/workflows/continue-as-new-to-different-workflow.ts
@@ -2,10 +2,13 @@
  * Tests continueAsNew to another Workflow
  * @module
  */
-import { makeContinueAsNewFunc } from '@temporalio/workflow';
+import { ContinueAsNewOptions, makeContinueAsNewFunc } from '@temporalio/workflow';
 import { sleeper } from './sleep';
 
-export async function continueAsNewToDifferentWorkflow(ms = 1): Promise<void> {
-  const continueAsNew = makeContinueAsNewFunc<typeof sleeper>({ workflowType: 'sleeper' });
+export async function continueAsNewToDifferentWorkflow(
+  ms = 1,
+  extraArgs?: Partial<ContinueAsNewOptions>
+): Promise<void> {
+  const continueAsNew = makeContinueAsNewFunc<typeof sleeper>({ workflowType: 'sleeper', ...(extraArgs ?? {}) });
   await continueAsNew(ms);
 }

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -189,7 +189,7 @@ export interface ContinueAsNewOptions {
   /**
    * Non-searchable attributes to attach to next Workflow run
    */
-  memo?: Record<string, any>;
+  memo?: Record<string, unknown>;
   /**
    * Searchable attributes to attach to next Workflow run
    */

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -939,7 +939,7 @@ export function makeContinueAsNewFunc<F extends Workflow>(
         arguments: toPayloads(activator.payloadConverter, ...args),
         headers,
         taskQueue: options.taskQueue,
-        memo: options.memo,
+        memo: options.memo && mapToPayloads(activator.payloadConverter, options.memo),
         searchAttributes: options.searchAttributes
           ? mapToPayloads(searchAttributePayloadConverter, options.searchAttributes)
           : undefined,


### PR DESCRIPTION
## What changed

- Changed the type of `ContinueAsNewOptions.memo` from `Record<string, any>` to `Record<string, unknown>`, so that it matches `BaseWorkflowOptions.memo`.
- Make sure that `makeContinueAsNewFunc()` properly encode `memo` if provided.

## Why

- `makeContinueAsNewFunc()` was previously copying new `memo` field as-is, without encoding them to Payload, resulting in a failure due to invalid data in request to core.

## Checklist

- Added integration tests