### PR TITLE
fix(workflow): SDK Internal patch causes non-determinism if no longer required

### DIFF
--- a/packages/test/src/test-sdk-internal-patch.ts
+++ b/packages/test/src/test-sdk-internal-patch.ts
@@ -1,0 +1,49 @@
+import crypto from 'node:crypto';
+import test from 'ava';
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { Worker } from './helpers';
+import * as workflows from './workflows/sdk-internal-patch-before';
+
+test('SDK Internal Patch does not cause non-determinism error if user code modified', async (t) => {
+  const env = await TestWorkflowEnvironment.createLocal();
+  try {
+    const workflowId = crypto.randomUUID();
+
+    // Create the first worker with pre-patched version of the workflow
+    const worker1 = await Worker.create({
+      connection: env.nativeConnection,
+      taskQueue: 'sdk-internal-patch',
+      workflowsPath: require.resolve('./workflows/sdk-internal-patch-before'),
+      // Avoid waiting for sticky execution timeout on each worker transition
+      maxCachedWorkflows: 0,
+    });
+
+    // Start the workflow and wait for the first task to be processed
+    const handle = await worker1.runUntil(async () => {
+      const handle = await env.client.workflow.start(workflows.sdkInternalPatch, {
+        taskQueue: 'sdk-internal-patch',
+        workflowId,
+      });
+      await handle.query('__stack_trace');
+      return handle;
+    });
+
+    // Create the second worker with post-patched version of the workflow
+    const worker2 = await Worker.create({
+      connection: env.nativeConnection,
+      taskQueue: 'sdk-internal-patch',
+      workflowsPath: require.resolve('./workflows/sdk-internal-patch-after'),
+      maxCachedWorkflows: 0,
+    });
+
+    // Trigger a signal and wait for it to be processed
+    await worker2.runUntil(async () => {
+      await handle.query('__stack_trace');
+    });
+
+    // If the workflow completes, commands are generated in the right order and SDK internal patch are safe
+    t.pass();
+  } finally {
+    await env.teardown();
+  }
+});

--- a/packages/test/src/workflows/sdk-internal-patch-after.ts
+++ b/packages/test/src/workflows/sdk-internal-patch-after.ts
@@ -1,0 +1,15 @@
+/**
+ * "Before" version of a workflow used to reproduce an issue with SDK internal patch,
+ * where the user modifies his code so that the SDK internal patch no longer gets generated.
+ *
+ * @module
+ */
+import { condition, sleep } from '@temporalio/workflow';
+
+/**
+ * Patches the workflow from ./patch-and-condition-pre-patch, adds a patched statement inside a condition.
+ */
+export async function sdkInternalPatch(): Promise<void> {
+  await condition(() => false, 10);
+  await sleep(10);
+}

--- a/packages/test/src/workflows/sdk-internal-patch-before.ts
+++ b/packages/test/src/workflows/sdk-internal-patch-before.ts
@@ -1,0 +1,15 @@
+/**
+ * "Before" version of a workflow used to reproduce an issue with SDK internal patch,
+ * where the user modifies his code so that the SDK internal patch no longer gets generated.
+ *
+ * @module
+ */
+import { condition, sleep } from '@temporalio/workflow';
+
+/**
+ * Patches the workflow from ./patch-and-condition-pre-patch, adds a patched statement inside a condition.
+ */
+export async function sdkInternalPatch(): Promise<void> {
+  await condition(() => false, 0);
+  await sleep(1000);
+}

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -618,6 +618,12 @@ export class Activator implements ActivationHandler {
           `Unsupported internal patch number: ${internalPatchNumber} > ${LATEST_INTERNAL_PATCH_NUMBER}`
         );
       if (this.internalPatchNumber < internalPatchNumber) this.internalPatchNumber = internalPatchNumber;
+      // Make sure the internal patch command exists at that point in history, even if the user modifies his code to
+      // no longer rely on the operation that initally required this internal patch. Otherwise, we risks:
+      // Nondeterminism(Non-deprecated patch marker encountered ... but there is no corresponding change command!)
+      this.pushCommand({
+        setPatchMarker: { patchId: `__sdk_internal_patch_number:${LATEST_INTERNAL_PATCH_NUMBER}`, deprecated: false },
+      });
     } else {
       this.knownPresentPatches.add(activation.patchId);
     }


### PR DESCRIPTION
## What changed

- On receiving notification of a SDK Internal Patch, an identical command is now immediately generated.

## Why

- If workflow code was modified so that it no longer required that SDK internal patch, then core would complain of non-determinism due to the fact that history contained a patch event, but no corresponding patch command had been generated by the workflow.
- SDK internal patch can't be marked as "deprecated", because they may have side effect on future events.