### PR TITLE
chore(client): Extract a BaseClient super class

### DIFF
--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -46,7 +46,7 @@ export type AsyncCompletionClientOptions = BaseClientOptions;
 
 export type LoadedAsyncCompletionClientOptions = LoadedWithDefaults<AsyncCompletionClientOptions>;
 
-function defaultAsyncClientOptions(): WithDefaults<AsyncCompletionClientOptions> {
+function defaultAsyncCompletionClientOptions(): WithDefaults<AsyncCompletionClientOptions> {
   return defaultBaseClientOptions();
 }
 
@@ -75,7 +75,7 @@ export class AsyncCompletionClient extends BaseClient {
   constructor(options?: AsyncCompletionClientOptions) {
     super(options);
     this.options = {
-      ...defaultAsyncClientOptions(),
+      ...defaultAsyncCompletionClientOptions(),
       ...filterNullAndUndefined(options ?? {}),
       loadedDataConverter: this.dataConverter,
     };

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -1,7 +1,17 @@
 import { Status } from '@grpc/grpc-js/build/src/constants';
 import { ensureTemporalFailure } from '@temporalio/common';
-import { encodeErrorToFailure, encodeToPayloads } from '@temporalio/common/lib/internal-non-workflow';
-import { BaseClient, BaseClientOptions, LoadedWithDefaults } from './base-client';
+import {
+  encodeErrorToFailure,
+  encodeToPayloads,
+  filterNullAndUndefined,
+} from '@temporalio/common/lib/internal-non-workflow';
+import {
+  BaseClient,
+  BaseClientOptions,
+  defaultBaseClientOptions,
+  LoadedWithDefaults,
+  WithDefaults,
+} from './base-client';
 import { isServerErrorResponse } from './errors';
 import { WorkflowService } from './types';
 
@@ -36,6 +46,10 @@ export type AsyncCompletionClientOptions = BaseClientOptions;
 
 export type LoadedAsyncCompletionClientOptions = LoadedWithDefaults<AsyncCompletionClientOptions>;
 
+function defaultAsyncClientOptions(): WithDefaults<AsyncCompletionClientOptions> {
+  return defaultBaseClientOptions();
+}
+
 /**
  * A mostly unique Activity identifier including its scheduling workflow's ID
  * and an optional runId.
@@ -60,7 +74,11 @@ export class AsyncCompletionClient extends BaseClient {
 
   constructor(options?: AsyncCompletionClientOptions) {
     super(options);
-    this.options = this.baseOptions;
+    this.options = {
+      ...defaultAsyncClientOptions(),
+      ...filterNullAndUndefined(options ?? {}),
+      loadedDataConverter: this.dataConverter,
+    };
   }
 
   /**

--- a/packages/client/src/base-client.ts
+++ b/packages/client/src/base-client.ts
@@ -78,7 +78,7 @@ export class BaseClient {
     return await this.connection.withMetadata(metadata, fn);
   }
 
-  public get dataConverter(): LoadedDataConverter {
+  protected get dataConverter(): LoadedDataConverter {
     return this.loadedDataConverter;
   }
 }

--- a/packages/client/src/base-client.ts
+++ b/packages/client/src/base-client.ts
@@ -39,7 +39,6 @@ export type WithDefaults<Options extends BaseClientOptions> = //
 
 export type LoadedWithDefaults<Options extends BaseClientOptions> = //
   WithDefaults<Options> & {
-    /** @deprecated: use client.dataConverter instead */
     loadedDataConverter: LoadedDataConverter;
   };
 

--- a/packages/client/src/base-client.ts
+++ b/packages/client/src/base-client.ts
@@ -1,0 +1,80 @@
+import { DataConverter, LoadedDataConverter } from '@temporalio/common';
+import { isLoadedDataConverter, loadDataConverter } from '@temporalio/common/lib/internal-non-workflow';
+import { Connection } from './connection';
+import { ConnectionLike, Metadata } from './types';
+import * as os from 'os';
+
+export interface BaseClientOptions {
+  /**
+   * {@link DataConverter} to use for serializing and deserializing payloads
+   */
+  dataConverter?: DataConverter;
+
+  /**
+   * Identity to report to the server
+   *
+   * @default `${process.pid}@${os.hostname()}`
+   */
+  identity?: string;
+
+  /**
+   * Connection to use to communicate with the server.
+   *
+   * By default, connects to localhost.
+   *
+   * Connections are expensive to construct and should be reused.
+   */
+  connection?: ConnectionLike;
+
+  /**
+   * Server namespace
+   *
+   * @default default
+   */
+  namespace?: string;
+}
+
+export type LoadedWithDefaults<Options extends BaseClientOptions> = //
+  Required<Omit<Options, 'connection'>> &
+    Pick<Options, 'connection'> & {
+      loadedDataConverter: LoadedDataConverter;
+    };
+
+export class BaseClient {
+  public readonly connection: ConnectionLike;
+  protected readonly baseOptions: LoadedWithDefaults<BaseClientOptions>;
+
+  protected constructor(options?: BaseClientOptions) {
+    this.connection = options?.connection ?? Connection.lazy();
+    const dataConverter = options?.dataConverter ?? {};
+    const loadedDataConverter = isLoadedDataConverter(dataConverter) ? dataConverter : loadDataConverter(dataConverter);
+    this.baseOptions = {
+      dataConverter,
+      identity: options?.identity ?? `${process.pid}@${os.hostname()}`,
+      namespace: options?.namespace ?? 'default',
+      loadedDataConverter,
+    };
+  }
+
+  /**
+   * Set the deadline for any service requests executed in `fn`'s scope.
+   */
+  public async withDeadline<R>(deadline: number | Date, fn: () => Promise<R>): Promise<R> {
+    return await this.connection.withDeadline(deadline, fn);
+  }
+
+  /**
+   * Set metadata for any service requests executed in `fn`'s scope.
+   *
+   * @returns returned value of `fn`
+   *
+   * @see {@link Connection.withMetadata}
+   */
+  public async withMetadata<R>(metadata: Metadata, fn: () => Promise<R>): Promise<R> {
+    return await this.connection.withMetadata(metadata, fn);
+  }
+
+  protected get dataConverter(): LoadedDataConverter {
+    return this.baseOptions.loadedDataConverter;
+  }
+}

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -128,6 +128,7 @@ export interface WorkflowClientCallsInterceptorFactoryInput {
  * @deprecated: Please define interceptors directly, without factory
  */
 export interface WorkflowClientCallsInterceptorFactory {
+  // eslint-disable-next-line deprecation/deprecation
   (input: WorkflowClientCallsInterceptorFactoryInput): WorkflowClientCallsInterceptor;
 }
 
@@ -138,6 +139,7 @@ export interface WorkflowClientCallsInterceptorFactory {
  */
 export interface WorkflowClientInterceptors {
   /** @deprecated */
+  // eslint-disable-next-line deprecation/deprecation
   calls?: WorkflowClientCallsInterceptorFactory[];
 }
 
@@ -173,6 +175,7 @@ export type CreateScheduleOutput = {
  * NOTE: Currently only for {@link WorkflowClient} and {@link ScheduleClient}. More will be added later as needed.
  */
 export interface ClientInterceptors {
+  // eslint-disable-next-line deprecation/deprecation
   workflow?: WorkflowClientInterceptors | WorkflowClientInterceptor[];
 
   /**

--- a/packages/test/src/test-failure-converter.ts
+++ b/packages/test/src/test-failure-converter.ts
@@ -51,7 +51,7 @@ test('Client and Worker use provided failureConverter', async (t) => {
     const { events } = await fetchWorkflowHistory(env.client, handle.workflowId);
     const payload = events?.[events.length - 1].workflowExecutionFailedEventAttributes?.failure?.encodedAttributes;
     const attrs = await decodeFromPayloadsAtIndex<DefaultEncodedFailureAttributes>(
-      env.client.options.loadedDataConverter,
+      env.client.dataConverter,
       0,
       payload ? [payload] : undefined
     );

--- a/packages/test/src/test-failure-converter.ts
+++ b/packages/test/src/test-failure-converter.ts
@@ -51,7 +51,7 @@ test('Client and Worker use provided failureConverter', async (t) => {
     const { events } = await fetchWorkflowHistory(env.client, handle.workflowId);
     const payload = events?.[events.length - 1].workflowExecutionFailedEventAttributes?.failure?.encodedAttributes;
     const attrs = await decodeFromPayloadsAtIndex<DefaultEncodedFailureAttributes>(
-      env.client.dataConverter,
+      env.client.options.loadedDataConverter,
       0,
       payload ? [payload] : undefined
     );

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -95,16 +95,11 @@ class TestEnvClient extends Client {
   constructor(options: TestEnvClientOptions) {
     super(options);
 
-    const { workflow, loadedDataConverter, interceptors, ...base } = this.options;
-
     // Recreate the client (this isn't optimal but it's better than adding public methods just for testing).
     // NOTE: we cast to "any" to work around `workflow` being a readonly attribute.
     (this as any).workflow = new TimeSkippingWorkflowClient({
-      ...base,
-      ...workflow,
+      ...this.workflow.options,
       connection: options.connection,
-      dataConverter: loadedDataConverter,
-      interceptors: interceptors.workflow,
       enableTimeSkipping: options.enableTimeSkipping,
     });
   }


### PR DESCRIPTION
## What changed

- Extracted a `BaseClient` super class over `Client`, `WorkflowClient`, `ScheduleClient` and `AsyncCompletionClient`.

## Why

- Improves maintainability