### PR TITLE
Use https submodule url for easier clones in CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sdk-core"]
 	path = packages/core-bridge/sdk-core
-	url = git@github.com:temporalio/sdk-core.git
+    url = https://github.com/temporalio/sdk-core.git


### PR DESCRIPTION
Git url is hard to make work in workflows ci