### PR TITLE
feat(client): Increase default gRPC retry policy maxAttempts to 13

### DIFF
--- a/packages/client/src/grpc-retry.ts
+++ b/packages/client/src/grpc-retry.ts
@@ -67,7 +67,7 @@ function withDefaultBackoffOptions({
   initialIntervalMs,
 }: Partial<BackoffOptions>): BackoffOptions {
   return {
-    maxAttempts: maxAttempts ?? 10,
+    maxAttempts: maxAttempts ?? 13,
     factor: factor ?? 2,
     maxJitter: maxJitter ?? 0.1,
     initialIntervalMs: initialIntervalMs ?? defaultInitialIntervalMs,


### PR DESCRIPTION
With the current 10 attempts, the cumulative time spent waiting could be as small as 9.2 seconds. If we raise it to 13, the client will wait at least 38 seconds before giving up. 

<img width="475" alt="image" src="https://user-images.githubusercontent.com/251288/210304610-5f492f5b-4c97-4f7b-85db-4edc939b0a50.png">
