### PR TITLE
feat(client): Throw more specific errors from Client APIs

### DIFF
--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -1,5 +1,6 @@
-import { Status } from '@grpc/grpc-js/build/src/constants';
-import { ensureTemporalFailure } from '@temporalio/common';
+import { status as grpcStatus } from '@grpc/grpc-js';
+import { NamespaceNotFoundError, ensureTemporalFailure } from '@temporalio/common';
+import type { temporal } from '@temporalio/proto';
 import {
   encodeErrorToFailure,
   encodeToPayloads,
@@ -96,8 +97,13 @@ export class AsyncCompletionClient extends BaseClient {
    */
   protected handleError(err: unknown): never {
     if (isServerErrorResponse(err)) {
-      if (err.code === Status.NOT_FOUND) {
-        throw new ActivityNotFoundError('Not found');
+      if (err.code === grpcStatus.NOT_FOUND) {
+        const matcher = err.message.match(/^5 NOT_FOUND: Namespace (.*?) is not found./);
+        if (matcher) {
+          throw new NamespaceNotFoundError(matcher[1]);
+        } else {
+          throw new ActivityNotFoundError('Not found');
+        }
       }
       throw new ActivityCompletionError(err.details || err.message);
     }
@@ -114,20 +120,21 @@ export class AsyncCompletionClient extends BaseClient {
   async complete(fullActivityId: FullActivityId, result: unknown): Promise<void>;
 
   async complete(taskTokenOrFullActivityId: Uint8Array | FullActivityId, result: unknown): Promise<void> {
+    const payloads = await encodeToPayloads(this.dataConverter, result);
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
         await this.workflowService.respondActivityTaskCompleted({
           identity: this.options.identity,
           namespace: this.options.namespace,
           taskToken: taskTokenOrFullActivityId,
-          result: { payloads: await encodeToPayloads(this.dataConverter, result) },
+          result: { payloads },
         });
       } else {
         await this.workflowService.respondActivityTaskCompletedById({
           identity: this.options.identity,
           namespace: this.options.namespace,
           ...taskTokenOrFullActivityId,
-          result: { payloads: await encodeToPayloads(this.dataConverter, result) },
+          result: { payloads },
         });
       }
     } catch (err) {
@@ -145,20 +152,21 @@ export class AsyncCompletionClient extends BaseClient {
   async fail(fullActivityId: FullActivityId, err: unknown): Promise<void>;
 
   async fail(taskTokenOrFullActivityId: Uint8Array | FullActivityId, err: unknown): Promise<void> {
+    const failure = await encodeErrorToFailure(this.dataConverter, ensureTemporalFailure(err));
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
         await this.workflowService.respondActivityTaskFailed({
           identity: this.options.identity,
           namespace: this.options.namespace,
           taskToken: taskTokenOrFullActivityId,
-          failure: await encodeErrorToFailure(this.dataConverter, ensureTemporalFailure(err)),
+          failure,
         });
       } else {
         await this.workflowService.respondActivityTaskFailedById({
           identity: this.options.identity,
           namespace: this.options.namespace,
           ...taskTokenOrFullActivityId,
-          failure: await encodeErrorToFailure(this.dataConverter, err),
+          failure,
         });
       }
     } catch (err) {
@@ -176,20 +184,21 @@ export class AsyncCompletionClient extends BaseClient {
   reportCancellation(fullActivityId: FullActivityId, details?: unknown): Promise<void>;
 
   async reportCancellation(taskTokenOrFullActivityId: Uint8Array | FullActivityId, details?: unknown): Promise<void> {
+    const payloads = await encodeToPayloads(this.dataConverter, details);
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
         await this.workflowService.respondActivityTaskCanceled({
           identity: this.options.identity,
           namespace: this.options.namespace,
           taskToken: taskTokenOrFullActivityId,
-          details: { payloads: await encodeToPayloads(this.dataConverter, details) },
+          details: { payloads },
         });
       } else {
         await this.workflowService.respondActivityTaskCanceledById({
           identity: this.options.identity,
           namespace: this.options.namespace,
           ...taskTokenOrFullActivityId,
-          details: { payloads: await encodeToPayloads(this.dataConverter, details) },
+          details: { payloads },
         });
       }
     } catch (err) {
@@ -207,36 +216,31 @@ export class AsyncCompletionClient extends BaseClient {
   heartbeat(fullActivityId: FullActivityId, details?: unknown): Promise<void>;
 
   async heartbeat(taskTokenOrFullActivityId: Uint8Array | FullActivityId, details?: unknown): Promise<void> {
+    const payloads = await encodeToPayloads(this.dataConverter, details);
     let cancelRequested = false;
     try {
-      const response = await this._sendHeartbeat(taskTokenOrFullActivityId, details);
-      cancelRequested = response.cancelRequested;
+      let response: temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatResponse;
+      if (taskTokenOrFullActivityId instanceof Uint8Array) {
+        response = await this.workflowService.recordActivityTaskHeartbeat({
+          identity: this.options.identity,
+          namespace: this.options.namespace,
+          taskToken: taskTokenOrFullActivityId,
+          details: { payloads },
+        });
+      } else {
+        response = await this.workflowService.recordActivityTaskHeartbeatById({
+          identity: this.options.identity,
+          namespace: this.options.namespace,
+          ...taskTokenOrFullActivityId,
+          details: { payloads },
+        });
+      }
+      cancelRequested = !!response.cancelRequested;
     } catch (err) {
       this.handleError(err);
     }
     if (cancelRequested) {
       throw new ActivityCancelledError('cancelled');
-    }
-  }
-
-  private async _sendHeartbeat(
-    taskTokenOrFullActivityId: Uint8Array | FullActivityId,
-    details?: unknown
-  ): Promise<{ cancelRequested: boolean }> {
-    if (taskTokenOrFullActivityId instanceof Uint8Array) {
-      return await this.workflowService.recordActivityTaskHeartbeat({
-        identity: this.options.identity,
-        namespace: this.options.namespace,
-        taskToken: taskTokenOrFullActivityId,
-        details: { payloads: await encodeToPayloads(this.dataConverter, details) },
-      });
-    } else {
-      return await this.workflowService.recordActivityTaskHeartbeatById({
-        identity: this.options.identity,
-        namespace: this.options.namespace,
-        ...taskTokenOrFullActivityId,
-        details: { payloads: await encodeToPayloads(this.dataConverter, details) },
-      });
     }
   }
 }

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -3,7 +3,7 @@ import * as grpc from '@grpc/grpc-js';
 import type { RPCImpl } from 'protobufjs';
 import { filterNullAndUndefined, normalizeTlsConfig, TLSConfig } from '@temporalio/common/lib/internal-non-workflow';
 import { Duration, msOptionalToNumber } from '@temporalio/common/lib/time';
-import { isServerErrorResponse, ServiceError } from './errors';
+import { isGrpcServiceError, ServiceError } from './errors';
 import { defaultGrpcRetryOptions, makeGrpcRetryInterceptor } from './grpc-retry';
 import pkg from './pkg';
 import { CallContext, HealthService, Metadata, OperatorService, WorkflowService } from './types';
@@ -276,7 +276,7 @@ export class Connection {
         try {
           await this.withDeadline(deadline, () => this.workflowService.getSystemInfo({}));
         } catch (err) {
-          if (isServerErrorResponse(err)) {
+          if (isGrpcServiceError(err)) {
             // Ignore old servers
             if (err.code !== grpc.status.UNIMPLEMENTED) {
               throw new ServiceError('Failed to connect to Temporal server', { cause: err });

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,4 +1,4 @@
-import { ServerErrorResponse } from '@grpc/grpc-js';
+import { ServiceError as GrpcServiceError } from '@grpc/grpc-js';
 import { RetryState, TemporalFailure } from '@temporalio/common';
 
 /**
@@ -47,10 +47,11 @@ export class WorkflowContinuedAsNewError extends Error {
   }
 }
 
-/**
- * Type assertion helper, assertion is mostly empty because any additional
- * properties are optional.
- */
-export function isServerErrorResponse(err: unknown): err is ServerErrorResponse {
-  return err instanceof Error;
+export function isGrpcServiceError(err: unknown): err is GrpcServiceError {
+  return err instanceof Error && (err as any).details !== undefined && (err as any).metadata !== undefined;
 }
+
+/**
+ * @deprecated Use `isGrpcServiceError` instead
+ */
+export const isServerErrorResponse = isGrpcServiceError;

--- a/packages/client/src/helpers.ts
+++ b/packages/client/src/helpers.ts
@@ -78,7 +78,7 @@ export async function executionInfoFromRaw<T>(
   };
 }
 
-type ErrorDetailsNames = `temporal.api.errordetails.v1.${keyof typeof temporal.api.errordetails.v1}`;
+type ErrorDetailsName = `temporal.api.errordetails.v1.${keyof typeof temporal.api.errordetails.v1}`;
 
 /**
  * If the error type can be determined based on embedded grpc error details,
@@ -92,21 +92,19 @@ export function rethrowKnownErrorTypes(err: GrpcServiceError): void {
   // We really don't expect multiple error details, but this really is an array, so just in case...
   for (const entry of getGrpcStatusDetails(err) ?? []) {
     if (!entry.type_url || !entry.value) continue;
-    const type = entry.type_url.replace(/^type.googleapis.com\//, '') as ErrorDetailsNames;
+    const type = entry.type_url.replace(/^type.googleapis.com\//, '') as ErrorDetailsName;
 
     switch (type) {
       case 'temporal.api.errordetails.v1.NamespaceNotFoundFailure': {
         const { namespace } = temporal.api.errordetails.v1.NamespaceNotFoundFailure.decode(entry.value);
         throw new NamespaceNotFoundError(namespace);
       }
-      default:
-        break;
     }
   }
 }
 
 function getGrpcStatusDetails(err: GrpcServiceError): google.rpc.Status['details'] | undefined {
-  const statusBuffer = err.metadata.get('grpc-status-details-bin')[0];
+  const statusBuffer = err.metadata.get('grpc-status-details-bin')?.[0];
   if (!statusBuffer || typeof statusBuffer === 'string') {
     return undefined;
   }

--- a/packages/client/src/helpers.ts
+++ b/packages/client/src/helpers.ts
@@ -1,13 +1,15 @@
+import { ServiceError as GrpcServiceError } from '@grpc/grpc-js';
 import {
   LoadedDataConverter,
   mapFromPayloads,
+  NamespaceNotFoundError,
   searchAttributePayloadConverter,
   SearchAttributes,
 } from '@temporalio/common';
 import { Replace } from '@temporalio/common/lib/type-helpers';
 import { optionalTsToDate, tsToDate } from '@temporalio/common/lib/time';
 import { decodeMapFromPayloads } from '@temporalio/common/lib/internal-non-workflow/codec-helpers';
-import { temporal } from '@temporalio/proto';
+import { temporal, google } from '@temporalio/proto';
 import { RawWorkflowExecutionInfo, WorkflowExecutionInfo, WorkflowExecutionStatusName } from './types';
 
 function workflowStatusCodeToName(code: temporal.api.enums.v1.WorkflowExecutionStatus): WorkflowExecutionStatusName {
@@ -74,4 +76,39 @@ export async function executionInfoFromRaw<T>(
       : undefined,
     raw: rawDataToEmbed,
   };
+}
+
+type ErrorDetailsNames = `temporal.api.errordetails.v1.${keyof typeof temporal.api.errordetails.v1}`;
+
+/**
+ * If the error type can be determined based on embedded grpc error details,
+ * then rethrow the appropriate TypeScript error. Otherwise do nothing.
+ *
+ * This function should be used before falling back to generic error handling
+ * based on grpc error code. Very few error types are currently supported, but
+ * this function will be expanded over time as more server error types are added.
+ */
+export function rethrowKnownErrorTypes(err: GrpcServiceError): void {
+  // We really don't expect multiple error details, but this really is an array, so just in case...
+  for (const entry of getGrpcStatusDetails(err) ?? []) {
+    if (!entry.type_url || !entry.value) continue;
+    const type = entry.type_url.replace(/^type.googleapis.com\//, '') as ErrorDetailsNames;
+
+    switch (type) {
+      case 'temporal.api.errordetails.v1.NamespaceNotFoundFailure': {
+        const { namespace } = temporal.api.errordetails.v1.NamespaceNotFoundFailure.decode(entry.value);
+        throw new NamespaceNotFoundError(namespace);
+      }
+      default:
+        break;
+    }
+  }
+}
+
+function getGrpcStatusDetails(err: GrpcServiceError): google.rpc.Status['details'] | undefined {
+  const statusBuffer = err.metadata.get('grpc-status-details-bin')[0];
+  if (!statusBuffer || typeof statusBuffer === 'string') {
+    return undefined;
+  }
+  return google.rpc.Status.decode(statusBuffer).details;
 }

--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -1,6 +1,6 @@
 import { status as grpcStatus } from '@grpc/grpc-js';
 import { v4 as uuid4 } from 'uuid';
-import { mapToPayloads, searchAttributePayloadConverter, Workflow } from '@temporalio/common';
+import { mapToPayloads, NamespaceNotFoundError, searchAttributePayloadConverter, Workflow } from '@temporalio/common';
 import { composeInterceptors, Headers } from '@temporalio/common/lib/interceptors';
 import {
   encodeMapToPayloads,
@@ -263,7 +263,7 @@ export class ScheduleClient extends BaseClient {
       if (err.code === grpcStatus.ALREADY_EXISTS) {
         throw new ScheduleAlreadyRunning('Schedule already exists and is running', opts.scheduleId);
       }
-      this.rethrowGrpcError(err, opts.scheduleId, 'Failed to create schedule');
+      this.rethrowGrpcError(err, 'Failed to create schedule', opts.scheduleId);
     }
   }
 
@@ -279,7 +279,7 @@ export class ScheduleClient extends BaseClient {
         scheduleId,
       });
     } catch (err: any) {
-      this.rethrowGrpcError(err, scheduleId, 'Failed to describe schedule');
+      this.rethrowGrpcError(err, 'Failed to describe schedule', scheduleId);
     }
   }
 
@@ -306,7 +306,7 @@ export class ScheduleClient extends BaseClient {
     try {
       return await this.workflowService.updateSchedule(req);
     } catch (err: any) {
-      this.rethrowGrpcError(err, scheduleId, 'Failed to update schedule');
+      this.rethrowGrpcError(err, 'Failed to update schedule', scheduleId);
     }
   }
 
@@ -326,7 +326,7 @@ export class ScheduleClient extends BaseClient {
         patch,
       });
     } catch (err: any) {
-      this.rethrowGrpcError(err, scheduleId, 'Failed to patch schedule');
+      this.rethrowGrpcError(err, 'Failed to patch schedule', scheduleId);
     }
   }
 
@@ -343,7 +343,7 @@ export class ScheduleClient extends BaseClient {
         scheduleId,
       });
     } catch (err: any) {
-      this.rethrowGrpcError(err, scheduleId, 'Failed to delete schedule');
+      this.rethrowGrpcError(err, 'Failed to delete schedule', scheduleId);
     }
   }
 
@@ -366,13 +366,16 @@ export class ScheduleClient extends BaseClient {
   public async *list(options?: ListScheduleOptions): AsyncIterable<ScheduleSummary> {
     let nextPageToken: Uint8Array | undefined = undefined;
     for (;;) {
-      const response: temporal.api.workflowservice.v1.IListSchedulesResponse = await this.workflowService.listSchedules(
-        {
+      let response: temporal.api.workflowservice.v1.ListSchedulesResponse;
+      try {
+        response = await this.workflowService.listSchedules({
           nextPageToken,
           namespace: this.options.namespace,
           maximumPageSize: options?.pageSize,
-        }
-      );
+        });
+      } catch (e) {
+        this.rethrowGrpcError(e, 'Failed to list schedules', undefined);
+      }
 
       for (const raw of response.schedules ?? []) {
         yield <ScheduleSummary>{
@@ -497,10 +500,15 @@ export class ScheduleClient extends BaseClient {
     };
   }
 
-  protected rethrowGrpcError(err: unknown, scheduleId: string, fallbackMessage: string): never {
+  protected rethrowGrpcError(err: unknown, fallbackMessage: string, scheduleId?: string): never {
     if (isServerErrorResponse(err)) {
       if (err.code === grpcStatus.NOT_FOUND) {
-        throw new ScheduleNotFoundError(err.details ?? 'Schedule not found', scheduleId);
+        const matcher = err.message.match(/^5 NOT_FOUND: Namespace (.*?) is not found./);
+        if (matcher) {
+          throw new NamespaceNotFoundError(matcher[1]);
+        } else {
+          throw new ScheduleNotFoundError(err.details ?? 'Schedule not found', scheduleId ?? '');
+        }
       }
       if (
         err.code === grpcStatus.INVALID_ARGUMENT &&

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -19,6 +19,7 @@ import {
   WorkflowNotFoundError,
   WorkflowResultType,
   extractWorkflowType,
+  NamespaceNotFoundError,
 } from '@temporalio/common';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import { History } from '@temporalio/common/lib/proto-utils';
@@ -487,7 +488,7 @@ export class WorkflowClient extends BaseClient {
       try {
         res = await this.workflowService.getWorkflowExecutionHistory(req);
       } catch (err) {
-        this.rethrowGrpcError(err, { workflowId, runId }, 'Failed to get Workflow execution history');
+        this.rethrowGrpcError(err, 'Failed to get Workflow execution history', { workflowId, runId });
       }
       const events = res.history?.events;
 
@@ -581,14 +582,19 @@ export class WorkflowClient extends BaseClient {
     }
   }
 
-  protected rethrowGrpcError(err: unknown, workflowExecution: WorkflowExecution, fallbackMessage: string): never {
+  protected rethrowGrpcError(err: unknown, fallbackMessage: string, workflowExecution?: WorkflowExecution): never {
     if (isServerErrorResponse(err)) {
       if (err.code === grpcStatus.NOT_FOUND) {
-        throw new WorkflowNotFoundError(
-          err.details ?? 'Workflow not found',
-          workflowExecution.workflowId,
-          workflowExecution.runId
-        );
+        const matcher = err.message.match(/^5 NOT_FOUND: Namespace (.*?) is not found./);
+        if (matcher) {
+          throw new NamespaceNotFoundError(matcher[1]);
+        } else {
+          throw new WorkflowNotFoundError(
+            err.details ?? 'Workflow not found',
+            workflowExecution?.workflowId ?? '',
+            workflowExecution?.runId
+          );
+        }
       }
       throw new ServiceError(fallbackMessage, { cause: err });
     }
@@ -601,23 +607,24 @@ export class WorkflowClient extends BaseClient {
    * Used as the final function of the query interceptor chain
    */
   protected async _queryWorkflowHandler(input: WorkflowQueryInput): Promise<unknown> {
+    const req: temporal.api.workflowservice.v1.IQueryWorkflowRequest = {
+      queryRejectCondition: input.queryRejectCondition,
+      namespace: this.options.namespace,
+      execution: input.workflowExecution,
+      query: {
+        queryType: input.queryType,
+        queryArgs: { payloads: await encodeToPayloads(this.dataConverter, ...input.args) },
+        header: { fields: input.headers },
+      },
+    };
     let response: temporal.api.workflowservice.v1.QueryWorkflowResponse;
     try {
-      response = await this.workflowService.queryWorkflow({
-        queryRejectCondition: input.queryRejectCondition,
-        namespace: this.options.namespace,
-        execution: input.workflowExecution,
-        query: {
-          queryType: input.queryType,
-          queryArgs: { payloads: await encodeToPayloads(this.dataConverter, ...input.args) },
-          header: { fields: input.headers },
-        },
-      });
+      response = await this.workflowService.queryWorkflow(req);
     } catch (err) {
       if (isServerErrorResponse(err) && err.code === grpcStatus.INVALID_ARGUMENT) {
         throw new QueryNotRegisteredError(err.message.replace(/^3 INVALID_ARGUMENT: /, ''), err.code);
       }
-      this.rethrowGrpcError(err, input.workflowExecution, 'Failed to query Workflow');
+      this.rethrowGrpcError(err, 'Failed to query Workflow', input.workflowExecution);
     }
     if (response.queryRejected) {
       if (response.queryRejected.status === undefined || response.queryRejected.status === null) {
@@ -638,19 +645,20 @@ export class WorkflowClient extends BaseClient {
    * Used as the final function of the signal interceptor chain
    */
   protected async _signalWorkflowHandler(input: WorkflowSignalInput): Promise<void> {
+    const req: temporal.api.workflowservice.v1.ISignalWorkflowExecutionRequest = {
+      identity: this.options.identity,
+      namespace: this.options.namespace,
+      workflowExecution: input.workflowExecution,
+      requestId: uuid4(),
+      // control is unused,
+      signalName: input.signalName,
+      header: { fields: input.headers },
+      input: { payloads: await encodeToPayloads(this.dataConverter, ...input.args) },
+    };
     try {
-      await this.workflowService.signalWorkflowExecution({
-        identity: this.options.identity,
-        namespace: this.options.namespace,
-        workflowExecution: input.workflowExecution,
-        requestId: uuid4(),
-        // control is unused,
-        signalName: input.signalName,
-        header: { fields: input.headers },
-        input: { payloads: await encodeToPayloads(this.dataConverter, ...input.args) },
-      });
+      await this.workflowService.signalWorkflowExecution(req);
     } catch (err) {
-      this.rethrowGrpcError(err, input.workflowExecution, 'Failed to signal Workflow');
+      this.rethrowGrpcError(err, 'Failed to signal Workflow', input.workflowExecution);
     }
   }
 
@@ -662,37 +670,37 @@ export class WorkflowClient extends BaseClient {
   protected async _signalWithStartWorkflowHandler(input: WorkflowSignalWithStartInput): Promise<string> {
     const { identity } = this.options;
     const { options, workflowType, signalName, signalArgs, headers } = input;
+    const req: temporal.api.workflowservice.v1.ISignalWithStartWorkflowExecutionRequest = {
+      namespace: this.options.namespace,
+      identity,
+      requestId: uuid4(),
+      workflowId: options.workflowId,
+      workflowIdReusePolicy: options.workflowIdReusePolicy,
+      workflowType: { name: workflowType },
+      input: { payloads: await encodeToPayloads(this.dataConverter, ...options.args) },
+      signalName,
+      signalInput: { payloads: await encodeToPayloads(this.dataConverter, ...signalArgs) },
+      taskQueue: {
+        kind: temporal.api.enums.v1.TaskQueueKind.TASK_QUEUE_KIND_UNSPECIFIED,
+        name: options.taskQueue,
+      },
+      workflowExecutionTimeout: options.workflowExecutionTimeout,
+      workflowRunTimeout: options.workflowRunTimeout,
+      workflowTaskTimeout: options.workflowTaskTimeout,
+      retryPolicy: options.retry ? compileRetryPolicy(options.retry) : undefined,
+      memo: options.memo ? { fields: await encodeMapToPayloads(this.dataConverter, options.memo) } : undefined,
+      searchAttributes: options.searchAttributes
+        ? {
+            indexedFields: mapToPayloads(searchAttributePayloadConverter, options.searchAttributes),
+          }
+        : undefined,
+      cronSchedule: options.cronSchedule,
+      header: { fields: headers },
+    };
     try {
-      const { runId } = await this.workflowService.signalWithStartWorkflowExecution({
-        namespace: this.options.namespace,
-        identity,
-        requestId: uuid4(),
-        workflowId: options.workflowId,
-        workflowIdReusePolicy: options.workflowIdReusePolicy,
-        workflowType: { name: workflowType },
-        input: { payloads: await encodeToPayloads(this.dataConverter, ...options.args) },
-        signalName,
-        signalInput: { payloads: await encodeToPayloads(this.dataConverter, ...signalArgs) },
-        taskQueue: {
-          kind: temporal.api.enums.v1.TaskQueueKind.TASK_QUEUE_KIND_UNSPECIFIED,
-          name: options.taskQueue,
-        },
-        workflowExecutionTimeout: options.workflowExecutionTimeout,
-        workflowRunTimeout: options.workflowRunTimeout,
-        workflowTaskTimeout: options.workflowTaskTimeout,
-        retryPolicy: options.retry ? compileRetryPolicy(options.retry) : undefined,
-        memo: options.memo ? { fields: await encodeMapToPayloads(this.dataConverter, options.memo) } : undefined,
-        searchAttributes: options.searchAttributes
-          ? {
-              indexedFields: mapToPayloads(searchAttributePayloadConverter, options.searchAttributes),
-            }
-          : undefined,
-        cronSchedule: options.cronSchedule,
-        header: { fields: headers },
-      });
-      return runId;
+      return (await this.workflowService.signalWithStartWorkflowExecution(req)).runId;
     } catch (err) {
-      this.rethrowGrpcError(err, { workflowId: options.workflowId }, 'Failed to signalWithStart Workflow');
+      this.rethrowGrpcError(err, 'Failed to signalWithStart Workflow', { workflowId: options.workflowId });
     }
   }
 
@@ -730,8 +738,7 @@ export class WorkflowClient extends BaseClient {
       header: { fields: headers },
     };
     try {
-      const res = await this.workflowService.startWorkflowExecution(req);
-      return res.runId;
+      return (await this.workflowService.startWorkflowExecution(req)).runId;
     } catch (err: any) {
       if (err.code === grpcStatus.ALREADY_EXISTS) {
         throw new WorkflowExecutionAlreadyStartedError(
@@ -740,7 +747,7 @@ export class WorkflowClient extends BaseClient {
           workflowType
         );
       }
-      this.rethrowGrpcError(err, { workflowId: opts.workflowId }, 'Failed to start Workflow');
+      this.rethrowGrpcError(err, 'Failed to start Workflow', { workflowId: opts.workflowId });
     }
   }
 
@@ -752,18 +759,19 @@ export class WorkflowClient extends BaseClient {
   protected async _terminateWorkflowHandler(
     input: WorkflowTerminateInput
   ): Promise<TerminateWorkflowExecutionResponse> {
+    const req: temporal.api.workflowservice.v1.ITerminateWorkflowExecutionRequest = {
+      namespace: this.options.namespace,
+      identity: this.options.identity,
+      ...input,
+      details: {
+        payloads: input.details ? await encodeToPayloads(this.dataConverter, ...input.details) : undefined,
+      },
+      firstExecutionRunId: input.firstExecutionRunId,
+    };
     try {
-      return await this.workflowService.terminateWorkflowExecution({
-        namespace: this.options.namespace,
-        identity: this.options.identity,
-        ...input,
-        details: {
-          payloads: input.details ? await encodeToPayloads(this.dataConverter, ...input.details) : undefined,
-        },
-        firstExecutionRunId: input.firstExecutionRunId,
-      });
+      return await this.workflowService.terminateWorkflowExecution(req);
     } catch (err) {
-      this.rethrowGrpcError(err, input.workflowExecution, 'Failed to terminate Workflow');
+      this.rethrowGrpcError(err, 'Failed to terminate Workflow', input.workflowExecution);
     }
   }
 
@@ -782,7 +790,7 @@ export class WorkflowClient extends BaseClient {
         firstExecutionRunId: input.firstExecutionRunId,
       });
     } catch (err) {
-      this.rethrowGrpcError(err, input.workflowExecution, 'Failed to cancel workflow');
+      this.rethrowGrpcError(err, 'Failed to cancel workflow', input.workflowExecution);
     }
   }
 
@@ -798,7 +806,7 @@ export class WorkflowClient extends BaseClient {
         execution: input.workflowExecution,
       });
     } catch (err) {
-      this.rethrowGrpcError(err, input.workflowExecution, 'Failed to describe workflow');
+      this.rethrowGrpcError(err, 'Failed to describe workflow', input.workflowExecution);
     }
   }
 
@@ -926,12 +934,17 @@ export class WorkflowClient extends BaseClient {
   protected async *_list(options?: ListOptions): AsyncIterable<WorkflowExecutionInfo> {
     let nextPageToken: Uint8Array = Buffer.alloc(0);
     for (;;) {
-      const response = await this.workflowService.listWorkflowExecutions({
-        namespace: this.options.namespace,
-        query: options?.query,
-        nextPageToken,
-        pageSize: options?.pageSize,
-      });
+      let response: temporal.api.workflowservice.v1.ListWorkflowExecutionsResponse;
+      try {
+        response = await this.workflowService.listWorkflowExecutions({
+          namespace: this.options.namespace,
+          query: options?.query,
+          nextPageToken,
+          pageSize: options?.pageSize,
+        });
+      } catch (e) {
+        this.rethrowGrpcError(e, 'Failed to list workflows', undefined);
+      }
       // Not decoding memo payloads concurrently even though we could have to keep the lazy nature of this iterator.
       // Decoding is done for `memo` fields which tend to be small.
       // We might decide to change that based on user feedback.

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -72,3 +72,14 @@ export class WorkflowNotFoundError extends Error {
     super(message);
   }
 }
+
+/**
+ * Thrown when the specified namespace is not known to Temporal Server.
+ */
+export class NamespaceNotFoundError extends Error {
+  public readonly name: string = 'NamespaceNotFoundError';
+
+  constructor(public readonly namespace: string) {
+    super(`Namespace not found: '${namespace}'`);
+  }
+}

--- a/packages/proto/scripts/compile-proto.js
+++ b/packages/proto/scripts/compile-proto.js
@@ -1,9 +1,8 @@
 const { rm, readFile, writeFile } = require('fs/promises');
 const { resolve } = require('path');
 const { promisify } = require('util');
-const dedent = require('dedent');
 const glob = require('glob');
-const { statSync, mkdirSync, readFileSync, writeFileSync } = require('fs');
+const { statSync, mkdirSync } = require('fs');
 const pbjs = require('protobufjs-cli/pbjs');
 const pbts = require('protobufjs-cli/pbts');
 
@@ -15,12 +14,14 @@ const protoBaseDir = resolve(__dirname, '../../core-bridge/sdk-core/protos');
 const coreProtoPath = resolve(protoBaseDir, 'local/temporal/sdk/core/core_interface.proto');
 const workflowServiceProtoPath = resolve(protoBaseDir, 'api_upstream/temporal/api/workflowservice/v1/service.proto');
 const operatorServiceProtoPath = resolve(protoBaseDir, 'api_upstream/temporal/api/operatorservice/v1/service.proto');
+const errorDetailsProtoPath = resolve(protoBaseDir, 'api_upstream/temporal/api/errordetails/v1/message.proto');
 const testServiceRRProtoPath = resolve(
   protoBaseDir,
   'testsrv_upstream/temporal/api/testservice/v1/request_response.proto'
 );
 const testServiceProtoPath = resolve(protoBaseDir, 'testsrv_upstream/temporal/api/testservice/v1/service.proto');
 const healthServiceProtoPath = resolve(protoBaseDir, 'grpc/health/v1/health.proto');
+const googleRpcStatusProtoPath = resolve(protoBaseDir, 'google/rpc/status.proto');
 
 function mtime(path) {
   try {
@@ -49,9 +50,11 @@ async function compileProtos(dtsOutputFile, ...args) {
     coreProtoPath,
     workflowServiceProtoPath,
     operatorServiceProtoPath,
+    errorDetailsProtoPath,
     testServiceRRProtoPath,
     testServiceProtoPath,
     healthServiceProtoPath,
+    googleRpcStatusProtoPath,
   ];
 
   console.log(`Creating protobuf JS definitions from ${coreProtoPath} and ${workflowServiceProtoPath}`);

--- a/packages/test/src/load/starter.ts
+++ b/packages/test/src/load/starter.ts
@@ -6,7 +6,7 @@ import * as grpc from '@grpc/grpc-js';
 import { v4 as uuid4 } from 'uuid';
 import { interval, range, Observable, OperatorFunction, ReplaySubject, pipe, lastValueFrom } from 'rxjs';
 import { bufferTime, map, mergeMap, tap, takeUntil } from 'rxjs/operators';
-import { Connection, isServerErrorResponse, ServiceError, WorkflowClient } from '@temporalio/client';
+import { Connection, ServiceError, WorkflowClient, isGrpcServiceError } from '@temporalio/client';
 import { toMB } from '@temporalio/worker/lib/utils';
 import { StarterArgSpec, starterArgSpec, getRequired } from './args';
 
@@ -28,7 +28,7 @@ async function runWorkflow({ client, workflowName, taskQueue, queryingOptions }:
         } catch (err) {
           if (
             err instanceof ServiceError &&
-            isServerErrorResponse(err.cause) &&
+            isGrpcServiceError(err.cause) &&
             err.cause.code !== undefined &&
             ACCEPTABLE_QUERY_ERROR_CODES.includes(err.cause.code)
           ) {

--- a/packages/test/src/test-async-completion.ts
+++ b/packages/test/src/test-async-completion.ts
@@ -2,7 +2,13 @@ import anyTest, { TestFn, ExecutionContext } from 'ava';
 import { Observable, Subject, firstValueFrom } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { v4 as uuid4 } from 'uuid';
-import { ActivityCancelledError, Client, ActivityNotFoundError, WorkflowFailedError } from '@temporalio/client';
+import {
+  ActivityCancelledError,
+  Client,
+  ActivityNotFoundError,
+  WorkflowFailedError,
+  Connection,
+} from '@temporalio/client';
 import { Info } from '@temporalio/activity';
 import { rootCause } from '@temporalio/common';
 import { isCancellation } from '@temporalio/workflow';
@@ -15,16 +21,40 @@ export interface Context {
   client: Client;
   activityStarted$: Observable<Info>;
   runPromise: Promise<void>;
+  notFoundTaskToken: Uint8Array;
 }
 
-// Valid server generated token
+// This is a valid server generated token. Since the token contains the id of the namespace from
+// which it was generated, trying to use it as-is will produce a namespace not found error. To avoid
+// this, use `makeNotFoundTaskToken` to replace the namespace Id by the one of the current namespace.
+// Protobuf reference: https://github.com/temporalio/temporal/blob/7314ea42e92f09e42d4edef76cbb5cee00b6c74c/proto/internal/temporal/server/api/token/v1/message.proto#L54
 const NOT_FOUND_TASK_TOKEN = new Uint8Array([
+  // 1. Namespace Id: string (len 36, UUID format)
   10, 36, 52, 101, 98, 48, 102, 49, 56, 52, 45, 101, 48, 51, 49, 45, 52, 52, 102, 97, 45, 56, 98, 48, 99, 45, 102, 48,
-  50, 55, 100, 48, 53, 53, 98, 101, 100, 99, 18, 36, 99, 55, 56, 55, 102, 55, 97, 102, 45, 50, 51, 99, 52, 45, 52, 56,
-  54, 98, 45, 57, 56, 98, 50, 45, 102, 53, 55, 57, 57, 55, 97, 100, 48, 97, 101, 54, 26, 36, 51, 51, 102, 101, 49, 50,
-  99, 56, 45, 98, 101, 52, 57, 45, 52, 49, 97, 50, 45, 56, 97, 98, 100, 45, 49, 55, 54, 53, 52, 57, 54, 101, 100, 101,
-  57, 101, 32, 5, 40, 1, 50, 1, 49, 66, 13, 99, 111, 109, 112, 108, 101, 116, 101, 65, 115, 121, 110, 99,
+  50, 55, 100, 48, 53, 53, 98, 101, 100, 99,
+  // 2. Workflow Id: string (len 36, UUID format)
+  18, 36, 99, 55, 56, 55, 102, 55, 97, 102, 45, 50, 51, 99, 52, 45, 52, 56, 54, 98, 45, 57, 56, 98, 50, 45, 102, 53, 55,
+  57, 57, 55, 97, 100, 48, 97, 101, 54,
+  // 3. Run Id: string (len 36, UUID format)
+  26, 36, 51, 51, 102, 101, 49, 50, 99, 56, 45, 98, 101, 52, 57, 45, 52, 49, 97, 50, 45, 56, 97, 98, 100, 45, 49, 55,
+  54, 53, 52, 57, 54, 101, 100, 101, 57, 101,
+  // 4. Scheduled Event Id: int64
+  32, 5,
+  // 5. Attempt: int32
+  40, 1,
+  // 6. Activity Id: string (len 1)
+  50, 1, 49,
+  // 8. Activity Type: string (len 13)
+  66, 13, 99, 111, 109, 112, 108, 101, 116, 101, 65, 115, 121, 110, 99,
 ]);
+
+//
+async function makeNotFoundTaskToken(conn: Connection, namespace: string): Promise<Uint8Array> {
+  const { namespaceInfo } = await conn.workflowService.describeNamespace({ namespace });
+  const buf = Buffer.copyBytesFrom(NOT_FOUND_TASK_TOKEN);
+  buf.subarray(2, 38).set(Buffer.from(namespaceInfo?.id as string));
+  return new Uint8Array(buf);
+}
 
 const taskQueue = 'async-activity-completion';
 const test = anyTest as TestFn<Context>;
@@ -49,11 +79,13 @@ if (RUN_INTEGRATION_TESTS) {
     runPromise.catch((err) => {
       console.error('Caught error while worker was running', err);
     });
+    const connection = await Connection.connect();
     t.context = {
       worker,
       runPromise,
       activityStarted$: infoSubject,
-      client: new Client(),
+      client: new Client({ connection }),
+      notFoundTaskToken: await makeNotFoundTaskToken(connection, 'default'),
     };
   });
 
@@ -89,7 +121,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Non existing activity async completion throws meaningful message', async (t) => {
-    await t.throwsAsync(t.context.client.activity.complete(NOT_FOUND_TASK_TOKEN, 'success'), {
+    await t.throwsAsync(t.context.client.activity.complete(t.context.notFoundTaskToken, 'success'), {
       instanceOf: ActivityNotFoundError,
     });
   });
@@ -133,7 +165,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Non existing activity async failure throws meaningful message', async (t) => {
-    await t.throwsAsync(t.context.client.activity.fail(NOT_FOUND_TASK_TOKEN, new Error('failure')), {
+    await t.throwsAsync(t.context.client.activity.fail(t.context.notFoundTaskToken, new Error('failure')), {
       instanceOf: ActivityNotFoundError,
     });
   });
@@ -154,7 +186,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Non existing activity async cancellation throws meaningful message', async (t) => {
-    await t.throwsAsync(t.context.client.activity.reportCancellation(NOT_FOUND_TASK_TOKEN, 'cancelled'), {
+    await t.throwsAsync(t.context.client.activity.reportCancellation(t.context.notFoundTaskToken, 'cancelled'), {
       instanceOf: ActivityNotFoundError,
     });
   });
@@ -231,7 +263,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Non existing activity async heartbeat throws meaningful message', async (t) => {
-    await t.throwsAsync(t.context.client.activity.heartbeat(NOT_FOUND_TASK_TOKEN, 'details'), {
+    await t.throwsAsync(t.context.client.activity.heartbeat(t.context.notFoundTaskToken, 'details'), {
       instanceOf: ActivityNotFoundError,
     });
   });

--- a/packages/test/src/test-async-completion.ts
+++ b/packages/test/src/test-async-completion.ts
@@ -51,7 +51,8 @@ const NOT_FOUND_TASK_TOKEN = new Uint8Array([
 //
 async function makeNotFoundTaskToken(conn: Connection, namespace: string): Promise<Uint8Array> {
   const { namespaceInfo } = await conn.workflowService.describeNamespace({ namespace });
-  const buf = Buffer.copyBytesFrom(NOT_FOUND_TASK_TOKEN);
+  const buf = Buffer.alloc(NOT_FOUND_TASK_TOKEN.length);
+  buf.set(NOT_FOUND_TASK_TOKEN);
   buf.subarray(2, 38).set(Buffer.from(namespaceInfo?.id as string));
   return new Uint8Array(buf);
 }

--- a/packages/test/src/test-client-errors.ts
+++ b/packages/test/src/test-client-errors.ts
@@ -1,0 +1,250 @@
+import anyTest, { TestFn } from 'ava';
+import {
+  ApplicationFailure,
+  Client,
+  NamespaceNotFoundError,
+  Next,
+  TerminateWorkflowExecutionResponse,
+  ValueError,
+  WorkflowClientInterceptor,
+  WorkflowTerminateInput,
+} from '@temporalio/client';
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+
+interface Context {
+  testEnv: TestWorkflowEnvironment;
+}
+
+const test = anyTest as TestFn<Context>;
+
+const unserializableObject = {
+  toJSON() {
+    throw new TypeError('Unserializable Object');
+  },
+};
+
+test.before(async (t) => {
+  t.context = {
+    testEnv: await TestWorkflowEnvironment.createLocal(),
+  };
+});
+
+test.after.always(async (t) => {
+  await t.context.testEnv?.teardown();
+});
+
+test('WorkflowClient - namespace not found', async (t) => {
+  const { connection } = t.context.testEnv;
+  const client = new Client({ connection, namespace: 'non-existent' });
+  await t.throwsAsync(
+    client.workflow.start('test', {
+      workflowId: 'test',
+      taskQueue: 'test',
+    }),
+    {
+      instanceOf: NamespaceNotFoundError,
+      message: "Namespace not found: 'non-existent'",
+    }
+  );
+});
+
+test('WorkflowClient - listWorkflows - namespace not found', async (t) => {
+  const { connection } = t.context.testEnv;
+  const client = new Client({ connection, namespace: 'non-existent' });
+  await t.throwsAsync(client.workflow.list()[Symbol.asyncIterator]().next(), {
+    instanceOf: NamespaceNotFoundError,
+    message: "Namespace not found: 'non-existent'",
+  });
+});
+
+test('WorkflowClient - start - invalid input payload', async (t) => {
+  const { connection } = t.context.testEnv;
+  const client = new Client({ connection });
+  const err: ValueError | undefined = await t.throwsAsync(
+    client.workflow.start('test', {
+      workflowId: 'test',
+      taskQueue: 'test',
+      args: [unserializableObject],
+    }),
+    {
+      instanceOf: ValueError,
+      message: 'Unable to convert [object Object] to payload',
+    }
+  );
+  t.true(err?.cause instanceof TypeError);
+  t.is((err?.cause as TypeError).message, 'Unserializable Object');
+});
+
+test('WorkflowClient - signalWithStart - invalid input payload', async (t) => {
+  const { connection } = t.context.testEnv;
+  const client = new Client({ connection });
+  const err: ValueError | undefined = await t.throwsAsync(
+    client.workflow.signalWithStart('test', {
+      workflowId: 'test',
+      taskQueue: 'test',
+      args: [unserializableObject],
+      signal: 'testSignal',
+    }),
+    {
+      instanceOf: ValueError,
+      message: 'Unable to convert [object Object] to payload',
+    }
+  );
+  t.true(err?.cause instanceof TypeError);
+  t.is((err?.cause as TypeError).message, 'Unserializable Object');
+});
+
+test('WorkflowClient - signalWorkflow - invalid input payload', async (t) => {
+  const { connection } = t.context.testEnv;
+  const client = new Client({ connection });
+  const err: ValueError | undefined = await t.throwsAsync(
+    client.workflow.getHandle('existant').signal<any[]>('test', [unserializableObject]),
+    {
+      instanceOf: ValueError,
+      message: 'Unable to convert [object Object] to payload',
+    }
+  );
+  t.true(err?.cause instanceof TypeError);
+  t.is((err?.cause as TypeError).message, 'Unserializable Object');
+});
+
+test('WorkflowClient - queryWorkflow - invalid input payload', async (t) => {
+  const { connection } = t.context.testEnv;
+  const client = new Client({ connection });
+  const err: ValueError | undefined = await t.throwsAsync(
+    client.workflow.getHandle('existant').query<any, any[]>('test', [unserializableObject]),
+    {
+      instanceOf: ValueError,
+      message: 'Unable to convert [object Object] to payload',
+    }
+  );
+  t.true(err?.cause instanceof TypeError);
+  t.is((err?.cause as TypeError).message, 'Unserializable Object');
+});
+
+test('WorkflowClient - terminateWorkflow - invalid details payload', async (t) => {
+  const { connection } = t.context.testEnv;
+  const client = new Client({
+    connection,
+    interceptors: {
+      workflow: [
+        {
+          async terminate(
+            input: WorkflowTerminateInput,
+            next: Next<WorkflowClientInterceptor, 'terminate'>
+          ): Promise<TerminateWorkflowExecutionResponse> {
+            return next({
+              ...input,
+              details: [unserializableObject],
+            });
+          },
+        },
+      ],
+    },
+  });
+  const err: ValueError | undefined = await t.throwsAsync(client.workflow.getHandle('existant').terminate('reason'), {
+    instanceOf: ValueError,
+    message: 'Unable to convert [object Object] to payload',
+  });
+  t.true(err?.cause instanceof TypeError);
+  t.is((err?.cause as TypeError).message, 'Unserializable Object');
+});
+
+test('ScheduleClient - namespace not found', async (t) => {
+  const { connection } = t.context.testEnv;
+  const client = new Client({ connection, namespace: 'non-existent' });
+  await t.throwsAsync(
+    client.schedule.create({
+      scheduleId: 'test',
+      spec: {
+        calendars: [{ hour: { start: 2, end: 7, step: 1 } }],
+      },
+      action: {
+        type: 'startWorkflow',
+        workflowType: 'test',
+        taskQueue: 'test',
+      },
+    }),
+    {
+      instanceOf: NamespaceNotFoundError,
+      message: "Namespace not found: 'non-existent'",
+    }
+  );
+});
+
+test('ScheduleClient - listSchedule - namespace not found', async (t) => {
+  const { connection } = t.context.testEnv;
+  const client = new Client({ connection, namespace: 'non-existent' });
+  await t.throwsAsync(client.schedule.list()[Symbol.asyncIterator]().next(), {
+    instanceOf: NamespaceNotFoundError,
+    message: "Namespace not found: 'non-existent'",
+  });
+});
+
+test('AsyncCompletionClient - namespace not found', async (t) => {
+  const { connection } = t.context.testEnv;
+  const client = new Client({ connection, namespace: 'non-existent' });
+  await t.throwsAsync(client.activity.complete(new Uint8Array([1]), 'result'), {
+    instanceOf: NamespaceNotFoundError,
+    message: "Namespace not found: 'non-existent'",
+  });
+});
+
+test('AsyncCompletionClient - complete - invalid payload', async (t) => {
+  const { connection } = t.context.testEnv;
+  const client = new Client({ connection });
+  const err: ValueError | undefined = await t.throwsAsync(
+    client.activity.complete(new Uint8Array([1]), unserializableObject),
+    {
+      instanceOf: ValueError,
+      message: 'Unable to convert [object Object] to payload',
+    }
+  );
+  t.true(err?.cause instanceof TypeError);
+  t.is((err?.cause as TypeError).message, 'Unserializable Object');
+});
+
+test('AsyncCompletionClient - fail - invalid payload', async (t) => {
+  const { connection } = t.context.testEnv;
+  const client = new Client({ connection });
+  const err: ValueError | undefined = await t.throwsAsync(
+    client.activity.fail(
+      new Uint8Array([1]),
+      ApplicationFailure.create({ type: 'test', details: [unserializableObject] })
+    ),
+    {
+      instanceOf: ValueError,
+      message: 'Unable to convert [object Object] to payload',
+    }
+  );
+  t.true(err?.cause instanceof TypeError);
+  t.is((err?.cause as TypeError).message, 'Unserializable Object');
+});
+
+test('AsyncCompletionClient - reportCancellation - invalid payload', async (t) => {
+  const { connection } = t.context.testEnv;
+  const client = new Client({ connection });
+  const err: ValueError | undefined = await t.throwsAsync(
+    client.activity.reportCancellation(new Uint8Array([1]), unserializableObject),
+    {
+      instanceOf: ValueError,
+      message: 'Unable to convert [object Object] to payload',
+    }
+  );
+  t.true(err?.cause instanceof TypeError);
+  t.is((err?.cause as TypeError).message, 'Unserializable Object');
+});
+
+test('AsyncCompletionClient - heartbeat - invalid payload', async (t) => {
+  const { connection } = t.context.testEnv;
+  const client = new Client({ connection });
+  const err: ValueError | undefined = await t.throwsAsync(
+    client.activity.heartbeat(new Uint8Array([1]), unserializableObject),
+    {
+      instanceOf: ValueError,
+      message: 'Unable to convert [object Object] to payload',
+    }
+  );
+  t.true(err?.cause instanceof TypeError);
+  t.is((err?.cause as TypeError).message, 'Unserializable Object');
+});

--- a/packages/test/src/test-client-errors.ts
+++ b/packages/test/src/test-client-errors.ts
@@ -60,7 +60,7 @@ test('WorkflowClient - listWorkflows - namespace not found', async (t) => {
 test('WorkflowClient - start - invalid input payload', async (t) => {
   const { connection } = t.context.testEnv;
   const client = new Client({ connection });
-  const err: ValueError | undefined = await t.throwsAsync(
+  await t.throwsAsync(
     client.workflow.start('test', {
       workflowId: 'test',
       taskQueue: 'test',
@@ -71,14 +71,12 @@ test('WorkflowClient - start - invalid input payload', async (t) => {
       message: 'Unable to convert [object Object] to payload',
     }
   );
-  t.true(err?.cause instanceof TypeError);
-  t.is((err?.cause as TypeError).message, 'Unserializable Object');
 });
 
 test('WorkflowClient - signalWithStart - invalid input payload', async (t) => {
   const { connection } = t.context.testEnv;
   const client = new Client({ connection });
-  const err: ValueError | undefined = await t.throwsAsync(
+  await t.throwsAsync(
     client.workflow.signalWithStart('test', {
       workflowId: 'test',
       taskQueue: 'test',
@@ -90,36 +88,24 @@ test('WorkflowClient - signalWithStart - invalid input payload', async (t) => {
       message: 'Unable to convert [object Object] to payload',
     }
   );
-  t.true(err?.cause instanceof TypeError);
-  t.is((err?.cause as TypeError).message, 'Unserializable Object');
 });
 
 test('WorkflowClient - signalWorkflow - invalid input payload', async (t) => {
   const { connection } = t.context.testEnv;
   const client = new Client({ connection });
-  const err: ValueError | undefined = await t.throwsAsync(
-    client.workflow.getHandle('existant').signal<any[]>('test', [unserializableObject]),
-    {
-      instanceOf: ValueError,
-      message: 'Unable to convert [object Object] to payload',
-    }
-  );
-  t.true(err?.cause instanceof TypeError);
-  t.is((err?.cause as TypeError).message, 'Unserializable Object');
+  await t.throwsAsync(client.workflow.getHandle('existant').signal<any[]>('test', [unserializableObject]), {
+    instanceOf: ValueError,
+    message: 'Unable to convert [object Object] to payload',
+  });
 });
 
 test('WorkflowClient - queryWorkflow - invalid input payload', async (t) => {
   const { connection } = t.context.testEnv;
   const client = new Client({ connection });
-  const err: ValueError | undefined = await t.throwsAsync(
-    client.workflow.getHandle('existant').query<any, any[]>('test', [unserializableObject]),
-    {
-      instanceOf: ValueError,
-      message: 'Unable to convert [object Object] to payload',
-    }
-  );
-  t.true(err?.cause instanceof TypeError);
-  t.is((err?.cause as TypeError).message, 'Unserializable Object');
+  await t.throwsAsync(client.workflow.getHandle('existant').query<any, any[]>('test', [unserializableObject]), {
+    instanceOf: ValueError,
+    message: 'Unable to convert [object Object] to payload',
+  });
 });
 
 test('WorkflowClient - terminateWorkflow - invalid details payload', async (t) => {
@@ -142,12 +128,10 @@ test('WorkflowClient - terminateWorkflow - invalid details payload', async (t) =
       ],
     },
   });
-  const err: ValueError | undefined = await t.throwsAsync(client.workflow.getHandle('existant').terminate('reason'), {
+  await t.throwsAsync(client.workflow.getHandle('existant').terminate('reason'), {
     instanceOf: ValueError,
     message: 'Unable to convert [object Object] to payload',
   });
-  t.true(err?.cause instanceof TypeError);
-  t.is((err?.cause as TypeError).message, 'Unserializable Object');
 });
 
 test('ScheduleClient - namespace not found', async (t) => {
@@ -193,21 +177,16 @@ test('AsyncCompletionClient - namespace not found', async (t) => {
 test('AsyncCompletionClient - complete - invalid payload', async (t) => {
   const { connection } = t.context.testEnv;
   const client = new Client({ connection });
-  const err: ValueError | undefined = await t.throwsAsync(
-    client.activity.complete(new Uint8Array([1]), unserializableObject),
-    {
-      instanceOf: ValueError,
-      message: 'Unable to convert [object Object] to payload',
-    }
-  );
-  t.true(err?.cause instanceof TypeError);
-  t.is((err?.cause as TypeError).message, 'Unserializable Object');
+  await t.throwsAsync(client.activity.complete(new Uint8Array([1]), unserializableObject), {
+    instanceOf: ValueError,
+    message: 'Unable to convert [object Object] to payload',
+  });
 });
 
 test('AsyncCompletionClient - fail - invalid payload', async (t) => {
   const { connection } = t.context.testEnv;
   const client = new Client({ connection });
-  const err: ValueError | undefined = await t.throwsAsync(
+  await t.throwsAsync(
     client.activity.fail(
       new Uint8Array([1]),
       ApplicationFailure.create({ type: 'test', details: [unserializableObject] })
@@ -217,34 +196,22 @@ test('AsyncCompletionClient - fail - invalid payload', async (t) => {
       message: 'Unable to convert [object Object] to payload',
     }
   );
-  t.true(err?.cause instanceof TypeError);
-  t.is((err?.cause as TypeError).message, 'Unserializable Object');
 });
 
 test('AsyncCompletionClient - reportCancellation - invalid payload', async (t) => {
   const { connection } = t.context.testEnv;
   const client = new Client({ connection });
-  const err: ValueError | undefined = await t.throwsAsync(
-    client.activity.reportCancellation(new Uint8Array([1]), unserializableObject),
-    {
-      instanceOf: ValueError,
-      message: 'Unable to convert [object Object] to payload',
-    }
-  );
-  t.true(err?.cause instanceof TypeError);
-  t.is((err?.cause as TypeError).message, 'Unserializable Object');
+  await t.throwsAsync(client.activity.reportCancellation(new Uint8Array([1]), unserializableObject), {
+    instanceOf: ValueError,
+    message: 'Unable to convert [object Object] to payload',
+  });
 });
 
 test('AsyncCompletionClient - heartbeat - invalid payload', async (t) => {
   const { connection } = t.context.testEnv;
   const client = new Client({ connection });
-  const err: ValueError | undefined = await t.throwsAsync(
-    client.activity.heartbeat(new Uint8Array([1]), unserializableObject),
-    {
-      instanceOf: ValueError,
-      message: 'Unable to convert [object Object] to payload',
-    }
-  );
-  t.true(err?.cause instanceof TypeError);
-  t.is((err?.cause as TypeError).message, 'Unserializable Object');
+  await t.throwsAsync(client.activity.heartbeat(new Uint8Array([1]), unserializableObject), {
+    instanceOf: ValueError,
+    message: 'Unable to convert [object Object] to payload',
+  });
 });

--- a/packages/test/src/test-payload-converter.ts
+++ b/packages/test/src/test-payload-converter.ts
@@ -76,7 +76,7 @@ test('JsonPayloadConverter converts from non undefined', (t) => {
   t.deepEqual(converter.toPayload('abc'), payload('abc'));
 
   t.is(converter.toPayload(undefined), undefined);
-  t.is(converter.toPayload(0n), undefined);
+  t.throws(() => converter.toPayload(0n), { instanceOf: TypeError, message: 'Do not know how to serialize a BigInt' });
 });
 
 test('JsonPayloadConverter converts to object', (t) => {

--- a/packages/test/src/test-payload-converter.ts
+++ b/packages/test/src/test-payload-converter.ts
@@ -76,7 +76,7 @@ test('JsonPayloadConverter converts from non undefined', (t) => {
   t.deepEqual(converter.toPayload('abc'), payload('abc'));
 
   t.is(converter.toPayload(undefined), undefined);
-  t.throws(() => converter.toPayload(0n), { instanceOf: TypeError, message: 'Do not know how to serialize a BigInt' });
+  t.is(converter.toPayload(0n), undefined);
 });
 
 test('JsonPayloadConverter converts to object', (t) => {

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -2,7 +2,6 @@ import { promisify } from 'node:util';
 import * as v8 from 'node:v8';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import * as timers from 'node:timers/promises';
 import { Heap } from 'heap-js';
 import { Subject, firstValueFrom } from 'rxjs';
 import * as native from '@temporalio/core-bridge';
@@ -282,7 +281,10 @@ export class Runtime {
           });
         }
         logger.flush();
-        const stop = await Promise.race([stopPollingForLogs.then(() => true), timers.setTimeout(3).then(() => false)]);
+        const stop = await Promise.race([
+          stopPollingForLogs.then(() => true),
+          new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 3)),
+        ]);
         if (stop) {
           break;
         }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -454,8 +454,9 @@ export class Worker {
     // so it can be automatically closed when this Worker shuts down.
     const connection = options.connection ?? (await InternalNativeConnection.connect());
     let nativeWorker: NativeWorkerLike;
+    const compiledOptionsWithBuildId = addBuildIdIfMissing(compiledOptions, bundle?.code);
     try {
-      nativeWorker = await nativeWorkerCtor.create(connection, addBuildIdIfMissing(compiledOptions, bundle?.code));
+      nativeWorker = await nativeWorkerCtor.create(connection, compiledOptionsWithBuildId);
     } catch (err) {
       // We just created this connection, close it
       if (!options.connection) {
@@ -464,7 +465,7 @@ export class Worker {
       throw err;
     }
     extractReferenceHolders(connection).add(nativeWorker);
-    return new this(nativeWorker, workflowCreator, compiledOptions, connection);
+    return new this(nativeWorker, workflowCreator, compiledOptionsWithBuildId, connection);
   }
 
   protected static async createWorkflowCreator(


### PR DESCRIPTION
## What changed

- All Client APIs now throw `NamespaceNotFoundError` when appropriate, rather than `WorkflowNotFound`, `ScheduleNotFound` or `ActivityNotFound` (fix #1145, fix #976)
- Errors that happen while preparing API requests from a `Client`, and particularly errors happening while converting input objects to payloads, now results in throwing an appropriate exception, rather than an opaque ServiceError.