### PR TITLE
fix(client): Add missing field in schedules

### DIFF
--- a/packages/client/src/schedule-helpers.ts
+++ b/packages/client/src/schedule-helpers.ts
@@ -320,6 +320,7 @@ export function decodeScheduleSpec(
     startAt: optionalTsToDate(pb.startTime),
     endAt: optionalTsToDate(pb.endTime),
     jitter: optionalTsToMs(pb.jitter),
+    timezone: pb.timezoneName ?? undefined,
   };
 }
 


### PR DESCRIPTION
## What changed

- Handle field `timezoneName` in schedule Proto to TypeScript decoding


## Why

- Missed that field in original PR