### PR TITLE
feat(workflow): Clone sink args at call time

### DIFF
--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -895,7 +895,8 @@ export function proxySinks<T extends Sinks>(): T {
                 activator.sinkCalls.push({
                   ifaceName: ifaceName as string,
                   fnName: fnName as string,
-                  args,
+                  // Only available from node 17.
+                  args: (globalThis as any).structuredClone ? (globalThis as any).structuredClone(args) : args,
                 });
               };
             },
@@ -1283,8 +1284,7 @@ export const log: LoggerSinks['defaultWorkerLogger'] = Object.fromEntries(
         return loggerSinks.defaultWorkerLogger[level](message, {
           // Inject the call time in nanosecond resolution as expected by the worker logger.
           [LogTimestamp]: getActivator().getTimeOfDay(),
-          // Only available from node 17.
-          ...((globalThis as any).structuredClone ? (globalThis as any).structuredClone(attrs) : attrs),
+          ...attrs,
         });
       },
     ];


### PR DESCRIPTION
Use [structuredClone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) to clone sink call arguments at call time.
While this adds some runtime overhead, it leads to a more predictable experience when an argument is mutated after being passed to a sink as well as better exceptions when passing a non-transferrable object to a sink.

Only available from Node.js >= 17.