### PR TITLE
feat: Workflow logger improvements

### DIFF
--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -21,6 +21,7 @@ import { parseWorkflowCode } from '@temporalio/worker/lib/worker';
 import * as activityFunctions from './activities';
 import { cleanStackTrace, REUSE_V8_CONTEXT, u8 } from './helpers';
 import { ProcessedSignal } from './workflows';
+import { LogTimestamp } from '@temporalio/worker';
 
 export interface Context {
   workflow: VMWorkflow | ReusableVMWorkflow;
@@ -1532,6 +1533,7 @@ test('logAndTimeout', async (t) => {
     message: 'Script execution timed out after 200ms',
   });
   const calls = await workflow.getAndResetSinkCalls();
+  delete calls[0].args[1][LogTimestamp];
   t.deepEqual(calls, [
     {
       ifaceName: 'defaultWorkerLogger',

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -14,6 +14,7 @@ import {
 } from '@temporalio/common';
 import { msToTs } from '@temporalio/common/lib/time';
 import { coresdk } from '@temporalio/proto';
+import { LogTimestamp } from '@temporalio/worker';
 import { WorkflowCodeBundler } from '@temporalio/worker/lib/workflow/bundler';
 import { VMWorkflow, VMWorkflowCreator } from '@temporalio/worker/lib/workflow/vm';
 import { ReusableVMWorkflow, ReusableVMWorkflowCreator } from '@temporalio/worker/lib/workflow/reusable-vm';
@@ -21,7 +22,6 @@ import { parseWorkflowCode } from '@temporalio/worker/lib/worker';
 import * as activityFunctions from './activities';
 import { cleanStackTrace, REUSE_V8_CONTEXT, u8 } from './helpers';
 import { ProcessedSignal } from './workflows';
-import { LogTimestamp } from '@temporalio/worker';
 
 export interface Context {
   workflow: VMWorkflow | ReusableVMWorkflow;

--- a/packages/worker/src/logger.ts
+++ b/packages/worker/src/logger.ts
@@ -25,7 +25,7 @@ export interface Logger {
 
 export { LogLevel };
 
-export const LogTimestamp = Symbol('log_timestamp');
+export const LogTimestamp = Symbol.for('log_timestamp');
 
 const severities: LogLevel[] = ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR'];
 

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -8,6 +8,7 @@ import { LoggerSinks } from '@temporalio/workflow';
 import { ActivityInboundLogInterceptor } from './activity-log-interceptor';
 import { NativeConnection } from './connection';
 import { WorkerInterceptors } from './interceptors';
+import { Logger } from './logger';
 import { Runtime } from './runtime';
 import { InjectedSinks } from './sinks';
 import { GiB } from './utils';
@@ -431,31 +432,36 @@ export interface ReplayWorkerOptions
  *
  * @param logger a {@link Logger} - defaults to the {@link Runtime} singleton logger.
  */
-export function defaultSinks(logger = Runtime.instance().logger): InjectedSinks<LoggerSinks> {
+export function defaultSinks(logger?: Logger): InjectedSinks<LoggerSinks> {
   return {
     defaultWorkerLogger: {
       trace: {
         fn(_, message, attrs) {
+          logger ??= Runtime.instance().logger;
           logger.trace(message, attrs);
         },
       },
       debug: {
         fn(_, message, attrs) {
+          logger ??= Runtime.instance().logger;
           logger.debug(message, attrs);
         },
       },
       info: {
         fn(_, message, attrs) {
+          logger ??= Runtime.instance().logger;
           logger.info(message, attrs);
         },
       },
       warn: {
         fn(_, message, attrs) {
+          logger ??= Runtime.instance().logger;
           logger.warn(message, attrs);
         },
       },
       error: {
         fn(_, message, attrs) {
+          logger ??= Runtime.instance().logger;
           logger.error(message, attrs);
         },
       },

--- a/packages/worker/src/workflow/vm.ts
+++ b/packages/worker/src/workflow/vm.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import vm from 'node:vm';
 import { IllegalStateError } from '@temporalio/common';
+import { getTimeOfDay } from '@temporalio/core-bridge';
+import { timeOfDayToBigint } from '../logger';
 import { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interface';
 import { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
 import {
@@ -56,7 +58,11 @@ export class VMWorkflowCreator implements WorkflowCreator {
       }
     ) as any;
 
-    workflowModule.initRuntime({ ...options, sourceMap: this.workflowBundle.sourceMap });
+    workflowModule.initRuntime({
+      ...options,
+      sourceMap: this.workflowBundle.sourceMap,
+      getTimeOfDay: () => timeOfDayToBigint(getTimeOfDay()),
+    });
     const activator = context.__TEMPORAL_ACTIVATOR__ as any;
 
     const newVM = new VMWorkflow(options.info, context, activator, workflowModule, isolateExecutionTimeoutMs);

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -384,8 +384,9 @@ export interface WorkflowCreateOptions {
   showStackTraceSources: boolean;
 }
 
-export interface WorkflowCreateOptionsWithSourceMap extends WorkflowCreateOptions {
+export interface WorkflowCreateOptionsInternal extends WorkflowCreateOptions {
   sourceMap: RawSourceMap;
+  getTimeOfDay(): bigint;
 }
 
 /**

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -29,7 +29,7 @@ import {
   EnhancedStackTrace,
   FileLocation,
   WorkflowInfo,
-  WorkflowCreateOptionsWithSourceMap,
+  WorkflowCreateOptionsInternal,
 } from './interfaces';
 import { SinkCall } from './sinks';
 import { untrackPromise } from './stack-helpers';
@@ -271,16 +271,26 @@ export class Activator implements ActivationHandler {
    */
   public readonly sentPatches = new Set<string>();
 
+  /**
+   * Buffered sink calls per activation
+   */
   sinkCalls = Array<SinkCall>();
+
+  /**
+   * A nanosecond resolution time function, externally injected
+   */
+  public readonly getTimeOfDay: () => bigint;
 
   constructor({
     info,
     now,
     showStackTraceSources,
     sourceMap,
+    getTimeOfDay,
     randomnessSeed,
     patches,
-  }: WorkflowCreateOptionsWithSourceMap) {
+  }: WorkflowCreateOptionsInternal) {
+    this.getTimeOfDay = getTimeOfDay;
     this.info = info;
     this.now = now;
     this.showStackTraceSources = showStackTraceSources;

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -10,7 +10,7 @@ import type { coresdk } from '@temporalio/proto';
 import { disableStorage } from './cancellation-scope';
 import { DeterminismViolationError } from './errors';
 import { WorkflowInterceptorsFactory } from './interceptors';
-import { WorkflowCreateOptionsWithSourceMap, WorkflowInfo } from './interfaces';
+import { WorkflowCreateOptionsInternal, WorkflowInfo } from './interfaces';
 import { Activator, getActivator } from './internals';
 import { SinkCall } from './sinks';
 import { setActivatorUntyped } from './global-attributes';
@@ -92,7 +92,7 @@ export function overrideGlobals(): void {
  *
  * Sets required internal state and instantiates the workflow and interceptors.
  */
-export function initRuntime(options: WorkflowCreateOptionsWithSourceMap): void {
+export function initRuntime(options: WorkflowCreateOptionsInternal): void {
   const info: WorkflowInfo = fixPrototypes(options.info);
   info.unsafe.now = OriginalDate.now;
   const activator = new Activator({ ...options, info });

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -38,7 +38,7 @@ import {
   WorkflowInfo,
 } from './interfaces';
 import { LocalActivityDoBackoff, getActivator, maybeGetActivator } from './internals';
-import { Sinks } from './sinks';
+import { LoggerSinks, Sinks } from './sinks';
 import { untrackPromise } from './stack-helpers';
 import { ChildWorkflowHandle, ExternalWorkflowHandle } from './workflow-handle';
 
@@ -1253,3 +1253,20 @@ export function upsertSearchAttributes(searchAttributes: SearchAttributes): void
 
 export const stackTraceQuery = defineQuery<string>('__stack_trace');
 export const enhancedStackTraceQuery = defineQuery<EnhancedStackTrace>('__enhanced_stack_trace');
+
+const loggerSinks = proxySinks<LoggerSinks>();
+
+/**
+ * Default workflow logger.
+ * This logger is replay-aware and will omit log messages on workflow replay.
+ * The messages emitted by this logger are funnelled to the worker's `defaultSinks`, which are installed by default.
+ *
+ * Note that since sinks are used to power this logger, any log attributes must be transferable via the
+ * {@link https://nodejs.org/api/worker_threads.html#worker_threads_port_postmessage_value_transferlist | postMessage}
+ * API.
+ *
+ * `defaultSinks` accepts a user logger and defaults to the `Runtime`'s logger.
+ *
+ * See the documentation for `WorkerOptions`, `defaultSinks`, and `Runtime` for more information.
+ */
+export const log = loggerSinks.defaultWorkerLogger;


### PR DESCRIPTION
- [Lazily initialize the default sinks logger](https://github.com/temporalio/sdk-typescript/commit/540896e03e9e0d1564c3d2198a1bc7c57d5b1795)
- [Export `log` from workflow](https://github.com/temporalio/sdk-typescript/commit/5a2789661bc4afa2c66056b4307d14f48146a0d4) - a logger that funnels messages to the default worker logger sink.

### Example:
```ts
import * as workflow from '@temporalio/workflow';

export async function myWorkflow(): Promise<void> {
  workflow.log.info('hello from my workflow', { key: 'value' });
}
```