### PR TITLE
doc(client): Dont specify exact count of prev/next schedules time

### DIFF
--- a/packages/client/src/schedule-types.ts
+++ b/packages/client/src/schedule-types.ts
@@ -207,12 +207,12 @@ export interface ScheduleSummary {
 
   info: {
     /**
-     * Most recent 10 Actions started (including manual triggers), sorted from older start time to newer.
+     * Most recent actions started (including manual triggers), sorted from older start time to newer.
      */
     recentActions: ScheduleExecutionResult[];
 
     /**
-     * Scheduled time of the next 10 executions of this Schedule
+     * Next upcoming scheduled times of this Schedule
      */
     nextActionTimes: Date[];
   };
@@ -332,12 +332,12 @@ export type ScheduleDescription = {
 
   info: {
     /**
-     * Most recent 10 Actions started (including manual triggers), sorted from older start time to newer.
+     * Most recent actions started (including manual triggers), sorted from older start time to newer.
      */
     recentActions: ScheduleExecutionResult[];
 
     /**
-     * Scheduled time of the next 10 executions of this Schedule
+     * Next upcoming scheduled times of this Schedule
      */
     nextActionTimes: Date[];
 


### PR DESCRIPTION
## What changed

- Modified schedule doc to not specify the exact number of most recent/future execution time.


## Why

- The numbers for listSchedules was incorrect (actual value is 5 rather than 10)
- Given that these numbers are tweakable at the server level, it seems more appropriate to consider the exact numbers as an implementation details rather than a contract.