### PR TITLE
fix: Fix `null` payload data in `historyFromJSON`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18162,6 +18162,7 @@
       }
     },
     "packages/activity": {
+      "name": "@temporalio/activity",
       "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
@@ -18170,6 +18171,7 @@
       }
     },
     "packages/client": {
+      "name": "@temporalio/client",
       "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
@@ -18197,6 +18199,7 @@
       }
     },
     "packages/common": {
+      "name": "@temporalio/common",
       "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
@@ -18209,6 +18212,7 @@
       }
     },
     "packages/core-bridge": {
+      "name": "@temporalio/core-bridge",
       "version": "1.7.2",
       "hasInstallScript": true,
       "license": "MIT",
@@ -18221,6 +18225,7 @@
       }
     },
     "packages/create-project": {
+      "name": "@temporalio/create",
       "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
@@ -18305,6 +18310,7 @@
       }
     },
     "packages/interceptors-opentelemetry": {
+      "name": "@temporalio/interceptors-opentelemetry",
       "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
@@ -18320,6 +18326,7 @@
       }
     },
     "packages/meta": {
+      "name": "temporalio",
       "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
@@ -18337,6 +18344,7 @@
       }
     },
     "packages/nyc-test-coverage": {
+      "name": "@temporalio/nyc-test-coverage",
       "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
@@ -18355,6 +18363,7 @@
       }
     },
     "packages/proto": {
+      "name": "@temporalio/proto",
       "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
@@ -18363,6 +18372,7 @@
       }
     },
     "packages/test": {
+      "name": "@temporalio/test",
       "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
@@ -18416,6 +18426,7 @@
       }
     },
     "packages/testing": {
+      "name": "@temporalio/testing",
       "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
@@ -18444,6 +18455,7 @@
       }
     },
     "packages/worker": {
+      "name": "@temporalio/worker",
       "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
@@ -18480,6 +18492,7 @@
       }
     },
     "packages/workflow": {
+      "name": "@temporalio/workflow",
       "version": "1.7.2",
       "license": "MIT",
       "dependencies": {

--- a/packages/test/src/test-proto-utils.ts
+++ b/packages/test/src/test-proto-utils.ts
@@ -22,3 +22,26 @@ test('cancel-fake-progress-replay', async (t) => {
   );
   t.is(hist.events?.[0].workflowExecutionStartedEventAttributes?.taskQueue?.kind, TaskQueueKind.TASK_QUEUE_KIND_NORMAL);
 });
+
+test('null payload data doesnt crash', async (t) => {
+  const sample = `{
+    "events": [
+      {
+        "eventId": "16",
+        "eventTime": "2022-07-06T00:33:18.000Z",
+        "eventType": "WorkflowExecutionCompleted",
+        "version": "0",
+        "taskId": "1057236",
+        "workflowExecutionCompletedEventAttributes": {
+          "result": { "payloads": [{ "metadata": { "encoding": "YmluYXJ5L251bGw=" }, "data": null }] },
+          "workflowTaskCompletedEventId": "15",
+          "newExecutionRunId": ""
+        }
+      }
+    ]
+  }`;
+
+  const histJSON = JSON.parse(sample);
+  const hist = historyFromJSON(histJSON);
+  t.deepEqual(hist.events?.[0].eventId, new Long(16));
+});

--- a/packages/test/src/test-proto-utils.ts
+++ b/packages/test/src/test-proto-utils.ts
@@ -24,24 +24,33 @@ test('cancel-fake-progress-replay', async (t) => {
 });
 
 test('null payload data doesnt crash', async (t) => {
-  const sample = `{
-    "events": [
+  const historyJson = {
+    events: [
       {
-        "eventId": "16",
-        "eventTime": "2022-07-06T00:33:18.000Z",
-        "eventType": "WorkflowExecutionCompleted",
-        "version": "0",
-        "taskId": "1057236",
-        "workflowExecutionCompletedEventAttributes": {
-          "result": { "payloads": [{ "metadata": { "encoding": "YmluYXJ5L251bGw=" }, "data": null }] },
-          "workflowTaskCompletedEventId": "15",
-          "newExecutionRunId": ""
-        }
-      }
-    ]
-  }`;
+        eventId: '16',
+        eventTime: '2022-07-06T00:33:18.000Z',
+        eventType: 'WorkflowExecutionCompleted',
+        version: '0',
+        taskId: '1057236',
+        workflowExecutionCompletedEventAttributes: {
+          result: { payloads: [{ metadata: { encoding: 'YmluYXJ5L251bGw=' }, data: null }] },
+          workflowTaskCompletedEventId: '15',
+          newExecutionRunId: '',
+        },
+      },
+    ],
+  };
 
-  const histJSON = JSON.parse(sample);
-  const hist = historyFromJSON(histJSON);
-  t.deepEqual(hist.events?.[0].eventId, new Long(16));
+  // This would throw an error if payload data was still null
+  const history = historyFromJSON(historyJson);
+
+  // Make sure that other history properties were not corrupted
+  t.is(
+    Buffer.from(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      history.events?.[0].workflowExecutionCompletedEventAttributes?.result?.payloads?.[0].metadata!
+        .encoding as Uint8Array
+    ).toString(),
+    'binary/null'
+  );
 });


### PR DESCRIPTION
## What changed and Why

- `fromProto3JSON` doesn't allow `null` values on 'bytes' fields. This turns out to be a problem for payloads. This fix this situation by recursively descending on events and fixing payloads that have null data field