### PR TITLE
fix(worker): Avoid webpack error on "node:" modules in workflows

### DIFF
--- a/packages/test/src/mocks/workflows-with-node-dependencies/example/client.ts
+++ b/packages/test/src/mocks/workflows-with-node-dependencies/example/client.ts
@@ -1,7 +1,10 @@
 import dns from 'dns';
+import http from 'node:http';
 
 export function exampleHeavyweightFunction(): void {
+  // Dummy code, only to ensure dependencies on 'dns' and 'node:http' do not get removed.
+  // This code will actually never run.
   dns.resolve('localhost', () => {
-    /* ignore */
+    http.get('localhost');
   });
 }

--- a/packages/test/src/test-bundler.ts
+++ b/packages/test/src/test-bundler.ts
@@ -61,7 +61,7 @@ if (RUN_INTEGRATION_TESTS) {
     const taskQueue = `${t.title}-${uuid4()}`;
     const workflowBundle = await bundleWorkflowCode({
       workflowsPath: require.resolve('./mocks/workflows-with-node-dependencies/issue-516'),
-      ignoreModules: ['dns'],
+      ignoreModules: ['dns', 'http'],
     });
     const worker = await Worker.create({
       taskQueue,


### PR DESCRIPTION
## What changed

- In the workflow bundler, ignored modules get replaced by an empty object from Webpack's `externals` hook, in addition to `aliases`.


## Why

- If workflow code add an import on some `node:` prefixed module, Webpack would fail to build, because that namespace is not supported for our target.
- Fixes #1036

