### PR TITLE
fix: Remove most instanceof checks from SDK

### DIFF
--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -104,10 +104,22 @@ export class CompleteAsyncError extends Error {
   constructor() {
     super();
   }
+
+  /**
+   * Instanceof check that is works when multiple versions of @temporalio/activity are installed.
+   */
+  public static is(error: unknown): error is CompleteAsyncError {
+    return error instanceof CompleteAsyncError || (error instanceof Error && error.name === 'CompleteAsyncError');
+  }
 }
 
-/** @ignore */
-export const asyncLocalStorage = new AsyncLocalStorage<Context>();
+// Make it safe to use @temporalio/activity with multiple versions installed.
+const asyncLocalStorageSymbol = Symbol.for('__temporal_activity_context_storage__');
+if (!(globalThis as any)[asyncLocalStorageSymbol]) {
+  (globalThis as any)[asyncLocalStorageSymbol] = new AsyncLocalStorage<Context>();
+}
+
+export const asyncLocalStorage: AsyncLocalStorage<Context> = (globalThis as any)[asyncLocalStorageSymbol];
 
 /**
  * Holds information about the current Activity Execution. Retrieved inside an Activity with `Context.current().info`.

--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -72,6 +72,7 @@
 import 'abort-controller/polyfill'; // eslint-disable-line import/no-unassigned-import
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { Duration, msToNumber } from '@temporalio/common/lib/time';
+import { LineageTrackingError } from '@temporalio/common';
 
 export {
   ActivityFunction,
@@ -98,18 +99,22 @@ export {
  *}
  *```
  */
-export class CompleteAsyncError extends Error {
+export class CompleteAsyncError extends LineageTrackingError {
   public readonly name: string = 'CompleteAsyncError';
 
   constructor() {
     super();
+    this.lineage.unshift('CompleteAsyncError');
   }
 
   /**
    * Instanceof check that is works when multiple versions of @temporalio/activity are installed.
    */
   public static is(error: unknown): error is CompleteAsyncError {
-    return error instanceof CompleteAsyncError || (error instanceof Error && error.name === 'CompleteAsyncError');
+    return (
+      error instanceof CompleteAsyncError ||
+      (LineageTrackingError.is(error) && error.lineage.includes('CompleteAsyncError'))
+    );
   }
 }
 

--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -108,7 +108,7 @@ export class CompleteAsyncError extends LineageTrackingError {
   }
 
   /**
-   * Instanceof check that is works when multiple versions of @temporalio/activity are installed.
+   * Instanceof check that works when multiple versions of @temporalio/activity are installed.
    */
   public static is(error: unknown): error is CompleteAsyncError {
     return (

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -1,4 +1,4 @@
-import { LineageTrackingError, TemporalFailure } from './failure';
+import { TemporalFailure } from './failure';
 
 /**
  * Thrown from code that receives a value that is unexpected or that it's unable to handle.
@@ -25,6 +25,8 @@ export class IllegalStateError extends Error {
   public readonly name: string = 'IllegalStateError';
 }
 
+const isWorkflowExecutionAlreadyStartedError = Symbol.for('__temporal_isWorkflowExecutionAlreadyStartedError');
+
 /**
  * This exception is thrown in the following cases:
  *  - Workflow with the same Workflow Id is currently running
@@ -38,8 +40,12 @@ export class WorkflowExecutionAlreadyStartedError extends TemporalFailure {
 
   constructor(message: string, public readonly workflowId: string, public readonly workflowType: string) {
     super(message);
-    this.lineage.unshift('WorkflowExecutionAlreadyStartedError');
   }
+
+  /**
+   * Marker to determine whether an error is an instance of WorkflowExecutionAlreadyStartedError.
+   */
+  protected readonly [isWorkflowExecutionAlreadyStartedError] = true;
 
   /**
    * Instanceof check that works when multiple versions of @temporalio/common are installed.
@@ -47,7 +53,7 @@ export class WorkflowExecutionAlreadyStartedError extends TemporalFailure {
   static is(error: unknown): error is WorkflowExecutionAlreadyStartedError {
     return (
       error instanceof WorkflowExecutionAlreadyStartedError ||
-      (LineageTrackingError.is(error) && error.lineage.includes('WorkflowExecutionAlreadyStartedError'))
+      (error instanceof Error && (error as any)[isWorkflowExecutionAlreadyStartedError])
     );
   }
 }

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -42,7 +42,7 @@ export class WorkflowExecutionAlreadyStartedError extends TemporalFailure {
   }
 
   /**
-   * Instanceof check that is works when multiple versions of @temporalio/common are installed.
+   * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is WorkflowExecutionAlreadyStartedError {
     return (

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -1,4 +1,4 @@
-import { TemporalFailure } from './failure';
+import { LineageTrackingError, TemporalFailure } from './failure';
 
 /**
  * Thrown from code that receives a value that is unexpected or that it's unable to handle.
@@ -38,6 +38,17 @@ export class WorkflowExecutionAlreadyStartedError extends TemporalFailure {
 
   constructor(message: string, public readonly workflowId: string, public readonly workflowType: string) {
     super(message);
+    this.lineage.unshift('WorkflowExecutionAlreadyStartedError');
+  }
+
+  /**
+   * Instanceof check that is works when multiple versions of @temporalio/common are installed.
+   */
+  static is(error: unknown): error is WorkflowExecutionAlreadyStartedError {
+    return (
+      error instanceof WorkflowExecutionAlreadyStartedError ||
+      (LineageTrackingError.is(error) && error.lineage.includes('WorkflowExecutionAlreadyStartedError'))
+    );
   }
 }
 

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -62,7 +62,7 @@ export class LineageTrackingError extends Error {
   }
 
   /**
-   * Instanceof check that is works when multiple versions of @temporalio/common are installed.
+   * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is LineageTrackingError {
     // Cast to any since isLineageTrackingError is intentionally left protected.
@@ -92,7 +92,7 @@ export class TemporalFailure extends LineageTrackingError {
   }
 
   /**
-   * Instanceof check that is works when multiple versions of @temporalio/common are installed.
+   * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is TemporalFailure {
     return (
@@ -111,7 +111,7 @@ export class ServerFailure extends TemporalFailure {
   }
 
   /**
-   * Instanceof check that is works when multiple versions of @temporalio/common are installed.
+   * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is ServerFailure {
     return (
@@ -160,7 +160,7 @@ export class ApplicationFailure extends TemporalFailure {
   }
 
   /**
-   * Instanceof check that is works when multiple versions of @temporalio/common are installed.
+   * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is ApplicationFailure {
     return (
@@ -263,7 +263,7 @@ export class CancelledFailure extends TemporalFailure {
   }
 
   /**
-   * Instanceof check that is works when multiple versions of @temporalio/common are installed.
+   * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is CancelledFailure {
     return (
@@ -285,7 +285,7 @@ export class TerminatedFailure extends TemporalFailure {
   }
 
   /**
-   * Instanceof check that is works when multiple versions of @temporalio/common are installed.
+   * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is TerminatedFailure {
     return (
@@ -311,7 +311,7 @@ export class TimeoutFailure extends TemporalFailure {
   }
 
   /**
-   * Instanceof check that is works when multiple versions of @temporalio/common are installed.
+   * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is TimeoutFailure {
     return (
@@ -342,7 +342,7 @@ export class ActivityFailure extends TemporalFailure {
   }
 
   /**
-   * Instanceof check that is works when multiple versions of @temporalio/common are installed.
+   * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is ActivityFailure {
     return (
@@ -372,7 +372,7 @@ export class ChildWorkflowFailure extends TemporalFailure {
   }
 
   /**
-   * Instanceof check that is works when multiple versions of @temporalio/common are installed.
+   * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is ChildWorkflowFailure {
     return (

--- a/packages/core-bridge/ts/errors.ts
+++ b/packages/core-bridge/ts/errors.ts
@@ -12,7 +12,7 @@ export class ShutdownError extends LineageTrackingError {
   }
 
   /**
-   * Instanceof check that is works when multiple versions of @temporalio/core-bridge are installed.
+   * Instanceof check that works when multiple versions of @temporalio/core-bridge are installed.
    */
   public static is(error: unknown): error is ShutdownError {
     return (

--- a/packages/core-bridge/ts/errors.ts
+++ b/packages/core-bridge/ts/errors.ts
@@ -5,6 +5,13 @@ import { IllegalStateError } from '@temporalio/common';
  */
 export class ShutdownError extends Error {
   public readonly name = 'ShutdownError';
+
+  /**
+   * Instanceof check that is works when multiple versions of @temporalio/core-bridge are installed.
+   */
+  public static is(error: unknown): error is ShutdownError {
+    return error instanceof ShutdownError || (error instanceof Error && error.name === 'ShutdownError');
+  }
 }
 
 /**
@@ -21,6 +28,7 @@ export class TransportError extends Error {
 export class UnexpectedError extends Error {
   public readonly name = 'UnexpectedError';
 }
+
 export { IllegalStateError };
 
 export function convertFromNamedError(e: unknown, keepStackTrace: boolean): unknown {

--- a/packages/core-bridge/ts/errors.ts
+++ b/packages/core-bridge/ts/errors.ts
@@ -1,16 +1,23 @@
-import { IllegalStateError } from '@temporalio/common';
+import { LineageTrackingError, IllegalStateError } from '@temporalio/common';
 
 /**
  * The worker has been shut down
  */
-export class ShutdownError extends Error {
+export class ShutdownError extends LineageTrackingError {
   public readonly name = 'ShutdownError';
+
+  constructor(message?: string) {
+    super(message);
+    this.lineage.unshift('ShutdownError');
+  }
 
   /**
    * Instanceof check that is works when multiple versions of @temporalio/core-bridge are installed.
    */
   public static is(error: unknown): error is ShutdownError {
-    return error instanceof ShutdownError || (error instanceof Error && error.name === 'ShutdownError');
+    return (
+      error instanceof ShutdownError || (LineageTrackingError.is(error) && error.lineage.includes('ShutdownError'))
+    );
   }
 }
 

--- a/packages/core-bridge/ts/errors.ts
+++ b/packages/core-bridge/ts/errors.ts
@@ -1,23 +1,23 @@
-import { LineageTrackingError, IllegalStateError } from '@temporalio/common';
+import { IllegalStateError } from '@temporalio/common';
+
+const isShutdownError: unique symbol = Symbol.for('__temporal_isShutdownError');
 
 /**
  * The worker has been shut down
  */
-export class ShutdownError extends LineageTrackingError {
+export class ShutdownError extends Error {
   public readonly name = 'ShutdownError';
 
-  constructor(message?: string) {
-    super(message);
-    this.lineage.unshift('ShutdownError');
-  }
+  /**
+   * Marker to determine whether an error is an instance of TerminatedFailure.
+   */
+  protected readonly [isShutdownError] = true;
 
   /**
    * Instanceof check that works when multiple versions of @temporalio/core-bridge are installed.
    */
-  public static is(error: unknown): error is ShutdownError {
-    return (
-      error instanceof ShutdownError || (LineageTrackingError.is(error) && error.lineage.includes('ShutdownError'))
-    );
+  static is(error: unknown): error is ShutdownError {
+    return error instanceof ShutdownError || (error instanceof Error && (error as any)[isShutdownError]);
   }
 }
 

--- a/packages/interceptors-opentelemetry/src/workflow/index.ts
+++ b/packages/interceptors-opentelemetry/src/workflow/index.ts
@@ -59,7 +59,7 @@ export class OpenTelemetryInboundInterceptor implements WorkflowInboundCallsInte
       spanName: `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}${workflowInfo().workflowType}`,
       fn: () => next(input),
       context,
-      acceptableErrors: (err) => err instanceof ContinueAsNew,
+      acceptableErrors: ContinueAsNew.is,
     });
   }
 }
@@ -120,7 +120,7 @@ export class OpenTelemetryOutboundInterceptor implements WorkflowOutboundCallsIn
           headers,
         });
       },
-      acceptableErrors: (err) => err instanceof ContinueAsNew,
+      acceptableErrors: ContinueAsNew.is,
     });
   }
 }

--- a/packages/worker/src/activity.ts
+++ b/packages/worker/src/activity.ts
@@ -1,5 +1,5 @@
 import 'abort-controller/polyfill'; // eslint-disable-line import/no-unassigned-import
-import { asyncLocalStorage, Context, Info } from '@temporalio/activity';
+import { asyncLocalStorage, CompleteAsyncError, Context, Info } from '@temporalio/activity';
 import {
   ActivityFunction,
   ApplicationFailure,
@@ -71,7 +71,7 @@ export class Activity {
         const result = await execute(input);
         return { completed: { result: await encodeToPayload(this.dataConverter, result) } };
       } catch (err) {
-        if (err instanceof Error && err.name === 'CompleteAsyncError') {
+        if (CompleteAsyncError.is(err)) {
           return { willCompleteAsync: {} };
         }
         if (this.cancelReason === 'HEARTBEAT_DETAILS_CONVERSION_FAILED') {
@@ -87,7 +87,7 @@ export class Activity {
           };
         } else if (this.cancelReason) {
           // Either a CancelledFailure that we threw or AbortError from AbortController
-          if (err instanceof CancelledFailure) {
+          if (CancelledFailure.is(err)) {
             const failure = await encodeErrorToFailure(this.dataConverter, err);
             failure.stackTrace = undefined;
             return { cancelled: { failure } };

--- a/packages/worker/src/workflow-log-interceptor.ts
+++ b/packages/worker/src/workflow-log-interceptor.ts
@@ -7,6 +7,7 @@ import {
   WorkflowInfo,
   WorkflowInterceptorsFactory,
   log,
+  ContinueAsNew,
 } from '@temporalio/workflow';
 import { untrackPromise } from '@temporalio/workflow/lib/stack-helpers';
 
@@ -43,7 +44,7 @@ export class WorkflowInboundLogInterceptor implements WorkflowInboundCallsInterc
           if (isCancellation(error)) {
             log.debug('Workflow completed as cancelled', this.logAttributes());
             throw error;
-          } else if (error.name === 'ContinueAsNew') {
+          } else if (ContinueAsNew.is(error)) {
             log.debug('Workflow continued as new', this.logAttributes());
             throw error;
           }

--- a/packages/workflow/src/errors.ts
+++ b/packages/workflow/src/errors.ts
@@ -1,3 +1,4 @@
+import { ActivityFailure, CancelledFailure, ChildWorkflowFailure } from '@temporalio/common';
 /**
  * Base class for all workflow errors
  */
@@ -12,19 +13,12 @@ export class DeterminismViolationError extends WorkflowError {
   public readonly name: string = 'DeterminismViolationError';
 }
 
-function looksLikeError(err: unknown): err is { name: string; cause?: unknown } {
-  return typeof err === 'object' && err != null && Object.prototype.hasOwnProperty.call(err, 'name');
-}
-
 /**
  * Returns whether provided `err` is caused by cancellation
  */
 export function isCancellation(err: unknown): boolean {
-  if (!looksLikeError(err)) return false;
   return (
-    err.name === 'CancelledFailure' ||
-    ((err.name === 'ActivityFailure' || err.name === 'ChildWorkflowFailure') &&
-      looksLikeError(err.cause) &&
-      err.cause.name === 'CancelledFailure')
+    CancelledFailure.is(err) ||
+    ((ActivityFailure.is(err) || ChildWorkflowFailure.is(err)) && CancelledFailure.is(err.cause))
   );
 }

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -174,6 +174,13 @@ export class ContinueAsNew extends Error {
   constructor(public readonly command: coresdk.workflow_commands.IContinueAsNewWorkflowExecution) {
     super('Workflow continued as new');
   }
+
+  /**
+   * Instanceof check that is works when multiple versions of @temporalio/workflow are installed.
+   */
+  public static is(error: unknown): error is ContinueAsNew {
+    return error instanceof ContinueAsNew || (error instanceof Error && error.name === 'ContinueAsNew');
+  }
 }
 
 /**

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -178,7 +178,7 @@ export class ContinueAsNew extends LineageTrackingError {
   }
 
   /**
-   * Instanceof check that is works when multiple versions of @temporalio/workflow are installed.
+   * Instanceof check that works when multiple versions of @temporalio/workflow are installed.
    */
   public static is(error: unknown): error is ContinueAsNew {
     return (

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -619,10 +619,10 @@ export class Activator implements ActivationHandler {
   async handleWorkflowFailure(error: unknown): Promise<void> {
     if (this.cancelled && isCancellation(error)) {
       this.pushCommand({ cancelWorkflowExecution: {} }, true);
-    } else if (error instanceof ContinueAsNew) {
+    } else if (ContinueAsNew.is(error)) {
       this.pushCommand({ continueAsNewWorkflowExecution: error.command }, true);
     } else {
-      if (!(error instanceof TemporalFailure)) {
+      if (!TemporalFailure.is(error)) {
         // This results in an unhandled rejection which will fail the activation
         // preventing it from completing.
         throw error;


### PR DESCRIPTION
The number one reported issue stems from instanceof checks and SDK module level variables, which fail when there are multiple versions of the SDK packages installed.

- Remove the instanceof checks in favor of coded `is` methods on the critical classes.
- Install the activity context local storage globally.

Note that the `is` methods do no use the class name, which may be lost when using minifiers.