### PR TITLE
feat(worker): Make OTel export period configurable

### DIFF
--- a/packages/core-bridge/src/conversions.rs
+++ b/packages/core-bridge/src/conversions.rs
@@ -260,15 +260,9 @@ impl ObjectHandleConversionsExt for Handle<'_, JsObject> {
                     } else {
                         Default::default()
                     };
-                let metric_periodicity = Some(Duration::from_millis(js_value_getter!(
-                    cx,
-                    otel,
-                    "metricPeriodicity",
-                    JsNumber
-                ) as u64));
                 telemetry_opts.tracing(TraceExportConfig {
                     filter,
-                    exporter: TraceExporter::Otel(OtelCollectorOptions { url, headers, metric_periodicity }),
+                    exporter: TraceExporter::Otel(OtelCollectorOptions { url, headers, metric_periodicity: None }),
                 });
             } else {
                 cx.throw_type_error(

--- a/packages/core-bridge/src/conversions.rs
+++ b/packages/core-bridge/src/conversions.rs
@@ -231,8 +231,14 @@ impl ObjectHandleConversionsExt for Handle<'_, JsObject> {
                     } else {
                         Default::default()
                     };
+                let metric_periodicity = Some(Duration::from_millis(js_value_getter!(
+                    cx,
+                    otel,
+                    "metricPeriodicity",
+                    JsNumber
+                ) as u64));
                 telemetry_opts
-                    .metrics(MetricsExporter::Otel(OtelCollectorOptions { url, headers }));
+                    .metrics(MetricsExporter::Otel(OtelCollectorOptions { url, headers, metric_periodicity }));
             } else {
                 cx.throw_type_error(
                     "Invalid telemetryOptions.metrics, missing `prometheus` or `otel` option",
@@ -254,9 +260,15 @@ impl ObjectHandleConversionsExt for Handle<'_, JsObject> {
                     } else {
                         Default::default()
                     };
+                let metric_periodicity = Some(Duration::from_millis(js_value_getter!(
+                    cx,
+                    otel,
+                    "metricPeriodicity",
+                    JsNumber
+                ) as u64));
                 telemetry_opts.tracing(TraceExportConfig {
                     filter,
-                    exporter: TraceExporter::Otel(OtelCollectorOptions { url, headers }),
+                    exporter: TraceExporter::Otel(OtelCollectorOptions { url, headers, metric_periodicity }),
                 });
             } else {
                 cx.throw_type_error(

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -241,7 +241,7 @@ export class Runtime {
           otel: {
             url: tracing.otel.url,
             headers: tracing.otel.headers,
-            metricPeriodicity: msToNumber(tracing.otel.metricPeriodicity ?? '1s'),
+            metricsExportInterval: undefined,
           },
         },
         metrics: metrics && {
@@ -251,7 +251,7 @@ export class Runtime {
                 otel: {
                   url: metrics.otel.url,
                   headers: metrics.otel.headers,
-                  metricPeriodicity: msToNumber(metrics.otel.metricPeriodicity ?? '1s'),
+                  metricsExportInterval: msToNumber(metrics.otel.metricsExportInterval ?? '1s'),
                 },
               }
             : {

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -7,6 +7,8 @@ import {
   TelemetryOptions,
   CompiledTelemetryOptions,
   ForwardLogger,
+  MetricsExporter,
+  OtelCollectorExporter,
 } from '@temporalio/core-bridge';
 import { filterNullAndUndefined, normalizeTlsConfig } from '@temporalio/common/lib/internal-non-workflow';
 import { IllegalStateError } from '@temporalio/common';
@@ -24,11 +26,16 @@ import { History } from '@temporalio/common/lib/proto-utils';
 import * as v8 from 'v8';
 import * as fs from 'fs';
 import * as os from 'os';
+import { msToNumber } from '@temporalio/common/lib/time';
 
 export { History };
 
 function isForwardingLogger(opts: TelemetryOptions['logging']): opts is ForwardLogger {
   return Object.hasOwnProperty.call(opts, 'forward');
+}
+
+function isOtelCollectorExporter(opts: MetricsExporter): opts is OtelCollectorExporter {
+  return Object.hasOwnProperty.call(opts, 'otel');
 }
 
 /**
@@ -207,7 +214,7 @@ export class Runtime {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   protected static compileOptions(options: RuntimeOptions): CompiledRuntimeOptions {
     // eslint-disable-next-line deprecation/deprecation
-    const { logging, tracing, tracingFilter, ...otherTelemetryOpts } = options.telemetryOptions ?? {};
+    const { logging, tracing, metrics, tracingFilter, ...otherTelemetryOpts } = options.telemetryOptions ?? {};
 
     const defaultFilter = tracingFilter ?? makeTelemetryFilterString({ core: 'INFO', other: 'INFO' });
     const loggingFilter = logging?.filter;
@@ -232,8 +239,26 @@ export class Runtime {
         tracing: tracing?.otel && {
           filter: defaultFilter,
           otel: {
-            ...filterNullAndUndefined(tracing.otel),
+            url: tracing.otel.url,
+            headers: tracing.otel.headers,
+            metricPeriodicity: msToNumber(tracing.otel.metricPeriodicity ?? '1s'),
           },
+        },
+        metrics: metrics && {
+          temporality: metrics.temporality,
+          ...(isOtelCollectorExporter(metrics)
+            ? {
+                otel: {
+                  url: metrics.otel.url,
+                  headers: metrics.otel.headers,
+                  metricPeriodicity: msToNumber(metrics.otel.metricPeriodicity ?? '1s'),
+                },
+              }
+            : {
+                prometheus: {
+                  bindAddress: metrics.prometheus.bindAddress,
+                },
+              }),
         },
         ...filterNullAndUndefined(otherTelemetryOpts ?? {}),
       },


### PR DESCRIPTION
## What changed

- Make metrics export period for OTel configurable ([reference](https://github.com/temporalio/sdk-core/pull/442))