### PR TITLE
fix: Remove `.post-create` before committing

### DIFF
--- a/packages/create-project/src/create-project.ts
+++ b/packages/create-project/src/create-project.ts
@@ -187,21 +187,22 @@ export async function createApp({
 
   console.log();
 
-  if (await tryGitInit(root, gitInit)) {
-    console.log('Initialized a git repository.');
-  }
-
   const messageFile = path.join(root, '.post-create');
-
-  console.log();
-  console.log(`${chalk.green('Success!')} Created project ${chalk.bold(appName)} at:`);
-  console.log();
-  console.log(chalk.bold(appPath + '/'));
-  console.log();
 
   try {
     await access(messageFile);
     const message = await readFile(messageFile, 'utf8');
+
+    await rm(messageFile);
+    if (await tryGitInit(root, gitInit)) {
+      console.log('Initialized a git repository.');
+    }
+
+    console.log();
+    console.log(`${chalk.green('Success!')} Created project ${chalk.bold(appName)} at:`);
+    console.log();
+    console.log(chalk.bold(appPath + '/'));
+    console.log();
 
     // Hack for creating a TemplateStringsArray
     // Required by chalk-template
@@ -211,7 +212,6 @@ export async function createApp({
       }
     }
     console.log(chalkTemplate(new MockTemplateString([message])));
-    await rm(messageFile);
   } catch (error) {
     const code = getErrorCode(error);
     if (code !== 'ENOENT') {


### PR DESCRIPTION

## What was changed
<!-- Describe what has changed in this PR -->


Currently it's deleted after the init/commit step, so user starts out dirty:

```
$ git status
On branch main
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    .post-create
```

## Checklist
<!--- add/delete as needed --->


2. How was this tested:

`packages/create-project/cli.js`

<img width="825" alt="image" src="https://user-images.githubusercontent.com/251288/211464492-f2e09448-b0bc-441e-8051-0204d24d9b98.png">

