### PR TITLE
fix: Better error messages, and more

### DIFF
--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -379,7 +379,7 @@ export class ScheduleClient extends BaseClient {
           scheduleId: raw.scheduleId,
 
           spec: decodeScheduleSpec(raw.info?.spec ?? {}),
-          action: raw.info?.workflowType?.name && {
+          action: raw.info?.workflowType && {
             type: 'startWorkflow',
             workflowType: raw.info.workflowType.name,
           },

--- a/packages/client/src/schedule-helpers.ts
+++ b/packages/client/src/schedule-helpers.ts
@@ -2,6 +2,7 @@ import Long from 'long'; // eslint-disable-line import/no-named-as-default
 import {
   compileRetryPolicy,
   decompileRetryPolicy,
+  extractWorkflowType,
   LoadedDataConverter,
   mapFromPayloads,
   mapToPayloads,
@@ -208,7 +209,7 @@ export function decodeOverlapPolicy(input?: temporal.api.enums.v1.ScheduleOverla
 
 export function compileScheduleOptions(options: ScheduleOptions): CompiledScheduleOptions {
   const workflowTypeOrFunc = options.action.workflowType;
-  const workflowType = typeof workflowTypeOrFunc === 'string' ? workflowTypeOrFunc : workflowTypeOrFunc.name;
+  const workflowType = extractWorkflowType(workflowTypeOrFunc);
   return {
     ...options,
     action: {
@@ -222,7 +223,7 @@ export function compileScheduleOptions(options: ScheduleOptions): CompiledSchedu
 
 export function compileUpdatedScheduleOptions(options: ScheduleUpdateOptions): CompiledScheduleUpdateOptions {
   const workflowTypeOrFunc = options.action.workflowType;
-  const workflowType = typeof workflowTypeOrFunc === 'string' ? workflowTypeOrFunc : workflowTypeOrFunc.name;
+  const workflowType = extractWorkflowType(workflowTypeOrFunc);
   return {
     ...options,
     action: {

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -18,6 +18,7 @@ import {
   WorkflowExecutionAlreadyStartedError,
   WorkflowNotFoundError,
   WorkflowResultType,
+  extractWorkflowType,
 } from '@temporalio/common';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import { History } from '@temporalio/common/lib/proto-utils';
@@ -345,7 +346,7 @@ export class WorkflowClient extends BaseClient {
     options: WithWorkflowArgs<T, WorkflowOptions>,
     interceptors: WorkflowClientInterceptor[]
   ): Promise<string> {
-    const workflowType = typeof workflowTypeOrFunc === 'string' ? workflowTypeOrFunc : workflowTypeOrFunc.name;
+    const workflowType = extractWorkflowType(workflowTypeOrFunc);
     assertRequiredWorkflowOptions(options);
     const compiledOptions = compileWorkflowOptions(ensureArgs(options));
 
@@ -369,7 +370,7 @@ export class WorkflowClient extends BaseClient {
     options: WithWorkflowArgs<T, WorkflowSignalWithStartOptions<SA>>,
     interceptors: WorkflowClientInterceptor[]
   ): Promise<string> {
-    const workflowType = typeof workflowTypeOrFunc === 'string' ? workflowTypeOrFunc : workflowTypeOrFunc.name;
+    const workflowType = extractWorkflowType(workflowTypeOrFunc);
     const { signal, signalArgs, ...rest } = options;
     assertRequiredWorkflowOptions(rest);
     const compiledOptions = compileWorkflowOptions(ensureArgs(rest));

--- a/packages/common/src/workflow-options.ts
+++ b/packages/common/src/workflow-options.ts
@@ -159,7 +159,7 @@ export function extractWorkflowType<T extends Workflow>(workflowTypeOrFunc: stri
   if (typeof workflowTypeOrFunc === 'string') return workflowTypeOrFunc as string;
   if (typeof workflowTypeOrFunc === 'function') {
     if (workflowTypeOrFunc?.name) return workflowTypeOrFunc.name;
-    throw new TypeError(`Invalid workflow type: the workflow function is anonymous`);
+    throw new TypeError('Invalid workflow type: the workflow function is anonymous');
   }
   throw new TypeError(
     `Invalid workflow type: expected either a string or a function, got '${typeof workflowTypeOrFunc}'`

--- a/packages/common/src/workflow-options.ts
+++ b/packages/common/src/workflow-options.ts
@@ -154,3 +154,14 @@ export function compileWorkflowOptions<T extends CommonWorkflowOptions>(options:
     workflowTaskTimeout: msOptionalToTs(workflowTaskTimeout),
   };
 }
+
+export function extractWorkflowType<T extends Workflow>(workflowTypeOrFunc: string | T): string {
+  if (typeof workflowTypeOrFunc === 'string') return workflowTypeOrFunc as string;
+  if (typeof workflowTypeOrFunc === 'function') {
+    if (workflowTypeOrFunc?.name) return workflowTypeOrFunc.name;
+    throw new TypeError(`Invalid workflow type: the workflow function is anonymous`);
+  }
+  throw new TypeError(
+    `Invalid workflow type: expected either a string or a function, got '${typeof workflowTypeOrFunc}'`
+  );
+}

--- a/packages/create-project/src/helpers/install.ts
+++ b/packages/create-project/src/helpers/install.ts
@@ -35,9 +35,8 @@ export async function updateNodeVersion({ root }: InstallArgs): Promise<void> {
   const versionAlreadyInPackageJson = 16;
   const minimumValidVersion = 14;
 
-  // For some reason, the @tsconfig/node20 package exists, but is currently unusable because it
-  // refers to a --lib value that isn't supported in latest release of TypeScript.
-  // FIXME: Update this once @tsconfig/node20 is fixed.
+  // The @tsconfig/node20 sets "--lib es2023", which require TypeScript 5.x.
+  // FIXME: Remove this once samples have been updated to TypeScript ^5.0.0.
   const maximumValidVersion = 18;
 
   const tsconfigNodeVersion = Math.max(minimumValidVersion, Math.min(currentNodeVersion, maximumValidVersion));

--- a/packages/create-project/src/helpers/install.ts
+++ b/packages/create-project/src/helpers/install.ts
@@ -35,8 +35,15 @@ export async function updateNodeVersion({ root }: InstallArgs): Promise<void> {
   const versionAlreadyInPackageJson = 16;
   const minimumValidVersion = 14;
 
-  if (currentNodeVersion >= minimumValidVersion && currentNodeVersion !== versionAlreadyInPackageJson) {
-    const packageName = `@tsconfig/node${currentNodeVersion}`;
+  // For some reason, the @tsconfig/node20 package exists, but is currently unusable because it
+  // refers to a --lib value that isn't supported in latest release of TypeScript.
+  // FIXME: Update this once @tsconfig/node20 is fixed.
+  const maximumValidVersion = 18;
+
+  const tsconfigNodeVersion = Math.max(minimumValidVersion, Math.min(currentNodeVersion, maximumValidVersion));
+
+  if (tsconfigNodeVersion !== versionAlreadyInPackageJson) {
+    const packageName = `@tsconfig/node${tsconfigNodeVersion}`;
 
     const packageExists = await isUrlOk(`https://registry.npmjs.org/${packageName}`);
     if (packageExists) {

--- a/packages/proto/scripts/compile-proto.js
+++ b/packages/proto/scripts/compile-proto.js
@@ -64,10 +64,12 @@ async function compileProtos(dtsOutputFile, ...args) {
     // pbts internally calls jsdoc, which do strict validation of jsdoc tags.
     // Unfortunately, some protobuf comment about cron syntax contains the
     // "@every" shorthand at the begining of a line, making it appear as a
-    // (invalid) jsdoc tag. We fix this by rewriting all cron shorthand
-    // using markdown "code" syntax.
+    // (invalid) jsdoc tag. Similarly, docusaurus trips on <interval> and other
+    // things that looks like html tags. We fix both cases by rewriting these
+    // using markdown "inline code" syntax.
     let tempFileContent = await readFile(tempFile, 'utf8');
     tempFileContent = tempFileContent.replace(/(@(?:yearly|monthly|weekly|daily|hourly|every))/g, '`$1`');
+    tempFileContent = tempFileContent.replace(/<((?:interval|phase|timezone)(?: [^>]+)?)>/g, '`<$1>`');
     await writeFile(tempFile, tempFileContent, 'utf-8');
 
     await promisify(pbts.main)(['--out', dtsOutputFile, tempFile]);

--- a/packages/test/scripts/compile-proto.js
+++ b/packages/test/scripts/compile-proto.js
@@ -28,7 +28,17 @@ function mtime(path) {
 }
 
 async function compileProtos(outputFile, ...args) {
-  const pbjsArgs = [...args, '--wrap', 'commonjs', '--force-long', '--no-verify', '--out', outputFile, ...protoFiles];
+  const pbjsArgs = [
+    ...args,
+    '--wrap',
+    'commonjs',
+    '--force-long',
+    '--no-verify',
+    '--alt-comment',
+    '--out',
+    outputFile,
+    ...protoFiles,
+  ];
   return await promisify(pbjs.main)(pbjsArgs);
 }
 

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -2,6 +2,7 @@ import {
   ActivityFunction,
   ActivityOptions,
   compileRetryPolicy,
+  extractWorkflowType,
   IllegalStateError,
   LocalActivityOptions,
   mapToPayloads,
@@ -698,7 +699,7 @@ export async function startChild<T extends Workflow>(
 ): Promise<ChildWorkflowHandle<T>> {
   const activator = getActivator();
   const optionsWithDefaults = addDefaultWorkflowOptions(options ?? ({} as any));
-  const workflowType = typeof workflowTypeOrFunc === 'string' ? workflowTypeOrFunc : workflowTypeOrFunc.name;
+  const workflowType = extractWorkflowType(workflowTypeOrFunc);
   const execute = composeInterceptors(
     activator.interceptors.outbound,
     'startChildWorkflowExecution',
@@ -797,7 +798,7 @@ export async function executeChild<T extends Workflow>(
 ): Promise<WorkflowResultType<T>> {
   const activator = getActivator();
   const optionsWithDefaults = addDefaultWorkflowOptions(options ?? ({} as any));
-  const workflowType = typeof workflowTypeOrFunc === 'string' ? workflowTypeOrFunc : workflowTypeOrFunc.name;
+  const workflowType = extractWorkflowType(workflowTypeOrFunc);
   const execute = composeInterceptors(
     activator.interceptors.outbound,
     'startChildWorkflowExecution',


### PR DESCRIPTION
## What changed

- Better error message when `executeWorkflow()` and similar are given a workflowFunction fucntion that is anonymous (fix #367)
- Better error message when Workflow-only APIs are called from non-Workflow execution context (fix #553)
- On `create`, do not use `@tsconfig/node20` because it is broken (fix #1125)
- Include proto comments in API files generated by protobufjs (fix #506)
- Minor refactor of schedule's error handling