### PR TITLE
feat(testing): Use temporal CLI to power local test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
       - run: npm test
         env:
-          # TODO: Run integration tests on MacOS / Windows probably using temporalite
+          # NOTE: Newer tests start their own server and are not subject to this env var.
           RUN_INTEGRATION_TESTS: ${{ startsWith(matrix.os, 'ubuntu') }}
           REUSE_V8_CONTEXT: ${{ matrix.reuse-v8-context }}
 

--- a/packages/core-bridge/Cargo.lock
+++ b/packages/core-bridge/Cargo.lock
@@ -1034,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
 dependencies = [
  "hashbrown 0.13.2",
 ]

--- a/packages/core-bridge/src/conversions.rs
+++ b/packages/core-bridge/src/conversions.rs
@@ -14,14 +14,15 @@ use temporal_sdk_core::{
     },
     api::worker::{WorkerConfig, WorkerConfigBuilder},
     ephemeral_server::{
-        TemporaliteConfig, TemporaliteConfigBuilder, TestServerConfig, TestServerConfigBuilder,
+        TemporalDevServerConfig, TemporalDevServerConfigBuilder, TestServerConfig,
+        TestServerConfigBuilder,
     },
     ClientOptions, ClientOptionsBuilder, ClientTlsConfig, RetryConfig, TlsConfig, Url,
 };
 
 pub enum EphemeralServerConfig {
     TestServer(TestServerConfig),
-    Temporalite(TemporaliteConfig),
+    DevServer(TemporalDevServerConfig),
 }
 
 pub trait ArrayHandleConversionsExt {
@@ -403,8 +404,8 @@ impl ObjectHandleConversionsExt for Handle<'_, JsObject> {
 
         let server_type = js_value_getter!(cx, self, "type", JsString);
         match server_type.as_str() {
-            "temporalite" => {
-                let mut config = TemporaliteConfigBuilder::default();
+            "dev-server" => {
+                let mut config = TemporalDevServerConfigBuilder::default();
                 config.exe(executable).port(port);
 
                 if let Some(extra_args) = js_optional_getter!(cx, self, "extraArgs", JsArray) {
@@ -427,9 +428,9 @@ impl ObjectHandleConversionsExt for Handle<'_, JsObject> {
                 }
 
                 match config.build() {
-                    Ok(config) => Ok(EphemeralServerConfig::Temporalite(config)),
+                    Ok(config) => Ok(EphemeralServerConfig::DevServer(config)),
                     Err(err) => {
-                        cx.throw_type_error(format!("Invalid temporalite config: {:?}", err))
+                        cx.throw_type_error(format!("Invalid dev server config: {:?}", err))
                     }
                 }
             }
@@ -450,7 +451,7 @@ impl ObjectHandleConversionsExt for Handle<'_, JsObject> {
                 }
             }
             s => cx.throw_type_error(format!(
-                "Invalid ephemeral server type: {}, expected 'temporalite' or 'time-skipping'",
+                "Invalid ephemeral server type: {}, expected 'dev-server' or 'time-skipping'",
                 s
             )),
         }

--- a/packages/core-bridge/src/runtime.rs
+++ b/packages/core-bridge/src/runtime.rs
@@ -273,9 +273,7 @@ pub fn start_bridge_loop(
                             EphemeralServerConfig::TestServer(config) => {
                                 config.start_server().await
                             }
-                            EphemeralServerConfig::Temporalite(config) => {
-                                config.start_server().await
-                            }
+                            EphemeralServerConfig::DevServer(config) => config.start_server().await,
                         };
                         match result {
                             Err(err) => {

--- a/packages/core-bridge/ts/index.ts
+++ b/packages/core-bridge/ts/index.ts
@@ -381,10 +381,10 @@ export interface TimeSkippingServerConfig {
 }
 
 /**
- * Configuration for temporalite.
+ * Configuration for the Temporal CLI dev server.
  */
-export interface TemporaliteConfig {
-  type: 'temporalite';
+export interface DevServerConfig {
+  type: 'dev-server';
   executable?: EphemeralServerExecutable;
   /**
    * Namespace to use - created at startup.
@@ -399,11 +399,13 @@ export interface TemporaliteConfig {
    */
   ip?: string;
   /**
-   * Sqlite DB filename if persisting or non-persistent if none.
+   * Sqlite DB filename if persisting or non-persistent if none (default).
    */
   db_filename?: string;
   /**
    * Whether to enable the UI.
+   *
+   * @default false
    */
   ui?: boolean;
   /**
@@ -424,9 +426,9 @@ export interface TemporaliteConfig {
 /**
  * Configuration for spawning an ephemeral Temporal server.
  *
- * Both the time-skipping test server and temporalite are supported.
+ * Both the time-skipping test server and Temporal CLI dev server are supported.
  */
-export type EphemeralServerConfig = TimeSkippingServerConfig | TemporaliteConfig;
+export type EphemeralServerConfig = TimeSkippingServerConfig | DevServerConfig;
 
 export interface Worker {
   type: 'Worker';

--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -115,8 +115,7 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
       metaClient,
     };
 
-    // In case we're running with temporalite or other non default server.
-    // NOTE: at the time this was added temporalite did not expose the grpc OperatorService.
+    // In case we're running with a server that doesn't use the docker-compose setup.
     try {
       await connection.operatorService.addSearchAttributes({
         namespace: 'default',

--- a/packages/test/src/test-ephemeral-server.ts
+++ b/packages/test/src/test-ephemeral-server.ts
@@ -41,7 +41,7 @@ test('TestEnvironment sets up test server and is able to run a single workflow',
   await runSimpleWorkflow(t, testEnv);
 });
 
-test('TestEnvironment sets up temporalite and is able to run a single workflow', async (t) => {
+test('TestEnvironment sets up dev server and is able to run a single workflow', async (t) => {
   const testEnv = await TestWorkflowEnvironment.createLocal();
   await runSimpleWorkflow(t, testEnv);
 });
@@ -51,8 +51,8 @@ test.todo('TestEnvironment sets up test server with specified port');
 test.todo('TestEnvironment sets up test server with latest version');
 test.todo('TestEnvironment sets up test server from executable path');
 
-test.todo('TestEnvironment sets up temporalite with extra args');
-test.todo('TestEnvironment sets up temporalite with latest version');
-test.todo('TestEnvironment sets up temporalite from executable path');
-test.todo('TestEnvironment sets up temporalite with custom log level');
-test.todo('TestEnvironment sets up temporalite with custom namespace, IP, db filename, and UI');
+test.todo('TestEnvironment sets up dev server with extra args');
+test.todo('TestEnvironment sets up dev server with latest version');
+test.todo('TestEnvironment sets up dev server from executable path');
+test.todo('TestEnvironment sets up dev server with custom log level');
+test.todo('TestEnvironment sets up dev server with custom namespace, IP, db filename, and UI');


### PR DESCRIPTION
BREAKING CHANGE: the `TemporaliteConfig` interface was deleted but it likely was not directly referenced as only the deprecated `create` method accepted it.

Closes #1055 