### PR TITLE
docs: add install protocal buffers step to CONTRIBUTING.md doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ See [sdk-structure.md](./docs/sdk-structure.md)
 
 - Install Node 16 and [Temporal Server](https://github.com/temporalio/docker-compose#temporal-server-docker-compose-files)
 - Install the [Rust toolchain](https://rustup.rs/)
+- Install [Protocal Buffers](https://github.com/protocolbuffers/protobuf/releases/)
 - Clone the [sdk-typescript](https://github.com/temporalio/sdk-typescript) repo:
   ```sh
   git clone https://github.com/temporalio/sdk-typescript.git


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added a line to CONTRIBUTING.md mentioning to install protocal buffers after rust.

## Why?
<!-- Tell your future self why have you made these changes -->
While following the contributing guide I got an error that protobuf wasn't installed on my MacBook during `npm ci` step. 
