### PR TITLE
feat(workflow): Add support for default workflow handler and default signal handler

### DIFF
--- a/packages/test/src/test-default-workflow.ts
+++ b/packages/test/src/test-default-workflow.ts
@@ -8,7 +8,7 @@ import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
 import { existing } from './workflows/default-workflow-function';
 
 if (RUN_INTEGRATION_TESTS) {
-  test('Default workflow handler is used if requested workflow does not exists', async (t) => {
+  test('Default workflow handler is used if requested workflow does not exist', async (t) => {
     const taskQueue = `${t.title}-${uuid4()}`;
     const worker = await Worker.create({
       taskQueue,
@@ -23,7 +23,7 @@ if (RUN_INTEGRATION_TESTS) {
     });
   });
 
-  test('Default workflow handler is not used if requested workflow does exists', async (t) => {
+  test('Default workflow handler is not used if requested workflow exists', async (t) => {
     const taskQueue = `${t.title}-${uuid4()}`;
     const worker = await Worker.create({
       taskQueue,

--- a/packages/test/src/test-default-workflow.ts
+++ b/packages/test/src/test-default-workflow.ts
@@ -3,37 +3,53 @@
  */
 import test from 'ava';
 import { v4 as uuid4 } from 'uuid';
-import { WorkflowClient } from '@temporalio/client';
-import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { Worker } from './helpers';
 import { existing } from './workflows/default-workflow-function';
 
-if (RUN_INTEGRATION_TESTS) {
-  test('Default workflow handler is used if requested workflow does not exist', async (t) => {
+test('Default workflow handler is used if requested workflow does not exist', async (t) => {
+  const env = await TestWorkflowEnvironment.createLocal();
+  try {
     const taskQueue = `${t.title}-${uuid4()}`;
     const worker = await Worker.create({
+      connection: env.nativeConnection,
       taskQueue,
       workflowsPath: require.resolve('./workflows/default-workflow-function'),
     });
-    const client = new WorkflowClient();
     await worker.runUntil(async () => {
-      const result = client.execute('non-existing', { taskQueue, workflowId: uuid4(), args: ['test', 'foo', 'bar'] });
+      const result = env.client.workflow.execute('non-existing', {
+        taskQueue,
+        workflowId: uuid4(),
+        args: ['test', 'foo', 'bar'],
+      });
       t.is((await result).handler, 'default');
       t.is((await result).workflowType, 'non-existing');
       t.deepEqual((await result).args, ['test', 'foo', 'bar']);
     });
-  });
+  } finally {
+    await env.teardown();
+  }
+});
 
-  test('Default workflow handler is not used if requested workflow exists', async (t) => {
+test('Default workflow handler is not used if requested workflow exists', async (t) => {
+  const env = await TestWorkflowEnvironment.createLocal();
+  try {
     const taskQueue = `${t.title}-${uuid4()}`;
     const worker = await Worker.create({
+      connection: env.nativeConnection,
       taskQueue,
       workflowsPath: require.resolve('./workflows/default-workflow-function'),
     });
-    const client = new WorkflowClient();
     await worker.runUntil(async () => {
-      const result = client.execute(existing, { taskQueue, workflowId: uuid4(), args: ['test', 'foo', 'bar'] });
+      const result = env.client.workflow.execute(existing, {
+        taskQueue,
+        workflowId: uuid4(),
+        args: ['test', 'foo', 'bar'],
+      });
       t.is((await result).handler, 'existing');
       t.deepEqual((await result).args, ['test', 'foo', 'bar']);
     });
-  });
-}
+  } finally {
+    await env.teardown();
+  }
+});

--- a/packages/test/src/test-default-workflow.ts
+++ b/packages/test/src/test-default-workflow.ts
@@ -1,0 +1,39 @@
+/**
+ * Test usage of a default workflow handler
+ */
+import test from 'ava';
+import { v4 as uuid4 } from 'uuid';
+import { WorkflowClient } from '@temporalio/client';
+import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { existing } from './workflows/default-workflow-function';
+
+if (RUN_INTEGRATION_TESTS) {
+  test('Default workflow handler is used if requested workflow does not exists', async (t) => {
+    const taskQueue = `${t.title}-${uuid4()}`;
+    const worker = await Worker.create({
+      taskQueue,
+      workflowsPath: require.resolve('./workflows/default-workflow-function'),
+    });
+    const client = new WorkflowClient();
+    await worker.runUntil(async () => {
+      const result = client.execute('non-existing', { taskQueue, workflowId: uuid4(), args: ['test', 'foo', 'bar'] });
+      t.is((await result).handler, 'default');
+      t.is((await result).workflowType, 'non-existing');
+      t.deepEqual((await result).args, ['test', 'foo', 'bar']);
+    });
+  });
+
+  test('Default workflow handler is not used if requested workflow does exists', async (t) => {
+    const taskQueue = `${t.title}-${uuid4()}`;
+    const worker = await Worker.create({
+      taskQueue,
+      workflowsPath: require.resolve('./workflows/default-workflow-function'),
+    });
+    const client = new WorkflowClient();
+    await worker.runUntil(async () => {
+      const result = client.execute(existing, { taskQueue, workflowId: uuid4(), args: ['test', 'foo', 'bar'] });
+      t.is((await result).handler, 'existing');
+      t.deepEqual((await result).args, ['test', 'foo', 'bar']);
+    });
+  });
+}

--- a/packages/test/src/workflows/default-workflow-function.ts
+++ b/packages/test/src/workflows/default-workflow-function.ts
@@ -1,0 +1,27 @@
+import { DefaultWorkflowFunction } from '@temporalio/workflow';
+
+export interface WorkflowTypeAndArgs {
+  handler: string;
+  workflowType?: string;
+  args: unknown[];
+}
+
+export async function existing(...args: unknown[]): Promise<WorkflowTypeAndArgs> {
+  return {
+    handler: 'existing',
+    args,
+  };
+}
+
+const defaultWorkflow: DefaultWorkflowFunction = async function (
+  workflowType: string,
+  ...args: unknown[]
+): Promise<WorkflowTypeAndArgs> {
+  return {
+    handler: 'default',
+    workflowType,
+    args,
+  };
+};
+
+export default defaultWorkflow;

--- a/packages/test/src/workflows/default-workflow-function.ts
+++ b/packages/test/src/workflows/default-workflow-function.ts
@@ -1,4 +1,4 @@
-import { DefaultWorkflowFunction } from '@temporalio/workflow';
+import { workflowInfo } from '@temporalio/workflow';
 
 export interface WorkflowTypeAndArgs {
   handler: string;
@@ -13,15 +13,10 @@ export async function existing(...args: unknown[]): Promise<WorkflowTypeAndArgs>
   };
 }
 
-const defaultWorkflow: DefaultWorkflowFunction = async function (
-  workflowType: string,
-  ...args: unknown[]
-): Promise<WorkflowTypeAndArgs> {
+export default async function (...args: unknown[]): Promise<WorkflowTypeAndArgs> {
   return {
     handler: 'default',
-    workflowType,
+    workflowType: workflowInfo().workflowType,
     args,
   };
-};
-
-export default defaultWorkflow;
+}

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -72,6 +72,7 @@ export * from './shield-in-shield';
 export * from './signal-handlers-clear';
 export * from './signal-target';
 export * from './signals-are-always-processed';
+export * from './signals-ordering';
 export * from './sinks';
 export * from './sleep';
 export * from './sleep-invalid-duration';

--- a/packages/test/src/workflows/signals-ordering.ts
+++ b/packages/test/src/workflows/signals-ordering.ts
@@ -1,0 +1,37 @@
+/**
+ * Workflow used for testing default signal handler and signal ordering
+ *
+ * @module
+ */
+
+import { setHandler, setDefaultSignalHandler, defineSignal } from '@temporalio/workflow';
+
+const signalA = defineSignal<[number]>('signalA');
+const signalB = defineSignal<[number]>('signalB');
+const signalC = defineSignal<[number]>('signalC');
+
+export interface ProcessedSignal {
+  handler: string;
+  signalName?: string;
+  args: unknown[];
+}
+
+export async function signalsOrdering(): Promise<ProcessedSignal[]> {
+  const processedSignals: ProcessedSignal[] = [];
+
+  setHandler(signalA, (...args: unknown[]) => {
+    processedSignals.push({ handler: 'signalA', args });
+    setHandler(signalA, undefined);
+  });
+  setHandler(signalB, (...args: unknown[]) => {
+    processedSignals.push({ handler: 'signalB', args });
+  });
+  setDefaultSignalHandler((signalName: string, ...args: unknown[]) => {
+    processedSignals.push({ handler: 'default', signalName, args });
+  });
+  setHandler(signalC, (...args: unknown[]) => {
+    processedSignals.push({ handler: 'signalC', args });
+  });
+
+  return processedSignals;
+}

--- a/packages/test/src/workflows/signals-ordering.ts
+++ b/packages/test/src/workflows/signals-ordering.ts
@@ -35,3 +35,35 @@ export async function signalsOrdering(): Promise<ProcessedSignal[]> {
 
   return processedSignals;
 }
+
+export async function signalsOrdering2(): Promise<ProcessedSignal[]> {
+  const processedSignals: ProcessedSignal[] = [];
+
+  function handlerA(...args: unknown[]) {
+    processedSignals.push({ handler: 'signalA', args });
+    setHandler(signalA, undefined);
+    setHandler(signalB, handlerB);
+  }
+
+  function handlerB(...args: unknown[]) {
+    processedSignals.push({ handler: 'signalB', args });
+    setHandler(signalB, undefined);
+    setHandler(signalC, handlerC);
+  }
+
+  function handlerC(...args: unknown[]) {
+    processedSignals.push({ handler: 'signalC', args });
+    setHandler(signalC, undefined);
+    setDefaultSignalHandler(handlerDefault);
+  }
+
+  function handlerDefault(signalName: string, ...args: unknown[]) {
+    processedSignals.push({ handler: 'default', signalName, args });
+    setDefaultSignalHandler(undefined);
+    setHandler(signalA, handlerA);
+  }
+
+  setHandler(signalA, handlerA);
+
+  return processedSignals;
+}

--- a/packages/worker/src/workflow/vm-shared.ts
+++ b/packages/worker/src/workflow/vm-shared.ts
@@ -338,7 +338,7 @@ export abstract class BaseVMWorkflow implements Workflow {
     await new Promise(setImmediate);
     if (this.unhandledRejection) {
       return {
-        runId: activation.runId,
+        runId: this.activator.info.runId,
         failed: { failure: this.activator.errorToFailure(this.unhandledRejection) },
       };
     }

--- a/packages/worker/src/workflow/vm-shared.ts
+++ b/packages/worker/src/workflow/vm-shared.ts
@@ -11,10 +11,6 @@ import { partition } from '../utils';
 import { Workflow } from './interface';
 import { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
 
-export interface ActivationContext {
-  isReplaying: boolean;
-}
-
 // Not present in @types/node for some reason
 const { promiseHooks } = v8 as any;
 

--- a/packages/worker/src/workflow/vm.ts
+++ b/packages/worker/src/workflow/vm.ts
@@ -2,12 +2,10 @@ import assert from 'assert';
 import { AsyncLocalStorage } from 'async_hooks';
 import vm from 'vm';
 import { gte } from 'semver';
-import { WorkflowInfo } from '@temporalio/workflow';
 import { IllegalStateError } from '@temporalio/common';
 import { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interface';
 import { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
 import {
-  ActivationContext,
   BaseVMWorkflow,
   globalHandlers,
   injectConsole,

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -88,6 +88,7 @@ export {
   ChildWorkflowOptions,
   ContinueAsNew,
   ContinueAsNewOptions,
+  DefaultWorkflowFunction,
   EnhancedStackTrace,
   FileLocation,
   FileSlice,

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -88,7 +88,6 @@ export {
   ChildWorkflowOptions,
   ContinueAsNew,
   ContinueAsNewOptions,
-  DefaultWorkflowFunction,
   EnhancedStackTrace,
   FileLocation,
   FileSlice,

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1,5 +1,13 @@
 import type { RawSourceMap } from 'source-map';
-import { RetryPolicy, TemporalFailure, CommonWorkflowOptions, SearchAttributes } from '@temporalio/common';
+import {
+  RetryPolicy,
+  TemporalFailure,
+  CommonWorkflowOptions,
+  SearchAttributes,
+  SignalDefinition,
+  QueryDefinition,
+  WorkflowReturnType,
+} from '@temporalio/common';
 import { checkExtends } from '@temporalio/common/lib/type-helpers';
 import type { coresdk } from '@temporalio/proto';
 
@@ -380,3 +388,47 @@ export interface WorkflowCreateOptions {
 export interface WorkflowCreateOptionsWithSourceMap extends WorkflowCreateOptions {
   sourceMap: RawSourceMap;
 }
+
+/**
+ * A handler function capable of accepting the arguments for a given SignalDefinition or QueryDefinition.
+ */
+export type Handler<
+  Ret,
+  Args extends any[],
+  T extends SignalDefinition<Args> | QueryDefinition<Ret, Args>
+> = T extends SignalDefinition<infer A>
+  ? (...args: A) => void | Promise<void>
+  : T extends QueryDefinition<infer R, infer A>
+  ? (...args: A) => R
+  : never;
+
+/**
+ * ???
+ */
+export type DefaultSignalHandler = (signalName: string, ...args: unknown[]) => void | Promise<void>;
+
+/**
+ * Type of the "default" workflow function. The default workflow function can be used to catch any
+ * workflow type that is not defined explicitely by the workflow bundle.
+ *
+ * A common use case for a default workflow function is to implement custom Domain Specific
+ * Languages (DSLs), where the definition of the workflow is loaded dynamically from some external
+ * source.
+ *
+ * Example usage:
+ * ```ts
+ * const defaultWorkflow: DefaultWorkflowFunction = async function (
+ *   workflowType: string,
+ *   ...args: unknown[]
+ * ): Promise<WorkflowTypeAndArgs> {
+ *   return {
+ *     handler: 'default',
+ *     workflowType,
+ *     args,
+ *   };
+ * };
+ *
+ * export default defaultWorkflow;
+ * ```
+ */
+export type DefaultWorkflowFunction = (workflowType: string, ...args: unknown[]) => WorkflowReturnType;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -6,7 +6,6 @@ import {
   SearchAttributes,
   SignalDefinition,
   QueryDefinition,
-  WorkflowReturnType,
 } from '@temporalio/common';
 import { checkExtends } from '@temporalio/common/lib/type-helpers';
 import type { coresdk } from '@temporalio/proto';
@@ -403,32 +402,6 @@ export type Handler<
   : never;
 
 /**
- * ???
+ * A handler function accepting signals calls for non-registered signal names.
  */
 export type DefaultSignalHandler = (signalName: string, ...args: unknown[]) => void | Promise<void>;
-
-/**
- * Type of the "default" workflow function. The default workflow function can be used to catch any
- * workflow type that is not defined explicitely by the workflow bundle.
- *
- * A common use case for a default workflow function is to implement custom Domain Specific
- * Languages (DSLs), where the definition of the workflow is loaded dynamically from some external
- * source.
- *
- * Example usage:
- * ```ts
- * const defaultWorkflow: DefaultWorkflowFunction = async function (
- *   workflowType: string,
- *   ...args: unknown[]
- * ): Promise<WorkflowTypeAndArgs> {
- *   return {
- *     handler: 'default',
- *     workflowType,
- *     args,
- *   };
- * };
- *
- * export default defaultWorkflow;
- * ```
- */
-export type DefaultWorkflowFunction = (workflowType: string, ...args: unknown[]) => WorkflowReturnType;

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -140,7 +140,7 @@ export class Activator implements ActivationHandler {
   /**
    * A signal handler that catches calls for non-registered signal names.
    */
-  defaultSignalHandler: DefaultSignalHandler | undefined;
+  defaultSignalHandler?: DefaultSignalHandler;
 
   /**
    * Source map file for looking up the source files in response to __enhanced_stack_trace

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -532,9 +532,9 @@ export class Activator implements ActivationHandler {
 
   public async signalWorkflowNextHandler({ signalName, args }: SignalInput): Promise<void> {
     const fn = this.signalHandlers.get(signalName);
-    if (fn !== undefined) {
+    if (typeof fn === 'function') {
       return await fn(...args);
-    } else if (this.defaultSignalHandler !== undefined) {
+    } else if (typeof this.defaultSignalHandler === 'function') {
       return await this.defaultSignalHandler(signalName, ...args);
     } else {
       throw new IllegalStateError(`No registered signal handler for signal ${signalName}`);

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -137,15 +137,20 @@ export function initRuntime(options: WorkflowCreateOptionsWithSourceMap): void {
   }
 
   const mod = importWorkflows();
-  const workflow = mod[info.workflowType];
-  if (typeof workflow !== 'function') {
+  const workflowFn = mod[info.workflowType];
+  const defaultWorfklowFn = mod['default'];
+
+  if (typeof workflowFn === 'function') {
+    activator.workflow = workflowFn;
+  } else if (typeof defaultWorfklowFn === 'function') {
+    activator.workflow = defaultWorfklowFn.bind(undefined, info.workflowType);
+  } else {
     const details =
-      workflow === undefined
+      workflowFn === undefined
         ? 'no such function is exported by the workflow bundle'
-        : `expected a function, but got: '${typeof info.workflowType}'`;
+        : `expected a function, but got: '${typeof workflowFn}'`;
     throw new TypeError(`Failed to initialize workflow of type '${info.workflowType}': ${details}`);
   }
-  activator.workflow = workflow;
 }
 
 /**

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -143,7 +143,7 @@ export function initRuntime(options: WorkflowCreateOptionsWithSourceMap): void {
   if (typeof workflowFn === 'function') {
     activator.workflow = workflowFn;
   } else if (typeof defaultWorfklowFn === 'function') {
-    activator.workflow = defaultWorfklowFn.bind(undefined, info.workflowType);
+    activator.workflow = defaultWorfklowFn;
   } else {
     const details =
       workflowFn === undefined

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -41,6 +41,7 @@ import { LocalActivityDoBackoff, getActivator, maybeGetActivator } from './inter
 import { Sinks } from './sinks';
 import { untrackPromise } from './stack-helpers';
 import { ChildWorkflowHandle, ExternalWorkflowHandle } from './workflow-handle';
+import { assert } from 'console';
 
 // Avoid a circular dependency
 registerSleepImplementation(sleep);
@@ -1159,14 +1160,18 @@ export function setHandler<Ret, Args extends any[], T extends SignalDefinition<A
     if (typeof handler === 'function') {
       activator.signalHandlers.set(def.name, handler as any);
       activator.dispatchBufferedSignals();
-    } else {
+    } else if (handler == null) {
       activator.signalHandlers.delete(def.name);
+    } else {
+      throw new TypeError(`Expected handler to be either a function or 'undefined'. Got: '${typeof handler}'`);
     }
   } else if (def.type === 'query') {
     if (typeof handler === 'function') {
       activator.queryHandlers.set(def.name, handler as any);
-    } else {
+    } else if (handler == null) {
       activator.queryHandlers.delete(def.name);
+    } else {
+      throw new TypeError(`Expected handler to be either a function or 'undefined'. Got: '${typeof handler}'`);
     }
   } else {
     throw new TypeError(`Invalid definition type: ${(def as any).type}`);
@@ -1187,8 +1192,10 @@ export function setDefaultSignalHandler(handler: DefaultSignalHandler | undefine
   if (typeof handler === 'function') {
     activator.defaultSignalHandler = handler;
     activator.dispatchBufferedSignals();
-  } else {
+  } else if (handler == null) {
     activator.defaultSignalHandler = undefined;
+  } else {
+    throw new TypeError(`Expected handler to be either a function or 'undefined'. Got: '${typeof handler}'`);
   }
 }
 

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -41,7 +41,6 @@ import { LocalActivityDoBackoff, getActivator, maybeGetActivator } from './inter
 import { Sinks } from './sinks';
 import { untrackPromise } from './stack-helpers';
 import { ChildWorkflowHandle, ExternalWorkflowHandle } from './workflow-handle';
-import { assert } from 'console';
 
 // Avoid a circular dependency
 registerSleepImplementation(sleep);

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1177,7 +1177,7 @@ export function setHandler<Ret, Args extends any[], T extends SignalDefinition<A
 export function setDefaultSignalHandler(handler: DefaultSignalHandler | undefined): void {
   const activator = getActivator();
   activator.defaultSignalHandler = handler;
-  if (handler !== undefined) dispatchBufferedSignals();
+  if (handler != null) dispatchBufferedSignals();
 }
 
 function dispatchBufferedSignals() {

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1158,7 +1158,7 @@ export function setHandler<Ret, Args extends any[], T extends SignalDefinition<A
   if (def.type === 'signal') {
     if (typeof handler === 'function') {
       activator.signalHandlers.set(def.name, handler as any);
-      dispatchBufferedSignals();
+      activator.dispatchBufferedSignals();
     } else {
       activator.signalHandlers.delete(def.name);
     }
@@ -1184,24 +1184,11 @@ export function setHandler<Ret, Args extends any[], T extends SignalDefinition<A
  */
 export function setDefaultSignalHandler(handler: DefaultSignalHandler | undefined): void {
   const activator = getActivator();
-  activator.defaultSignalHandler = handler;
-  if (handler != null) dispatchBufferedSignals();
-}
-
-function dispatchBufferedSignals() {
-  const activator = getActivator();
-  const bufferedSignals = activator.bufferedSignals;
-  while (bufferedSignals.length) {
-    if (typeof activator.defaultSignalHandler === 'function') {
-      // We have a default signal handler, so all signals are dispatchable
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      activator.signalWorkflow(bufferedSignals.shift()!);
-    } else {
-      const foundIndex = bufferedSignals.findIndex((signal) => activator.signalHandlers.has(signal.signalName ?? ''));
-      if (foundIndex === -1) break;
-      const [signal] = bufferedSignals.splice(foundIndex, 1);
-      activator.signalWorkflow(signal);
-    }
+  if (typeof handler === 'function') {
+    activator.defaultSignalHandler = handler;
+    activator.dispatchBufferedSignals();
+  } else {
+    activator.defaultSignalHandler = undefined;
   }
 }
 


### PR DESCRIPTION
## What changed

- A workflow bundle can now do `export default async function (workflowType: string, ...args: unknown[]): Promise<unknown> { ... }` to define a default workflow handler.
- A workflow function can now do `setDefaultSignalHandler((signalName: string, ...args: unknown[]) => { ... })` to set a function that will handle signals sent for non-registered signal names.

## Why
- Partially covers #1015
- Resolves #973
- Resolves #846