### PR TITLE
fix(workflow): Correctly handle condition with timeout of 0

### DIFF
--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -52,7 +52,7 @@ import { cleanOptionalStackTrace, u8 } from './helpers';
 import * as workflows from './workflows';
 import { withZeroesHTTPServer } from './zeroes-http-server';
 
-const { EVENT_TYPE_TIMER_STARTED, EVENT_TYPE_TIMER_FIRED, EVENT_TYPE_TIMER_CANCELED } =
+const { EVENT_TYPE_TIMER_STARTED, EVENT_TYPE_TIMER_FIRED, EVENT_TYPE_TIMER_CANCELED, EVENT_TYPE_MARKER_RECORDED } =
   iface.temporal.api.enums.v1.EventType;
 
 const timerEventTypes = new Set([EVENT_TYPE_TIMER_STARTED, EVENT_TYPE_TIMER_FIRED, EVENT_TYPE_TIMER_CANCELED]);
@@ -1420,5 +1420,28 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
       histories
     );
     t.pass();
+  });
+
+  test('Condition with timeout 0 does not block indefinitely', async (t) => {
+    const { client } = t.context;
+    const workflowId = uuid4();
+    const handle = await client.start(workflows.conditionTimeout0Simple, {
+      taskQueue: 'test',
+      workflowId,
+    });
+
+    t.is(await handle.result(), 0);
+
+    const history = await handle.fetchHistory();
+    const timerStartedEvents = history.events!.filter(({ eventType }) => eventType! === EVENT_TYPE_TIMER_STARTED);
+    t.is(timerStartedEvents.length, 2);
+    t.is(timerStartedEvents[0].timerStartedEventAttributes!.timerId, '1');
+    t.is(tsToMs(timerStartedEvents[0].timerStartedEventAttributes!.startToFireTimeout), 1000);
+    t.is(timerStartedEvents[1].timerStartedEventAttributes!.timerId, '2');
+    t.is(tsToMs(timerStartedEvents[1].timerStartedEventAttributes!.startToFireTimeout), 1);
+
+    const markersEvents = history.events!.filter(({ eventType }) => eventType! === EVENT_TYPE_MARKER_RECORDED);
+    t.is(markersEvents.length, 1);
+    t.is(markersEvents[0].markerRecordedEventAttributes!.markerName, CHANGE_MARKER_NAME);
   });
 }

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -1872,3 +1872,83 @@ test('query not found - successString', async (t) => {
     );
   }
 });
+
+test('condition with timeout 0 maintain pre 1.5.0 compatibility - conditionTimeout0', async (t) => {
+  const { workflowType } = t.context;
+  {
+    const act: coresdk.workflow_activation.IWorkflowActivation = {
+      runId: 'test-runId',
+      timestamp: msToTs(Date.now()),
+      isReplaying: true,
+      jobs: [makeStartWorkflowJob(workflowType)],
+    };
+    const completion = await activate(t, act);
+    compareCompletion(t, completion, makeSuccess([]));
+  }
+  {
+    const completion = await activate(t, await makeSignalWorkflow('a', []));
+    compareCompletion(
+      t,
+      completion,
+      makeSuccess([
+        makeSetPatchMarker('__sdk_internal_patch_number:1', false),
+        makeStartTimerCommand({
+          seq: 1,
+          startToFireTimeout: msToTs(1),
+        }),
+      ])
+    );
+  }
+  {
+    const completion = await activate(t, await makeFireTimer(1));
+    compareCompletion(
+      t,
+      completion,
+      makeSuccess([makeCompleteWorkflowExecution(defaultPayloadConverter.toPayload(1))])
+    );
+  }
+});
+
+test('condition with timeout 0 in >1.5.0 - conditionTimeout0', async (t) => {
+  const { workflowType } = t.context;
+  {
+    const act: coresdk.workflow_activation.IWorkflowActivation = {
+      runId: 'test-runId',
+      timestamp: msToTs(Date.now()),
+      jobs: [makeStartWorkflowJob(workflowType)],
+    };
+    const completion = await activate(t, act);
+    compareCompletion(
+      t,
+      completion,
+      makeSuccess([
+        makeSetPatchMarker('__sdk_internal_patch_number:1', false),
+        makeStartTimerCommand({
+          seq: 1,
+          startToFireTimeout: msToTs(1),
+        }),
+      ])
+    );
+  }
+  {
+    const completion = await activate(t, await makeFireTimer(1));
+    compareCompletion(
+      t,
+      completion,
+      makeSuccess([
+        makeStartTimerCommand({
+          seq: 2,
+          startToFireTimeout: msToTs(1),
+        }),
+      ])
+    );
+  }
+  {
+    const completion = await activate(t, await makeFireTimer(2));
+    compareCompletion(
+      t,
+      completion,
+      makeSuccess([makeCompleteWorkflowExecution(defaultPayloadConverter.toPayload(0))])
+    );
+  }
+});

--- a/packages/test/src/workflows/condition-timeout-0.ts
+++ b/packages/test/src/workflows/condition-timeout-0.ts
@@ -1,0 +1,42 @@
+/**
+ * Prior to 1.5.0, `condition(fn, 0)` was treated the same as `condition(..., undefined)`,
+ * which means that the condition would block indefinitely and would return undefined once
+ * fn evaluates to true, rather than returning true or false.
+ */
+import { condition, setHandler, defineSignal, sleep, ApplicationFailure } from '@temporalio/workflow';
+
+export const aSignal = defineSignal('a');
+export const bSignal = defineSignal('b');
+
+export async function conditionTimeout0(): Promise<number> {
+  let counter = 0;
+
+  let aSignalReceived = false;
+  setHandler(aSignal, () => {
+    aSignalReceived = true;
+  });
+
+  let bSignalReceived = false;
+  setHandler(bSignal, () => {
+    bSignalReceived = true;
+  });
+
+  const aResult = await condition(() => aSignalReceived, 0);
+  if (aResult === true || aResult === undefined) counter += 1;
+
+  const bResult = await condition(() => bSignalReceived, 0);
+  if (bResult === true || bResult === undefined) counter += 10;
+
+  return counter;
+}
+
+export async function conditionTimeout0Simple(): Promise<number> {
+  let validationTimerFired = false;
+  sleep(1000)
+    .then(() => (validationTimerFired = true))
+    .catch((e) => console.log(e));
+
+  const res = await condition(() => validationTimerFired, 0);
+  if (res === false) return 0;
+  throw ApplicationFailure.nonRetryable(`Unexpected result: '${res}'`);
+}

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -26,6 +26,7 @@ export * from './child-workflow-termination';
 export * from './child-workflow-timeout';
 export * from './condition';
 export * from './condition-completion-race';
+export * from './condition-timeout-0';
 export * from './continue-as-new-same-workflow';
 export * from './continue-as-new-to-different-workflow';
 export * from './date';

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1080,7 +1080,11 @@ export function condition(fn: () => boolean, timeout: number | string): Promise<
 export function condition(fn: () => boolean): Promise<void>;
 
 export async function condition(fn: () => boolean, timeout?: number | string): Promise<void | boolean> {
-  if (timeout) {
+  // Prior to 1.5.0, `condition(fn, 0)` was treated as equivalent to `condition(fn, undefined)`
+  if (timeout === 0 && !getActivator().checkInternalPatchAtLeast(1)) {
+    return conditionInner(fn);
+  }
+  if (typeof timeout === 'number' || typeof timeout === 'string') {
     return CancellationScope.cancellable(async () => {
       try {
         return await Promise.race([sleep(timeout).then(() => false), conditionInner(fn).then(() => true)]);


### PR DESCRIPTION
## What changed

- In workflows, `condition(fn, 0)` was incorrectly handled the same as `condition(fn, undefined)`, ie. the function would block indefinitely and would return nothing once `fn` evaluates to `true`. It now behaves the same as `condition(fn, 1)`, ie. the function will sleep (at most) for a very short time, then return `true` if `fn` evaluated to `true`, or `false` if `timeout` reached its expiration.
- Compatibility with existing workflow histories is maintained, through an internal patch.
- Introduced a SDK internal patch mechanism, which will make it easier and more efficient to support similar bug fixes in the future.