### PR TITLE
fix: Pin version of @grpc/grpc-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -481,9 +481,9 @@
       "dev": true
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.1.tgz",
-      "integrity": "sha512-GVtMU4oh/TeKkWGzXUEsyZtyvSUIT1z49RtGH1UnEGeL+sLuxKl8QH3KZTlSB329R1sWJmesm5hQ5CxXdYH9dg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
+      "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -15465,7 +15465,7 @@
       "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
-        "@grpc/grpc-js": "^1.6.7",
+        "@grpc/grpc-js": "~1.7.3",
         "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
         "abort-controller": "^3.0.0",
@@ -15679,7 +15679,7 @@
       "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
-        "@grpc/grpc-js": "^1.6.8",
+        "@grpc/grpc-js": "~1.7.3",
         "@grpc/proto-loader": "^0.7.0",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
@@ -15719,7 +15719,7 @@
       "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
-        "@grpc/grpc-js": "^1.6.7",
+        "@grpc/grpc-js": "~1.7.3",
         "@temporalio/activity": "file:../activity",
         "@temporalio/client": "file:../client",
         "@temporalio/common": "file:../common",
@@ -16103,9 +16103,9 @@
       "dev": true
     },
     "@grpc/grpc-js": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.1.tgz",
-      "integrity": "sha512-GVtMU4oh/TeKkWGzXUEsyZtyvSUIT1z49RtGH1UnEGeL+sLuxKl8QH3KZTlSB329R1sWJmesm5hQ5CxXdYH9dg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
+      "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -18162,7 +18162,7 @@
     "@temporalio/client": {
       "version": "file:packages/client",
       "requires": {
-        "@grpc/grpc-js": "^1.6.7",
+        "@grpc/grpc-js": "~1.7.3",
         "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
         "abort-controller": "^3.0.0",
@@ -18314,7 +18314,7 @@
     "@temporalio/test": {
       "version": "file:packages/test",
       "requires": {
-        "@grpc/grpc-js": "^1.6.8",
+        "@grpc/grpc-js": "~1.7.3",
         "@grpc/proto-loader": "^0.7.0",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
@@ -18350,7 +18350,7 @@
     "@temporalio/testing": {
       "version": "file:packages/testing",
       "requires": {
-        "@grpc/grpc-js": "^1.6.7",
+        "@grpc/grpc-js": "~1.7.3",
         "@temporalio/activity": "file:../activity",
         "@temporalio/client": "file:../client",
         "@temporalio/common": "file:../common",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,7 +13,7 @@
   "author": "Temporal Technologies Inc. <sdk@temporal.io>",
   "license": "MIT",
   "dependencies": {
-    "@grpc/grpc-js": "^1.6.7",
+    "@grpc/grpc-js": "~1.7.3",
     "@temporalio/common": "file:../common",
     "@temporalio/proto": "file:../proto",
     "abort-controller": "^3.0.0",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -26,7 +26,7 @@
   "author": "Temporal Technologies Inc. <sdk@temporal.io>",
   "license": "MIT",
   "dependencies": {
-    "@grpc/grpc-js": "^1.6.8",
+    "@grpc/grpc-js": "~1.7.3",
     "@grpc/proto-loader": "^0.7.0",
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/core": "^1.8.0",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -12,7 +12,7 @@
   "author": "Temporal Technologies Inc. <sdk@temporal.io>",
   "license": "MIT",
   "dependencies": {
-    "@grpc/grpc-js": "^1.6.7",
+    "@grpc/grpc-js": "~1.7.3",
     "@temporalio/activity": "file:../activity",
     "@temporalio/client": "file:../client",
     "@temporalio/common": "file:../common",


### PR DESCRIPTION
## What changed

- Pinned package @grpc/grpc-js to ~1.7.3


## Why

- 1.8.3 cause a 10 second delay on node shutdown (fix #1023)
- 1.8.0 introduced an integrated retry mechanism which will duplicate our own, causing much more retries than expected

## Notes

- I willimmediately open a distinct issue for updating to >1.8.x at a later time