### PR TITLE
fix: Fail workflow task if local activity not registered with worker

### DIFF
--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -1,4 +1,3 @@
-import type { temporal } from '@temporalio/proto';
 import { decode, encode } from '../encoding';
 import { PayloadConverterError, ValueError } from '../errors';
 import { Payload } from '../interfaces';

--- a/packages/test/src/test-local-activities.ts
+++ b/packages/test/src/test-local-activities.ts
@@ -25,7 +25,6 @@ import {
 import * as workflow from '@temporalio/workflow';
 import { test as anyTest, bundlerOptions, Worker } from './helpers';
 import { ConnectionInjectorInterceptor } from './activities/interceptors';
-import * as assert from 'assert';
 
 // FIXME MOVE THIS SECTION SOMEWHERE IT CAN BE SHARED //
 

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -64,8 +64,8 @@ test.before(async (t) => {
   const bundler = new WorkflowCodeBundler({ workflowsPath });
   const workflowBundle = parseWorkflowCode((await bundler.createBundle()).code);
   t.context.workflowCreator = REUSE_V8_CONTEXT
-    ? await TestReusableVMWorkflowCreator.create(workflowBundle, 200)
-    : await TestVMWorkflowCreator.create(workflowBundle, 200);
+    ? await TestReusableVMWorkflowCreator.create(workflowBundle, 200, new Set())
+    : await TestVMWorkflowCreator.create(workflowBundle, 200, new Set());
 });
 
 test.after.always(async (t) => {

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -3,7 +3,8 @@ import * as v8 from 'node:v8';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import { Heap } from 'heap-js';
-import { Subject, firstValueFrom } from 'rxjs';
+import { BehaviorSubject, lastValueFrom, of } from 'rxjs';
+import { concatMap, delay, map, repeat, takeWhile } from 'rxjs/operators';
 import * as native from '@temporalio/core-bridge';
 import {
   pollLogs,
@@ -134,7 +135,7 @@ export class Runtime {
   protected pendingCreations = 0;
   /** Track the registered native objects to automatically shutdown when all have been deregistered */
   protected readonly backRefs = new Set<TrackedNativeObject>();
-  protected readonly stopPollingForLogs = new Subject<void>();
+  protected readonly shouldPollForLogs = new BehaviorSubject<boolean>(false);
   protected readonly logPollPromise: Promise<void>;
   public readonly logger: Logger;
   protected readonly shutdownSignalCallbacks = new Set<() => void>();
@@ -265,30 +266,30 @@ export class Runtime {
   }
 
   protected async initLogPolling(logger: CoreLogger): Promise<void> {
+    this.shouldPollForLogs.next(true);
+
     if (!this.isForwardingLogs()) {
       return;
     }
-
-    const stopPollingForLogs = firstValueFrom(this.stopPollingForLogs);
-
     const poll = promisify(pollLogs);
     try {
-      for (;;) {
-        const logs = await poll(this.native);
-        for (const log of logs) {
-          logger.log(log.level, log.message, {
-            [LogTimestamp]: timeOfDayToBigint(log.timestamp),
-          });
-        }
-        logger.flush();
-        const stop = await Promise.race([
-          stopPollingForLogs.then(() => true),
-          new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 3)),
-        ]);
-        if (stop) {
-          break;
-        }
-      }
+      await lastValueFrom(
+        of(this.shouldPollForLogs).pipe(
+          map((subject) => subject.getValue()),
+          takeWhile((shouldPoll) => shouldPoll),
+          concatMap(() => poll(this.native)),
+          map((logs) => {
+            for (const log of logs) {
+              logger.log(log.level, log.message, {
+                [LogTimestamp]: timeOfDayToBigint(log.timestamp),
+              });
+            }
+            logger.flush();
+          }),
+          delay(3), // Don't go wild polling as fast as possible
+          repeat()
+        )
+      );
     } catch (error) {
       // Log using the original logger instead of buffering
       this.options.logger.warn('Error gathering forwarded logs from core', { error });
@@ -473,7 +474,7 @@ export class Runtime {
   public async shutdown(): Promise<void> {
     delete Runtime._instance;
     this.teardownShutdownHook();
-    this.stopPollingForLogs.next();
+    this.shouldPollForLogs.next(false);
     // This will effectively drain all logs
     await this.logPollPromise;
     await promisify(runtimeShutdown)(this.native);

--- a/packages/worker/src/workflow/threaded-vm.ts
+++ b/packages/worker/src/workflow/threaded-vm.ts
@@ -136,6 +136,7 @@ export interface ThreadedVMWorkflowCreatorOptions {
   threadPoolSize: number;
   isolateExecutionTimeoutMs: number;
   reuseV8Context: boolean;
+  registeredActivityNames: Set<string>;
 }
 
 /**
@@ -152,13 +153,20 @@ export class ThreadedVMWorkflowCreator implements WorkflowCreator {
     workflowBundle,
     isolateExecutionTimeoutMs,
     reuseV8Context,
+    registeredActivityNames,
   }: ThreadedVMWorkflowCreatorOptions): Promise<ThreadedVMWorkflowCreator> {
     const workerThreadClients = Array(threadPoolSize)
       .fill(0)
       .map(() => new WorkerThreadClient(new NodeWorker(require.resolve('./workflow-worker-thread'))));
     await Promise.all(
       workerThreadClients.map((client) =>
-        client.send({ type: 'init', workflowBundle, isolateExecutionTimeoutMs, reuseV8Context })
+        client.send({
+          type: 'init',
+          workflowBundle,
+          isolateExecutionTimeoutMs,
+          reuseV8Context,
+          registeredActivityNames,
+        })
       )
     );
     return new this(workerThreadClients);

--- a/packages/worker/src/workflow/workflow-worker-thread.ts
+++ b/packages/worker/src/workflow/workflow-worker-thread.ts
@@ -31,10 +31,18 @@ async function handleRequest({ requestId, input }: WorkerThreadRequest): Promise
   switch (input.type) {
     case 'init':
       if (input.reuseV8Context) {
-        workflowCreator = await ReusableVMWorkflowCreator.create(input.workflowBundle, input.isolateExecutionTimeoutMs);
+        workflowCreator = await ReusableVMWorkflowCreator.create(
+          input.workflowBundle,
+          input.isolateExecutionTimeoutMs,
+          input.registeredActivityNames
+        );
         workflowGetter = (runId) => ReusableVMWorkflowCreator.workflowByRunId.get(runId);
       } else {
-        workflowCreator = await VMWorkflowCreator.create(input.workflowBundle, input.isolateExecutionTimeoutMs);
+        workflowCreator = await VMWorkflowCreator.create(
+          input.workflowBundle,
+          input.isolateExecutionTimeoutMs,
+          input.registeredActivityNames
+        );
         workflowGetter = (runId) => VMWorkflowCreator.workflowByRunId.get(runId);
       }
       return ok(requestId);

--- a/packages/worker/src/workflow/workflow-worker-thread/input.ts
+++ b/packages/worker/src/workflow/workflow-worker-thread/input.ts
@@ -15,6 +15,7 @@ export interface Init {
   type: 'init';
   isolateExecutionTimeoutMs: number;
   workflowBundle: WorkflowBundleWithSourceMapAndFilename;
+  registeredActivityNames: Set<string>;
   reuseV8Context: boolean;
 }
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -401,6 +401,7 @@ export interface WorkflowCreateOptions {
 
 export interface WorkflowCreateOptionsInternal extends WorkflowCreateOptions {
   sourceMap: RawSourceMap;
+  registeredActivityNames: Set<string>;
   getTimeOfDay(): bigint;
 }
 

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -281,6 +281,8 @@ export class Activator implements ActivationHandler {
    */
   public readonly getTimeOfDay: () => bigint;
 
+  public readonly registeredActivityNames: Set<string>;
+
   constructor({
     info,
     now,
@@ -289,6 +291,7 @@ export class Activator implements ActivationHandler {
     getTimeOfDay,
     randomnessSeed,
     patches,
+    registeredActivityNames,
   }: WorkflowCreateOptionsInternal) {
     this.getTimeOfDay = getTimeOfDay;
     this.info = info;
@@ -296,6 +299,7 @@ export class Activator implements ActivationHandler {
     this.showStackTraceSources = showStackTraceSources;
     this.sourceMap = sourceMap;
     this.random = alea(randomnessSeed);
+    this.registeredActivityNames = registeredActivityNames;
 
     if (info.unsafe.isReplaying) {
       for (const patchId of patches) {

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -199,6 +199,11 @@ async function scheduleLocalActivityNextHandler({
   originalScheduleTime,
 }: LocalActivityInput): Promise<unknown> {
   const activator = getActivator();
+  // Eagerly fail the local activity (which will in turn fail the workflow task.
+  // Do not fail on replay where the local activities may not be registered on the replay worker.
+  if (!workflowInfo().unsafe.isReplaying && !activator.registeredActivityNames.has(activityType)) {
+    throw new ReferenceError(`Local activity of type '${activityType}' not registered on worker`);
+  }
   validateLocalActivityOptions(options);
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Previously the worker would needlessly retry these local activities.
With this change, the worker fails the workflow task allowing a user to deploy a fix.

Replaces https://github.com/temporalio/sdk-typescript/pull/1150 with better behavior.
Matches Java behavior https://github.com/temporalio/sdk-java/pull/1628.