### PR TITLE
chore: Update CHANGELOG.md file in prep for 1.8.0 and make last minute API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Breaking changes marked with a :boom:
 ### Features
 
 - [`worker`] Add support for using multiple concurrent pollers to getch Workflow Task and Activity Task from Task Queues
-  (#1132). The number of pollers for each type can be controlled through the `WorkerOptions.maxConcurrentWorkflowTaskPolls`
+  ([#1132](https://github.com/temporalio/sdk-typescript/pull/1132)). The number of pollers for each type can be controlled through the `WorkerOptions.maxConcurrentWorkflowTaskPolls`
   and `WorkerOptions.maxConcurrentActivityTaskPolls` properties. Properly adjusting these values should allow better
   filling of the corresponding execution slots, which may signficiantly improve a Worker's throughput. Default are
   10 Workflow Task Pollers and 2 Activity Task Pollers; we however strongly recommend tuning these values
@@ -20,24 +20,23 @@ Breaking changes marked with a :boom:
   also tuned. This was not problem previously because the single poller was unlikely to fill in all execution slot
   anyway, so maximum would rarely be reached.
 
-- [`workflow`] The `reuseV8Context` worker option is no longer marked as experimental (#1132). This is a major
-  optimization of the Workflow sandboxing runtime; it allows the worker to reuse execution context across Workflows,
-  without compromising the safety of the deterministic sandbox. It significantly reduces RAM and CPU usage. The formula
-  used to auto-configure `maxCachedWorkflows` has also been reviewed to reflect a lower memory usage requirement when
-  `reuseV8Context` is enabled.
+- [`workflow`] The `reuseV8Context` worker option is no longer marked as experimental ([#1132](https://github.com/temporalio/sdk-typescript/pull/1132)).
+  This is a major optimization of the Workflow sandboxing runtime; it allows the worker to reuse execution context
+  across Workflows, without compromising the safety of the deterministic sandbox. It significantly reduces RAM and CPU
+  usage. The formula used to auto-configure `maxCachedWorkflows` has also been reviewed to reflect a lower memory usage
+  requirement when `reuseV8Context` is enabled.
 
-  At this point, you still need to opt-in to this feature by adding `reuseV8Context: true` to your
-  `WorkerOptions`, as we believe most teams should reconsider their workers's performance settings
-  after enabling this option.
+  At this point, you still need to opt-in to this feature by adding `reuseV8Context: true` to your `WorkerOptions`, as
+  we believe most teams should reconsider their workers's performance settings after enabling this option.
 
-  :boom: Note that we are planing enabling this option by default starting with 1.9.0. If for some
-  reason, you prefer to delay enabling this optimization, then we recommend that you explicitely add
-  `reuseV8Context: false` to your worker options.
+  :boom: Note that we are planing enabling this option by default starting with 1.9.0. If for some reason, you prefer to
+  delay enabling this optimization, then we recommend that you explicitely add `reuseV8Context: false` to your worker
+  options.
 
-- We now provide out-of-the-box log support from both Workflows and Activity contexts (#1117, #1138).
+- We now provide out-of-the-box log support from both Workflows and Activity contexts ([#1117](https://github.com/temporalio/sdk-typescript/pull/1117), [#1138](https://github.com/temporalio/sdk-typescript/pull/1138))).
 
-  For Workflows, the logger funnels messages through the `defaultWorkerLogger` sink, which itself
-  defaults to forwarding messages to `Runtime.instance().logger`.
+  For Workflows, the logger funnels messages through the `defaultWorkerLogger` sink, which itself defaults to forwarding
+  messages to `Runtime.instance().logger`.
 
   Example usage:
 
@@ -49,10 +48,9 @@ Breaking changes marked with a :boom:
   }
   ```
 
-  For Activities, the logger can be accessed as `Context.logger`. It defaults to
-  `Runtime.instance().logger`, but may be overriden by interceptors (ie. to set a custom logger).
-  `ActivityInboundLogInterceptor` is still installed by default, adding enriched metadata from
-  activity context on each log entry.
+  For Activities, the logger can be accessed as `Context.logger`. It defaults to `Runtime.instance().logger`, but may be
+  overriden by interceptors (ie. to set a custom logger). `ActivityInboundLogInterceptor` is still installed by default,
+  adding enriched metadata from activity context on each log entry.
 
   Example usage:
 
@@ -65,22 +63,20 @@ Breaking changes marked with a :boom:
   }
   ```
 
-- :boom: Protect against 'ms' durations errors (#1136) There has been several reports of situations
-  where invalid durations resulted in unexpected and hard to diagnose issues (eg. can you can
-  predict what `const bool = condition(fn, '1 month')` will do?) We now provide type definitions for
-  "ms-formated strings", through the newly introduced `Duration` type, which is either a
-  well formed `ms`-formated string or a number of milliseconds. Invalid ms-formated-strings will
-  also throw at runtime.
+- :boom: Protect against 'ms' durations errors ([#1136](https://github.com/temporalio/sdk-typescript/pull/1136)) There
+  has been several reports of situations where invalid durations resulted in unexpected and hard to diagnose issues
+  (eg. can you can predict what `const bool = condition(fn, '1 month')` will do?) We now provide type definitions for
+  "ms-formated strings", through the newly introduced `Duration` type, which is either a well formed `ms`-formated
+  string or a number of milliseconds. Invalid ms-formated-strings will also throw at runtime.
 
-  Note: this might cause build errors in situations where a non-const string value is passed
-  somewhere we expect a `Duration`. Consider either validating and converting these strings _before_
-  passing them as `Duration`, or simply cast them to `Duration` and deal with runtime exception that
-  might be thrown if an invalid value is provided.
+  Note: this might cause build errors in situations where a non-const string value is passed somewhere we expect a
+  `Duration`. Consider either validating and converting these strings _before_ passing them as `Duration`, or simply
+  cast them to `Duration` and deal with runtime exception that might be thrown if an invalid value is provided.
 
-- [`workflow`] Clone sink args at call time on Node 17+ (#1118) A subtile aspect of Workflow Sinks
-  is that calls are actually buffered and get executed only once the current Workflow Task completes.
-  That sometime caused unexpected behavior where an object passed as argument to a sink function is
-  mutated afterward.
+- [`workflow`] Clone sink args at call time on Node 17+ ([#1118](https://github.com/temporalio/sdk-typescript/pull/1118)).
+  A subtile aspect of Workflow Sinks is that calls are actually buffered and get executed only once the current
+  Workflow Task completes. That sometime caused unexpected behavior where an object passed as argument to a sink
+  function is mutated afterward.
 
   On Node.js 17+, we now clone sink arguments at call time, using `structuredClone`. While this adds
   some runtime overhead, it leads to more predictable experience, as well as better exceptions when
@@ -89,14 +85,14 @@ Breaking changes marked with a :boom:
 ### Bug Fixes
 
 - [`core`] Metrics that should be produced by the SDK Core's internal Client would previously not
-  get emited. This has been fixed. (#1119)
-- [`client`] Fix incorrect schedule spec boundaries checks on hour and day of month (#1120)
+  get emited. This has been fixed. ([#1119](https://github.com/temporalio/sdk-typescript/pull/1119))
+- [`client`] Fix incorrect schedule spec boundaries checks on hour and day of month ([#1120](https://github.com/temporalio/sdk-typescript/pull/1120))
 - [`workflow`] We know throw more meaningful errors when Workflow-only APIs are used from
-  non-Workflow context, and some other situations. (#1126)
-- Eemoved most `instanceof` checks from SDK, and remplaced them by `XxxError.is(...)` checks, based on the presence of
+  non-Workflow context, and some other situations. ([#1126](https://github.com/temporalio/sdk-typescript/pull/1126))
+- Removed most `instanceof` checks from SDK, and remplaced them by `XxxError.is(...)` checks, based on the presence of
   a symbol property. We believe this should help resolve most of the problems that previously been observed when
-  multiple copies or different versions of SDK packages are installed in a same project.
-- [`workflow`] Make Local Activily timeouts in `ActivityInfo` match those of non-Local Activities (#1133)
+  multiple copies or different versions of SDK packages are installed in a same project (([#1128](https://github.com/temporalio/sdk-typescript/pull/1128))).
+- [`workflow`] Make Local Activily timeouts in `ActivityInfo` match those of non-Local Activities ([#1133](https://github.com/temporalio/sdk-typescript/pull/1133))
 
 ## [1.7.4] - 2023-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ Breaking changes marked with a :boom:
   some runtime overhead, it leads to more predictable experience, as well as better exceptions when
   passing non-transferrable objects to a sink.
 
+- [`core`] Add the `sticky_cache_total_forced_eviction` metric ([Core #569](https://github.com/temporalio/sdk-core/pull/569)).
+
 ### Bug Fixes
 
 - [`core`] Metrics that should be produced by the SDK Core's internal Client would previously not
@@ -92,7 +94,7 @@ Breaking changes marked with a :boom:
 - Removed most `instanceof` checks from SDK, and remplaced them by `XxxError.is(...)` checks, based on the presence of
   a symbol property. We believe this should help resolve most of the problems that previously been observed when
   multiple copies or different versions of SDK packages are installed in a same project (([#1128](https://github.com/temporalio/sdk-typescript/pull/1128))).
-- [`workflow`] Make Local Activily timeouts in `ActivityInfo` match those of non-Local Activities ([#1133](https://github.com/temporalio/sdk-typescript/pull/1133))
+- [`workflow`] Make Local Activily timeouts in `ActivityInfo` match those of non-Local Activities ([#1133](https://github.com/temporalio/sdk-typescript/pull/1133), [Core #569](https://github.com/temporalio/sdk-core/pull/569)).
 
 ## [1.7.4] - 2023-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,29 +67,31 @@ Breaking changes marked with a :boom:
   // Check if build id is reachable...
   ```
 
-- [`worker`] Add support for using multiple concurrent pollers to getch Workflow Task and Activity Task from Task Queues
-  ([#1132](https://github.com/temporalio/sdk-typescript/pull/1132)). The number of pollers for each type can be controlled through the `WorkerOptions.maxConcurrentWorkflowTaskPolls`
+- [`worker`] Add support for using multiple concurrent pollers to fetch Workflow Tasks and Activity Tasks from Task Queues
+  ([#1132](https://github.com/temporalio/sdk-typescript/pull/1132)).
+
+  The number of pollers for each type can be controlled through the `WorkerOptions.maxConcurrentWorkflowTaskPolls`
   and `WorkerOptions.maxConcurrentActivityTaskPolls` properties. Properly adjusting these values should allow better
-  filling of the corresponding execution slots, which may signficiantly improve a Worker's throughput. Default are
+  filling of the corresponding execution slots, which may signficiantly improve a Worker's throughput. Defaults are
   10 Workflow Task Pollers and 2 Activity Task Pollers; we however strongly recommend tuning these values
   based on workload specific performance tests.
 
   Default value for `maxConcurrentWorkflowTaskExecutions` has also been reduced to 40 (it was previously 100), as recent
   performance tests demonstrate that higher values increase the risk of Workflow Task Timeouts unless other options are
-  also tuned. This was not problem previously because the single poller was unlikely to fill in all execution slot
-  anyway, so maximum would rarely be reached.
+  also tuned. This was not problem previously because the single poller was unlikely to fill all execution slots, so
+  maximum would rarely be reached.
 
 - [`workflow`] The `reuseV8Context` worker option is no longer marked as experimental ([#1132](https://github.com/temporalio/sdk-typescript/pull/1132)).
-  This is a major optimization of the Workflow sandboxing runtime; it allows the worker to reuse execution context
-  across Workflows, without compromising the safety of the deterministic sandbox. It significantly reduces RAM and CPU
-  usage. The formula used to auto-configure `maxCachedWorkflows` has also been reviewed to reflect a lower memory usage
-  requirement when `reuseV8Context` is enabled.
+  This is a major optimization of the Workflow sandboxing runtime; it allows the worker to reuse a single execution
+  context across Workflow instances, without compromising the safety of the deterministic sandbox. It significantly
+  reduces RAM and CPU usage. The formula used to auto-configure `maxCachedWorkflows` has also been reviewed to reflect a
+  lower memory usage requirement when `reuseV8Context` is enabled.
 
   At this point, you still need to opt-in to this feature by adding `reuseV8Context: true` to your `WorkerOptions`, as
   we believe most teams should reconsider their workers's performance settings after enabling this option.
 
   :boom: Note that we are planing enabling this option by default starting with 1.9.0. If for some reason, you prefer to
-  delay enabling this optimization, then we recommend that you explicitely add `reuseV8Context: false` to your worker
+  delay enabling this optimization, then we recommend that you explicitly add `reuseV8Context: false` to your worker
   options.
 
 - We now provide out-of-the-box log support from both Workflows and Activity contexts ([#1117](https://github.com/temporalio/sdk-typescript/pull/1117), [#1138](https://github.com/temporalio/sdk-typescript/pull/1138))).
@@ -118,28 +120,28 @@ Breaking changes marked with a :boom:
 
   export async function myActivity(): Promise<void> {
     const context = activity.Context.current();
-    context.logger.info('hello from my activity', { key: 'value' });
+    context.log.info('hello from my activity', { key: 'value' });
   }
   ```
 
-- :boom: Protect against 'ms' durations errors ([#1136](https://github.com/temporalio/sdk-typescript/pull/1136)) There
-  has been several reports of situations where invalid durations resulted in unexpected and hard to diagnose issues
-  (eg. can you can predict what `const bool = condition(fn, '1 month')` will do?) We now provide type definitions for
-  "ms-formated strings", through the newly introduced `Duration` type, which is either a well formed `ms`-formated
-  string or a number of milliseconds. Invalid ms-formated-strings will also throw at runtime.
+- :boom: Protect against 'ms' durations errors ([#1136](https://github.com/temporalio/sdk-typescript/pull/1136)).
+  There have been several reports of situations where invalid durations resulted in unexpected and hard to diagnose
+  issues (e.g. can you can predict what `const bool = condition(fn, '1 month')` will do?). We now provide type
+  definitions for "ms-formated strings" through the newly introduced `Duration` type, which is either a well formed
+  `ms`-formated string or a number of milliseconds. Invalid ms-formated-strings will also throw at runtime.
 
   Note: this might cause build errors in situations where a non-const string value is passed somewhere we expect a
   `Duration`. Consider either validating and converting these strings _before_ passing them as `Duration`, or simply
   cast them to `Duration` and deal with runtime exception that might be thrown if an invalid value is provided.
 
-- [`workflow`] Clone sink args at call time on Node 17+ ([#1118](https://github.com/temporalio/sdk-typescript/pull/1118)).
-  A subtile aspect of Workflow Sinks is that calls are actually buffered and get executed only once the current
-  Workflow Task completes. That sometime caused unexpected behavior where an object passed as argument to a sink
-  function is mutated afterward.
+- [`workflow`] Clone sink args at call time on Node 17+
+  ([#1118](https://github.com/temporalio/sdk-typescript/pull/1118)). A subtle aspect of Workflow Sinks is that calls
+  are actually buffered and get executed only once the current Workflow activation completes. That sometime caused
+  unexpected behavior where an object passed as argument to a sink function is mutated after the invocation.
 
-  On Node.js 17+, we now clone sink arguments at call time, using `structuredClone`. While this adds
-  some runtime overhead, it leads to more predictable experience, as well as better exceptions when
-  passing non-transferrable objects to a sink.
+  On Node.js 17+, we now clone sink arguments at call time, using `structuredClone`. While this adds some runtime
+  overhead, it leads to more predictable experience, as well as better exceptions when passing non-transferrable objects
+  to a sink.
 
 - [`core`] Add the `sticky_cache_total_forced_eviction` metric ([Core #569](https://github.com/temporalio/sdk-core/pull/569)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,9 @@ Breaking changes marked with a :boom:
   overhead, it leads to more predictable experience, as well as better exceptions when passing non-transferrable objects
   to a sink.
 
-- [`core`] Add the `sticky_cache_total_forced_eviction` metric ([Core #569](https://github.com/temporalio/sdk-core/pull/569)).
+- [`core`] Add the `sticky_cache_total_forced_eviction` metric ([Core #569](https://github.com/temporalio/sdk-core/pull/569))
+
+- [`client`] Throw more specific errors from Client APIs ([#1147](https://github.com/temporalio/sdk-typescript/pull/1147))
 
 ### Bug Fixes
 
@@ -156,6 +158,13 @@ Breaking changes marked with a :boom:
   a symbol property. We believe this should help resolve most of the problems that previously been observed when
   multiple copies or different versions of SDK packages are installed in a same project (([#1128](https://github.com/temporalio/sdk-typescript/pull/1128))).
 - [`workflow`] Make Local Activily timeouts in `ActivityInfo` match those of non-Local Activities ([#1133](https://github.com/temporalio/sdk-typescript/pull/1133), [Core #569](https://github.com/temporalio/sdk-core/pull/569)).
+- [`workflow`] Ensure payload converters keep Uint8Array type equality ([#1143](https://github.com/temporalio/sdk-typescript/pull/1133))
+- Fail workflow task if local activity not registered with worker ([#1152](https://github.com/temporalio/sdk-typescript/pull/1152))
+- [`core`] Don't increment terminal command metrics when replaying ([Core #572](https://github.com/temporalio/sdk-core/pull/572))
+
+### Documentation
+
+- Improve documentation for activity heartbeat and cancellationSignal ([#1151](https://github.com/temporalio/sdk-typescript/pull/1151))
 
 ## [1.7.4] - 2023-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,100 @@ All notable changes to this project will be documented in this file.
 
 Breaking changes marked with a :boom:
 
+## [1.8.0] - 2023-06-22
+
+### Features
+
+- [`worker`] Add support for using multiple concurrent pollers to getch Workflow Task and Activity Task from Task Queues
+  (#1132). The number of pollers for each type can be controlled through the `WorkerOptions.maxConcurrentWorkflowTaskPolls`
+  and `WorkerOptions.maxConcurrentActivityTaskPolls` properties. Properly adjusting these values should allow better
+  filling of the corresponding execution slots, which may signficiantly improve a Worker's throughput. Default are
+  10 Workflow Task Pollers and 2 Activity Task Pollers; we however strongly recommend tuning these values
+  based on workload specific performance tests.
+
+  Default value for `maxConcurrentWorkflowTaskExecutions` has also been reduced to 40 (it was previously 100), as recent
+  performance tests demonstrate that higher values increase the risk of Workflow Task Timeouts unless other options are
+  also tuned. This was not problem previously because the single poller was unlikely to fill in all execution slot
+  anyway, so maximum would rarely be reached.
+
+- [`workflow`] The `reuseV8Context` worker option is no longer marked as experimental (#1132). This is a major
+  optimization of the Workflow sandboxing runtime; it allows the worker to reuse execution context across Workflows,
+  without compromising the safety of the deterministic sandbox. It significantly reduces RAM and CPU usage. The formula
+  used to auto-configure `maxCachedWorkflows` has also been reviewed to reflect a lower memory usage requirement when
+  `reuseV8Context` is enabled.
+
+  At this point, you still need to opt-in to this feature by adding `reuseV8Context: true` to your
+  `WorkerOptions`, as we believe most teams should reconsider their workers's performance settings
+  after enabling this option.
+
+  :boom: Note that we are planing enabling this option by default starting with 1.9.0. If for some
+  reason, you prefer to delay enabling this optimization, then we recommend that you explicitely add
+  `reuseV8Context: false` to your worker options.
+
+- We now provide out-of-the-box log support from both Workflows and Activity contexts (#1117, #1138).
+
+  For Workflows, the logger funnels messages through the `defaultWorkerLogger` sink, which itself
+  defaults to forwarding messages to `Runtime.instance().logger`.
+
+  Example usage:
+
+  ```ts
+  import * as workflow from '@temporalio/workflow';
+
+  export async function myWorkflow(): Promise<void> {
+    workflow.log.info('hello from my workflow', { key: 'value' });
+  }
+  ```
+
+  For Activities, the logger can be accessed as `Context.logger`. It defaults to
+  `Runtime.instance().logger`, but may be overriden by interceptors (ie. to set a custom logger).
+  `ActivityInboundLogInterceptor` is still installed by default, adding enriched metadata from
+  activity context on each log entry.
+
+  Example usage:
+
+  ```ts
+  import * as activity from '@temporalio/activity';
+
+  export async function myActivity(): Promise<void> {
+    const context = activity.Context.current();
+    context.logger.info('hello from my activity', { key: 'value' });
+  }
+  ```
+
+- :boom: Protect against 'ms' durations errors (#1136) There has been several reports of situations
+  where invalid durations resulted in unexpected and hard to diagnose issues (eg. can you can
+  predict what `const bool = condition(fn, '1 month')` will do?) We now provide type definitions for
+  "ms-formated strings", through the newly introduced `Duration` type, which is either a
+  well formed `ms`-formated string or a number of milliseconds. Invalid ms-formated-strings will
+  also throw at runtime.
+
+  Note: this might cause build errors in situations where a non-const string value is passed
+  somewhere we expect a `Duration`. Consider either validating and converting these strings _before_
+  passing them as `Duration`, or simply cast them to `Duration` and deal with runtime exception that
+  might be thrown if an invalid value is provided.
+
+- [`workflow`] Clone sink args at call time on Node 17+ (#1118) A subtile aspect of Workflow Sinks
+  is that calls are actually buffered and get executed only once the current Workflow Task completes.
+  That sometime caused unexpected behavior where an object passed as argument to a sink function is
+  mutated afterward.
+
+  On Node.js 17+, we now clone sink arguments at call time, using `structuredClone`. While this adds
+  some runtime overhead, it leads to more predictable experience, as well as better exceptions when
+  passing non-transferrable objects to a sink.
+
+### Bug Fixes
+
+- [`core`] Metrics that should be produced by the SDK Core's internal Client would previously not
+  get emited. This has been fixed. (#1119)
+- [`client`] Fix incorrect schedule spec boundaries checks on hour and day of month (#1120)
+- [`workflow`] We know throw more meaningful errors when Workflow-only APIs are used from
+  non-Workflow context, and some other situations. (#1126)
+- Eemoved most `instanceof` checks from SDK, and remplaced them by `XxxError.is(...)` checks, based on the presence of
+  a symbol property. We believe this should help resolve most of the problems that previously been observed when
+  multiple copies or different versions of SDK packages are installed in a same project.
+- [`workflow`] Make Local Activily timeouts in `ActivityInfo` match those of non-Local Activities (#1133)
+
 ## [1.7.4] - 2023-04-27
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ Breaking changes marked with a :boom:
 - [`workflow`] Ensure payload converters keep Uint8Array type equality ([#1143](https://github.com/temporalio/sdk-typescript/pull/1133))
 - Fail workflow task if local activity not registered with worker ([#1152](https://github.com/temporalio/sdk-typescript/pull/1152))
 - [`core`] Don't increment terminal command metrics when replaying ([Core #572](https://github.com/temporalio/sdk-core/pull/572))
+- [`core`] Fix start-to-close local activity timeouts not being retryable like they should be ([#Core 576](https://github.com/temporalio/sdk-core/pull/576))
 
 ### Documentation
 

--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -255,7 +255,7 @@ export class Context {
    * `ActivityInboundLogInterceptor` with your custom Logger. You may also subclass `ActivityInboundLogInterceptor` to
    * customize attributes that are emitted as metadata.
    */
-  public logger: Logger;
+  public log: Logger;
 
   /**
    * **Not** meant to instantiated by Activity code, used by the worker.
@@ -273,7 +273,7 @@ export class Context {
     this.cancelled = cancelled;
     this.cancellationSignal = cancellationSignal;
     this.heartbeatFn = heartbeat;
-    this.logger = logger;
+    this.log = logger;
   }
 
   /**

--- a/packages/client/src/task-queue-client.ts
+++ b/packages/client/src/task-queue-client.ts
@@ -133,7 +133,7 @@ export class TaskQueueClient extends BaseClient {
    * `NotFetched` entry in {@link BuildIdReachability.taskQueueReachability}. The caller may issue
    * another call to get the reachability for those task queues.
    */
-  public async getBuildIdReachability(options: ReachabilityOptions): Promise<ReachabilityResponse> {
+  public async getReachability(options: ReachabilityOptions): Promise<ReachabilityResponse> {
     let resp;
     const buildIds = options.buildIds?.map((bid) => {
       if (bid === UnversionedBuildId) {
@@ -167,7 +167,7 @@ export class TaskQueueClient extends BaseClient {
 }
 
 /**
- * Options for {@link TaskQueueClient.getBuildIdReachability}
+ * Options for {@link TaskQueueClient.getReachability}
  */
 export type ReachabilityOptions = RequireAtLeastOne<BaseReachabilityOptions, 'buildIds' | 'taskQueues'>;
 

--- a/packages/core-bridge/src/conversions.rs
+++ b/packages/core-bridge/src/conversions.rs
@@ -335,7 +335,7 @@ impl ObjectHandleConversionsExt for Handle<'_, JsObject> {
         match WorkerConfigBuilder::default()
             .worker_build_id(js_value_getter!(cx, self, "buildId", JsString))
             .client_identity_override(Some(js_value_getter!(cx, self, "identity", JsString)))
-            .use_worker_versioning(js_value_getter!(cx, self, "useWorkerVersioning", JsBoolean))
+            .use_worker_versioning(js_value_getter!(cx, self, "useVersioning", JsBoolean))
             .no_remote_activities(!enable_remote_activities)
             .max_outstanding_workflow_tasks(max_outstanding_workflow_tasks)
             .max_outstanding_activities(max_outstanding_activities)

--- a/packages/core-bridge/ts/index.ts
+++ b/packages/core-bridge/ts/index.ts
@@ -276,7 +276,7 @@ export interface WorkerOptions {
    *
    * For more information, see https://docs.temporal.io/workers#worker-versioning
    */
-  useWorkerVersioning: boolean;
+  useVersioning: boolean;
 
   /**
    * The task queue the worker will pull from

--- a/packages/test/src/test-activity-log-interceptor.ts
+++ b/packages/test/src/test-activity-log-interceptor.ts
@@ -30,7 +30,7 @@ test("Activity Context's logger defaults to Runtime's Logger", async (t) => {
   const env = new MockActivityEnvironment();
   const logs: LogEntry[] = await env.run(async () => {
     const ctx = activity.Context.current();
-    ctx.logger.debug('log message from activity');
+    ctx.log.debug('log message from activity');
     return (ctx as MyTestActivityContext).logs;
   });
   const activityLogEntry = logs.find((entry) => entry.message === 'log message from activity');
@@ -44,7 +44,7 @@ test("Activity Log Interceptor dont override Context's logger by default", async
     const ctx = activity.Context.current();
     const interceptor = new ActivityInboundLogInterceptor(ctx);
     const execute = composeInterceptors([interceptor], 'execute', async () => {
-      ctx.logger.debug('log message from activity');
+      ctx.log.debug('log message from activity');
     });
     try {
       await execute({ args: [], headers: {} });
@@ -87,7 +87,7 @@ async function runActivity(
 
 test('ActivityInboundLogInterceptor overrides Context logger if specified', async (t) => {
   const logs = await runActivity(async () => {
-    activity.Context.current().logger.debug('log message from activity');
+    activity.Context.current().log.debug('log message from activity');
   });
   t.is(logs.length, 3);
   const [_, midLog] = logs;

--- a/packages/test/src/test-ephemeral-server.ts
+++ b/packages/test/src/test-ephemeral-server.ts
@@ -6,6 +6,7 @@ import { Worker } from './helpers';
 
 interface Context {
   bundle: WorkflowBundle;
+  taskQueue: string;
 }
 
 const test = anyTest as TestFn<Context>;
@@ -14,9 +15,13 @@ test.before(async (t) => {
   t.context.bundle = await bundleWorkflowCode({ workflowsPath: require.resolve('./workflows') });
 });
 
+test.beforeEach(async (t) => {
+  t.context.taskQueue = t.title.replace(/ /g, '_');
+});
+
 async function runSimpleWorkflow(t: ExecutionContext<Context>, testEnv: TestWorkflowEnvironment) {
   try {
-    const taskQueue = 'test';
+    const { taskQueue } = t.context;
     const { client, nativeConnection, namespace } = testEnv;
     const worker = await Worker.create({
       connection: nativeConnection,

--- a/packages/worker/src/activity-log-interceptor.ts
+++ b/packages/worker/src/activity-log-interceptor.ts
@@ -35,10 +35,10 @@ export class ActivityInboundLogInterceptor implements ActivityInboundCallsInterc
     // Otherwise, use the logger that is already set on the activity context.
     // By default, that will be Runtime.logger, but another interceptor might have overriden it,
     // in which case we would want to use that one as our parent logger.
-    const parentLogger = logger ?? ctx.logger;
+    const parentLogger = logger ?? ctx.log;
     this.logger = parentLogger; // eslint-disable-line deprecation/deprecation
 
-    this.ctx.logger = Object.fromEntries(
+    this.ctx.log = Object.fromEntries(
       (['trace', 'debug', 'info', 'warn', 'error'] as const).map((level) => {
         return [
           level,
@@ -60,7 +60,7 @@ export class ActivityInboundLogInterceptor implements ActivityInboundCallsInterc
   async execute(input: ActivityExecuteInput, next: Next<ActivityInboundCallsInterceptor, 'execute'>): Promise<unknown> {
     let error: any = UNINITIALIZED; // In case someone decides to throw undefined...
     const startTime = process.hrtime.bigint();
-    this.ctx.logger.debug('Activity started');
+    this.ctx.log.debug('Activity started');
     try {
       return await next(input);
     } catch (err: any) {
@@ -71,18 +71,18 @@ export class ActivityInboundLogInterceptor implements ActivityInboundCallsInterc
       const durationMs = Number(durationNanos / 1_000_000n);
 
       if (error === UNINITIALIZED) {
-        this.ctx.logger.debug('Activity completed', { durationMs });
+        this.ctx.log.debug('Activity completed', { durationMs });
       } else if (
         typeof error === 'object' &&
         error != null &&
         (CancelledFailure.is(error) || error.name === 'AbortError') &&
         this.ctx.cancellationSignal.aborted
       ) {
-        this.ctx.logger.debug('Activity completed as cancelled', { durationMs });
+        this.ctx.log.debug('Activity completed as cancelled', { durationMs });
       } else if (CompleteAsyncError.is(error)) {
-        this.ctx.logger.debug('Activity will complete asynchronously', { durationMs });
+        this.ctx.log.debug('Activity will complete asynchronously', { durationMs });
       } else {
-        this.ctx.logger.warn('Activity failed', { error, durationMs });
+        this.ctx.log.warn('Activity failed', { error, durationMs });
       }
     }
   }

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -83,7 +83,7 @@ export interface WorkerOptions {
    *
    * This is used to uniquely identify the worker's code for a handful of purposes, including the
    * worker versioning feature if you have opted into that with
-   * {@link WorkerOptions.useWorkerVersioning}. It will also populate the `binaryChecksum` field
+   * {@link WorkerOptions.useVersioning}. It will also populate the `binaryChecksum` field
    * on older servers.
    *
    * @default `@temporalio/worker` package name and version + checksum of workflow bundle's code
@@ -101,7 +101,7 @@ export interface WorkerOptions {
    *
    * @experimental
    */
-  useWorkerVersioning?: boolean;
+  useVersioning?: boolean;
 
   /**
    * The namespace this worker will connect to
@@ -485,7 +485,7 @@ export type WorkerOptionsWithDefaults = WorkerOptions &
       WorkerOptions,
       | 'namespace'
       | 'identity'
-      | 'useWorkerVersioning'
+      | 'useVersioning'
       | 'shutdownGraceTime'
       | 'maxConcurrentActivityTaskExecutions'
       | 'maxConcurrentLocalActivityExecutions'
@@ -550,6 +550,7 @@ export interface ReplayWorkerOptions
     | 'maxTaskQueueActivitiesPerSecond'
     | 'stickyQueueScheduleToStartTimeout'
     | 'maxCachedWorkflows'
+    | 'useVersioning'
   > {
   /**
    *  A optional name for this replay worker. It will be combined with an incremental ID to form a unique
@@ -631,7 +632,7 @@ export function addDefaultWorkerOptions(options: WorkerOptions): WorkerOptionsWi
   return {
     namespace: namespace ?? 'default',
     identity: `${process.pid}@${os.hostname()}`,
-    useWorkerVersioning: options.useWorkerVersioning ?? false,
+    useVersioning: options.useVersioning ?? false,
     shutdownGraceTime: 0,
     maxConcurrentLocalActivityExecutions: 100,
     enableNonLocalActivities: true,


### PR DESCRIPTION
## What changed

- Updated CHANGELOG.md file in prep for 1.8.0.
- [Update core to get local activity start-to-close fix](https://github.com/temporalio/sdk-typescript/pull/1148/commits/e920da3263e7f2248738d533ae27b6c41eb6d8ad)
- [Fix flake in test-isolation](https://github.com/temporalio/sdk-typescript/pull/1148/commits/7153d4dc4449ed59d2859a81dd9cc8ca66b304c9)
- [Rename activity context logger to log, moar changelog edits](https://github.com/temporalio/sdk-typescript/pull/1148/commits/8379ca42ab60a09d251242393d1515cb142bb740)
- [Add versioning changelog and minor API changes](https://github.com/temporalio/sdk-typescript/pull/1148/commits/7999b73536d168e4e5f8caed82768afe2a7693a7)