### PR TITLE
chore(create-project): Depend on tar ^6.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17679,19 +17679,19 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
+        "minipass": "^4.0.0",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">=10"
       }
     },
     "node_modules/tar-stream": {
@@ -17708,6 +17708,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
+      "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/temp-dir": {
@@ -19683,7 +19694,7 @@
         "glob": "^8.0.3",
         "got": "^12.1.0",
         "prompts": "^2.4.2",
-        "tar": "^6.1.11",
+        "tar": "^6.1.13",
         "update-check": "1.5.4",
         "validate-npm-package-name": "^4.0.0"
       },
@@ -23900,7 +23911,7 @@
         "glob": "^8.0.3",
         "got": "^12.1.0",
         "prompts": "^2.4.2",
-        "tar": "^6.1.11",
+        "tar": "^6.1.13",
         "update-check": "1.5.4",
         "validate-npm-package-name": "^4.0.0"
       },
@@ -36518,16 +36529,26 @@
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
     },
     "tar": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
+        "minipass": "^4.0.0",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
+          "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "tar-stream": {

--- a/packages/create-project/package.json
+++ b/packages/create-project/package.json
@@ -27,7 +27,7 @@
     "glob": "^8.0.3",
     "got": "^12.1.0",
     "prompts": "^2.4.2",
-    "tar": "^6.1.11",
+    "tar": "^6.1.13",
     "update-check": "1.5.4",
     "validate-npm-package-name": "^4.0.0"
   },


### PR DESCRIPTION
If you have earlier versions of tar in your npm cache `npx @temporalio/create` will fail with node 18.

https://github.com/temporalio/temporal-learning/pull/39