### PR TITLE
fix(create-project): Support samples without tsconfigs

### DIFF
--- a/packages/create-project/src/helpers/install.ts
+++ b/packages/create-project/src/helpers/install.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from 'fs/promises';
 
 import { spawn } from './subprocess.js';
 import { isUrlOk } from './samples.js';
+import { getErrorCode } from './get-error-code.js';
 
 interface InstallArgs {
   root: string;
@@ -45,8 +46,18 @@ export async function updateNodeVersion({ root }: InstallArgs): Promise<void> {
       await writeFile(fileName, fileString.replace(`@tsconfig/node${versionAlreadyInPackageJson}`, packageName));
 
       const tsconfigJson = `${root}/tsconfig.json`;
-      fileString = (await readFile(tsconfigJson)).toString();
-      await writeFile(tsconfigJson, fileString.replace(`@tsconfig/node${versionAlreadyInPackageJson}`, packageName));
+
+      try {
+        fileString = (await readFile(tsconfigJson)).toString();
+        await writeFile(tsconfigJson, fileString.replace(`@tsconfig/node${versionAlreadyInPackageJson}`, packageName));
+      } catch (error) {
+        const code = getErrorCode(error);
+
+        // If the file doesn't exist, that's fine
+        if (code !== 'ENOENT') {
+          throw error;
+        }
+      }
     }
 
     await writeFile(`${root}/.nvmrc`, currentNodeVersion.toString());


### PR DESCRIPTION

## What was changed
<!-- Describe what has changed in this PR -->

Ignore ENOENT errors from trying to edit `tsconfig.json` in sample root.

## Why?
<!-- Tell your future self why have you made these changes -->

So tool doesn't crash in Node 17+.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

https://github.com/temporalio/samples-typescript/issues/251

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

`./cli.js --sample food-delivery`

Thanks @cliffordfajardo for reporting! 😊