### PR TITLE
chore(core): Run clippy/fmt from npm's lint/format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,14 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16
+      - name: Install protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: packages/core-bridge
       - run: npm ci --ignore-scripts
       # eslint-import-resolver-typescript requires packages to be built
       - name: Compile all non-rust code

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "ci-stress": "node ./packages/test/lib/load/run-all-stress-ci-scenarios.js",
     "ci-nightly": "node ./packages/test/lib/load/run-all-nightly-scenarios.js",
     "wait-namespace": "node ./scripts/wait-on-temporal.mjs",
-    "lint": "eslint packages/*/src --ext .ts --no-error-on-unmatched-pattern --fix && prettier --write .",
-    "lint.check": "eslint packages/*/src --ext .ts --no-error-on-unmatched-pattern && prettier --end-of-line auto --check .",
+    "lint": "eslint packages/*/src --ext .ts --no-error-on-unmatched-pattern --fix && prettier --write . && lerna run --no-bail --stream lint",
+    "lint.check": "eslint packages/*/src --ext .ts --no-error-on-unmatched-pattern && prettier --end-of-line auto --check .  && lerna run --no-bail --stream lint.check",
     "lint.prune": "ts-prune --error -p tsconfig.prune.json --ignore \"used in module\" --skip \".d.ts\"",
-    "format": "prettier --write .",
+    "format": "prettier --write . && lerna run --no-bail --stream format",
     "clean": "node ./scripts/clean.mjs",
     "docs": "lerna run --stream maybe-install-deps-and-build-docs"
   },

--- a/packages/core-bridge/package.json
+++ b/packages/core-bridge/package.json
@@ -8,7 +8,10 @@
     "build-rust": "node ./scripts/build.js --force",
     "build": "npm run build-rust",
     "build-rust-release": "npm run build-rust -- --release",
-    "install": "node ./scripts/build.js"
+    "install": "node ./scripts/build.js",
+    "format": "cargo fmt",
+    "lint": "cargo clippy --fix",
+    "lint.check": "cargo clippy"
   },
   "keywords": [
     "temporal",

--- a/packages/core-bridge/src/conversions.rs
+++ b/packages/core-bridge/src/conversions.rs
@@ -237,8 +237,11 @@ impl ObjectHandleConversionsExt for Handle<'_, JsObject> {
                     "metricPeriodicity",
                     JsNumber
                 ) as u64));
-                telemetry_opts
-                    .metrics(MetricsExporter::Otel(OtelCollectorOptions { url, headers, metric_periodicity }));
+                telemetry_opts.metrics(MetricsExporter::Otel(OtelCollectorOptions {
+                    url,
+                    headers,
+                    metric_periodicity,
+                }));
             } else {
                 cx.throw_type_error(
                     "Invalid telemetryOptions.metrics, missing `prometheus` or `otel` option",
@@ -262,12 +265,14 @@ impl ObjectHandleConversionsExt for Handle<'_, JsObject> {
                     };
                 telemetry_opts.tracing(TraceExportConfig {
                     filter,
-                    exporter: TraceExporter::Otel(OtelCollectorOptions { url, headers, metric_periodicity: None }),
+                    exporter: TraceExporter::Otel(OtelCollectorOptions {
+                        url,
+                        headers,
+                        metric_periodicity: None,
+                    }),
                 });
             } else {
-                cx.throw_type_error(
-                    "Invalid telemetryOptions.tracing, missing `otel` option",
-                )?
+                cx.throw_type_error("Invalid telemetryOptions.tracing, missing `otel` option")?
             }
         }
 

--- a/packages/core-bridge/src/errors.rs
+++ b/packages/core-bridge/src/errors.rs
@@ -20,11 +20,11 @@ pub trait CustomError {
     where
         C: Context<'a>;
 
-    fn from_string<'a, C>(&self, cx: &mut C, message: impl Into<String>) -> JsResult<'a, JsObject>
+    fn construct_from_string<'a, C>(&self, cx: &mut C, message: impl Into<String>) -> JsResult<'a, JsObject>
     where
         C: Context<'a>;
 
-    fn from_error<'a, C, E>(&self, cx: &mut C, err: E) -> JsResult<'a, JsObject>
+    fn construct_from_error<'a, C, E>(&self, cx: &mut C, err: E) -> JsResult<'a, JsObject>
     where
         C: Context<'a>,
         E: std::error::Error;
@@ -46,7 +46,7 @@ impl CustomError for OnceCell<Root<JsFunction>> {
         error.construct(cx, args)
     }
 
-    fn from_string<'a, C>(&self, cx: &mut C, message: impl Into<String>) -> JsResult<'a, JsObject>
+    fn construct_from_string<'a, C>(&self, cx: &mut C, message: impl Into<String>) -> JsResult<'a, JsObject>
     where
         C: Context<'a>,
     {
@@ -54,12 +54,12 @@ impl CustomError for OnceCell<Root<JsFunction>> {
         self.construct(cx, args)
     }
 
-    fn from_error<'a, C, E>(&self, cx: &mut C, err: E) -> JsResult<'a, JsObject>
+    fn construct_from_error<'a, C, E>(&self, cx: &mut C, err: E) -> JsResult<'a, JsObject>
     where
         C: Context<'a>,
         E: std::error::Error,
     {
-        self.from_string(cx, format!("{:?}", err))
+        self.construct_from_string(cx, format!("{:?}", err))
     }
 }
 

--- a/packages/core-bridge/src/helpers.rs
+++ b/packages/core-bridge/src/helpers.rs
@@ -62,7 +62,7 @@ where
 {
     let err_str = format!("{}", err);
     callback_with_error(cx, callback, move |cx| {
-        UNEXPECTED_ERROR.from_string(cx, err_str)
+        UNEXPECTED_ERROR.construct_from_string(cx, err_str)
     })
 }
 

--- a/packages/core-bridge/src/testing.rs
+++ b/packages/core-bridge/src/testing.rs
@@ -32,10 +32,10 @@ pub fn get_ephemeral_server_target(mut cx: FunctionContext) -> JsResult<JsString
     let target = server
         .borrow()
         .as_ref()
-        .map(|s| cx.string(s.core_server.blocking_lock().target.to_owned()));
+        .map(|s| cx.string(s.core_server.blocking_lock().target.as_str()));
     if target.is_none() {
         ILLEGAL_STATE_ERROR
-            .from_string(&mut cx, "Tried to use closed test server")
+            .construct_from_string(&mut cx, "Tried to use closed test server")
             .and_then(|err| cx.throw(err))?;
     };
     Ok(target.unwrap())


### PR DESCRIPTION
## What changed

- `npm run format` now execute `cargo fmt` in the core-bridge package
- Similarly, `npm run lint` now execute `cargo cargo` in core-bridge

## Why

Rust code contained in package core-bridge but outside the core-sdk submodule can benefit from cargo fmt and cargo clippy, but it is easy to forget running them after modifying core-bridge's code.

Running these commands from that NPM package's format and lint scripts would help ensure that they are regularly run.

Fixes #970
Fixes #120