### PR TITLE
fix: Use Connection class for test env connection property

### DIFF
--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -165,7 +165,7 @@ export class TestWorkflowEnvironment {
   /**
    * Get an established {@link Connection} to the ephemeral server
    */
-  public readonly connection: ConnectionLike;
+  public readonly connection: Connection;
 
   /**
    * A {@link TestEnvClient} for interacting with the ephemeral server

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -17,7 +17,6 @@ import {
   AsyncCompletionClient,
   Client,
   ClientOptions,
-  ConnectionLike,
   WorkflowClient,
   WorkflowClientOptions,
   WorkflowResultOptions,


### PR DESCRIPTION
To allow accessing the operator service without the need to cast to `Connection`.