### PR TITLE
Stronger query and signal definitions

### DIFF
--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -47,7 +47,7 @@ export interface WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs extends an
   /**
    * SignalDefinition or name of signal
    */
-  signal: SignalDefinition | string;
+  signal: SignalDefinition<SignalArgs> | string;
 
   /**
    * Arguments to invoke the signal handler with

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -47,7 +47,7 @@ export interface QueryDefinition<Ret, Args extends any[] = [], Name extends stri
    * This field is not present at run-time.
    */
   [argsBrand]: Args;
-    /**
+  /**
    * Virtual type brand to maintain a distinction between {@link QueryDefinition} types with different return types.
    * This field is not present at run-time.
    */

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -19,7 +19,7 @@ declare const argsBrand: unique symbol;
 /**
  * An interface representing a Workflow signal definition, as returned from {@link defineSignal}
  *
- * @remarks `Args` can be used for parameter type inference in handler functions and *WorkflowHandle methods.  
+ * @remarks `Args` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
  * `Name` can optionally be specified with a string literal type to preserve type-level knowledge of the signal name.
  */
 export interface SignalDefinition<Args extends any[] = [], Name extends string = string> {
@@ -36,7 +36,7 @@ declare const retBrand: unique symbol;
 /**
  * An interface representing a Workflow query definition as returned from {@link defineQuery}
  *
- * @remarks `Args` and `Ret` can be used for parameter type inference in handler functions and *WorkflowHandle methods.  
+ * @remarks `Args` and `Ret` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
  * `Name` can optionally be specified with a string literal type to preserve type-level knowledge of the query name.
  */
 export interface QueryDefinition<Ret, Args extends any[] = [], Name extends string = string> {

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -15,26 +15,31 @@ export type WorkflowQueryType = (...args: any[]) => any;
  */
 export type Workflow = (...args: any[]) => WorkflowReturnType;
 
+declare const argsBrand: unique symbol;
 /**
  * An interface representing a Workflow signal definition, as returned from {@link defineSignal}
  *
  * @remarks `_Args` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export interface SignalDefinition<_Args extends any[] = []> {
+export interface SignalDefinition<Args extends any[] = [], Name extends string = string> {
   type: 'signal';
-  name: string;
+  name: Name;
+  [argsBrand]: Args;
 }
 
+declare const retBrand: unique symbol;
 /**
  * An interface representing a Workflow query definition as returned from {@link defineQuery}
  *
  * @remarks `_Args` and `_Ret` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export interface QueryDefinition<_Ret, _Args extends any[] = []> {
+export interface QueryDefinition<Ret, Args extends any[] = [], Name extends string = string> {
   type: 'query';
-  name: string;
+  name: Name;
+  [argsBrand]: Args;
+  [retBrand]: Ret;
 }
 
 /** Get the "unwrapped" return type (without Promise) of the execute handler from Workflow type `W` */

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -19,12 +19,16 @@ declare const argsBrand: unique symbol;
 /**
  * An interface representing a Workflow signal definition, as returned from {@link defineSignal}
  *
- * @remarks `Args` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
+ * @remarks `Args` can be used for parameter type inference in handler functions and *WorkflowHandle methods.  
+ * `Name` can optionally be specified with a string literal type to preserve type-level knowledge of the signal name.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface SignalDefinition<Args extends any[] = [], Name extends string = string> {
   type: 'signal';
   name: Name;
+  /**
+   * Virtual type brand to maintain a distinction between {@link SignalDefinition} types with different args.
+   * This field is not present at run-time.
+   */
   [argsBrand]: Args;
 }
 
@@ -32,13 +36,21 @@ declare const retBrand: unique symbol;
 /**
  * An interface representing a Workflow query definition as returned from {@link defineQuery}
  *
- * @remarks `Args` and `Ret` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
+ * @remarks `Args` and `Ret` can be used for parameter type inference in handler functions and *WorkflowHandle methods.  
+ * `Name` can optionally be specified with a string literal type to preserve type-level knowledge of the query name.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface QueryDefinition<Ret, Args extends any[] = [], Name extends string = string> {
   type: 'query';
   name: Name;
+  /**
+   * Virtual type brand to maintain a distinction between {@link QueryDefinition} types with different args.
+   * This field is not present at run-time.
+   */
   [argsBrand]: Args;
+    /**
+   * Virtual type brand to maintain a distinction between {@link QueryDefinition} types with different return types.
+   * This field is not present at run-time.
+   */
   [retBrand]: Ret;
 }
 

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -19,7 +19,7 @@ declare const argsBrand: unique symbol;
 /**
  * An interface representing a Workflow signal definition, as returned from {@link defineSignal}
  *
- * @remarks `_Args` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
+ * @remarks `Args` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface SignalDefinition<Args extends any[] = [], Name extends string = string> {
@@ -32,7 +32,7 @@ declare const retBrand: unique symbol;
 /**
  * An interface representing a Workflow query definition as returned from {@link defineQuery}
  *
- * @remarks `_Args` and `_Ret` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
+ * @remarks `Args` and `Ret` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface QueryDefinition<Ret, Args extends any[] = [], Name extends string = string> {

--- a/packages/common/src/workflow-handle.ts
+++ b/packages/common/src/workflow-handle.ts
@@ -21,7 +21,10 @@ export interface BaseWorkflowHandle<T extends Workflow> {
    * await handle.signal(incrementSignal, 3);
    * ```
    */
-  signal<Args extends any[] = [], Name extends string = string>(def: SignalDefinition<Args, Name> | string, ...args: Args): Promise<void>;
+  signal<Args extends any[] = [], Name extends string = string>(
+    def: SignalDefinition<Args, Name> | string,
+    ...args: Args
+  ): Promise<void>;
 
   /**
    * The workflowId of the current Workflow

--- a/packages/common/src/workflow-handle.ts
+++ b/packages/common/src/workflow-handle.ts
@@ -21,7 +21,7 @@ export interface BaseWorkflowHandle<T extends Workflow> {
    * await handle.signal(incrementSignal, 3);
    * ```
    */
-  signal<Args extends any[] = []>(def: SignalDefinition<Args> | string, ...args: Args): Promise<void>;
+  signal<Args extends any[] = [], Name extends string = string>(def: SignalDefinition<Args, Name> | string, ...args: Args): Promise<void>;
 
   /**
    * The workflowId of the current Workflow

--- a/packages/test/src/test-interface-type-safety.ts
+++ b/packages/test/src/test-interface-type-safety.ts
@@ -8,18 +8,20 @@ test('SignalDefinition Name type safety', () => {
   const signalA = defineSignal<[string], 'a'>('a');
   const signalB = defineSignal<[string], 'b'>('b');
 
-  // @ts-expect-error Assert expect a type error when attempting to intermix named signal types
+  type TypeAssertion = typeof signalB extends typeof signalA ? 'intermixable' : 'not-intermixable';
+  
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const cannotIntermixNames: typeof signalA = signalB;
+  const assertion: TypeAssertion = 'not-intermixable';
 });
 
 test('SignalDefinition Args type safety', () => {
   const signalString = defineSignal<[string]>('a');
   const signalNumber = defineSignal<[number]>('b');
 
-  // @ts-expect-error Assert expect a type error when attempting to intermix named signal types
+  type TypeAssertion = typeof signalNumber extends typeof signalString ? 'intermixable' : 'not-intermixable';
+  
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const cannotIntermixArgTypes: typeof signalString = signalNumber;
+  const assertion: TypeAssertion = 'not-intermixable';
 });
 
 test('QueryDefinition Name type safety', () => {
@@ -29,23 +31,26 @@ test('QueryDefinition Name type safety', () => {
   const queryA = defineQuery<void, [string], 'a'>('a');
   const queryB = defineQuery<void, [string], 'b'>('b');
 
-  // @ts-expect-error Assert expect a type error when attempting to intermix named query types
+  type TypeAssertion = typeof queryB extends typeof queryA ? 'intermixable' : 'not-intermixable';
+  
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const cannotIntermixNames: typeof queryA = queryB;
+  const assertion: TypeAssertion = 'not-intermixable';
 });
 
 test('QueryDefinition Args and Ret type safety', () => {
     const retVariantA = defineQuery<string>('a');
     const retVariantB = defineQuery<number>('b');
   
-    // @ts-expect-error Assert expect a type error when attempting to intermix queries with different return types
+    type RetTypeAssertion = typeof retVariantB extends typeof retVariantA ? 'intermixable' : 'not-intermixable';
+  
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const cannotIntermixRetTypes: typeof retVariantA = retVariantB;
+    const retAssertion: RetTypeAssertion = 'not-intermixable';
 
     const argVariantA = defineQuery<string, [number]>('a');
     const argVariantB = defineQuery<string, [string]>('b');
   
-    // @ts-expect-error Assert expect a type error when attempting to intermix queries with different arg types
+    type ArgTypeAssertion = typeof argVariantB extends typeof argVariantA ? 'intermixable' : 'not-intermixable';
+  
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const cannotIntermixRetTypes: typeof argVariantA = argVariantB;
+    const argAssertion: ArgTypeAssertion = 'not-intermixable';
 });

--- a/packages/test/src/test-interface-type-safety.ts
+++ b/packages/test/src/test-interface-type-safety.ts
@@ -9,7 +9,7 @@ test('SignalDefinition Name type safety', () => {
   const signalB = defineSignal<[string], 'b'>('b');
 
   type TypeAssertion = typeof signalB extends typeof signalA ? 'intermixable' : 'not-intermixable';
-  
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const assertion: TypeAssertion = 'not-intermixable';
 });
@@ -19,7 +19,7 @@ test('SignalDefinition Args type safety', () => {
   const signalNumber = defineSignal<[number]>('b');
 
   type TypeAssertion = typeof signalNumber extends typeof signalString ? 'intermixable' : 'not-intermixable';
-  
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const assertion: TypeAssertion = 'not-intermixable';
 });
@@ -32,25 +32,25 @@ test('QueryDefinition Name type safety', () => {
   const queryB = defineQuery<void, [string], 'b'>('b');
 
   type TypeAssertion = typeof queryB extends typeof queryA ? 'intermixable' : 'not-intermixable';
-  
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const assertion: TypeAssertion = 'not-intermixable';
 });
 
 test('QueryDefinition Args and Ret type safety', () => {
-    const retVariantA = defineQuery<string>('a');
-    const retVariantB = defineQuery<number>('b');
-  
-    type RetTypeAssertion = typeof retVariantB extends typeof retVariantA ? 'intermixable' : 'not-intermixable';
-  
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const retAssertion: RetTypeAssertion = 'not-intermixable';
+  const retVariantA = defineQuery<string>('a');
+  const retVariantB = defineQuery<number>('b');
 
-    const argVariantA = defineQuery<string, [number]>('a');
-    const argVariantB = defineQuery<string, [string]>('b');
-  
-    type ArgTypeAssertion = typeof argVariantB extends typeof argVariantA ? 'intermixable' : 'not-intermixable';
-  
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const argAssertion: ArgTypeAssertion = 'not-intermixable';
+  type RetTypeAssertion = typeof retVariantB extends typeof retVariantA ? 'intermixable' : 'not-intermixable';
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const retAssertion: RetTypeAssertion = 'not-intermixable';
+
+  const argVariantA = defineQuery<string, [number]>('a');
+  const argVariantB = defineQuery<string, [string]>('b');
+
+  type ArgTypeAssertion = typeof argVariantB extends typeof argVariantA ? 'intermixable' : 'not-intermixable';
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const argAssertion: ArgTypeAssertion = 'not-intermixable';
 });

--- a/packages/test/src/test-interface-type-safety.ts
+++ b/packages/test/src/test-interface-type-safety.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import { defineSignal, defineQuery } from '@temporalio/workflow';
 
-test('SignalDefinition Name type safety', () => {
+test('SignalDefinition Name type safety', (t) => {
   // @ts-expect-error Assert expect a type error when generic and concrete names do not match
   defineSignal<[string], 'mismatch'>('illegal value');
 
@@ -10,21 +10,21 @@ test('SignalDefinition Name type safety', () => {
 
   type TypeAssertion = typeof signalB extends typeof signalA ? 'intermixable' : 'not-intermixable';
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const assertion: TypeAssertion = 'not-intermixable';
+  const _assertion: TypeAssertion = 'not-intermixable';
+  t.pass();
 });
 
-test('SignalDefinition Args type safety', () => {
+test('SignalDefinition Args type safety', (t) => {
   const signalString = defineSignal<[string]>('a');
   const signalNumber = defineSignal<[number]>('b');
 
   type TypeAssertion = typeof signalNumber extends typeof signalString ? 'intermixable' : 'not-intermixable';
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const assertion: TypeAssertion = 'not-intermixable';
+  const _assertion: TypeAssertion = 'not-intermixable';
+  t.pass();
 });
 
-test('QueryDefinition Name type safety', () => {
+test('QueryDefinition Name type safety', (t) => {
   // @ts-expect-error Assert expect a type error when generic and concrete names do not match
   defineQuery<void, [string], 'mismatch'>('illegal value');
 
@@ -33,24 +33,23 @@ test('QueryDefinition Name type safety', () => {
 
   type TypeAssertion = typeof queryB extends typeof queryA ? 'intermixable' : 'not-intermixable';
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const assertion: TypeAssertion = 'not-intermixable';
+  const _assertion: TypeAssertion = 'not-intermixable';
+  t.pass();
 });
 
-test('QueryDefinition Args and Ret type safety', () => {
+test('QueryDefinition Args and Ret type safety', (t) => {
   const retVariantA = defineQuery<string>('a');
   const retVariantB = defineQuery<number>('b');
 
   type RetTypeAssertion = typeof retVariantB extends typeof retVariantA ? 'intermixable' : 'not-intermixable';
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const retAssertion: RetTypeAssertion = 'not-intermixable';
+  const _retAssertion: RetTypeAssertion = 'not-intermixable';
 
   const argVariantA = defineQuery<string, [number]>('a');
   const argVariantB = defineQuery<string, [string]>('b');
 
   type ArgTypeAssertion = typeof argVariantB extends typeof argVariantA ? 'intermixable' : 'not-intermixable';
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const argAssertion: ArgTypeAssertion = 'not-intermixable';
+  const _argAssertion: ArgTypeAssertion = 'not-intermixable';
+  t.pass();
 });

--- a/packages/test/src/test-interface-type-safety.ts
+++ b/packages/test/src/test-interface-type-safety.ts
@@ -1,0 +1,51 @@
+import test from 'ava';
+import { defineSignal, defineQuery } from '@temporalio/workflow';
+
+test('SignalDefinition Name type safety', () => {
+  // @ts-expect-error Assert expect a type error when generic and concrete names do not match
+  defineSignal<[string], 'mismatch'>('illegal value');
+
+  const signalA = defineSignal<[string], 'a'>('a');
+  const signalB = defineSignal<[string], 'b'>('b');
+
+  // @ts-expect-error Assert expect a type error when attempting to intermix named signal types
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const cannotIntermixNames: typeof signalA = signalB;
+});
+
+test('SignalDefinition Args type safety', () => {
+  const signalString = defineSignal<[string]>('a');
+  const signalNumber = defineSignal<[number]>('b');
+
+  // @ts-expect-error Assert expect a type error when attempting to intermix named signal types
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const cannotIntermixArgTypes: typeof signalString = signalNumber;
+});
+
+test('QueryDefinition Name type safety', () => {
+  // @ts-expect-error Assert expect a type error when generic and concrete names do not match
+  defineQuery<void, [string], 'mismatch'>('illegal value');
+
+  const queryA = defineQuery<void, [string], 'a'>('a');
+  const queryB = defineQuery<void, [string], 'b'>('b');
+
+  // @ts-expect-error Assert expect a type error when attempting to intermix named query types
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const cannotIntermixNames: typeof queryA = queryB;
+});
+
+test('QueryDefinition Args and Ret type safety', () => {
+    const retVariantA = defineQuery<string>('a');
+    const retVariantB = defineQuery<number>('b');
+  
+    // @ts-expect-error Assert expect a type error when attempting to intermix queries with different return types
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const cannotIntermixRetTypes: typeof retVariantA = retVariantB;
+
+    const argVariantA = defineQuery<string, [number]>('a');
+    const argVariantB = defineQuery<string, [string]>('b');
+  
+    // @ts-expect-error Assert expect a type error when attempting to intermix queries with different arg types
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const cannotIntermixRetTypes: typeof argVariantA = argVariantB;
+});

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1122,7 +1122,9 @@ function conditionInner(fn: () => boolean): Promise<void> {
  * Definitions are used to register handler in the Workflow via {@link setHandler} and to signal Workflows using a {@link WorkflowHandle}, {@link ChildWorkflowHandle} or {@link ExternalWorkflowHandle}.
  * Definitions can be reused in multiple Workflows.
  */
-export function defineSignal<Args extends any[] = [], Name extends string = string>(name: Name): SignalDefinition<Args, Name> {
+export function defineSignal<Args extends any[] = [], Name extends string = string>(
+  name: Name
+): SignalDefinition<Args, Name> {
   return {
     type: 'signal',
     name,
@@ -1135,7 +1137,9 @@ export function defineSignal<Args extends any[] = [], Name extends string = stri
  * Definitions are used to register handler in the Workflow via {@link setHandler} and to query Workflows using a {@link WorkflowHandle}.
  * Definitions can be reused in multiple Workflows.
  */
-export function defineQuery<Ret, Args extends any[] = [], Name extends string =  string>(name: Name): QueryDefinition<Ret, Args, Name> {
+export function defineQuery<Ret, Args extends any[] = [], Name extends string = string>(
+  name: Name
+): QueryDefinition<Ret, Args, Name> {
   return {
     type: 'query',
     name,

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1135,7 +1135,7 @@ export function defineSignal<Args extends any[] = [], Name extends string = stri
  * Definitions are used to register handler in the Workflow via {@link setHandler} and to query Workflows using a {@link WorkflowHandle}.
  * Definitions can be reused in multiple Workflows.
  */
-export function defineQuery<Ret, Args extends any[] = [], Name extends string =  string>(name: string): QueryDefinition<Ret, Args, Name> {
+export function defineQuery<Ret, Args extends any[] = [], Name extends string =  string>(name: Name): QueryDefinition<Ret, Args, Name> {
   return {
     type: 'query',
     name,

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1122,11 +1122,11 @@ function conditionInner(fn: () => boolean): Promise<void> {
  * Definitions are used to register handler in the Workflow via {@link setHandler} and to signal Workflows using a {@link WorkflowHandle}, {@link ChildWorkflowHandle} or {@link ExternalWorkflowHandle}.
  * Definitions can be reused in multiple Workflows.
  */
-export function defineSignal<Args extends any[] = []>(name: string): SignalDefinition<Args> {
+export function defineSignal<Args extends any[] = [], Name extends string = string>(name: Name): SignalDefinition<Args, Name> {
   return {
     type: 'signal',
     name,
-  };
+  } as SignalDefinition<Args, Name>;
 }
 
 /**
@@ -1135,11 +1135,11 @@ export function defineSignal<Args extends any[] = []>(name: string): SignalDefin
  * Definitions are used to register handler in the Workflow via {@link setHandler} and to query Workflows using a {@link WorkflowHandle}.
  * Definitions can be reused in multiple Workflows.
  */
-export function defineQuery<Ret, Args extends any[] = []>(name: string): QueryDefinition<Ret, Args> {
+export function defineQuery<Ret, Args extends any[] = [], Name extends string =  string>(name: string): QueryDefinition<Ret, Args, Name> {
   return {
     type: 'query',
     name,
-  };
+  } as QueryDefinition<Ret, Args, Name>;
 }
 
 /**


### PR DESCRIPTION
## What was changed

This PR makes two refinements to the `SignalDefinition` and `QueryDefinition` types:
1. `Args` and `Ret` types are branded into the resulting types, using virtual symbolic brands. This addresses #1051
2. The `name` field is allowed to be narrowed to sub-type of `string` via an optional generic which defaults to `string`. I've used the least-intrusive option available here, which leaves behavior completely unchanged for existing callers, at the expense of making strict names a bit more verbose. This addresses #1052 

## Why?

Because #1051 and #1052 are making me sad.

## Checklist

1. Closes #1051 and #1052
2. How was this tested:  
    - [x] `npm run test`
    - [x] Added type-level tests
3. We may want to update the [Workflow TS docs](https://github.com/temporalio/documentation/blob/40176f12b79a73cc23481a3effdd98ddc2289e5e/docs-src/typescript/workflows.md)