### PR TITLE
fix: Remove instanceof Error checks from `is` methods

### DIFF
--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -117,7 +117,7 @@ export class CompleteAsyncError extends Error {
    * Instanceof check that works when multiple versions of @temporalio/activity are installed.
    */
   static is(error: unknown): error is CompleteAsyncError {
-    return error instanceof CompleteAsyncError || (error instanceof Error && (error as any)[isCompleteAsyncError]);
+    return error instanceof CompleteAsyncError || (error as any)?.[isCompleteAsyncError] === true;
   }
 }
 

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -66,7 +66,7 @@ export class TemporalFailure extends Error {
    * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is TemporalFailure {
-    return error instanceof TemporalFailure || (error instanceof Error && (error as any)[isTemporalFailure]);
+    return error instanceof TemporalFailure || (error as any)?.[isTemporalFailure] === true;
   }
 }
 
@@ -89,7 +89,7 @@ export class ServerFailure extends TemporalFailure {
    * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is ServerFailure {
-    return error instanceof ServerFailure || (error instanceof Error && (error as any)[isServerFailure]);
+    return error instanceof ServerFailure || (error as any)?.[isServerFailure] === true;
   }
 }
 
@@ -142,7 +142,7 @@ export class ApplicationFailure extends TemporalFailure {
    * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is ApplicationFailure {
-    return error instanceof ApplicationFailure || (error instanceof Error && (error as any)[isApplicationFailure]);
+    return error instanceof ApplicationFailure || (error as any)?.[isApplicationFailure] === true;
   }
 
   /**
@@ -248,7 +248,7 @@ export class CancelledFailure extends TemporalFailure {
    * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is CancelledFailure {
-    return error instanceof CancelledFailure || (error instanceof Error && (error as any)[isCancelledFailure]);
+    return error instanceof CancelledFailure || (error as any)?.[isCancelledFailure] === true;
   }
 }
 
@@ -273,7 +273,7 @@ export class TerminatedFailure extends TemporalFailure {
    * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is TerminatedFailure {
-    return error instanceof TerminatedFailure || (error instanceof Error && (error as any)[isTerminatedFailure]);
+    return error instanceof TerminatedFailure || (error as any)?.[isTerminatedFailure] === true;
   }
 }
 
@@ -302,7 +302,7 @@ export class TimeoutFailure extends TemporalFailure {
    * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is TimeoutFailure {
-    return error instanceof TimeoutFailure || (error instanceof Error && (error as any)[isTimeoutFailure]);
+    return error instanceof TimeoutFailure || (error as any)?.[isTimeoutFailure] === true;
   }
 }
 
@@ -337,7 +337,7 @@ export class ActivityFailure extends TemporalFailure {
    * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is ActivityFailure {
-    return error instanceof ActivityFailure || (error instanceof Error && (error as any)[isActivityFailure]);
+    return error instanceof ActivityFailure || (error as any)?.[isActivityFailure] === true;
   }
 }
 
@@ -371,7 +371,7 @@ export class ChildWorkflowFailure extends TemporalFailure {
    * Instanceof check that works when multiple versions of @temporalio/common are installed.
    */
   static is(error: unknown): error is ChildWorkflowFailure {
-    return error instanceof ChildWorkflowFailure || (error instanceof Error && (error as any)[isChildWorkflowFailure]);
+    return error instanceof ChildWorkflowFailure || (error as any)?.[isChildWorkflowFailure] === true;
   }
 }
 

--- a/packages/core-bridge/ts/errors.ts
+++ b/packages/core-bridge/ts/errors.ts
@@ -17,7 +17,7 @@ export class ShutdownError extends Error {
    * Instanceof check that works when multiple versions of @temporalio/core-bridge are installed.
    */
   static is(error: unknown): error is ShutdownError {
-    return error instanceof ShutdownError || (error instanceof Error && (error as any)[isShutdownError]);
+    return error instanceof ShutdownError || (error as any)?.[isShutdownError] === true;
   }
 }
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -186,7 +186,7 @@ export class ContinueAsNew extends Error {
    * Instanceof check that works when multiple versions of @temporalio/workflow are installed.
    */
   static is(error: unknown): error is ContinueAsNew {
-    return error instanceof ContinueAsNew || (error instanceof Error && (error as any)[isContinueAsNew]);
+    return error instanceof ContinueAsNew || (error as any)?.[isContinueAsNew] === true;
   }
 }
 


### PR DESCRIPTION
This doesn't work when errors are passed from different v8 contexts.
Only known to affect ShutdownError with jest (see https://github.com/jestjs/jest/issues/2549).