### PR TITLE
chore: Refactor mass history replayer API (Part 1)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "prettier"
   ],
   "rules": {
+    "eqeqeq": ["error", "always", { "null": "ignore" }],
     "no-duplicate-imports": "error",
     "object-shorthand": ["error", "always"],
     "deprecation/deprecation": "warn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19625,6 +19625,7 @@
         "@grpc/grpc-js": "^1.6.7",
         "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
+        "abort-controller": "^3.0.0",
         "long": "^5.2.0",
         "uuid": "^8.3.2"
       },
@@ -23840,6 +23841,7 @@
         "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
         "@types/long": "^5.0.0",
+        "abort-controller": "^3.0.0",
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
         "uuid": "^8.3.2"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,6 +16,7 @@
     "@grpc/grpc-js": "^1.6.7",
     "@temporalio/common": "file:../common",
     "@temporalio/proto": "file:../proto",
+    "abort-controller": "^3.0.0",
     "long": "^5.2.0",
     "uuid": "^8.3.2"
   },

--- a/packages/client/src/iterators-utils.ts
+++ b/packages/client/src/iterators-utils.ts
@@ -1,5 +1,6 @@
 import { EventEmitter, on, once } from 'node:events';
 import { AbortController } from 'abort-controller';
+
 export interface MapAsyncOptions {
   /**
    * How many items to map concurrently. If set to less than 2 (or not set), then items are not mapped concurrently.

--- a/packages/client/src/iterators-utils.ts
+++ b/packages/client/src/iterators-utils.ts
@@ -1,0 +1,56 @@
+import { EventEmitter, on } from 'node:events';
+
+export async function* mapAsyncIterable<A, B>(
+  source: AsyncIterable<A>,
+  func: (val: A) => Promise<B>
+): AsyncIterable<B> {
+  for await (const x of source) {
+    yield func(x);
+  }
+}
+
+export async function* raceMapAsyncIterable<A, B>(
+  source: AsyncIterable<A>,
+  mapFn: (val: A) => Promise<B>,
+  concurrency: number
+): AsyncIterable<B> {
+  const emiter = new EventEmitter();
+  const sourceIterator = source[Symbol.asyncIterator]();
+  let sourceIteratorDone = false;
+  let pendingPromisesCount = 0;
+  let pendingResultsCount = 0;
+
+  async function maybeStartTasks() {
+    while (!sourceIteratorDone && pendingPromisesCount + pendingResultsCount < concurrency) {
+      const val = await sourceIterator.next();
+      if (val.done) {
+        sourceIteratorDone = true;
+        return pendingPromisesCount > 0;
+      }
+
+      pendingPromisesCount++;
+      (async () => {
+        try {
+          emiter.emit('result', await mapFn(val.value));
+          pendingResultsCount++;
+        } finally {
+          pendingPromisesCount--;
+        }
+        return maybeStartTasks();
+      })().catch((e) => console.error(e)); // FIXME-JWH: Deal with exceptions
+    }
+
+    return !sourceIteratorDone || pendingPromisesCount > 0;
+  }
+
+  // The listener must be registered before we start emiting events
+  // through the emiter; otherwise, these events get silently discarded.
+  const emiterEventsIterable = on(emiter, 'result');
+
+  if (!(await maybeStartTasks())) return;
+  for await (const [res] of emiterEventsIterable) {
+    pendingResultsCount--;
+    yield res as B;
+    if (!(await maybeStartTasks())) return;
+  }
+}

--- a/packages/client/src/iterators-utils.ts
+++ b/packages/client/src/iterators-utils.ts
@@ -1,5 +1,5 @@
 import { EventEmitter, on, once } from 'node:events';
-
+import { AbortController } from 'abort-controller';
 export interface MapAsyncOptions {
   /**
    * How many items to map concurrently. If set to less than 2 (or not set), then items are not mapped concurrently.

--- a/packages/client/src/iterators-utils.ts
+++ b/packages/client/src/iterators-utils.ts
@@ -1,14 +1,32 @@
 import { EventEmitter, on } from 'node:events';
 
+/**
+ * Return an async iterable that transforms items from a source iterable by mapping each item
+ * through a mapping function.
+ *
+ * @param source the source async iterable
+ * @param mapFn a mapping function to apply on every item of the source iterable
+ */
 export async function* mapAsyncIterable<A, B>(
   source: AsyncIterable<A>,
-  func: (val: A) => Promise<B>
+  mapFn: (val: A) => Promise<B>
 ): AsyncIterable<B> {
   for await (const x of source) {
-    yield func(x);
+    yield mapFn(x);
   }
 }
 
+/**
+ * Return an async iterable that transforms items from a source iterable by concurrently mapping
+ * each item through a mapping function.
+ *
+ * Mapped items are returned by the resulting iterator in the order they complete processing,
+ * not the order in which the corresponding source items were obtained from the source iterator.
+ *
+ * @param source the source async iterable
+ * @param mapFn a mapping function to apply on every item of the source iterable
+ * @param concurrency maximum number of items to map concurrently
+ */
 export async function* raceMapAsyncIterable<A, B>(
   source: AsyncIterable<A>,
   mapFn: (val: A) => Promise<B>,
@@ -37,7 +55,7 @@ export async function* raceMapAsyncIterable<A, B>(
           pendingPromisesCount--;
         }
         return maybeStartTasks();
-      })().catch((e) => console.error(e)); // FIXME-JWH: Deal with exceptions
+      })().catch((e) => emiter.emit('error', e));
     }
 
     return !sourceIteratorDone || pendingPromisesCount > 0;

--- a/packages/client/src/iterators-utils.ts
+++ b/packages/client/src/iterators-utils.ts
@@ -1,37 +1,42 @@
 import { EventEmitter, on } from 'node:events';
 
+export interface MapAsyncOptions {
+  /**
+   * How many items to map concurrently. If set to less than 2 (or not set), then items are not mapped concurrently.
+   *
+   * When items are mapped concurrently, mapped items are returned by the resulting iterator in the order they complete
+   * mapping, not the order in which the corresponding source items were obtained from the source iterator.
+   *
+   * @default 1 (ie. items are not mapped concurrently)
+   */
+  concurrency?: number;
+}
+
 /**
  * Return an async iterable that transforms items from a source iterable by mapping each item
  * through a mapping function.
+ *
+ * If `concurrency > 1`, then up to `concurrency` items may be mapped concurrently. In that case,
+ * items are returned by the resulting iterator in the order they complete processing, not the order
+ * in which the corresponding source items were obtained from the source iterator.
  *
  * @param source the source async iterable
  * @param mapFn a mapping function to apply on every item of the source iterable
  */
 export async function* mapAsyncIterable<A, B>(
   source: AsyncIterable<A>,
-  mapFn: (val: A) => Promise<B>
-): AsyncIterable<B> {
-  for await (const x of source) {
-    yield mapFn(x);
-  }
-}
-
-/**
- * Return an async iterable that transforms items from a source iterable by concurrently mapping
- * each item through a mapping function.
- *
- * Mapped items are returned by the resulting iterator in the order they complete processing,
- * not the order in which the corresponding source items were obtained from the source iterator.
- *
- * @param source the source async iterable
- * @param mapFn a mapping function to apply on every item of the source iterable
- * @param concurrency maximum number of items to map concurrently
- */
-export async function* raceMapAsyncIterable<A, B>(
-  source: AsyncIterable<A>,
   mapFn: (val: A) => Promise<B>,
-  concurrency: number
+  options: MapAsyncOptions
 ): AsyncIterable<B> {
+  const { concurrency } = { concurrency: 1, ...(options ?? {}) };
+
+  if (concurrency < 2) {
+    for await (const x of source) {
+      yield mapFn(x);
+    }
+    return;
+  }
+
   const emiter = new EventEmitter();
   const sourceIterator = source[Symbol.asyncIterator]();
   let sourceIteratorDone = false;

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -67,7 +67,7 @@ import {
   LoadedWithDefaults,
   WithDefaults,
 } from './base-client';
-import { raceMapAsyncIterable } from './iterators-utils';
+import { mapAsyncIterable } from './iterators-utils';
 
 /**
  * A client side handle to a single Workflow instance.
@@ -939,13 +939,13 @@ export class WorkflowClient extends BaseClient {
     return {
       [Symbol.asyncIterator]: () => this._list(options)[Symbol.asyncIterator](),
       intoHistories: (intoHistoriesOptions?: IntoHistoriesOptions) => {
-        return raceMapAsyncIterable(
+        return mapAsyncIterable(
           this._list(options),
           async ({ workflowId, runId }) => ({
             workflowId,
             history: await this.getHandle(workflowId, runId).fetchHistory(),
           }),
-          intoHistoriesOptions?.concurrency ?? 5
+          { concurrency: intoHistoriesOptions?.concurrency ?? 5 }
         );
       },
     };

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -958,7 +958,7 @@ export class WorkflowClient extends BaseClient {
             workflowId,
             history: await this.getHandle(workflowId, runId)
               .fetchHistory()
-              .catch((e) => undefined),
+              .catch((_) => undefined),
           }),
           { concurrency: intoHistoriesOptions?.concurrency ?? 5 }
         );

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -62,3 +62,11 @@ export type ActivityInterface = Record<string, ActivityFunction>;
  * Mapping of Activity name to function
  */
 export type UntypedActivities = Record<string, ActivityFunction>;
+
+/**
+ * A workflow's history and ID. Useful for replay.
+ */
+export interface HistoryAndWorkflowId {
+  workflowId: string;
+  history: temporal.api.history.v1.History | unknown;
+}

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -68,5 +68,5 @@ export type UntypedActivities = Record<string, ActivityFunction>;
  */
 export interface HistoryAndWorkflowId {
   workflowId: string;
-  history: temporal.api.history.v1.History | unknown;
+  history: temporal.api.history.v1.History | unknown | undefined;
 }

--- a/packages/test/src/test-failure-converter.ts
+++ b/packages/test/src/test-failure-converter.ts
@@ -1,6 +1,5 @@
 import { TestWorkflowEnvironment } from '@temporalio/testing';
 import { Worker } from '@temporalio/worker';
-import { fetchWorkflowHistory } from '@temporalio/worker/lib/replay';
 import { randomUUID } from 'crypto';
 import { test, bundlerOptions, ByteSkewerPayloadCodec } from './helpers';
 import {
@@ -48,7 +47,7 @@ test('Client and Worker use provided failureConverter', async (t) => {
     t.true(err.cause?.stack?.startsWith('ApplicationFailure: error message\n'));
 
     // Verify failure was indeed encoded
-    const { events } = await fetchWorkflowHistory(env.client, handle.workflowId);
+    const { events } = await handle.fetchHistory();
     const payload = events?.[events.length - 1].workflowExecutionFailedEventAttributes?.failure?.encodedAttributes;
     const attrs = await decodeFromPayloadsAtIndex<DefaultEncodedFailureAttributes>(
       env.client.options.loadedDataConverter,

--- a/packages/test/src/test-iterators-utils.ts
+++ b/packages/test/src/test-iterators-utils.ts
@@ -1,0 +1,131 @@
+import { mapAsyncIterable, raceMapAsyncIterable } from '@temporalio/client/lib/iterators-utils';
+import test from 'ava';
+
+test(`mapAsyncIterable returns mapped values`, async (t) => {
+  async function* source(): AsyncIterable<number> {
+    yield 1;
+    yield new Promise((resolve) => setTimeout(resolve, 50)).then(() => 2);
+    yield Promise.resolve(3);
+  }
+  const iterable = mapAsyncIterable(source(), multBy10);
+
+  const results: number[] = [];
+  for await (const res of iterable) {
+    results.push(res);
+  }
+  t.deepEqual(results, [10, 20, 30]);
+});
+
+test(`mapAsyncIterable's source function not executed until the mapped iterator actually get invoked`, async (t) => {
+  let invoked = false;
+
+  async function* name(): AsyncIterable<number> {
+    invoked = true;
+    yield 1;
+  }
+
+  const iterable = mapAsyncIterable(name(), multBy10);
+  const iterator = iterable[Symbol.asyncIterator]();
+
+  await Promise.resolve();
+
+  t.false(invoked);
+  t.is(await (await iterator.next()).value, 10);
+  t.true(invoked);
+});
+
+test(`mapAsyncIterable doesn't consume more input that required`, async (t) => {
+  let counter = 0;
+
+  async function* name(): AsyncIterable<number> {
+    for (;;) {
+      yield counter++;
+    }
+  }
+
+  const iterable = mapAsyncIterable(name(), multBy10);
+  const iterator = iterable[Symbol.asyncIterator]();
+
+  t.is(await (await iterator.next()).value, 0);
+  t.is(await (await iterator.next()).value, 10);
+  await Promise.resolve();
+  t.is(counter, 2);
+});
+
+test(`raceMapAsyncIterable run tasks concurrently`, async (t) => {
+  async function* name(): AsyncIterable<number> {
+    yield 200;
+    yield 1;
+    yield 1;
+    yield 200;
+    yield 1;
+    yield 1;
+    yield 200;
+    yield 1;
+    yield 1;
+  }
+
+  const iterable = raceMapAsyncIterable(name(), sleepThatTime, 4);
+
+  const startTime = Date.now();
+  const values: number[] = [];
+  for await (const val of iterable) {
+    values.push(val);
+  }
+  const endTime = Date.now();
+
+  t.deepEqual(values, [1, 1, 1, 1, 1, 1, 200, 200, 200]);
+  t.truthy(endTime - startTime < 400);
+});
+
+test(`raceMapAsyncIterable source function not executed until the mapped iterator actually get invoked`, async (t) => {
+  let invoked = false;
+
+  async function* name(): AsyncIterable<number> {
+    invoked = true;
+    yield 1;
+  }
+
+  const iterable = raceMapAsyncIterable(name(), multBy10, 4);
+  const iterator = iterable[Symbol.asyncIterator]();
+
+  await Promise.resolve();
+
+  t.false(invoked);
+  t.is(await (await iterator.next()).value, 10);
+  t.true(invoked);
+});
+
+test(`raceMapAsyncIterable doesn't consume more input than required`, async (t) => {
+  let counter = 0;
+
+  async function* name(): AsyncIterable<number> {
+    for (;;) {
+      yield ++counter;
+    }
+  }
+
+  const iterable = raceMapAsyncIterable(name(), sleepThatTime, 5);
+  const iterator = iterable[Symbol.asyncIterator]();
+
+  t.is((await iterator.next()).value, 1);
+  t.is((await iterator.next()).value, 2);
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  t.is((await iterator.next()).value, 3);
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  // Exact count could vary slightly due to some promise timing, but should be
+  // no more than (number of items read from output iterator + concurrency - 1)
+  // The minus one at the end of the formula is because the `maybeStartTasks()`
+  // following the yield in `raceMapAsyncIterable()` will only be called on
+  // next call to `iterator.next()`;
+  t.true(counter <= 7);
+});
+
+async function multBy10(x: number): Promise<number> {
+  return Promise.resolve(x * 10);
+}
+
+async function sleepThatTime(x: number): Promise<number> {
+  return new Promise((resolve) => setTimeout(() => resolve(x), x));
+}

--- a/packages/test/src/test-local-activities.ts
+++ b/packages/test/src/test-local-activities.ts
@@ -88,10 +88,7 @@ if (RUN_INTEGRATION_TESTS) {
       t.deepEqual(res, args);
 
       // Double check we have all local activity markers in history
-      const { history } = await client.workflowService.getWorkflowExecutionHistory({
-        namespace: 'default',
-        execution: { workflowId: handle.workflowId },
-      });
+      const history = await handle.fetchHistory();
       const markers = history?.events?.filter(
         (ev) => ev.eventType === temporal.api.enums.v1.EventType.EVENT_TYPE_MARKER_RECORDED
       );
@@ -160,10 +157,7 @@ if (RUN_INTEGRATION_TESTS) {
         taskQueue,
       });
       await handle.result();
-      const { history } = await client.workflowService.getWorkflowExecutionHistory({
-        namespace: 'default',
-        execution: { workflowId: handle.workflowId },
-      });
+      const history = await handle.fetchHistory();
       if (history?.events == null) {
         throw new Error('Expected non null events');
       }
@@ -244,10 +238,7 @@ if (RUN_INTEGRATION_TESTS) {
         workflowTaskTimeout: '3s',
       });
       await handle.result();
-      const { history } = await client.workflowService.getWorkflowExecutionHistory({
-        namespace: 'default',
-        execution: { workflowId: handle.workflowId },
-      });
+      const history = await handle.fetchHistory();
       const timers = history?.events?.filter(
         (ev) => ev.eventType === temporal.api.enums.v1.EventType.EVENT_TYPE_TIMER_FIRED
       );

--- a/packages/test/src/test-replay.ts
+++ b/packages/test/src/test-replay.ts
@@ -113,7 +113,7 @@ test('multiple-histories-replay', async (t) => {
       workflowsPath: require.resolve('./workflows'),
       replayName: t.title,
     },
-    { histories }
+    histories
   );
   t.is(res.errors.length, 0);
 });
@@ -132,7 +132,7 @@ test('multiple-histories-replay-fails-fast', async (t) => {
         workflowsPath: require.resolve('./workflows'),
         replayName: t.title,
       },
-      { histories }
+      histories
     )
   );
 });
@@ -150,7 +150,7 @@ test('multiple-histories-replay-fails-slow', async (t) => {
       replayName: t.title,
       failFast: false,
     },
-    { histories }
+    histories
   );
   t.is(res.errors.length, 1);
 });

--- a/packages/test/src/test-schedules.ts
+++ b/packages/test/src/test-schedules.ts
@@ -422,7 +422,7 @@ if (RUN_INTEGRATION_TESTS) {
             .sort();
 
           const createdSchedulesIds = Object.values(createdScheduleHandles).map((x) => x.scheduleId);
-          if (createdSchedulesIds.length != listedScheduleIds.length) throw new Error('Missing list entries');
+          if (createdSchedulesIds.length !== listedScheduleIds.length) throw new Error('Missing list entries');
 
           t.deepEqual(listedScheduleIds, createdSchedulesIds);
         },

--- a/packages/test/src/workflows/activity-failures.ts
+++ b/packages/test/src/workflows/activity-failures.ts
@@ -41,7 +41,7 @@ export function assertApplicationFailure(
   if (!(err instanceof ApplicationFailure)) {
     throw new Error(`Expected ApplicationFailure, got ${err}`);
   }
-  if (err.type !== type || err.nonRetryable != nonRetryable || err.message !== originalMessage) {
+  if (err.type !== type || err.nonRetryable !== nonRetryable || err.message !== originalMessage) {
     throw ApplicationFailure.nonRetryable(
       `Expected ${type} with nonRetryable=${nonRetryable} originalMessage=${originalMessage}, got ${err}`
     );

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -48,7 +48,7 @@ export {
   WorkflowBundlePath,
   WorkflowBundlePathWithSourceMap, // eslint-disable-line deprecation/deprecation
 } from './worker-options';
-export { ReplayError, ReplayExecutions, ReplayHistories, ReplayHistoriesOrExecutions, ReplayResults } from './replay';
+export { ReplayError, ReplayHistoriesIterable, ReplayResults } from './replay';
 export { WorkflowInboundLogInterceptor, workflowLogAttributes } from './workflow-log-interceptor';
 export {
   BundleOptions,

--- a/packages/worker/src/replay.ts
+++ b/packages/worker/src/replay.ts
@@ -1,6 +1,5 @@
-import { Client, WorkflowExecution } from '@temporalio/client';
-import { coresdk, temporal } from '@temporalio/proto';
-import { History } from './runtime';
+import { HistoryAndWorkflowId } from '@temporalio/client';
+import { coresdk } from '@temporalio/proto';
 
 export type EvictionReason = coresdk.workflow_activation.RemoveFromCache.EvictionReason;
 export const EvictionReason = coresdk.workflow_activation.RemoveFromCache.EvictionReason;
@@ -48,71 +47,11 @@ export interface ReplayRunOptions {
 }
 
 /**
- * A workflow's history and ID. Useful for replay.
- */
-export interface HistoryAndWorkflowId {
-  workflowId: string;
-  history: temporal.api.history.v1.History | unknown;
-}
-
-/**
- * An object containing an iterable of histories and their workflow IDs used for batch replaying.
+ * An iterable on worflow histories and their IDs, used for batch replaying.
  *
  * @experimental - this API is not considered stable
  */
-export interface ReplayHistories {
-  histories: AsyncIterable<HistoryAndWorkflowId> | Iterable<HistoryAndWorkflowId>;
-}
-/**
- * An object containing a client and an iterable of workflowIds and optional runIds to used for batch replaying.
- *
- * The client is used to download the histories concurrently.
- *
- * @experimental - this API is not considered stable
- */
-export interface ReplayExecutions {
-  /**
-   * Client used to download histories.
-   */
-  client: Client;
-  /**
-   * (Async) Iterable of workflow executions to use as a source for history replays.
-   */
-  executions: AsyncIterable<WorkflowExecution> | Iterable<WorkflowExecution>;
-  /**
-   * Maximum number of histories that will be fetched concurrently.
-   *
-   * @default 5
-   */
-  maxConcurrency?: number;
-}
-
-/**
- * Histories or executions to replay.
- *
- * @experimental - this API is not considered stable
- */
-export type ReplayHistoriesOrExecutions = ReplayExecutions | ReplayHistories;
-
-/**
- * @internal
- */
-export async function fetchWorkflowHistory(client: Client, workflowId: string, runId?: string): Promise<History> {
-  let nextPageToken: Uint8Array | undefined = undefined;
-  const history = Array<temporal.api.history.v1.IHistoryEvent>();
-  for (;;) {
-    const response: temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse =
-      await client.connection.workflowService.getWorkflowExecutionHistory({
-        nextPageToken,
-        namespace: client.options.namespace,
-        execution: { workflowId, runId },
-      });
-    history.push(...(response.history?.events ?? []));
-    if (response.nextPageToken == null || response.nextPageToken.length === 0) break;
-    nextPageToken = response.nextPageToken;
-  }
-  return temporal.api.history.v1.History.create({ events: history });
-}
+export type ReplayHistoriesIterable = AsyncIterable<HistoryAndWorkflowId> | Iterable<HistoryAndWorkflowId>;
 
 /**
  * Handles known possible cases of replay eviction reasons.


### PR DESCRIPTION
## What changed

- In client package, introduce `WorkflowHandle.fetchHistory()` which returns the complete history for a workflow. That function might be useful in testing and replaces function `fetchWorkflowHistory`.
- The iterable returned by `WorkflowClient.list()` can now be easily transformed to an iterable of Workflow histories, using `WorkflowClient.list().intoHistories()`. Multiple Workflow histories are fetched in parallel (with a concurency of 5 by default).
- `WorkflowClient.list().intoHistories()` is now the proper way to provide histories to `Worker.runReplayHistories()` when those histories have to be fetched from an actual server. The previous experimental interface `ReplayExecutions` is no longer accepted.