### PR TITLE
chore: Remove CI step to print build information

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Print build information
-        run: 'echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}, node: ${{ matrix.node }}'
       - uses: actions/checkout@v2
         with:
           submodules: recursive


### PR DESCRIPTION
For security concerns, could be a vector for shell injection.
Not a huge concern but also better removed than not.