### PR TITLE
feat: Add startTime to WorkflowInfo, and more

### DIFF
--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -185,7 +185,8 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
           if (
             !history?.events?.some(
               ({ workflowTaskFailedEventAttributes }) =>
-                workflowTaskFailedEventAttributes?.failure?.message === "'not-found' is not a function"
+                workflowTaskFailedEventAttributes?.failure?.message ===
+                "Failed to initialize workflow of type 'not-found': no such function is exported by the workflow bundle"
             )
           ) {
             throw new Error('Cannot find workflow task failed event');
@@ -646,7 +647,8 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
       CustomKeywordField: ['test-value'],
       CustomIntField: [1, 2],
       CustomDatetimeField: [date.toISOString(), date.toISOString()],
-      datetimeInstanceofWorks: [false],
+      datetimeInstanceofWorks: [true],
+      arrayInstanceofWorks: [true],
       datetimeType: ['Date'],
     });
   });
@@ -712,6 +714,8 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
       workflowType: 'returnWorkflowInfo',
       workflowId,
       historyLength: 3,
+      startTime: result.startTime,
+      runStartTime: result.runStartTime,
       // unsafe.now is a function, so doesn't make it through serialization, but .now is required, so we need to cast
       unsafe: { isReplaying: false } as UnsafeWorkflowInfo,
     });

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -94,6 +94,8 @@ async function createWorkflow(
       searchAttributes: {},
       historyLength: 3,
       unsafe: { isReplaying: false, now: Date.now },
+      startTime: new Date(),
+      runStartTime: new Date(),
     },
     randomnessSeed: Long.fromInt(1337).toBytes(),
     now: startTime,

--- a/packages/test/src/workflows/return-search-attributes.ts
+++ b/packages/test/src/workflows/return-search-attributes.ts
@@ -7,5 +7,6 @@ export async function returnSearchAttributes(): Promise<SearchAttributes | undef
     ...sa,
     datetimeType: [Object.getPrototypeOf(datetime).constructor.name],
     datetimeInstanceofWorks: [datetime instanceof Date],
+    arrayInstanceofWorks: [sa.CustomIntField instanceof Array],
   };
 }

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -457,8 +457,8 @@ export function appendDefaultInterceptors(
 }
 
 export function addDefaultWorkerOptions(options: WorkerOptions): WorkerOptionsWithDefaults {
-  const { maxCachedWorkflows, showStackTraceSources, debugMode, namespace, ...rest } = options;
-
+  const { maxCachedWorkflows, showStackTraceSources, namespace, ...rest } = options;
+  const debugMode = options.debugMode || isSet(process.env.TEMPORAL_DEBUG);
   return {
     namespace: namespace ?? 'default',
     identity: `${process.pid}@${os.hostname()}`,
@@ -482,6 +482,12 @@ export function addDefaultWorkerOptions(options: WorkerOptions): WorkerOptionsWi
     sinks: defaultSinks(),
     ...rest,
   };
+}
+
+function isSet(env: string | undefined): boolean {
+  if (env === undefined) return false;
+  env = env.toLocaleLowerCase();
+  return env === '1' || env === 't' || env === 'true';
 }
 
 export function compileWorkerOptions(opts: WorkerOptionsWithDefaults): CompiledWorkerOptions {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1146,9 +1146,7 @@ export class Worker {
                         )
                       ) {
                         throw new TypeError(
-                          `Expected StartWorkflow with workflowId, workflowType, randomnessSeed, firstExecutionRunId, attempt and startTime. Got ${JSON.stringify(
-                            maybeStartWorkflow
-                          )}`
+                          `Malformed StartWorkflow activation: ${JSON.stringify(maybeStartWorkflow)}`
                         );
                       }
                       if (activation.timestamp == null) {

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -81,11 +81,15 @@ export interface WorkflowInfo {
    */
   continuedFromExecutionRunId?: string;
 
-  // TODO expose from Core
   /**
-   * Time at which the Workflow Run started
+   * Time at which this Workflow Execution Chain was started
    */
-  // startTime: Date;
+  startTime: Date;
+
+  /**
+   * Time at which the current Workflow Run started
+   */
+  runStartTime: Date;
 
   /**
    * Milliseconds after which the Workflow Execution is automatically terminated by Temporal Server. Set via {@link WorkflowOptions.workflowExecutionTimeout}.

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -82,7 +82,7 @@ export interface WorkflowInfo {
   continuedFromExecutionRunId?: string;
 
   /**
-   * Time at which this Workflow Execution Chain was started
+   * Time at which this [Workflow Execution Chain](https://docs.temporal.io/workflows#workflow-execution-chain) was started
    */
   startTime: Date;
 


### PR DESCRIPTION
## What changed

- Can now start workers in debug mode by setting environment variable `TEMPORAL_DEBUG=true` (fix #1020)
- No longer warn about no activities when running a replay-only Worker (fix #890)
- Improved error message when requested workflow type is not an exported function (fix #375)
- `instanceof` on `WorkflowInfo` fields now works as expected (fix #659)
- Added `startTime` and `runStartTime` on `WorkflowInfo` (fix #1005, fix #694)
