### PR TITLE
feat!: Protect against ms durations errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18206,9 +18206,17 @@
         "@opentelemetry/api": "^1.4.1",
         "@temporalio/proto": "file:../proto",
         "long": "^5.2.0",
-        "ms": "^2.1.3",
+        "ms": "^3.0.0-canary.1",
         "proto3-json-serializer": "^1.0.3",
         "protobufjs": "^7.0.0"
+      }
+    },
+    "packages/common/node_modules/ms": {
+      "version": "3.0.0-canary.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
+      "engines": {
+        "node": ">=12.13"
       }
     },
     "packages/core-bridge": {
@@ -18439,7 +18447,7 @@
         "@temporalio/worker": "file:../worker",
         "@temporalio/workflow": "file:../workflow",
         "abort-controller": "^3.0.0",
-        "ms": "^2.1.3"
+        "ms": "^3.0.0-canary.1"
       }
     },
     "packages/testing/node_modules/@grpc/grpc-js": {
@@ -18452,6 +18460,14 @@
       },
       "engines": {
         "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "packages/testing/node_modules/ms": {
+      "version": "3.0.0-canary.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
+      "engines": {
+        "node": ">=12.13"
       }
     },
     "packages/worker": {
@@ -18471,7 +18487,7 @@
         "cargo-cp-artifact": "^0.1.6",
         "heap-js": "^2.2.0",
         "memfs": "^3.4.6",
-        "ms": "^2.1.3",
+        "ms": "^3.0.0-canary.1",
         "rxjs": "^7.5.5",
         "source-map": "^0.7.4",
         "source-map-loader": "^4.0.0",
@@ -18481,6 +18497,14 @@
       },
       "engines": {
         "node": ">= 14.18.0"
+      }
+    },
+    "packages/worker/node_modules/ms": {
+      "version": "3.0.0-canary.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
+      "engines": {
+        "node": ">=12.13"
       }
     },
     "packages/worker/node_modules/source-map": {
@@ -20994,9 +21018,16 @@
         "@opentelemetry/api": "^1.4.1",
         "@temporalio/proto": "file:../proto",
         "long": "^5.2.0",
-        "ms": "^2.1.3",
+        "ms": "^3.0.0-canary.1",
         "proto3-json-serializer": "^1.0.3",
         "protobufjs": "^7.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "3.0.0-canary.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+          "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g=="
+        }
       }
     },
     "@temporalio/core-bridge": {
@@ -21165,7 +21196,7 @@
         "@temporalio/worker": "file:../worker",
         "@temporalio/workflow": "file:../workflow",
         "abort-controller": "^3.0.0",
-        "ms": "^2.1.3"
+        "ms": "^3.0.0-canary.1"
       },
       "dependencies": {
         "@grpc/grpc-js": {
@@ -21176,6 +21207,11 @@
             "@grpc/proto-loader": "^0.7.0",
             "@types/node": ">=12.12.47"
           }
+        },
+        "ms": {
+          "version": "3.0.0-canary.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+          "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g=="
         }
       }
     },
@@ -21194,7 +21230,7 @@
         "cargo-cp-artifact": "^0.1.6",
         "heap-js": "^2.2.0",
         "memfs": "^3.4.6",
-        "ms": "^2.1.3",
+        "ms": "^3.0.0-canary.1",
         "rxjs": "^7.5.5",
         "source-map": "^0.7.4",
         "source-map-loader": "^4.0.0",
@@ -21203,6 +21239,11 @@
         "webpack": "^5.75.0"
       },
       "dependencies": {
+        "ms": {
+          "version": "3.0.0-canary.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+          "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g=="
+        },
         "source-map": {
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",

--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -71,7 +71,7 @@
 
 import 'abort-controller/polyfill'; // eslint-disable-line import/no-unassigned-import
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { msToNumber } from '@temporalio/common/lib/time';
+import { Duration, msToNumber } from '@temporalio/common/lib/time';
 
 export {
   ActivityFunction,
@@ -279,7 +279,7 @@ export class Context {
    * @param ms Sleep duration: number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    * @returns A Promise that either resolves when `ms` is reached or rejects when the Activity is cancelled
    */
-  public sleep(ms: number | string): Promise<void> {
+  public sleep(ms: Duration): Promise<void> {
     let handle: NodeJS.Timeout;
     const timer = new Promise<void>((resolve) => {
       handle = setTimeout(resolve, msToNumber(ms));

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import * as grpc from '@grpc/grpc-js';
 import type { RPCImpl } from 'protobufjs';
 import { filterNullAndUndefined, normalizeTlsConfig, TLSConfig } from '@temporalio/common/lib/internal-non-workflow';
-import { msOptionalToNumber } from '@temporalio/common/lib/time';
+import { Duration, msOptionalToNumber } from '@temporalio/common/lib/time';
 import { isServerErrorResponse, ServiceError } from './errors';
 import { defaultGrpcRetryOptions, makeGrpcRetryInterceptor } from './grpc-retry';
 import pkg from './pkg';
@@ -81,7 +81,7 @@ export interface ConnectionOptions {
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    * @default 10 seconds
    */
-  connectTimeout?: number | string;
+  connectTimeout?: Duration;
 }
 
 export type ConnectionOptionsWithDefaults = Required<Omit<ConnectionOptions, 'tls' | 'connectTimeout'>> & {

--- a/packages/client/src/schedule-types.ts
+++ b/packages/client/src/schedule-types.ts
@@ -1,5 +1,5 @@
 import { checkExtends, Replace } from '@temporalio/common/lib/type-helpers';
-import { SearchAttributes, Workflow } from '@temporalio/common';
+import { Duration, SearchAttributes, Workflow } from '@temporalio/common';
 import type { temporal } from '@temporalio/proto';
 import { WorkflowStartOptions } from './workflow-options';
 
@@ -46,7 +46,7 @@ export interface ScheduleOptions<A extends ScheduleOptionsAction = ScheduleOptio
      * @default 1 minute
      * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
      */
-    catchupWindow?: number | string;
+    catchupWindow?: Duration;
 
     /**
      * When an Action times out or reaches the end of its Retry Policy, {@link pause}.
@@ -465,7 +465,7 @@ export interface ScheduleSpec {
    * @default 0
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  jitter?: number | string;
+  jitter?: Duration;
 
   /**
    * IANA timezone name, for example `US/Pacific`.
@@ -659,7 +659,7 @@ export interface IntervalSpec {
    *
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  every: number | string;
+  every: Duration;
 
   /**
    * Value is rounded to the nearest second.
@@ -667,7 +667,7 @@ export interface IntervalSpec {
    * @default 0
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  offset?: number | string;
+  offset?: Duration;
 }
 
 /**

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,7 +15,7 @@
     "@opentelemetry/api": "^1.4.1",
     "@temporalio/proto": "file:../proto",
     "long": "^5.2.0",
-    "ms": "^2.1.3",
+    "ms": "^3.0.0-canary.1",
     "proto3-json-serializer": "^1.0.3",
     "protobufjs": "^7.0.0"
   },

--- a/packages/common/src/activity-options.ts
+++ b/packages/common/src/activity-options.ts
@@ -1,6 +1,7 @@
 import type { coresdk } from '@temporalio/proto';
 import { RetryPolicy } from './retry-policy';
 import { checkExtends } from './type-helpers';
+import { Duration } from './time';
 
 // Avoid importing the proto implementation to reduce workflow bundle size
 // Copied from coresdk.workflow_commands.ActivityCancellationType
@@ -37,7 +38,7 @@ export interface ActivityOptions {
    * Heartbeat interval. Activity must heartbeat before this interval passes after a last heartbeat or activity start.
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  heartbeatTimeout?: string | number;
+  heartbeatTimeout?: Duration;
 
   /**
    * RetryPolicy that define how activity is retried in case of failure. If this is not set, then the server-defined default activity retry policy will be used. To ensure zero retries, set maximum attempts to 1.
@@ -56,7 +57,7 @@ export interface ActivityOptions {
    * @default `scheduleToCloseTimeout` or unlimited
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  startToCloseTimeout?: string | number;
+  startToCloseTimeout?: Duration;
 
   /**
    * Time that the Activity Task can stay in the Task Queue before it is picked up by a Worker. Do not specify this timeout unless using host specific Task Queues for Activity Tasks are being used for routing.
@@ -65,7 +66,7 @@ export interface ActivityOptions {
    * @default `scheduleToCloseTimeout` or unlimited
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  scheduleToStartTimeout?: string | number;
+  scheduleToStartTimeout?: Duration;
 
   /**
    * Total time that a workflow is willing to wait for Activity to complete.
@@ -76,7 +77,7 @@ export interface ActivityOptions {
    * @default unlimited
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  scheduleToCloseTimeout?: string | number;
+  scheduleToCloseTimeout?: Duration;
 
   /**
    * Determines what the SDK does when the Activity is cancelled.
@@ -120,7 +121,7 @@ export interface LocalActivityOptions {
    *
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  startToCloseTimeout?: string | number;
+  startToCloseTimeout?: Duration;
 
   /**
    * Limits time the local activity can idle internally before being executed. That can happen if
@@ -132,7 +133,7 @@ export interface LocalActivityOptions {
    * @default unlimited
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  scheduleToStartTimeout?: string | number;
+  scheduleToStartTimeout?: Duration;
 
   /**
    * Indicates how long the caller is willing to wait for local activity completion. Limits how
@@ -144,7 +145,7 @@ export interface LocalActivityOptions {
    * @default unlimited
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  scheduleToCloseTimeout?: string | number;
+  scheduleToCloseTimeout?: Duration;
 
   /**
    * If the activity is retrying and backoff would exceed this value, a server side timer will be scheduled for the next attempt.
@@ -153,7 +154,7 @@ export interface LocalActivityOptions {
    * @default 1 minute
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    **/
-  localRetryThreshold?: string | number;
+  localRetryThreshold?: Duration;
 
   /**
    * Determines what the SDK does when the Activity is cancelled.

--- a/packages/common/src/deprecated-time.ts
+++ b/packages/common/src/deprecated-time.ts
@@ -1,5 +1,5 @@
 import * as time from './time';
-import { Timestamp } from './time';
+import { type Timestamp, Duration } from './time';
 
 /**
  * Lossy conversion function from Timestamp to number due to possible overflow.
@@ -35,7 +35,7 @@ export function msNumberToTs(millis: number): Timestamp {
  * @hidden
  * @deprecated - meant for internal use only
  */
-export function msToTs(str: string | number): Timestamp {
+export function msToTs(str: Duration): Timestamp {
   return time.msToTs(str);
 }
 
@@ -43,7 +43,7 @@ export function msToTs(str: string | number): Timestamp {
  * @hidden
  * @deprecated - meant for internal use only
  */
-export function msOptionalToTs(str: string | number | undefined): Timestamp | undefined {
+export function msOptionalToTs(str: Duration | undefined): Timestamp | undefined {
   return time.msOptionalToTs(str);
 }
 
@@ -51,7 +51,7 @@ export function msOptionalToTs(str: string | number | undefined): Timestamp | un
  * @hidden
  * @deprecated - meant for internal use only
  */
-export function msOptionalToNumber(val: string | number | undefined): number | undefined {
+export function msOptionalToNumber(val: Duration | undefined): number | undefined {
   return time.msOptionalToNumber(val);
 }
 
@@ -59,7 +59,7 @@ export function msOptionalToNumber(val: string | number | undefined): number | u
  * @hidden
  * @deprecated - meant for internal use only
  */
-export function msToNumber(val: string | number): number {
+export function msToNumber(val: Duration): number {
   return time.msToNumber(val);
 }
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -19,7 +19,7 @@ export * from './failure';
 export { Headers, Next } from './interceptors';
 export * from './interfaces';
 export * from './retry-policy';
-export { Timestamp } from './time';
+export { type Timestamp, Duration } from './time';
 export * from './workflow-handle';
 export * from './workflow-options';
 

--- a/packages/common/src/retry-policy.ts
+++ b/packages/common/src/retry-policy.ts
@@ -1,6 +1,6 @@
 import type { temporal } from '@temporalio/proto';
 import { ValueError } from './errors';
-import { msOptionalToNumber, msOptionalToTs, msToNumber, msToTs, optionalTsToMs } from './time';
+import { Duration, msOptionalToNumber, msOptionalToTs, msToNumber, msToTs, optionalTsToMs } from './time';
 
 /**
  * Options for retrying Workflows and Activities
@@ -19,7 +19,7 @@ export interface RetryPolicy {
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    * @default 1 second
    */
-  initialInterval?: string | number;
+  initialInterval?: Duration;
   /**
    * Maximum number of attempts. When exceeded, retries stop (even if {@link ActivityOptions.scheduleToCloseTimeout}
    * hasn't been reached).
@@ -35,7 +35,7 @@ export interface RetryPolicy {
    * @default 100x of {@link initialInterval}
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  maximumInterval?: string | number;
+  maximumInterval?: Duration;
 
   /**
    * List of application failures types to not retry.

--- a/packages/common/src/workflow-options.ts
+++ b/packages/common/src/workflow-options.ts
@@ -1,7 +1,7 @@
 import type { temporal, google } from '@temporalio/proto';
 import { SearchAttributes, Workflow } from './interfaces';
 import { RetryPolicy } from './retry-policy';
-import { msOptionalToTs } from './time';
+import { Duration, msOptionalToTs } from './time';
 import { checkExtends, Replace } from './type-helpers';
 
 // Avoid importing the proto implementation to reduce workflow bundle size
@@ -113,7 +113,7 @@ export interface WorkflowDurationOptions {
    *
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  workflowRunTimeout?: string | number;
+  workflowRunTimeout?: Duration;
 
   /**
    *
@@ -123,14 +123,14 @@ export interface WorkflowDurationOptions {
    *
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  workflowExecutionTimeout?: string | number;
+  workflowExecutionTimeout?: Duration;
 
   /**
    * Maximum execution time of a single workflow task. Default is 10 seconds.
    *
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  workflowTaskTimeout?: string | number;
+  workflowTaskTimeout?: Duration;
 }
 
 export type CommonWorkflowOptions = BaseWorkflowOptions & WorkflowDurationOptions;

--- a/packages/core-bridge/ts/index.ts
+++ b/packages/core-bridge/ts/index.ts
@@ -1,4 +1,5 @@
 import { SpanContext } from '@opentelemetry/api';
+import { Duration } from '@temporalio/common';
 import type { TLSConfig } from '@temporalio/common/lib/internal-non-workflow';
 
 export { TLSConfig };
@@ -118,7 +119,7 @@ export interface OtelCollectorExporter {
      * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
      * @defaults 1 second
      */
-    metricsExportInterval?: string | number;
+    metricsExportInterval?: Duration;
   };
 }
 

--- a/packages/test/src/load/all-scenarios.ts
+++ b/packages/test/src/load/all-scenarios.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
-import ms from 'ms';
+import { msToNumber } from '@temporalio/common/lib/time';
 import * as workflows from '../workflows';
 import { Spec, AllInOneArgSpec } from './args';
 
@@ -48,7 +48,7 @@ export const longHistoriesWithSmallCache100Iters: Args = {
 
 export const longHaul: Args = {
   ...baseArgs,
-  '--for-seconds': ms('4h') / 1000,
+  '--for-seconds': msToNumber('4h') / 1000,
   '--min-wfs-per-sec': 5,
   '--concurrent-wf-clients': 100,
   '--workflow': workflows.cancelFakeProgress.name,

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -20,8 +20,7 @@
     "@temporalio/proto": "file:../proto",
     "@temporalio/worker": "file:../worker",
     "@temporalio/workflow": "file:../workflow",
-    "abort-controller": "^3.0.0",
-    "ms": "^2.1.3"
+    "abort-controller": "^3.0.0"
   },
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -11,7 +11,6 @@
 import 'abort-controller/polyfill'; // eslint-disable-line import/no-unassigned-import
 import path from 'node:path';
 import events from 'node:events';
-import ms from 'ms';
 import * as activity from '@temporalio/activity';
 import {
   AsyncCompletionClient,
@@ -21,8 +20,8 @@ import {
   WorkflowClientOptions,
   WorkflowResultOptions,
 } from '@temporalio/client';
-import { ActivityFunction, CancelledFailure } from '@temporalio/common';
-import { msToTs, tsToMs } from '@temporalio/common/lib/time';
+import { ActivityFunction, CancelledFailure, Duration } from '@temporalio/common';
+import { msToNumber, msToTs, tsToMs } from '@temporalio/common/lib/time';
 import { NativeConnection, Runtime } from '@temporalio/worker';
 import {
   EphemeralServer,
@@ -341,11 +340,11 @@ export class TestWorkflowEnvironment {
    * });
    * ```
    */
-  sleep = async (durationMs: number | string): Promise<void> => {
+  sleep = async (durationMs: Duration): Promise<void> => {
     if (this.supportsTimeSkipping) {
       await (this.connection as Connection).testService.unlockTimeSkippingWithSleep({ duration: msToTs(durationMs) });
     } else {
-      await new Promise((resolve) => setTimeout(resolve, typeof durationMs === 'string' ? ms(durationMs) : durationMs));
+      await new Promise((resolve) => setTimeout(resolve, msToNumber(durationMs)));
     }
   };
 

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -25,7 +25,6 @@
     "cargo-cp-artifact": "^0.1.6",
     "heap-js": "^2.2.0",
     "memfs": "^3.4.6",
-    "ms": "^2.1.3",
     "rxjs": "^7.5.5",
     "source-map": "^0.7.4",
     "source-map-loader": "^4.0.0",

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -2,7 +2,7 @@ import * as os from 'node:os';
 import * as v8 from 'node:v8';
 import type { Configuration as WebpackConfiguration } from 'webpack';
 import { DataConverter, LoadedDataConverter } from '@temporalio/common';
-import { msOptionalToNumber, msToNumber } from '@temporalio/common/lib/time';
+import { Duration, msOptionalToNumber, msToNumber } from '@temporalio/common/lib/time';
 import { loadDataConverter } from '@temporalio/common/lib/internal-non-workflow';
 import { LoggerSinks } from '@temporalio/workflow';
 import { ActivityInboundLogInterceptor } from './activity-log-interceptor';
@@ -130,7 +130,7 @@ export interface WorkerOptions {
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    * @default 0
    */
-  shutdownGraceTime?: string | number;
+  shutdownGraceTime?: Duration;
 
   /**
    * Time to wait before giving up on graceful shutdown and forcefully terminating the worker.
@@ -142,7 +142,7 @@ export interface WorkerOptions {
    *
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  shutdownForceTime?: string | number;
+  shutdownForceTime?: Duration;
 
   /**
    * Provide a custom {@link DataConverter}.
@@ -205,7 +205,7 @@ export interface WorkerOptions {
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    * @default 10s
    */
-  stickyQueueScheduleToStartTimeout?: string;
+  stickyQueueScheduleToStartTimeout?: Duration;
 
   /**
    * The number of Workflow isolates to keep in cached in memory
@@ -228,7 +228,7 @@ export interface WorkerOptions {
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    * @default 60 seconds
    */
-  maxHeartbeatThrottleInterval?: number | string;
+  maxHeartbeatThrottleInterval?: Duration;
 
   /**
    * Default interval for throttling activity heartbeats in case
@@ -239,7 +239,7 @@ export interface WorkerOptions {
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    * @default 30 seconds
    */
-  defaultHeartbeatThrottleInterval?: number | string;
+  defaultHeartbeatThrottleInterval?: Duration;
 
   /**
    * A mapping of interceptor type to a list of factories or module paths.
@@ -379,7 +379,7 @@ export type WorkerOptionsWithDefaults = WorkerOptions &
      *
      * @default 5s
      */
-    isolateExecutionTimeout: string | number;
+    isolateExecutionTimeout: Duration;
   };
 
 /**

--- a/packages/workflow/src/cancellation-scope.ts
+++ b/packages/workflow/src/cancellation-scope.ts
@@ -1,5 +1,5 @@
 import type { AsyncLocalStorage as ALS } from 'node:async_hooks';
-import { CancelledFailure, IllegalStateError } from '@temporalio/common';
+import { CancelledFailure, Duration, IllegalStateError } from '@temporalio/common';
 import { untrackPromise } from './stack-helpers';
 
 // AsyncLocalStorage is injected via vm module into global scope.
@@ -202,7 +202,7 @@ export class RootCancellationScope extends CancellationScope {
 }
 
 /** This function is here to avoid a circular dependency between this module and workflow.ts */
-let sleep = (_: number | string): Promise<void> => {
+let sleep = (_: Duration): Promise<void> => {
   throw new IllegalStateError('Workflow has not been properly initialized');
 };
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -6,6 +6,7 @@ import {
   SearchAttributes,
   SignalDefinition,
   QueryDefinition,
+  Duration,
 } from '@temporalio/common';
 import { checkExtends } from '@temporalio/common/lib/type-helpers';
 import type { coresdk } from '@temporalio/proto';
@@ -191,12 +192,12 @@ export interface ContinueAsNewOptions {
    * Timeout for the entire Workflow run
    * @format {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  workflowRunTimeout?: string;
+  workflowRunTimeout?: Duration;
   /**
    * Timeout for a single Workflow task
    * @format {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
-  workflowTaskTimeout?: string;
+  workflowTaskTimeout?: Duration;
   /**
    * Non-searchable attributes to attach to next Workflow run
    */

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -17,7 +17,7 @@ import {
   WorkflowResultType,
   WorkflowReturnType,
 } from '@temporalio/common';
-import { msOptionalToTs, msToNumber, msToTs, tsToMs } from '@temporalio/common/lib/time';
+import { Duration, msOptionalToTs, msToNumber, msToTs, tsToMs } from '@temporalio/common/lib/time';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import { CancellationScope, registerSleepImplementation } from './cancellation-scope';
 import {
@@ -108,7 +108,7 @@ function timerNextHandler(input: TimerInput) {
  * @param ms sleep duration - number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}.
  * If given a negative number or 0, value will be set to 1.
  */
-export function sleep(ms: number | string): Promise<void> {
+export function sleep(ms: Duration): Promise<void> {
   const activator = assertInWorkflowContext('Workflow.sleep(...) may only be used from a Workflow Execution');
   const seq = activator.nextSeqs.timer++;
 
@@ -1085,14 +1085,14 @@ function patchInternal(patchId: string, deprecated: boolean): boolean {
  *
  * @returns a boolean indicating whether the condition was true before the timeout expires
  */
-export function condition(fn: () => boolean, timeout: number | string): Promise<boolean>;
+export function condition(fn: () => boolean, timeout: Duration): Promise<boolean>;
 
 /**
  * Returns a Promise that resolves when `fn` evaluates to `true`.
  */
 export function condition(fn: () => boolean): Promise<void>;
 
-export async function condition(fn: () => boolean, timeout?: number | string): Promise<void | boolean> {
+export async function condition(fn: () => boolean, timeout?: Duration): Promise<void | boolean> {
   assertInWorkflowContext('Workflow.condition(...) may only be used from a Workflow Execution.');
   // Prior to 1.5.0, `condition(fn, 0)` was treated as equivalent to `condition(fn, undefined)`
   if (timeout === 0 && !patched(CONDITION_0_PATCH)) {


### PR DESCRIPTION
## What changed

- Added type definitions for "ms-formated strings"
- Introduced a Duration type which is either a ms-formated string or a number of milliseconds
- Make ms-formated-string to number conversions throw on invalid time specifications

## Why
- Invalid time specifiers would previously cause misterious issues: including unhandled commands (ie. `sleep('1 month')`) or `condition` behaving as if no timeout was provided (ie. `condition(fn, '1 month')`)
- Fix #1046 and #1066