### PR TITLE
fix(client): Schedules specs can be empty

### DIFF
--- a/packages/client/src/schedule-helpers.ts
+++ b/packages/client/src/schedule-helpers.ts
@@ -24,7 +24,6 @@ import {
   optionalTsToMs,
   tsToDate,
 } from '@temporalio/common/lib/time';
-import { RequireAtLeastOne } from '@temporalio/common/src/type-helpers';
 import {
   CalendarSpec,
   CalendarSpecDescription,
@@ -300,9 +299,7 @@ export function encodeScheduleState(state?: ScheduleOptions['state']): temporal.
   };
 }
 
-export function decodeScheduleSpec(
-  pb: temporal.api.schedule.v1.IScheduleSpec
-): RequireAtLeastOne<ScheduleSpecDescription, 'calendars' | 'intervals'> {
+export function decodeScheduleSpec(pb: temporal.api.schedule.v1.IScheduleSpec): ScheduleSpecDescription {
   // Note: the server will have compiled calendar and cron_string fields into
   // structured_calendar (and maybe interval and timezone_name), so at this
   // point, we'll see only structured_calendar, interval, etc.

--- a/packages/common/src/type-helpers.ts
+++ b/packages/common/src/type-helpers.ts
@@ -12,11 +12,6 @@ export function checkExtends<_Orig, _Copy extends _Orig>(): void {
 
 export type Replace<Base, New> = Omit<Base, keyof New> & New;
 
-export type RequireAtLeastOne<Base, Keys extends keyof Base> = Omit<Base, Keys> &
-  {
-    [K in Keys]-?: Required<Pick<Base, K>> & Partial<Pick<Base, Exclude<Keys, K>>>;
-  }[Keys];
-
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }

--- a/packages/test/src/test-schedules.ts
+++ b/packages/test/src/test-schedules.ts
@@ -122,6 +122,29 @@ if (RUN_INTEGRATION_TESTS) {
     }
   });
 
+  test('Can create schedule without any spec', async (t) => {
+    const { client } = t.context;
+    const scheduleId = `can-create-schedule-without-any-spec-${randomUUID()}`;
+    const handle = await client.schedule.create({
+      scheduleId,
+      spec: {},
+      action: {
+        type: 'startWorkflow',
+        workflowType: dummyWorkflow,
+        taskQueue,
+      },
+    });
+
+    try {
+      const describedSchedule = await handle.describe();
+      t.deepEqual(describedSchedule.spec.calendars, []);
+      t.deepEqual(describedSchedule.spec.intervals, []);
+      t.deepEqual(describedSchedule.spec.skip, []);
+    } finally {
+      await handle.delete();
+    }
+  });
+
   test('Can create schedule with startWorkflow action (no arg)', async (t) => {
     const { client } = t.context;
     const scheduleId = `can-create-schedule-with-startWorkflow-action-${randomUUID()}`;

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -345,9 +345,7 @@ export type WorkerOptionsWithDefaults = WorkerOptions &
     /**
      * Controls the number of Worker threads the Worker should create.
      *
-     * Threads are used to create {@link https://nodejs.org/api/vm.html | vm }s for the
-     *
-     * isolated Workflow environment.
+     * Threads are used to create {@link https://nodejs.org/api/vm.html | vm }s for the isolated Workflow environment.
      *
      * New Workflows are created on this pool in a round-robin fashion.
      *


### PR DESCRIPTION
## What changed

- In `create` and `update` schedules, `spec` is still required, but can be empty. It is no longer required that the a schedule has at least one calandar, one interval or one cron spec.
- In `list`, all schedule properties (except `scheduleId`) are now optional, with a comment indicating that this structure is eventual consistent. This might change on server at some point in the future, but this matches the server behaviour for 1.18.x and 1.19.x.
- Duplicated fields from `ScheduleSummary` to `ScheduleDescription` to avoid further complexification of doc.

## Why

- Fix #1013
- Fix #967