### PR TITLE
feat: Get rid of experimental AsyncLocalStorage.enterWith call

### DIFF
--- a/packages/testing/src/connection.ts
+++ b/packages/testing/src/connection.ts
@@ -24,6 +24,7 @@ export class Connection extends BaseConnection {
       client: ctorOptions.client,
       callContextStorage: ctorOptions.callContextStorage,
       interceptors: ctorOptions.options.interceptors,
+      staticMetadata: ctorOptions.options.metadata,
     });
     const testService = TestService.create(rpcImpl, false, false);
     return { ...ctorOptions, testService };


### PR DESCRIPTION
It's an experimental API in Node.js and not available in Deno.