### PR TITLE
chore: Update unionfs (avoid broken release)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17259,9 +17259,9 @@
       "dev": true
     },
     "node_modules/unionfs": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/unionfs/-/unionfs-4.4.0.tgz",
-      "integrity": "sha512-N+TuJHJ3PjmzIRCE1d2N3VN4qg/P78eh/nxzwHnzpg3W2Mvf8Wvi7J1mvv6eNkb8neUeSdFSQsKna0eXVyF4+w==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/unionfs/-/unionfs-4.5.1.tgz",
+      "integrity": "sha512-hn8pzkh0/80mpsIT/YBJKa4+BF/9pNh0IgysBi0CjL95Uok8Hus69TNfgeJckoUNwfTpBq26+F7edO1oBINaIw==",
       "dependencies": {
         "fs-monkey": "^1.0.0"
       }
@@ -18476,7 +18476,7 @@
         "source-map": "^0.7.4",
         "source-map-loader": "^4.0.0",
         "swc-loader": "^0.2.3",
-        "unionfs": "^4.4.0",
+        "unionfs": "^4.5.1",
         "webpack": "^5.75.0"
       },
       "engines": {
@@ -21199,7 +21199,7 @@
         "source-map": "^0.7.4",
         "source-map-loader": "^4.0.0",
         "swc-loader": "^0.2.3",
-        "unionfs": "^4.4.0",
+        "unionfs": "^4.5.1",
         "webpack": "^5.75.0"
       },
       "dependencies": {
@@ -31703,9 +31703,9 @@
       "dev": true
     },
     "unionfs": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/unionfs/-/unionfs-4.4.0.tgz",
-      "integrity": "sha512-N+TuJHJ3PjmzIRCE1d2N3VN4qg/P78eh/nxzwHnzpg3W2Mvf8Wvi7J1mvv6eNkb8neUeSdFSQsKna0eXVyF4+w==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/unionfs/-/unionfs-4.5.1.tgz",
+      "integrity": "sha512-hn8pzkh0/80mpsIT/YBJKa4+BF/9pNh0IgysBi0CjL95Uok8Hus69TNfgeJckoUNwfTpBq26+F7edO1oBINaIw==",
       "requires": {
         "fs-monkey": "^1.0.0"
       }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -30,7 +30,7 @@
     "source-map": "^0.7.4",
     "source-map-loader": "^4.0.0",
     "swc-loader": "^0.2.3",
-    "unionfs": "^4.4.0",
+    "unionfs": "^4.5.1",
     "webpack": "^5.75.0"
   },
   "bugs": {


### PR DESCRIPTION
## What changed

- Updated unionfs (jump over release 4.5.0, which is broken) - Fix #1131