### PR TITLE
Accept WorkflowOptions as const

### DIFF
--- a/packages/client/src/schedule-helpers.ts
+++ b/packages/client/src/schedule-helpers.ts
@@ -215,7 +215,7 @@ export function compileScheduleOptions(options: ScheduleOptions): CompiledSchedu
       ...options.action,
       workflowId: options.action.workflowId ?? `${options.scheduleId}-workflow`,
       workflowType,
-      args: options.action.args ?? [],
+      args: (options.action.args ?? []) as unknown[],
     },
   };
 }
@@ -228,7 +228,7 @@ export function compileUpdatedScheduleOptions(options: ScheduleUpdateOptions): C
     action: {
       ...options.action,
       workflowType,
-      args: options.action.args ?? [],
+      args: (options.action.args ?? []) as unknown[],
     },
   };
 }

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -62,7 +62,7 @@ export type WorkflowResultType<W extends Workflow> = ReturnType<W> extends Promi
  *
  * Dates are serialized as ISO strings.
  */
-export type SearchAttributes = Record<string, SearchAttributeValue | undefined>;
+export type SearchAttributes = Record<string, SearchAttributeValue | Readonly<SearchAttributeValue> | undefined>;
 export type SearchAttributeValue = string[] | number[] | boolean[] | Date[];
 
 export interface ActivityFunction<P extends any[] = any[], R = any> {

--- a/packages/common/src/workflow-options.ts
+++ b/packages/common/src/workflow-options.ts
@@ -96,13 +96,13 @@ export type WithWorkflowArgs<W extends Workflow, T> = T &
         /**
          * Arguments to pass to the Workflow
          */
-        args: Parameters<W>;
+        args: Parameters<W> | Readonly<Parameters<W>>;
       }
     : {
         /**
          * Arguments to pass to the Workflow
          */
-        args?: Parameters<W>;
+        args?: Parameters<W> | Readonly<Parameters<W>>;
       });
 
 export interface WorkflowDurationOptions {

--- a/packages/test/src/test-schedules.ts
+++ b/packages/test/src/test-schedules.ts
@@ -45,16 +45,17 @@ if (RUN_INTEGRATION_TESTS) {
   test('Can create schedule with calendar', async (t) => {
     const { client } = t.context;
     const scheduleId = `can-create-schedule-with-calendar-${randomUUID()}`;
+    const action = {
+      type: 'startWorkflow',
+      workflowType: dummyWorkflow,
+      taskQueue,
+    } as const;
     const handle = await client.schedule.create({
       scheduleId,
       spec: {
         calendars: [{ hour: { start: 2, end: 7, step: 1 } }],
       },
-      action: {
-        type: 'startWorkflow',
-        workflowType: dummyWorkflow,
-        taskQueue,
-      },
+      action,
     });
 
     try {
@@ -181,23 +182,24 @@ if (RUN_INTEGRATION_TESTS) {
   test('Can create schedule with startWorkflow action (with args)', async (t) => {
     const { client } = t.context;
     const scheduleId = `can-create-schedule-with-startWorkflow-action-${randomUUID()}`;
+    const action = {
+      type: 'startWorkflow',
+      workflowType: dummyWorkflowWith2Args,
+      args: [3, 4],
+      taskQueue,
+      memo: {
+        'my-memo': 'foo',
+      },
+      searchAttributes: {
+        CustomKeywordField: ['test-value2'],
+      },
+    } as const;
     const handle = await client.schedule.create({
       scheduleId,
       spec: {
         calendars: [{ hour: { start: 2, end: 7, step: 1 } }],
       },
-      action: {
-        type: 'startWorkflow',
-        workflowType: dummyWorkflowWith2Args,
-        args: [3, 4],
-        taskQueue,
-        memo: {
-          'my-memo': 'foo',
-        },
-        searchAttributes: {
-          CustomKeywordField: ['test-value2'],
-        },
-      },
+      action,
     });
 
     try {

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -694,7 +694,7 @@ export async function startChild<T extends Workflow>(
   options?: WithWorkflowArgs<T, ChildWorkflowOptions>
 ): Promise<ChildWorkflowHandle<T>> {
   const activator = getActivator();
-  const optionsWithDefaults = addDefaultWorkflowOptions(options ?? {});
+  const optionsWithDefaults = addDefaultWorkflowOptions(options ?? ({} as any));
   const workflowType = typeof workflowTypeOrFunc === 'string' ? workflowTypeOrFunc : workflowTypeOrFunc.name;
   const execute = composeInterceptors(
     activator.interceptors.outbound,
@@ -793,7 +793,7 @@ export async function executeChild<T extends Workflow>(
   options?: WithWorkflowArgs<T, ChildWorkflowOptions>
 ): Promise<WorkflowResultType<T>> {
   const activator = getActivator();
-  const optionsWithDefaults = addDefaultWorkflowOptions(options ?? {});
+  const optionsWithDefaults = addDefaultWorkflowOptions(options ?? ({} as any));
   const workflowType = typeof workflowTypeOrFunc === 'string' ? workflowTypeOrFunc : workflowTypeOrFunc.name;
   const execute = composeInterceptors(
     activator.interceptors.outbound,


### PR DESCRIPTION
Before this change, TypeScript would have difficulties inferring the type for workflow options provided via the various SDK APIs when defined out of context.

 For example, the following code would not compile:
```ts
const options = {
  workflowId: uuid4(),
  taskQueue: 'some-queue',
  searchAttributes: { someIntAttr: [1] },
  args: [3],
} as const;
const handle = await client.start(workflows.sleeper, options);
```

Note that args can only be inferred if the options are defined `as const` or the args are cast into a tuple (e.g. `args: [3] as [number]`).