### PR TITLE
feat(workflow): Logger improvements

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -50,7 +50,11 @@ export {
   WorkflowBundlePathWithSourceMap, // eslint-disable-line deprecation/deprecation
 } from './worker-options';
 export { ReplayError, ReplayHistoriesIterable, ReplayResult } from './replay';
-export { WorkflowInboundLogInterceptor, workflowLogAttributes } from './workflow-log-interceptor';
+export {
+  WorkflowInboundLogInterceptor, // eslint-disable-line deprecation/deprecation
+  WorkflowLogInterceptor,
+  workflowLogAttributes,
+} from './workflow-log-interceptor';
 export {
   BundleOptions,
   bundleWorkflowCode,

--- a/packages/workflow/src/interceptors.ts
+++ b/packages/workflow/src/interceptors.ts
@@ -8,7 +8,7 @@
 
 import { ActivityOptions, Headers, LocalActivityOptions, Next, Timestamp, WorkflowExecution } from '@temporalio/common';
 import type { coresdk } from '@temporalio/proto';
-import { ChildWorkflowOptionsWithDefaults, ContinueAsNewOptions } from './interfaces';
+import { ChildWorkflowOptionsWithDefaults, ContinueAsNewOptions, WorkflowInfo } from './interfaces';
 
 export { Next, Headers };
 
@@ -118,6 +118,8 @@ export interface SignalWorkflowInput {
       };
 }
 
+export type GetLogAttributesInput = Record<string, unknown>;
+
 /**
  * Implement any of these methods to intercept Workflow code calls to the Temporal APIs, like scheduling an activity and starting a timer
  */
@@ -161,6 +163,13 @@ export interface WorkflowOutboundCallsInterceptor {
     input: StartChildWorkflowExecutionInput,
     next: Next<this, 'startChildWorkflowExecution'>
   ) => Promise<[Promise<string>, Promise<unknown>]>;
+
+  /**
+   * Called on each invocation of the `workflow.log` methods.
+   *
+   * The attributes returned in this call are attached to every log message.
+   */
+  getLogAttributes?: (input: GetLogAttributesInput, next: Next<this, 'getLogAttributes'>) => Record<string, unknown>;
 }
 
 /** Input for WorkflowInternalsInterceptor.concludeActivation */

--- a/packages/workflow/src/interceptors.ts
+++ b/packages/workflow/src/interceptors.ts
@@ -8,7 +8,7 @@
 
 import { ActivityOptions, Headers, LocalActivityOptions, Next, Timestamp, WorkflowExecution } from '@temporalio/common';
 import type { coresdk } from '@temporalio/proto';
-import { ChildWorkflowOptionsWithDefaults, ContinueAsNewOptions, WorkflowInfo } from './interfaces';
+import { ChildWorkflowOptionsWithDefaults, ContinueAsNewOptions } from './interfaces';
 
 export { Next, Headers };
 
@@ -118,6 +118,7 @@ export interface SignalWorkflowInput {
       };
 }
 
+/** Input for WorkflowOutboundCallsInterceptor.getLogAttributes */
 export type GetLogAttributesInput = Record<string, unknown>;
 
 /**

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -283,6 +283,8 @@ export class Activator implements ActivationHandler {
 
   public readonly registeredActivityNames: Set<string>;
 
+  public logAttributes: Record<string, unknown> = {};
+
   constructor({
     info,
     now,

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -283,7 +283,7 @@ export class Activator implements ActivationHandler {
 
   public readonly registeredActivityNames: Set<string>;
 
-  public logAttributes: Record<string, unknown> = {};
+  public logAttributes: (workflowInfo: WorkflowInfo) => Record<string, unknown> = () => ({});
 
   constructor({
     info,

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -283,8 +283,6 @@ export class Activator implements ActivationHandler {
 
   public readonly registeredActivityNames: Set<string>;
 
-  public logAttributes: (workflowInfo: WorkflowInfo) => Record<string, unknown> = () => ({});
-
   constructor({
     info,
     now,

--- a/packages/workflow/src/sinks.ts
+++ b/packages/workflow/src/sinks.ts
@@ -45,10 +45,10 @@ export interface SinkCall {
  */
 export interface LoggerSinks extends Sinks {
   defaultWorkerLogger: {
-    trace(message: string, attrs: Record<string, unknown>): void;
-    debug(message: string, attrs: Record<string, unknown>): void;
-    info(message: string, attrs: Record<string, unknown>): void;
-    warn(message: string, attrs: Record<string, unknown>): void;
-    error(message: string, attrs: Record<string, unknown>): void;
+    trace(message: string, attrs?: Record<string, unknown>): void;
+    debug(message: string, attrs?: Record<string, unknown>): void;
+    info(message: string, attrs?: Record<string, unknown>): void;
+    warn(message: string, attrs?: Record<string, unknown>): void;
+    error(message: string, attrs?: Record<string, unknown>): void;
   };
 }

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1308,11 +1308,11 @@ export const log: LoggerSinks['defaultWorkerLogger'] = Object.fromEntries(
   (['trace', 'debug', 'info', 'warn', 'error'] as Array<keyof LoggerSinks['defaultWorkerLogger']>).map((level) => {
     return [
       level,
-      (message: string, attrs: Record<string, unknown>) => {
-        assertInWorkflowContext('Workflow.log(...) may only be used from a Workflow Execution.)');
+      (message: string, attrs?: Record<string, unknown>) => {
+        const activator = assertInWorkflowContext('Workflow.log(...) may only be used from a Workflow Execution.');
         return loggerSinks.defaultWorkerLogger[level](message, {
           // Inject the call time in nanosecond resolution as expected by the worker logger.
-          [LogTimestamp]: getActivator().getTimeOfDay(),
+          [LogTimestamp]: activator.getTimeOfDay(),
           ...attrs,
         });
       },

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1313,7 +1313,7 @@ export const log: LoggerSinks['defaultWorkerLogger'] = Object.fromEntries(
         return loggerSinks.defaultWorkerLogger[level](message, {
           // Inject the call time in nanosecond resolution as expected by the worker logger.
           [LogTimestamp]: activator.getTimeOfDay(),
-          ...activator.logAttributes,
+          ...activator.logAttributes(workflowInfo()),
           ...attrs,
         });
       },

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1310,10 +1310,11 @@ export const log: LoggerSinks['defaultWorkerLogger'] = Object.fromEntries(
       level,
       (message: string, attrs?: Record<string, unknown>) => {
         const activator = assertInWorkflowContext('Workflow.log(...) may only be used from a Workflow Execution.');
+        const getLogAttributes = composeInterceptors(activator.interceptors.outbound, 'getLogAttributes', (a) => a);
         return loggerSinks.defaultWorkerLogger[level](message, {
           // Inject the call time in nanosecond resolution as expected by the worker logger.
           [LogTimestamp]: activator.getTimeOfDay(),
-          ...activator.logAttributes(workflowInfo()),
+          ...getLogAttributes({}),
           ...attrs,
         });
       },

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1313,6 +1313,7 @@ export const log: LoggerSinks['defaultWorkerLogger'] = Object.fromEntries(
         return loggerSinks.defaultWorkerLogger[level](message, {
           // Inject the call time in nanosecond resolution as expected by the worker logger.
           [LogTimestamp]: activator.getTimeOfDay(),
+          ...activator.logAttributes,
           ...attrs,
         });
       },


### PR DESCRIPTION
- [Make log attributes optional for defaultWorkerLogger sink](https://github.com/temporalio/sdk-typescript/commit/8d3a3f1770a0962b9f92367f31795d6ce9f66994)
- [Attach log attributes to every workflow log message](https://github.com/temporalio/sdk-typescript/commit/5938b701526a0dc4f199e8cef037250b3177888f)

The approach taken in this PR (compared to the alternative #1158) attaches the log attributes in workflow context where the user has more control.