### PR TITLE
fix(client): Simplify WorkflowClient interceptors

### DIFF
--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -17,7 +17,7 @@ import { CompiledWorkflowOptions } from './workflow-options';
 
 export { Next, Headers };
 
-/** Input for WorkflowClientCallsInterceptor.start */
+/** Input for WorkflowClientInterceptor.start */
 export interface WorkflowStartInput {
   /** Name of Workflow to start */
   readonly workflowType: string;
@@ -25,7 +25,7 @@ export interface WorkflowStartInput {
   readonly options: CompiledWorkflowOptions;
 }
 
-/** Input for WorkflowClientCallsInterceptor.signal */
+/** Input for WorkflowClientInterceptor.signal */
 export interface WorkflowSignalInput {
   readonly signalName: string;
   readonly args: unknown[];
@@ -33,7 +33,7 @@ export interface WorkflowSignalInput {
   readonly headers: Headers;
 }
 
-/** Input for WorkflowClientCallsInterceptor.signalWithStart */
+/** Input for WorkflowClientInterceptor.signalWithStart */
 export interface WorkflowSignalWithStartInput {
   readonly workflowType: string;
   readonly signalName: string;
@@ -42,7 +42,7 @@ export interface WorkflowSignalWithStartInput {
   readonly options: CompiledWorkflowOptions;
 }
 
-/** Input for WorkflowClientCallsInterceptor.query */
+/** Input for WorkflowClientInterceptor.query */
 export interface WorkflowQueryInput {
   readonly queryType: string;
   readonly args: unknown[];
@@ -51,7 +51,7 @@ export interface WorkflowQueryInput {
   readonly headers: Headers;
 }
 
-/** Input for WorkflowClientCallsInterceptor.terminate */
+/** Input for WorkflowClientInterceptor.terminate */
 export interface WorkflowTerminateInput {
   readonly workflowExecution: WorkflowExecution;
   readonly reason?: string;
@@ -59,13 +59,13 @@ export interface WorkflowTerminateInput {
   readonly firstExecutionRunId?: string;
 }
 
-/** Input for WorkflowClientCallsInterceptor.cancel */
+/** Input for WorkflowClientInterceptor.cancel */
 export interface WorkflowCancelInput {
   readonly workflowExecution: WorkflowExecution;
   readonly firstExecutionRunId?: string;
 }
 
-/** Input for WorkflowClientCallsInterceptor.describe */
+/** Input for WorkflowClientInterceptor.describe */
 export interface WorkflowDescribeInput {
   readonly workflowExecution: WorkflowExecution;
 }
@@ -73,7 +73,7 @@ export interface WorkflowDescribeInput {
 /**
  * Implement any of these methods to intercept WorkflowClient outbound calls
  */
-export interface WorkflowClientCallsInterceptor {
+export interface WorkflowClientInterceptor {
   /**
    * Intercept a service call to startWorkflowExecution
    *
@@ -113,6 +113,10 @@ export interface WorkflowClientCallsInterceptor {
   describe?: (input: WorkflowDescribeInput, next: Next<this, 'describe'>) => Promise<DescribeWorkflowExecutionResponse>;
 }
 
+/** @deprecated: Use WorkflowClientInterceptor instead */
+export type WorkflowClientCallsInterceptor = WorkflowClientInterceptor;
+
+/** @deprecated */
 export interface WorkflowClientCallsInterceptorFactoryInput {
   workflowId: string;
   runId?: string;
@@ -120,6 +124,8 @@ export interface WorkflowClientCallsInterceptorFactoryInput {
 
 /**
  * A function that takes {@link CompiledWorkflowOptions} and returns an interceptor
+ *
+ * @deprecated: Please define interceptors directly, without factory
  */
 export interface WorkflowClientCallsInterceptorFactory {
   (input: WorkflowClientCallsInterceptorFactoryInput): WorkflowClientCallsInterceptor;
@@ -127,8 +133,11 @@ export interface WorkflowClientCallsInterceptorFactory {
 
 /**
  * A mapping of interceptor type of a list of factory functions
+ *
+ * @deprecated: Please define interceptors directly, without factory
  */
 export interface WorkflowClientInterceptors {
+  /** @deprecated */
   calls?: WorkflowClientCallsInterceptorFactory[];
 }
 
@@ -164,7 +173,7 @@ export type CreateScheduleOutput = {
  * NOTE: Currently only for {@link WorkflowClient} and {@link ScheduleClient}. More will be added later as needed.
  */
 export interface ClientInterceptors {
-  workflow?: WorkflowClientInterceptors;
+  workflow?: WorkflowClientInterceptors | WorkflowClientInterceptor[];
 
   /**
    * @experimental

--- a/packages/interceptors-opentelemetry/src/client/index.ts
+++ b/packages/interceptors-opentelemetry/src/client/index.ts
@@ -1,5 +1,5 @@
 import * as otel from '@opentelemetry/api';
-import { Next, WorkflowClientCallsInterceptor, WorkflowStartInput } from '@temporalio/client';
+import { Next, WorkflowClientInterceptor, WorkflowStartInput } from '@temporalio/client';
 import { headersWithContext, RUN_ID_ATTR_KEY } from '@temporalio/common/lib/otel';
 import { instrument } from '../instrumentation';
 import { SpanName, SPAN_DELIMITER } from '../workflow';
@@ -13,14 +13,14 @@ export interface InterceptorOptions {
  *
  * Wraps the operation in an opentelemetry Span and passes it to the Workflow via headers.
  */
-export class OpenTelemetryWorkflowClientCallsInterceptor implements WorkflowClientCallsInterceptor {
+export class OpenTelemetryWorkflowClientInterceptor implements WorkflowClientInterceptor {
   protected readonly tracer: otel.Tracer;
 
   constructor(options?: InterceptorOptions) {
     this.tracer = options?.tracer ?? otel.trace.getTracer('@temporalio/interceptor-client');
   }
 
-  async start(input: WorkflowStartInput, next: Next<WorkflowClientCallsInterceptor, 'start'>): Promise<string> {
+  async start(input: WorkflowStartInput, next: Next<WorkflowClientInterceptor, 'start'>): Promise<string> {
     return await instrument({
       tracer: this.tracer,
       spanName: `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}${input.workflowType}`,

--- a/packages/interceptors-opentelemetry/src/index.ts
+++ b/packages/interceptors-opentelemetry/src/index.ts
@@ -10,4 +10,8 @@
 
 export * from './workflow';
 export * from './worker';
-export { OpenTelemetryWorkflowClientCallsInterceptor } from './client';
+export {
+  OpenTelemetryWorkflowClientInterceptor,
+  /** deprecated: Use OpenTelemetryWorkflowClientInterceptor instead */
+  OpenTelemetryWorkflowClientInterceptor as OpenTelemetryWorkflowClientCallsInterceptor,
+} from './client';

--- a/packages/test/src/test-otel.ts
+++ b/packages/test/src/test-otel.ts
@@ -8,7 +8,7 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import * as opentelemetry from '@opentelemetry/sdk-node';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { Connection, WorkflowClient } from '@temporalio/client';
-import { OpenTelemetryWorkflowClientCallsInterceptor } from '@temporalio/interceptors-opentelemetry/lib/client';
+import { OpenTelemetryWorkflowClientInterceptor } from '@temporalio/interceptors-opentelemetry/lib/client';
 import {
   makeWorkflowExporter,
   OpenTelemetryActivityInboundInterceptor,
@@ -65,9 +65,7 @@ if (RUN_INTEGRATION_TESTS) {
     });
 
     const client = new WorkflowClient({
-      interceptors: {
-        calls: [() => new OpenTelemetryWorkflowClientCallsInterceptor()],
-      },
+      interceptors: [new OpenTelemetryWorkflowClientInterceptor()],
     });
     await worker.runUntil(client.execute(workflows.smorgasbord, { taskQueue: 'test-otel', workflowId: uuid4() }));
     await otel.shutdown();
@@ -174,9 +172,7 @@ if (RUN_INTEGRATION_TESTS) {
     });
 
     const client = new WorkflowClient({
-      interceptors: {
-        calls: [() => new OpenTelemetryWorkflowClientCallsInterceptor()],
-      },
+      interceptors: [new OpenTelemetryWorkflowClientInterceptor()],
     });
     await worker.runUntil(
       client.execute(workflows.cancelFakeProgress, { taskQueue: 'test-otel', workflowId: uuid4() })


### PR DESCRIPTION
## What changed

- In `WorkflowClientOptions`, interceptors should now be provided as an array of interceptor object, rather than an array of factory to those objects under a field named `calls`.
- Previous form is still allowed though deprecated

Before:
```
interceptors: {
    calls: [
        (workflowId) => {
            create(...) => { ... }
        }
    ]
}
```

Now:
```
interceptors: [
    {
            create(...) => { ... }
    }
]
```


## Why

- The indirection was not useful and made interceptors looks complicated
- As discussed in https://github.com/temporalio/sdk-typescript/pull/937#discussion_r1010663304


## Checklist

- Updated tests
- Need to update doc and code samples