### PR TITLE
feat(workflow): Logger improvements

### DIFF
--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -13,6 +13,7 @@ import { Runtime } from './runtime';
 import { InjectedSinks } from './sinks';
 import { MiB } from './utils';
 import { defaultWorflowInterceptorModules, WorkflowBundleWithSourceMap } from './workflow/bundler';
+import { workflowLogAttributes } from './workflow-log-interceptor';
 
 export type { WebpackConfiguration };
 
@@ -565,38 +566,41 @@ export interface ReplayWorkerOptions
  * Returns the `defaultWorkerLogger` sink which forwards logs from the Workflow sandbox to a given logger.
  *
  * @param logger a {@link Logger} - defaults to the {@link Runtime} singleton logger.
+ *
+ * @param attributesGetter a function that maps WorkflowInfo to a set of log attributes that are attached to every log
+ * record - experimental.
  */
-export function defaultSinks(logger?: Logger): InjectedSinks<LoggerSinks> {
+export function defaultSinks(logger?: Logger, attributesGetter = workflowLogAttributes): InjectedSinks<LoggerSinks> {
   return {
     defaultWorkerLogger: {
       trace: {
-        fn(_, message, attrs) {
+        fn(info, message, attrs) {
           logger ??= Runtime.instance().logger;
-          logger.trace(message, attrs);
+          logger.trace(message, { ...attributesGetter(info), ...attrs });
         },
       },
       debug: {
-        fn(_, message, attrs) {
+        fn(info, message, attrs) {
           logger ??= Runtime.instance().logger;
-          logger.debug(message, attrs);
+          logger.debug(message, { ...attributesGetter(info), ...attrs });
         },
       },
       info: {
-        fn(_, message, attrs) {
+        fn(info, message, attrs) {
           logger ??= Runtime.instance().logger;
-          logger.info(message, attrs);
+          logger.info(message, { ...attributesGetter(info), ...attrs });
         },
       },
       warn: {
-        fn(_, message, attrs) {
+        fn(info, message, attrs) {
           logger ??= Runtime.instance().logger;
-          logger.warn(message, attrs);
+          logger.warn(message, { ...attributesGetter(info), ...attrs });
         },
       },
       error: {
-        fn(_, message, attrs) {
+        fn(info, message, attrs) {
           logger ??= Runtime.instance().logger;
-          logger.error(message, attrs);
+          logger.error(message, { ...attributesGetter(info), ...attrs });
         },
       },
     },

--- a/packages/worker/src/workflow-log-interceptor.ts
+++ b/packages/worker/src/workflow-log-interceptor.ts
@@ -3,9 +3,8 @@ import {
   Next,
   WorkflowExecuteInput,
   WorkflowInboundCallsInterceptor,
-  workflowInfo,
-  WorkflowInfo,
   WorkflowInterceptorsFactory,
+  WorkflowInfo,
   log,
   ContinueAsNew,
 } from '@temporalio/workflow';
@@ -26,15 +25,11 @@ export function workflowLogAttributes(info: WorkflowInfo): Record<string, unknow
 
 /** Logs Workflow execution starts and completions */
 export class WorkflowInboundLogInterceptor implements WorkflowInboundCallsInterceptor {
-  protected logAttributes(): Record<string, unknown> {
-    return workflowLogAttributes(workflowInfo());
-  }
-
   execute(input: WorkflowExecuteInput, next: Next<WorkflowInboundCallsInterceptor, 'execute'>): Promise<unknown> {
-    log.debug('Workflow started', this.logAttributes());
+    log.debug('Workflow started');
     const p = next(input).then(
       (res) => {
-        log.debug('Workflow completed', this.logAttributes());
+        log.debug('Workflow completed');
         return res;
       },
       (error) => {
@@ -42,14 +37,14 @@ export class WorkflowInboundLogInterceptor implements WorkflowInboundCallsInterc
         // e.g. by jest or when multiple versions are installed.
         if (typeof error === 'object' && error != null) {
           if (isCancellation(error)) {
-            log.debug('Workflow completed as cancelled', this.logAttributes());
+            log.debug('Workflow completed as cancelled');
             throw error;
           } else if (ContinueAsNew.is(error)) {
-            log.debug('Workflow continued as new', this.logAttributes());
+            log.debug('Workflow continued as new');
             throw error;
           }
         }
-        log.warn('Workflow failed', { error, ...this.logAttributes() });
+        log.warn('Workflow failed', { error });
         throw error;
       }
     );

--- a/packages/workflow/src/sinks.ts
+++ b/packages/workflow/src/sinks.ts
@@ -45,10 +45,10 @@ export interface SinkCall {
  */
 export interface LoggerSinks extends Sinks {
   defaultWorkerLogger: {
-    trace(message: string, attrs: Record<string, unknown>): void;
-    debug(message: string, attrs: Record<string, unknown>): void;
-    info(message: string, attrs: Record<string, unknown>): void;
-    warn(message: string, attrs: Record<string, unknown>): void;
-    error(message: string, attrs: Record<string, unknown>): void;
+    trace(message: string, attrs?: Record<string, unknown>): void;
+    debug(message: string, attrs?: Record<string, unknown>): void;
+    info(message: string, attrs?: Record<string, unknown>): void;
+    warn(message: string, attrs?: Record<string, unknown>): void;
+    error(message: string, attrs?: Record<string, unknown>): void;
   };
 }

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1308,11 +1308,11 @@ export const log: LoggerSinks['defaultWorkerLogger'] = Object.fromEntries(
   (['trace', 'debug', 'info', 'warn', 'error'] as Array<keyof LoggerSinks['defaultWorkerLogger']>).map((level) => {
     return [
       level,
-      (message: string, attrs: Record<string, unknown>) => {
-        assertInWorkflowContext('Workflow.log(...) may only be used from a Workflow Execution.)');
+      (message: string, attrs?: Record<string, unknown>) => {
+        const activator = assertInWorkflowContext('Workflow.log(...) may only be used from a Workflow Execution.');
         return loggerSinks.defaultWorkerLogger[level](message, {
           // Inject the call time in nanosecond resolution as expected by the worker logger.
-          [LogTimestamp]: getActivator().getTimeOfDay(),
+          [LogTimestamp]: activator.getTimeOfDay(),
           ...attrs,
         });
       },


### PR DESCRIPTION
- [Make log attributes optional for defaultWorkerLogger sink](https://github.com/temporalio/sdk-typescript/commit/8d3a3f1770a0962b9f92367f31795d6ce9f66994)
- [Move getting log context from interceptor to sink](https://github.com/temporalio/sdk-typescript/commit/4984534d584b366602998b5f1cda992877d1577a) in order to attach log attributes to all `workflow.log` calls, not just ones made by the `WorkflowInboundLogInterceptor`

The approach taken in this PR trades off the power of modifying the default log attributes from workflow context for simplicity and future extensibility where we may expose workflow task interceptors on the main Node.js thread that can be used to augment the default attributes for logs emitted in `worker.ts` (e.g. https://github.com/temporalio/sdk-typescript/blob/dbcc9e8ef5832296ed739c2bf9c846761b46b47e/packages/worker/src/worker.ts#L1201).