### PR TITLE
feat(worker): Add support for concurrent pollers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18446,8 +18446,7 @@
         "@temporalio/proto": "file:../proto",
         "@temporalio/worker": "file:../worker",
         "@temporalio/workflow": "file:../workflow",
-        "abort-controller": "^3.0.0",
-        "ms": "^3.0.0-canary.1"
+        "abort-controller": "^3.0.0"
       }
     },
     "packages/testing/node_modules/@grpc/grpc-js": {
@@ -18460,14 +18459,6 @@
       },
       "engines": {
         "node": "^8.13.0 || >=10.10.0"
-      }
-    },
-    "packages/testing/node_modules/ms": {
-      "version": "3.0.0-canary.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
-      "engines": {
-        "node": ">=12.13"
       }
     },
     "packages/worker": {
@@ -18487,7 +18478,6 @@
         "cargo-cp-artifact": "^0.1.6",
         "heap-js": "^2.2.0",
         "memfs": "^3.4.6",
-        "ms": "^3.0.0-canary.1",
         "rxjs": "^7.5.5",
         "source-map": "^0.7.4",
         "source-map-loader": "^4.0.0",
@@ -18497,14 +18487,6 @@
       },
       "engines": {
         "node": ">= 14.18.0"
-      }
-    },
-    "packages/worker/node_modules/ms": {
-      "version": "3.0.0-canary.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
-      "engines": {
-        "node": ">=12.13"
       }
     },
     "packages/worker/node_modules/source-map": {
@@ -21195,8 +21177,7 @@
         "@temporalio/proto": "file:../proto",
         "@temporalio/worker": "file:../worker",
         "@temporalio/workflow": "file:../workflow",
-        "abort-controller": "^3.0.0",
-        "ms": "^3.0.0-canary.1"
+        "abort-controller": "^3.0.0"
       },
       "dependencies": {
         "@grpc/grpc-js": {
@@ -21207,11 +21188,6 @@
             "@grpc/proto-loader": "^0.7.0",
             "@types/node": ">=12.12.47"
           }
-        },
-        "ms": {
-          "version": "3.0.0-canary.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-          "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g=="
         }
       }
     },
@@ -21230,7 +21206,6 @@
         "cargo-cp-artifact": "^0.1.6",
         "heap-js": "^2.2.0",
         "memfs": "^3.4.6",
-        "ms": "^3.0.0-canary.1",
         "rxjs": "^7.5.5",
         "source-map": "^0.7.4",
         "source-map-loader": "^4.0.0",
@@ -21239,11 +21214,6 @@
         "webpack": "^5.75.0"
       },
       "dependencies": {
-        "ms": {
-          "version": "3.0.0-canary.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-          "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g=="
-        },
         "source-map": {
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",

--- a/packages/core-bridge/src/conversions.rs
+++ b/packages/core-bridge/src/conversions.rs
@@ -294,6 +294,10 @@ impl ObjectHandleConversionsExt for Handle<'_, JsObject> {
             js_value_getter!(cx, self, "maxConcurrentLocalActivityExecutions", JsNumber) as usize;
         let max_outstanding_workflow_tasks =
             js_value_getter!(cx, self, "maxConcurrentWorkflowTaskExecutions", JsNumber) as usize;
+        let max_concurrent_wft_polls =
+            js_value_getter!(cx, self, "maxConcurrentWorkflowTaskPolls", JsNumber) as usize;
+        let max_concurrent_at_polls =
+            js_value_getter!(cx, self, "maxConcurrentActivityTaskPolls", JsNumber) as usize;
         let sticky_queue_schedule_to_start_timeout = Duration::from_millis(js_value_getter!(
             cx,
             self,
@@ -335,6 +339,8 @@ impl ObjectHandleConversionsExt for Handle<'_, JsObject> {
             .max_outstanding_workflow_tasks(max_outstanding_workflow_tasks)
             .max_outstanding_activities(max_outstanding_activities)
             .max_outstanding_local_activities(max_outstanding_local_activities)
+            .max_concurrent_wft_polls(max_concurrent_wft_polls)
+            .max_concurrent_at_polls(max_concurrent_at_polls)
             .max_cached_workflows(max_cached_workflows)
             .sticky_queue_schedule_to_start_timeout(sticky_queue_schedule_to_start_timeout)
             .graceful_shutdown_period(graceful_shutdown_period)

--- a/packages/core-bridge/src/runtime.rs
+++ b/packages/core-bridge/src/runtime.rs
@@ -120,8 +120,9 @@ pub fn start_bridge_loop(
 ) {
     let mut tokio_builder = tokio::runtime::Builder::new_multi_thread();
     tokio_builder.enable_all().thread_name("core");
-    let core_runtime =
-        Arc::new(CoreRuntime::new(telemetry_options, tokio_builder).expect("Failed to create CoreRuntime"));
+    let core_runtime = Arc::new(
+        CoreRuntime::new(telemetry_options, tokio_builder).expect("Failed to create CoreRuntime"),
+    );
 
     core_runtime.tokio_handle().block_on(async {
         loop {

--- a/packages/core-bridge/ts/index.ts
+++ b/packages/core-bridge/ts/index.ts
@@ -277,6 +277,16 @@ export interface WorkerOptions {
   maxConcurrentLocalActivityExecutions: number;
 
   /**
+   * Maximum number of Workflow tasks to poll concurrently.
+   */
+  maxConcurrentWorkflowTaskPolls: number;
+
+  /**
+   * Maximum number of Activity tasks to poll concurrently.
+   */
+  maxConcurrentActivityTaskPolls: number;
+
+  /**
    * If set to `false` this worker will only handle workflow tasks and local activities, it will not
    * poll for activity tasks.
    */

--- a/packages/test/src/load/args.ts
+++ b/packages/test/src/load/args.ts
@@ -11,11 +11,15 @@ export type Spec = Record<string, () => any>;
 export interface SetupArgSpec extends Spec {
   '--ns': typeof String;
   '--server-address': typeof String;
+  '--client-cert-path': typeof String;
+  '--client-key-path': typeof String;
 }
 
 export const setupArgSpec: SetupArgSpec = {
   '--ns': String,
   '--server-address': String,
+  '--client-cert-path': String,
+  '--client-key-path': String,
 };
 
 export interface StarterArgSpec extends Spec {
@@ -33,6 +37,8 @@ export interface StarterArgSpec extends Spec {
   '--do-query': typeof String;
   '--initial-query-delay-ms': typeof Number;
   '--query-interval-ms': typeof Number;
+  '--client-cert-path': typeof String;
+  '--client-key-path': typeof String;
 }
 
 export const starterArgSpec: StarterArgSpec = {
@@ -50,6 +56,8 @@ export const starterArgSpec: StarterArgSpec = {
   '--do-query': String,
   '--initial-query-delay-ms': Number,
   '--query-interval-ms': Number,
+  '--client-cert-path': String,
+  '--client-key-path': String,
 };
 
 export interface WorkerArgSpec extends Spec {
@@ -59,12 +67,17 @@ export interface WorkerArgSpec extends Spec {
   '--max-concurrent-at-executions': typeof Number;
   '--max-concurrent-wft-executions': typeof Number;
   '--max-concurrent-la-executions': typeof Number;
+  '--max-wft-pollers': typeof Number;
+  '--max-at-pollers': typeof Number;
+  '--wf-thread-pool-size': typeof Number;
   '--log-level': typeof String;
   '--log-file': typeof String;
   '--server-address': typeof String;
   '--otel-url': typeof String;
   '--status-port': typeof Number;
   '--shutdown-grace-time-ms': typeof String;
+  '--client-cert-path': typeof String;
+  '--client-key-path': typeof String;
 }
 
 export const workerArgSpec: WorkerArgSpec = {
@@ -74,13 +87,17 @@ export const workerArgSpec: WorkerArgSpec = {
   '--max-concurrent-at-executions': Number,
   '--max-concurrent-wft-executions': Number,
   '--max-concurrent-la-executions': Number,
-  '--isolate-pool-size': Number,
+  '--max-wft-pollers': Number,
+  '--max-at-pollers': Number,
+  '--wf-thread-pool-size': Number,
   '--log-level': String,
   '--log-file': String,
   '--server-address': String,
   '--otel-url': String,
   '--status-port': Number,
   '--shutdown-grace-time-ms': String,
+  '--client-cert-path': String,
+  '--client-key-path': String,
 };
 
 export interface WrapperArgSpec extends Spec {

--- a/packages/test/src/load/worker.ts
+++ b/packages/test/src/load/worker.ts
@@ -1,12 +1,12 @@
-import fs, { read, readFileSync } from 'node:fs';
-import http from 'node:http';
-import { inspect } from 'node:util';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
-import * as opentelemetry from '@opentelemetry/sdk-node';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
-import arg from 'arg';
-import { LogLevel, TelemetryOptions } from '@temporalio/core-bridge';
-import { Connection } from '@temporalio/client';
+import fs, { readFileSync } from "node:fs";
+import http from "node:http";
+import { inspect } from "node:util";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
+import * as opentelemetry from "@opentelemetry/sdk-node";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import arg from "arg";
+import { LogLevel, TelemetryOptions } from "@temporalio/core-bridge";
+import { Connection } from "@temporalio/client";
 import {
   DefaultLogger,
   LogEntry,
@@ -14,17 +14,20 @@ import {
   Runtime,
   Worker,
   makeTelemetryFilterString,
-} from '@temporalio/worker';
-import * as activities from '../activities';
-import { ConnectionInjectorInterceptor } from '../activities/interceptors';
-import { getRequired, WorkerArgSpec, workerArgSpec } from './args';
+} from "@temporalio/worker";
+import * as activities from "../activities";
+import { ConnectionInjectorInterceptor } from "../activities/interceptors";
+import { getRequired, WorkerArgSpec, workerArgSpec } from "./args";
 
 /**
  * Optionally start the opentelemetry node SDK
  */
-async function withOptionalOtel(args: arg.Result<WorkerArgSpec>, fn: () => Promise<any>): Promise<void> {
-  const url = args['--otel-url'];
-  const taskQueue = getRequired(args, '--task-queue');
+async function withOptionalOtel(
+  args: arg.Result<WorkerArgSpec>,
+  fn: () => Promise<any>
+): Promise<void> {
+  const url = args["--otel-url"];
+  const taskQueue = getRequired(args, "--task-queue");
 
   if (!url) {
     await fn();
@@ -34,7 +37,7 @@ async function withOptionalOtel(args: arg.Result<WorkerArgSpec>, fn: () => Promi
   const traceExporter = new OTLPTraceExporter({ url });
   const otel = new opentelemetry.NodeSDK({
     resource: new opentelemetry.resources.Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: 'load-worker',
+      [SemanticResourceAttributes.SERVICE_NAME]: "load-worker",
       taskQueue,
     }),
     traceExporter,
@@ -63,24 +66,24 @@ async function withOptionalStatusServer(
 
   const server = await new Promise<http.Server>((resolve, reject) => {
     const server = http.createServer((req, res) => {
-      if (req.method !== 'GET') {
-        res.writeHead(405, 'Method not allowed');
+      if (req.method !== "GET") {
+        res.writeHead(405, "Method not allowed");
         res.end();
         return;
       }
-      if (req.url !== '/') {
-        res.writeHead(404, 'Not found');
+      if (req.url !== "/") {
+        res.writeHead(404, "Not found");
         res.end();
         return;
       }
-      res.setHeader('Content-Type', 'application/json');
+      res.setHeader("Content-Type", "application/json");
       res.write(JSON.stringify(worker.getStatus()));
       res.end();
     });
     server.listen(port, () => resolve(server));
-    server.once('error', reject);
+    server.once("error", reject);
   });
-  console.log('Status server listening on', server?.address());
+  console.log("Status server listening on", server?.address());
   try {
     await fn();
   } finally {
@@ -96,30 +99,36 @@ function createLogFunction(stream: fs.WriteStream) {
     if (meta === undefined) {
       stream.write(`${date.toISOString()} [${level}] ${message}\n`);
     } else {
-      stream.write(`${date.toISOString()} [${level}] ${message} ${inspect(meta)}\n`);
+      stream.write(
+        `${date.toISOString()} [${level}] ${message} ${inspect(meta)}\n`
+      );
     }
   };
 }
 
 async function main() {
   const args = arg<WorkerArgSpec>(workerArgSpec);
-  const maxConcurrentActivityTaskExecutions = args['--max-concurrent-at-executions'] ?? 100;
-  const maxConcurrentWorkflowTaskExecutions = args['--max-concurrent-wft-executions'] ?? 100;
-  const maxConcurrentLocalActivityExecutions = args['--max-concurrent-la-executions'] ?? 100;
-  const maxCachedWorkflows = args['--max-cached-wfs'];
-  const maxConcurrentWorkflowTaskPolls = args['--max-wft-pollers'] ?? 2;
-  const maxConcurrentActivityTaskPolls = args['--max-at-pollers'] ?? 2;
-  const workflowThreadPoolSize: number | undefined = args['--wf-thread-pool-size'];
-  const oTelUrl = args['--otel-url'];
-  const logLevel = (args['--log-level'] || 'INFO').toUpperCase();
-  const logFile = args['--log-file'];
-  const serverAddress = getRequired(args, '--server-address');
-  const clientCertPath = args['--client-cert-path'];
-  const clientKeyPath = args['--client-key-path'];
-  const namespace = getRequired(args, '--ns');
-  const taskQueue = getRequired(args, '--task-queue');
-  const statusPort = args['--status-port'];
-  const shutdownGraceTime = args['--shutdown-grace-time'] || '30s';
+  const maxConcurrentActivityTaskExecutions =
+    args["--max-concurrent-at-executions"] ?? 100;
+  const maxConcurrentWorkflowTaskExecutions =
+    args["--max-concurrent-wft-executions"] ?? 100;
+  const maxConcurrentLocalActivityExecutions =
+    args["--max-concurrent-la-executions"] ?? 100;
+  const maxCachedWorkflows = args["--max-cached-wfs"];
+  const maxConcurrentWorkflowTaskPolls = args["--max-wft-pollers"] ?? 2;
+  const maxConcurrentActivityTaskPolls = args["--max-at-pollers"] ?? 2;
+  const workflowThreadPoolSize: number | undefined =
+    args["--wf-thread-pool-size"];
+  const oTelUrl = args["--otel-url"];
+  const logLevel = (args["--log-level"] || "INFO").toUpperCase();
+  const logFile = args["--log-file"];
+  const serverAddress = getRequired(args, "--server-address");
+  const clientCertPath = args["--client-cert-path"];
+  const clientKeyPath = args["--client-key-path"];
+  const namespace = getRequired(args, "--ns");
+  const taskQueue = getRequired(args, "--task-queue");
+  const statusPort = args["--status-port"];
+  const shutdownGraceTime = args["--shutdown-grace-time"] || "30s";
 
   const telemetryOptions: TelemetryOptions = {
     logging: {
@@ -137,7 +146,10 @@ async function main() {
   };
 
   const logger = logFile
-    ? new DefaultLogger(logLevel as any, createLogFunction(fs.createWriteStream(logFile, 'utf8')))
+    ? new DefaultLogger(
+        logLevel as any,
+        createLogFunction(fs.createWriteStream(logFile, "utf8"))
+      )
     : new DefaultLogger(logLevel as any);
   Runtime.install({
     telemetryOptions,
@@ -171,7 +183,7 @@ async function main() {
       connection,
       namespace,
       activities,
-      workflowsPath: require.resolve('../workflows'),
+      workflowsPath: require.resolve("../workflows"),
       taskQueue,
       maxConcurrentActivityTaskExecutions,
       maxConcurrentLocalActivityExecutions,
@@ -182,14 +194,21 @@ async function main() {
       maxConcurrentActivityTaskPolls,
       maxConcurrentWorkflowTaskPolls,
       interceptors: {
-        activityInbound: [() => new ConnectionInjectorInterceptor(clientConnection)],
+        activityInbound: [
+          () => new ConnectionInjectorInterceptor(clientConnection),
+        ],
       },
       // Can't reuse the helper because it defines `test` and ava thinks it's an ava test.
-      reuseV8Context: ['1', 't', 'true'].includes((process.env.REUSE_V8_CONTEXT ?? 'false').toLowerCase()),
+      reuseV8Context: ["1", "t", "true"].includes(
+        (process.env.REUSE_V8_CONTEXT ?? "false").toLowerCase()
+      ),
     });
 
     await withOptionalStatusServer(worker, statusPort, async () => {
-      const interval = setInterval(() => logger.info('worker status', worker.getStatus()), 30_000);
+      const interval = setInterval(
+        () => logger.info("worker status", worker.getStatus()),
+        30_000
+      );
       try {
         await worker.run();
       } finally {

--- a/packages/test/src/load/worker.ts
+++ b/packages/test/src/load/worker.ts
@@ -1,12 +1,12 @@
-import fs, { readFileSync } from "node:fs";
-import http from "node:http";
-import { inspect } from "node:util";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
-import * as opentelemetry from "@opentelemetry/sdk-node";
-import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
-import arg from "arg";
-import { LogLevel, TelemetryOptions } from "@temporalio/core-bridge";
-import { Connection } from "@temporalio/client";
+import fs, { readFileSync } from 'node:fs';
+import http from 'node:http';
+import { inspect } from 'node:util';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
+import * as opentelemetry from '@opentelemetry/sdk-node';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import arg from 'arg';
+import { LogLevel, TelemetryOptions } from '@temporalio/core-bridge';
+import { Connection } from '@temporalio/client';
 import {
   DefaultLogger,
   LogEntry,
@@ -14,20 +14,17 @@ import {
   Runtime,
   Worker,
   makeTelemetryFilterString,
-} from "@temporalio/worker";
-import * as activities from "../activities";
-import { ConnectionInjectorInterceptor } from "../activities/interceptors";
-import { getRequired, WorkerArgSpec, workerArgSpec } from "./args";
+} from '@temporalio/worker';
+import * as activities from '../activities';
+import { ConnectionInjectorInterceptor } from '../activities/interceptors';
+import { getRequired, WorkerArgSpec, workerArgSpec } from './args';
 
 /**
  * Optionally start the opentelemetry node SDK
  */
-async function withOptionalOtel(
-  args: arg.Result<WorkerArgSpec>,
-  fn: () => Promise<any>
-): Promise<void> {
-  const url = args["--otel-url"];
-  const taskQueue = getRequired(args, "--task-queue");
+async function withOptionalOtel(args: arg.Result<WorkerArgSpec>, fn: () => Promise<any>): Promise<void> {
+  const url = args['--otel-url'];
+  const taskQueue = getRequired(args, '--task-queue');
 
   if (!url) {
     await fn();
@@ -37,7 +34,7 @@ async function withOptionalOtel(
   const traceExporter = new OTLPTraceExporter({ url });
   const otel = new opentelemetry.NodeSDK({
     resource: new opentelemetry.resources.Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: "load-worker",
+      [SemanticResourceAttributes.SERVICE_NAME]: 'load-worker',
       taskQueue,
     }),
     traceExporter,
@@ -66,24 +63,24 @@ async function withOptionalStatusServer(
 
   const server = await new Promise<http.Server>((resolve, reject) => {
     const server = http.createServer((req, res) => {
-      if (req.method !== "GET") {
-        res.writeHead(405, "Method not allowed");
+      if (req.method !== 'GET') {
+        res.writeHead(405, 'Method not allowed');
         res.end();
         return;
       }
-      if (req.url !== "/") {
-        res.writeHead(404, "Not found");
+      if (req.url !== '/') {
+        res.writeHead(404, 'Not found');
         res.end();
         return;
       }
-      res.setHeader("Content-Type", "application/json");
+      res.setHeader('Content-Type', 'application/json');
       res.write(JSON.stringify(worker.getStatus()));
       res.end();
     });
     server.listen(port, () => resolve(server));
-    server.once("error", reject);
+    server.once('error', reject);
   });
-  console.log("Status server listening on", server?.address());
+  console.log('Status server listening on', server?.address());
   try {
     await fn();
   } finally {
@@ -99,36 +96,30 @@ function createLogFunction(stream: fs.WriteStream) {
     if (meta === undefined) {
       stream.write(`${date.toISOString()} [${level}] ${message}\n`);
     } else {
-      stream.write(
-        `${date.toISOString()} [${level}] ${message} ${inspect(meta)}\n`
-      );
+      stream.write(`${date.toISOString()} [${level}] ${message} ${inspect(meta)}\n`);
     }
   };
 }
 
 async function main() {
   const args = arg<WorkerArgSpec>(workerArgSpec);
-  const maxConcurrentActivityTaskExecutions =
-    args["--max-concurrent-at-executions"] ?? 100;
-  const maxConcurrentWorkflowTaskExecutions =
-    args["--max-concurrent-wft-executions"] ?? 100;
-  const maxConcurrentLocalActivityExecutions =
-    args["--max-concurrent-la-executions"] ?? 100;
-  const maxCachedWorkflows = args["--max-cached-wfs"];
-  const maxConcurrentWorkflowTaskPolls = args["--max-wft-pollers"] ?? 2;
-  const maxConcurrentActivityTaskPolls = args["--max-at-pollers"] ?? 2;
-  const workflowThreadPoolSize: number | undefined =
-    args["--wf-thread-pool-size"];
-  const oTelUrl = args["--otel-url"];
-  const logLevel = (args["--log-level"] || "INFO").toUpperCase();
-  const logFile = args["--log-file"];
-  const serverAddress = getRequired(args, "--server-address");
-  const clientCertPath = args["--client-cert-path"];
-  const clientKeyPath = args["--client-key-path"];
-  const namespace = getRequired(args, "--ns");
-  const taskQueue = getRequired(args, "--task-queue");
-  const statusPort = args["--status-port"];
-  const shutdownGraceTime = args["--shutdown-grace-time"] || "30s";
+  const maxConcurrentActivityTaskExecutions = args['--max-concurrent-at-executions'] ?? 100;
+  const maxConcurrentWorkflowTaskExecutions = args['--max-concurrent-wft-executions'] ?? 100;
+  const maxConcurrentLocalActivityExecutions = args['--max-concurrent-la-executions'] ?? 100;
+  const maxCachedWorkflows = args['--max-cached-wfs'];
+  const maxConcurrentWorkflowTaskPolls = args['--max-wft-pollers'] ?? 2;
+  const maxConcurrentActivityTaskPolls = args['--max-at-pollers'] ?? 2;
+  const workflowThreadPoolSize: number | undefined = args['--wf-thread-pool-size'];
+  const oTelUrl = args['--otel-url'];
+  const logLevel = (args['--log-level'] || 'INFO').toUpperCase();
+  const logFile = args['--log-file'];
+  const serverAddress = getRequired(args, '--server-address');
+  const clientCertPath = args['--client-cert-path'];
+  const clientKeyPath = args['--client-key-path'];
+  const namespace = getRequired(args, '--ns');
+  const taskQueue = getRequired(args, '--task-queue');
+  const statusPort = args['--status-port'];
+  const shutdownGraceTime = args['--shutdown-grace-time'] || '30s';
 
   const telemetryOptions: TelemetryOptions = {
     logging: {
@@ -146,10 +137,7 @@ async function main() {
   };
 
   const logger = logFile
-    ? new DefaultLogger(
-        logLevel as any,
-        createLogFunction(fs.createWriteStream(logFile, "utf8"))
-      )
+    ? new DefaultLogger(logLevel as any, createLogFunction(fs.createWriteStream(logFile, 'utf8')))
     : new DefaultLogger(logLevel as any);
   Runtime.install({
     telemetryOptions,
@@ -183,7 +171,7 @@ async function main() {
       connection,
       namespace,
       activities,
-      workflowsPath: require.resolve("../workflows"),
+      workflowsPath: require.resolve('../workflows'),
       taskQueue,
       maxConcurrentActivityTaskExecutions,
       maxConcurrentLocalActivityExecutions,
@@ -194,21 +182,14 @@ async function main() {
       maxConcurrentActivityTaskPolls,
       maxConcurrentWorkflowTaskPolls,
       interceptors: {
-        activityInbound: [
-          () => new ConnectionInjectorInterceptor(clientConnection),
-        ],
+        activityInbound: [() => new ConnectionInjectorInterceptor(clientConnection)],
       },
       // Can't reuse the helper because it defines `test` and ava thinks it's an ava test.
-      reuseV8Context: ["1", "t", "true"].includes(
-        (process.env.REUSE_V8_CONTEXT ?? "false").toLowerCase()
-      ),
+      reuseV8Context: ['1', 't', 'true'].includes((process.env.REUSE_V8_CONTEXT ?? 'false').toLowerCase()),
     });
 
     await withOptionalStatusServer(worker, statusPort, async () => {
-      const interval = setInterval(
-        () => logger.info("worker status", worker.getStatus()),
-        30_000
-      );
+      const interval = setInterval(() => logger.info('worker status', worker.getStatus()), 30_000);
       try {
         await worker.run();
       } finally {

--- a/packages/test/src/load/worker.ts
+++ b/packages/test/src/load/worker.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import fs, { read, readFileSync } from 'node:fs';
 import http from 'node:http';
 import { inspect } from 'node:util';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
@@ -107,10 +107,15 @@ async function main() {
   const maxConcurrentWorkflowTaskExecutions = args['--max-concurrent-wft-executions'] ?? 100;
   const maxConcurrentLocalActivityExecutions = args['--max-concurrent-la-executions'] ?? 100;
   const maxCachedWorkflows = args['--max-cached-wfs'];
+  const maxConcurrentWorkflowTaskPolls = args['--max-wft-pollers'] ?? 2;
+  const maxConcurrentActivityTaskPolls = args['--max-at-pollers'] ?? 2;
+  const workflowThreadPoolSize: number | undefined = args['--wf-thread-pool-size'];
   const oTelUrl = args['--otel-url'];
   const logLevel = (args['--log-level'] || 'INFO').toUpperCase();
   const logFile = args['--log-file'];
   const serverAddress = getRequired(args, '--server-address');
+  const clientCertPath = args['--client-cert-path'];
+  const clientKeyPath = args['--client-key-path'];
   const namespace = getRequired(args, '--ns');
   const taskQueue = getRequired(args, '--task-queue');
   const statusPort = args['--status-port'];
@@ -139,12 +144,26 @@ async function main() {
     logger,
   });
 
+  const tlsConfig =
+    clientCertPath && clientKeyPath
+      ? {
+          tls: {
+            clientCertPair: {
+              crt: readFileSync(clientCertPath),
+              key: readFileSync(clientKeyPath),
+            },
+          },
+        }
+      : {};
+
   const clientConnection = await Connection.connect({
     address: serverAddress,
+    ...tlsConfig,
   });
 
   const connection = await NativeConnection.connect({
     address: serverAddress,
+    ...tlsConfig,
   });
 
   await withOptionalOtel(args, async () => {
@@ -159,6 +178,9 @@ async function main() {
       maxConcurrentWorkflowTaskExecutions,
       maxCachedWorkflows,
       shutdownGraceTime,
+      workflowThreadPoolSize,
+      maxConcurrentActivityTaskPolls,
+      maxConcurrentWorkflowTaskPolls,
       interceptors: {
         activityInbound: [() => new ConnectionInjectorInterceptor(clientConnection)],
       },

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -179,7 +179,7 @@ if (RUN_INTEGRATION_TESTS) {
 
     t.deepEqual(recordedMessages, [
       'Workflow execution started, replaying: false, hl: 3',
-      'Workflow execution completed, replaying: false, hl: 12',
+      'Workflow execution completed, replaying: false, hl: 8',
     ]);
   });
 
@@ -212,6 +212,6 @@ if (RUN_INTEGRATION_TESTS) {
       'Workflow execution started, replaying: false, hl: 3',
       'Workflow execution started, replaying: true, hl: 3',
     ]);
-    t.is(recordedMessages[recordedMessages.length - 1], 'Workflow execution completed, replaying: false, hl: 12');
+    t.is(recordedMessages[recordedMessages.length - 1], 'Workflow execution completed, replaying: false, hl: 8');
   });
 }

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -162,8 +162,8 @@ if (RUN_INTEGRATION_TESTS) {
       ...defaultOptions,
       taskQueue,
       sinks,
-      maxCachedWorkflows: 1,
-      maxConcurrentWorkflowTaskExecutions: 1,
+      maxCachedWorkflows: 0,
+      maxConcurrentWorkflowTaskExecutions: 2,
     });
     const client = new WorkflowClient();
     await Promise.all([
@@ -201,8 +201,8 @@ if (RUN_INTEGRATION_TESTS) {
       ...defaultOptions,
       taskQueue,
       sinks,
-      maxCachedWorkflows: 1,
-      maxConcurrentWorkflowTaskExecutions: 1,
+      maxCachedWorkflows: 0,
+      maxConcurrentWorkflowTaskExecutions: 2,
     });
     const client = new WorkflowClient();
     await worker.runUntil(client.execute(workflows.logSinkTester, { taskQueue, workflowId: uuid4() }));

--- a/packages/test/src/workflows/log-sink-tester.ts
+++ b/packages/test/src/workflows/log-sink-tester.ts
@@ -16,7 +16,7 @@ export async function logSinkTester(): Promise<void> {
       wf.workflowInfo().historyLength
     }`
   );
-  // We rely on this test to run with workflow cache disabled. This sleep() will
+  // We rely on this test to run with workflow cache disabled. This sleep()
   // therefore ends the current WFT, evicting the workflow from cache, and thus
   // causing replay of the first sink call.
   await wf.sleep(1);

--- a/packages/test/src/workflows/log-sink-tester.ts
+++ b/packages/test/src/workflows/log-sink-tester.ts
@@ -7,7 +7,6 @@
 
 import * as wf from '@temporalio/workflow';
 import { LoggerSinks } from './definitions';
-import { successString } from './success-string';
 
 const { logger } = wf.proxySinks<LoggerSinks>();
 
@@ -17,10 +16,10 @@ export async function logSinkTester(): Promise<void> {
       wf.workflowInfo().historyLength
     }`
   );
-  // We rely on the test to run with max cached workflows of 1.
-  // Executing this child will flush the current workflow from the cache
-  // causing replay or the first sink call.
-  await wf.executeChild(successString);
+  // We rely on this test to run with workflow cache disabled. This sleep() will
+  // therefore ends the current WFT, evicting the workflow from cache, and thus
+  // causing replay of the first sink call.
+  await wf.sleep(1);
   logger.info(
     `Workflow execution completed, replaying: ${wf.workflowInfo().unsafe.isReplaying}, hl: ${
       wf.workflowInfo().historyLength

--- a/packages/testing/src/utils.ts
+++ b/packages/testing/src/utils.ts
@@ -18,6 +18,8 @@ export async function waitOnNamespace(
       if (
         err.details.includes('workflow history not found') ||
         err.details.includes('Workflow executionsRow not found') ||
+        err.details.includes('operation GetCurrentExecution') ||
+        err.details.includes('operation GetWorkflowExecution encountered not found') ||
         err.details.includes(runId)
       ) {
         break;

--- a/packages/testing/src/utils.ts
+++ b/packages/testing/src/utils.ts
@@ -1,6 +1,8 @@
 import { Connection } from '@temporalio/client';
 import { msToTs } from '@temporalio/common/lib/time';
 
+// Starting with 1.20, we should no longer need to wait on namespace
+// TODO: Remove all of this once we are confident that this is no longer required
 export async function waitOnNamespace(
   connection: Connection,
   namespace: string,

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -541,31 +541,51 @@ export class Runtime {
 
   protected checkHeapSizeLimit(): void {
     if (process.platform === 'linux') {
-      const cgroupMemoryConstraint = Number(
-        this.tryReadFileSync(/* cgroup v2 */ '/sys/fs/cgroup/memory.max') ??
-          this.tryReadFileSync(/* cgroup v1 */ '/sys/fs/cgroup/memory/memory.limit_in_bytes')
-      );
+      // References:
+      // - https://facebookmicrosites.github.io/cgroup2/docs/memory-controller.html
+      // - https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
+      const cgroupMemoryConstraint =
+        this.tryReadNumberFileSync(/* cgroup v2 */ '/sys/fs/cgroup/memory.high') ??
+        this.tryReadNumberFileSync(/* cgroup v2 */ '/sys/fs/cgroup/memory.max') ??
+        this.tryReadNumberFileSync(/* cgroup v1 */ '/sys/fs/cgroup/memory/memory.limit_in_bytes');
+      const cgroupMemoryReservation =
+        this.tryReadNumberFileSync(/* cgroup v2 */ '/sys/fs/cgroup/memory.low') ??
+        this.tryReadNumberFileSync(/* cgroup v2 */ '/sys/fs/cgroup/memory.min') ??
+        this.tryReadNumberFileSync(/* cgroup v1 */ '/sys/fs/cgroup/memory/soft_limit_in_bytes');
 
-      if (cgroupMemoryConstraint < os.totalmem() && cgroupMemoryConstraint < v8.getHeapStatistics().heap_size_limit) {
-        const totalMemInMb = toMB(os.totalmem(), 0);
-        const suggestedOldSpaceSizeInMb = toMB(os.totalmem() * 0.75, 0);
+      const applicableMemoryConstraint = cgroupMemoryReservation ?? cgroupMemoryConstraint;
+      if (
+        applicableMemoryConstraint &&
+        applicableMemoryConstraint < os.totalmem() &&
+        applicableMemoryConstraint < v8.getHeapStatistics().heap_size_limit
+      ) {
+        let dockerArgs = '';
+        if (cgroupMemoryConstraint) {
+          dockerArgs += `--memory=${toMB(cgroupMemoryConstraint, 0)}m `;
+        }
+        if (cgroupMemoryReservation) {
+          dockerArgs += `--memory-reservation=${toMB(cgroupMemoryReservation, 0)}m `;
+        }
+
+        const suggestedOldSpaceSizeInMb = toMB(applicableMemoryConstraint * 0.75, 0);
 
         this.logger.warn(
           `This program is running inside a containerized environment with a memory constraint ` +
-            `(eg. docker --memory ${totalMemInMb}m). Node itself does not consider this memory constraint ` +
+            `(eg. '${dockerArgs}' or similar). Node itself does not consider this memory constraint ` +
             `in how it manages its heap memory. There is consequently a high probability that ` +
             `the process will crash due to running out of memory. To increase reliability, we recommend ` +
             `adding '--max-old-space-size=${suggestedOldSpaceSizeInMb}' to your node arguments. ` +
-            `Refer to https://docs.temporal.io/application-development/worker-performance for more ` +
-            `advice on tuning your workers.`
+            `Refer to https://docs.temporal.io/dev-guide/typescript/foundations#run-a-worker-on-docker ` +
+            `for more advices on tuning your Workers.`
         );
       }
     }
   }
 
-  protected tryReadFileSync(file: string): string | undefined {
+  protected tryReadNumberFileSync(file: string): number | undefined {
     try {
-      return fs.readFileSync(file, { encoding: 'ascii' }) as string;
+      const val = Number(fs.readFileSync(file, { encoding: 'ascii' }));
+      return isNaN(val) ? undefined : val;
     } catch (e) {
       return undefined;
     }

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -571,7 +571,7 @@ export class Runtime {
             `the process will crash due to running out of memory. To increase reliability, we recommend ` +
             `adding '--max-old-space-size=${suggestedOldSpaceSizeInMb}' to your node arguments. ` +
             `Refer to https://docs.temporal.io/dev-guide/typescript/foundations#run-a-worker-on-docker ` +
-            `for more advices on tuning your Workers.`
+            `for more advice on tuning your Workers.`
         );
       }
     }

--- a/packages/worker/src/utils.ts
+++ b/packages/worker/src/utils.ts
@@ -2,7 +2,6 @@ import type { coresdk } from '@temporalio/proto';
 import { IllegalStateError, ParentWorkflowInfo } from '@temporalio/workflow';
 
 export const MiB = 1024 ** 2;
-export const GiB = MiB * 1024;
 
 // ts-prune-ignore-next (no idea why ts-prune is complaining all of a sudden)
 export function partition<T>(arr: T[], predicate: (x: T) => boolean): [T[], T[]] {

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -206,7 +206,7 @@ export interface WorkerOptions {
    * `maxConcurrentWorkflowTaskExecutions` slots despite a backlog of Workflow
    * Tasks in the Task Queue (ie. due to network latency). Can't be higher than
    * `maxConcurrentWorkflowTaskExecutions`.
-   * @default min(5, maxConcurrentWorkflowTaskExecutions)
+   * @default min(2, maxConcurrentWorkflowTaskExecutions)
    */
   maxConcurrentWorkflowTaskPolls?: number;
 
@@ -216,7 +216,7 @@ export interface WorkerOptions {
    * `maxConcurrentActivityTaskExecutions` slots despite a backlog of Activity
    * Tasks in the Task Queue (ie. due to network latency). Can't be higher than
    * `maxConcurrentActivityTaskExecutions`.
-   * @default min(5, maxConcurrentActivityTaskExecutions)
+   * @default min(2, maxConcurrentActivityTaskExecutions)
    */
   maxConcurrentActivityTaskPolls?: number;
 
@@ -243,6 +243,17 @@ export interface WorkerOptions {
    * @default `max(maxHeapMemory / 1GiB - 1, 1) * 250`
    */
   maxCachedWorkflows?: number;
+
+  /**
+   * Controls the number of Worker threads the Worker should create.
+   *
+   * Threads are used to create {@link https://nodejs.org/api/vm.html | vm }s for the isolated Workflow environment.
+   *
+   * New Workflows are created on this pool in a round-robin fashion.
+   *
+   * @default 1 for reuseV8Context, otherwise 8. Ignored if `debugMode` is enabled.
+   */
+  workflowThreadPoolSize?: number;
 
   /**
    * Longest interval for throttling activity heartbeats
@@ -373,6 +384,7 @@ export type WorkerOptionsWithDefaults = WorkerOptions &
       | 'enableNonLocalActivities'
       | 'stickyQueueScheduleToStartTimeout'
       | 'maxCachedWorkflows'
+      | 'workflowThreadPoolSize'
       | 'maxHeartbeatThrottleInterval'
       | 'defaultHeartbeatThrottleInterval'
       | 'enableSDKTracing'
@@ -519,8 +531,8 @@ export function addDefaultWorkerOptions(options: WorkerOptions): WorkerOptionsWi
     shutdownGraceTime: 0,
     maxConcurrentLocalActivityExecutions: 100,
     enableNonLocalActivities: true,
-    maxConcurrentWorkflowTaskPolls: Math.min(5, maxConcurrentWorkflowTaskExecutions),
-    maxConcurrentActivityTaskPolls: Math.min(5, maxConcurrentActivityTaskExecutions),
+    maxConcurrentWorkflowTaskPolls: Math.min(2, maxConcurrentWorkflowTaskExecutions),
+    maxConcurrentActivityTaskPolls: Math.min(2, maxConcurrentActivityTaskExecutions),
     stickyQueueScheduleToStartTimeout: '10s',
     maxHeartbeatThrottleInterval: '60s',
     defaultHeartbeatThrottleInterval: '30s',

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -54,9 +54,9 @@ export function isPathBundleOption(bundleOpt: WorkflowBundleOption): bundleOpt i
 /**
  * Options to configure the {@link Worker}
  *
- * Some options can signifciantly affect Workers performance. Default settings are generally appropriate for
- * day-to-day developments, but unlikely to be suitable for production use. We recommend that you explicitely set
- * values every performance-related options on production deployment.
+ * Some options can significantly affect Worker's performance. Default settings are generally appropriate for
+ * day-to-day development, but unlikely to be suitable for production use. We recommend that you explicitly set
+ * values for every performance-related option on production deployment.
  */
 export interface WorkerOptions {
   /**
@@ -69,9 +69,9 @@ export interface WorkerOptions {
   /**
    * A human-readable string that can identify your worker
    *
-   * Note that in most production environments, the `identity` value set by default may be unhelful for traceability
-   * purpose. It is highly recommended that you set this value to something that will allow you to efficiently identify
-   * that particular Worker container/process/logs in your infrastructure (eg. the task ID allocated to this container
+   * Note that in most production environments, the `identity` value set by default may be unhelpful for traceability
+   * purposes. It is highly recommended that you set this value to something that will allow you to efficiently identify
+   * that particular Worker container/process/logs in your infrastructure (ex: the task ID allocated to this container
    * by your orchestrator).
    *
    * @default `${process.pid}@${os.hostname()}`
@@ -205,7 +205,7 @@ export interface WorkerOptions {
   /**
    * Maximum number of Workflow Tasks to execute concurrently.
    *
-   * In general, a Workflow Worker's performance is mostly network bound (due to latency in communications with the
+   * In general, a Workflow Worker's performance is mostly network bound (due to communication latency with the
    * Temporal server). Accepting multiple Workflow Tasks concurrently helps compensate for network latency, until the
    * point where the Worker gets CPU bound.
    *
@@ -219,10 +219,10 @@ export interface WorkerOptions {
    *
    * As a general guidelines:
    * - High latency to Temporal Server => Increase this number
-   * - Very Short Workflow Tasks (ie. that notably implies no Local Activities) => increase this number
+   * - Very short Workflow Tasks (no lengthy Local Activities) => increase this number
    * - Very long/heavy Workflow Histories => decrease this number
    * - Low CPU usage despite backlog of Workflow Tasks => increase this number
-   * - High number of Workflow Task Timeout => decrease this number
+   * - High number of Workflow Task timeouts => decrease this number
    *
    * In our reference performance test against Temporal Cloud, running with a single Workflow thread and the Reuse V8
    * Context option enabled, we reached peak performance with a `maxConcurrentWorkflowTaskExecutions` of `120`, and
@@ -236,9 +236,9 @@ export interface WorkerOptions {
   /**
    * Maximum number of Workflow Tasks to poll concurrently.
    *
-   * In general, a Workflow Worker's performance is mostly network bound (due to latency in communications with the
+   * In general, a Workflow Worker's performance is mostly network bound (due to communication latency with the
    * Temporal server). Polling multiple Workflow Tasks concurrently helps compensate for this latency, by ensuring that
-   * the Worker never get starved, waiting for the server to return new Workflow Tasks to execute.
+   * the Worker is not starved waiting for the server to return new Workflow Tasks to execute.
    *
    * This setting is highly related with {@link WorkerOptions.maxConcurrentWorkflowTaskExecutions}. In various
    * performance tests, we generally got optimal performance by setting this value to about half of
@@ -251,7 +251,7 @@ export interface WorkerOptions {
    * - By default, set this value to half of `maxConcurrentWorkflowTaskExecutions`.
    * - **Increase** if actual number of Workflow Tasks being processed concurrently is lower than
    *   `maxConcurrentWorkflowTaskExecutions` despite a backlog of Workflow Tasks in the Task Queue.
-   * - Keep low on Task Queues that have very few concurrent Workflow Executions.
+   * - Keep this value low for Task Queues which have very few concurrent Workflow Executions.
    *
    * Can't be higher than `maxConcurrentWorkflowTaskExecutions`, and can't be lower than 2.
    * @default min(10, maxConcurrentWorkflowTaskExecutions)

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -295,8 +295,8 @@ export interface WorkerOptions {
    * memory. In one reference performance test, memory usage grew by approximately 1 MB per cached Workflow (that is
    * including memory used for activity executions of these Workflows). Your millage may vary.
    *
-   * @default if `reuseV8Context = true`, then `max(maxHeapMemory - 400MB, 1) * (250WF / 1024MB)`.
-   *          Otherwise `max(maxHeapMemory - 200MB, 1) * (600WF / 1024MB)`
+   * @default if `reuseV8Context = true`, then `max(floor(max(maxHeapMemory - 200MB, 0) * (600WF / 1024MB)), 10)`.
+   *          Otherwise `max(floor(max(maxHeapMemory - 400MB, 0) * (250WF / 1024MB)), 10)`
    */
   maxCachedWorkflows?: number;
 
@@ -581,8 +581,8 @@ export function addDefaultWorkerOptions(options: WorkerOptions): WorkerOptionsWi
 
   const heapSizeMiB = v8.getHeapStatistics().heap_size_limit / MiB;
   const defaultMaxCachedWorkflows = reuseV8Context
-    ? Math.floor((Math.max(heapSizeMiB - 200, 1) * 600) / 1024)
-    : Math.floor((Math.max(heapSizeMiB - 400, 1) * 250) / 1024);
+    ? Math.max(Math.floor((Math.max(heapSizeMiB - 200, 0) * 600) / 1024), 10)
+    : Math.max(Math.floor((Math.max(heapSizeMiB - 400, 0) * 250) / 1024), 10);
 
   return {
     namespace: namespace ?? 'default',

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -395,11 +395,9 @@ export interface WorkerOptions {
    * From running basic stress tests we've observed 2/3 reduction in memory usage and 1/3 to 1/2 in CPU usage with this
    * feature turned on.
    *
-   * This feature is experimental and requires further testing before it can be considered stable or made default.
+   * Note that we plan to turn this option on by default starting with 1.9.0.
    *
-   * Introduced in SDK version 1.6.0
-   *
-   * @experimental
+   * @default false (will change in the future)
    */
   reuseV8Context?: boolean;
 

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -137,12 +137,12 @@ export function initRuntime(options: WorkflowCreateOptionsInternal): void {
 
   const mod = importWorkflows();
   const workflowFn = mod[info.workflowType];
-  const defaultWorfklowFn = mod['default'];
+  const defaultWorkflowFn = mod['default'];
 
   if (typeof workflowFn === 'function') {
     activator.workflow = workflowFn;
-  } else if (typeof defaultWorfklowFn === 'function') {
-    activator.workflow = defaultWorfklowFn;
+  } else if (typeof defaultWorkflowFn === 'function') {
+    activator.workflow = defaultWorkflowFn;
   } else {
     const details =
       workflowFn === undefined

--- a/scripts/wait-on-temporal.mjs
+++ b/scripts/wait-on-temporal.mjs
@@ -19,7 +19,9 @@ try {
         err.details &&
         (err.details.includes('workflow history not found') ||
           err.details.includes('Workflow executionsRow not found') ||
-          err.details.includes('operation GetCurrentExecution'))
+          err.details.includes('operation GetCurrentExecution') ||
+          err.details.includes('operation GetWorkflowExecution encountered not found') ||
+          err.details.includes(runId))
       ) {
         break;
       }

--- a/scripts/wait-on-temporal.mjs
+++ b/scripts/wait-on-temporal.mjs
@@ -5,6 +5,8 @@ const maxAttempts = 100;
 const retryIntervalSecs = 1;
 const runId = '26323773-ab30-4442-9a20-c5640b31a7a3';
 
+// Starting with 1.20, we should no longer need to wait on namespace
+// TODO: Remove all of this once we are confident that this is no longer required
 try {
   for (let attempt = 1; attempt <= maxAttempts; ++attempt) {
     try {

--- a/scripts/wait-on-temporal.mjs
+++ b/scripts/wait-on-temporal.mjs
@@ -3,6 +3,7 @@ import { Connection } from '@temporalio/client';
 
 const maxAttempts = 100;
 const retryIntervalSecs = 1;
+const runId = '26323773-ab30-4442-9a20-c5640b31a7a3';
 
 try {
   for (let attempt = 1; attempt <= maxAttempts; ++attempt) {
@@ -12,7 +13,7 @@ try {
       // See: https://github.com/temporalio/temporal/issues/1336
       await client.workflowService.getWorkflowExecutionHistory({
         namespace: 'default',
-        execution: { workflowId: 'fake', runId: '26323773-ab30-4442-9a20-c5640b31a7a3' },
+        execution: { workflowId: 'fake', runId },
       });
     } catch (err) {
       if (


### PR DESCRIPTION
## What changed

- Added `WorkerOptions` properties `maxConcurrentWorkflowTaskPolls` and `maxConcurrentActivityTaskPolls`, which allow controlling the number of pollers to be used to fetch Workflow/Activity tasks from the  Task Queue. Properly adjusting these values should allow better filling of the corresponding execution slots.
- Remove the `@experimental` tag on `reuseV8Context`
- Better auto-configuration of `maxCachedWorkflows`, including using a different formula when `reuseV8Context` is enabled (fix #838)
- Default value for `maxConcurrentWorkflowTaskExecutions` has been reduced to 40 (was previously 100), as higher values increase the risk of Workflow Task Timeouts unless other options are also tuned. This was not problem previously because the single poller was unlikely to fill in all execution slot anyway, so max would rarely reached).
- Load balance create workflows requests amongst WF threads (fix #608)
- Better documentation of some performance/scaling-related properties in `WorkerOptions`.
- Add more options to internal performance test runners, including specifying mTLS options (for testing against Temporal Cloud, pollers and WF thread pool size)
- Updated Core to 782282e7
