### PR TITLE
Use custom symbol-based impl of `instanceof`

### DIFF
--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -73,6 +73,7 @@ import 'abort-controller/polyfill'; // eslint-disable-line import/no-unassigned-
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { Logger, Duration } from '@temporalio/common';
 import { msToNumber } from '@temporalio/common/lib/time';
+import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
 
 export {
   ActivityFunction,
@@ -81,8 +82,6 @@ export {
   CancelledFailure,
   UntypedActivities,
 } from '@temporalio/common';
-
-const isCompleteAsyncError = Symbol.for('__temporal_isCompleteAsyncError');
 
 /**
  * Throw this error from an Activity in order to make the Worker forget about this Activity.
@@ -101,23 +100,12 @@ const isCompleteAsyncError = Symbol.for('__temporal_isCompleteAsyncError');
  *}
  *```
  */
+@symbolBasedInstanceOf('CompleteAsyncError')
 export class CompleteAsyncError extends Error {
   public readonly name: string = 'CompleteAsyncError';
 
   constructor() {
     super();
-  }
-
-  /**
-   * Marker to determine whether an error is an instance of CompleteAsyncError.
-   */
-  protected readonly [isCompleteAsyncError] = true;
-
-  /**
-   * Instanceof check that works when multiple versions of @temporalio/activity are installed.
-   */
-  static is(error: unknown): error is CompleteAsyncError {
-    return error instanceof CompleteAsyncError || (error as any)?.[isCompleteAsyncError] === true;
   }
 }
 

--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -73,7 +73,7 @@ import 'abort-controller/polyfill'; // eslint-disable-line import/no-unassigned-
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { Logger, Duration } from '@temporalio/common';
 import { msToNumber } from '@temporalio/common/lib/time';
-import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
+import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 
 export {
   ActivityFunction,
@@ -100,14 +100,8 @@ export {
  *}
  *```
  */
-@symbolBasedInstanceOf('CompleteAsyncError')
-export class CompleteAsyncError extends Error {
-  public readonly name: string = 'CompleteAsyncError';
-
-  constructor() {
-    super();
-  }
-}
+@SymbolBasedInstanceOfError('CompleteAsyncError')
+export class CompleteAsyncError extends Error {}
 
 // Make it safe to use @temporalio/activity with multiple versions installed.
 const asyncLocalStorageSymbol = Symbol.for('__temporal_activity_context_storage__');

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -6,6 +6,7 @@ import {
   encodeToPayloads,
   filterNullAndUndefined,
 } from '@temporalio/common/lib/internal-non-workflow';
+import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
 import {
   BaseClient,
   BaseClientOptions,
@@ -21,6 +22,7 @@ import { rethrowKnownErrorTypes } from './helpers';
  * Thrown by {@link AsyncCompletionClient} when trying to complete or heartbeat an Activity that does not exist in the
  * system.
  */
+@symbolBasedInstanceOf('ActivityNotFoundError')
 export class ActivityNotFoundError extends Error {
   public readonly name = 'ActivityNotFoundError';
 }
@@ -29,6 +31,7 @@ export class ActivityNotFoundError extends Error {
  * Thrown by {@link AsyncCompletionClient} when trying to complete or heartbeat
  * an Activity for any reason apart from {@link ActivityNotFoundError}.
  */
+@symbolBasedInstanceOf('ActivityCompletionError')
 export class ActivityCompletionError extends Error {
   public readonly name = 'ActivityCompletionError';
 }
@@ -37,6 +40,7 @@ export class ActivityCompletionError extends Error {
  * Thrown by {@link AsyncCompletionClient.heartbeat} when the Workflow has
  * requested to cancel the reporting Activity.
  */
+@symbolBasedInstanceOf('ActivityCancelledError')
 export class ActivityCancelledError extends Error {
   public readonly name = 'ActivityCancelledError';
 }

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -6,7 +6,7 @@ import {
   encodeToPayloads,
   filterNullAndUndefined,
 } from '@temporalio/common/lib/internal-non-workflow';
-import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
+import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 import {
   BaseClient,
   BaseClientOptions,
@@ -22,28 +22,22 @@ import { rethrowKnownErrorTypes } from './helpers';
  * Thrown by {@link AsyncCompletionClient} when trying to complete or heartbeat an Activity that does not exist in the
  * system.
  */
-@symbolBasedInstanceOf('ActivityNotFoundError')
-export class ActivityNotFoundError extends Error {
-  public readonly name = 'ActivityNotFoundError';
-}
+@SymbolBasedInstanceOfError('ActivityNotFoundError')
+export class ActivityNotFoundError extends Error {}
 
 /**
  * Thrown by {@link AsyncCompletionClient} when trying to complete or heartbeat
  * an Activity for any reason apart from {@link ActivityNotFoundError}.
  */
-@symbolBasedInstanceOf('ActivityCompletionError')
-export class ActivityCompletionError extends Error {
-  public readonly name = 'ActivityCompletionError';
-}
+@SymbolBasedInstanceOfError('ActivityCompletionError')
+export class ActivityCompletionError extends Error {}
 
 /**
  * Thrown by {@link AsyncCompletionClient.heartbeat} when the Workflow has
  * requested to cancel the reporting Activity.
  */
-@symbolBasedInstanceOf('ActivityCancelledError')
-export class ActivityCancelledError extends Error {
-  public readonly name = 'ActivityCancelledError';
-}
+@SymbolBasedInstanceOfError('ActivityCancelledError')
+export class ActivityCancelledError extends Error {}
 
 /**
  * Options used to configure {@link AsyncCompletionClient}

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,9 +1,11 @@
 import { ServiceError as GrpcServiceError } from '@grpc/grpc-js';
 import { RetryState, TemporalFailure } from '@temporalio/common';
+import { isError, isRecord, symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
 
 /**
  * Generic Error class for errors coming from the service
  */
+@symbolBasedInstanceOf('ServiceError')
 export class ServiceError extends Error {
   public readonly name: string = 'ServiceError';
   public readonly cause?: Error;
@@ -23,6 +25,7 @@ export class ServiceError extends Error {
  * For example if the workflow is cancelled, `cause` will be set to
  * {@link CancelledFailure}.
  */
+@symbolBasedInstanceOf('WorkflowFailedError')
 export class WorkflowFailedError extends Error {
   public readonly name: string = 'WorkflowFailedError';
   public constructor(
@@ -40,6 +43,7 @@ export class WorkflowFailedError extends Error {
  *
  * Only thrown if asked not to follow the chain of execution (see {@link WorkflowOptions.followRuns}).
  */
+@symbolBasedInstanceOf('WorkflowContinuedAsNewError')
 export class WorkflowContinuedAsNewError extends Error {
   public readonly name: string = 'WorkflowExecutionContinuedAsNewError';
   public constructor(message: string, public readonly newExecutionRunId: string) {
@@ -48,7 +52,11 @@ export class WorkflowContinuedAsNewError extends Error {
 }
 
 export function isGrpcServiceError(err: unknown): err is GrpcServiceError {
-  return err instanceof Error && (err as any).details !== undefined && (err as any).metadata !== undefined;
+  return (
+    isError(err) &&
+    typeof (err as GrpcServiceError)?.details === 'string' &&
+    isRecord((err as GrpcServiceError).metadata)
+  );
 }
 
 /**

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,13 +1,12 @@
 import { ServiceError as GrpcServiceError } from '@grpc/grpc-js';
 import { RetryState, TemporalFailure } from '@temporalio/common';
-import { isError, isRecord, symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
+import { isError, isRecord, SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 
 /**
  * Generic Error class for errors coming from the service
  */
-@symbolBasedInstanceOf('ServiceError')
+@SymbolBasedInstanceOfError('ServiceError')
 export class ServiceError extends Error {
-  public readonly name: string = 'ServiceError';
   public readonly cause?: Error;
 
   constructor(message: string, opts?: { cause: Error }) {
@@ -25,9 +24,8 @@ export class ServiceError extends Error {
  * For example if the workflow is cancelled, `cause` will be set to
  * {@link CancelledFailure}.
  */
-@symbolBasedInstanceOf('WorkflowFailedError')
+@SymbolBasedInstanceOfError('WorkflowFailedError')
 export class WorkflowFailedError extends Error {
-  public readonly name: string = 'WorkflowFailedError';
   public constructor(
     message: string,
     public readonly cause: TemporalFailure | undefined,
@@ -43,9 +41,8 @@ export class WorkflowFailedError extends Error {
  *
  * Only thrown if asked not to follow the chain of execution (see {@link WorkflowOptions.followRuns}).
  */
-@symbolBasedInstanceOf('WorkflowContinuedAsNewError')
+@SymbolBasedInstanceOfError('WorkflowExecutionContinuedAsNewError')
 export class WorkflowContinuedAsNewError extends Error {
-  public readonly name: string = 'WorkflowExecutionContinuedAsNewError';
   public constructor(message: string, public readonly newExecutionRunId: string) {
     super(message);
   }

--- a/packages/client/src/iterators-utils.ts
+++ b/packages/client/src/iterators-utils.ts
@@ -1,5 +1,6 @@
 import 'abort-controller/polyfill'; // eslint-disable-line import/no-unassigned-import
 import { EventEmitter, on, once } from 'node:events';
+import { isAbortError } from '@temporalio/common/lib/type-helpers';
 
 export interface MapAsyncOptions {
   /**
@@ -108,7 +109,7 @@ export async function* mapAsyncIterable<A, B>(
       yield res;
     }
   } catch (err: unknown) {
-    if ((err as Error)?.name === 'AbortError') {
+    if (isAbortError(err)) {
       return;
     }
     throw err;

--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -9,7 +9,7 @@ import {
 } from '@temporalio/common/lib/internal-non-workflow';
 import { temporal } from '@temporalio/proto';
 import { optionalDateToTs, optionalTsToDate, optionalTsToMs, tsToDate } from '@temporalio/common/lib/time';
-import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
+import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 import { CreateScheduleInput, CreateScheduleOutput, ScheduleClientInterceptor } from './interceptors';
 import { WorkflowService } from './types';
 import { isGrpcServiceError, ServiceError } from './errors';
@@ -527,10 +527,8 @@ export class ScheduleClient extends BaseClient {
  *
  * @experimental
  */
-@symbolBasedInstanceOf('ScheduleAlreadyRunning')
+@SymbolBasedInstanceOfError('ScheduleAlreadyRunning')
 export class ScheduleAlreadyRunning extends Error {
-  public readonly name: string = 'ScheduleAlreadyRunning';
-
   constructor(message: string, public readonly scheduleId: string) {
     super(message);
   }
@@ -544,10 +542,8 @@ export class ScheduleAlreadyRunning extends Error {
  *
  * @experimental
  */
-@symbolBasedInstanceOf('ScheduleNotFoundError')
+@SymbolBasedInstanceOfError('ScheduleNotFoundError')
 export class ScheduleNotFoundError extends Error {
-  public readonly name: string = 'ScheduleNotFoundError';
-
   constructor(message: string, public readonly scheduleId: string) {
     super(message);
   }

--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -527,7 +527,7 @@ export class ScheduleClient extends BaseClient {
  *
  * @experimental
  */
-@symbolBasedInstanceOf('ScheduleAlreadyExistsError')
+@symbolBasedInstanceOf('ScheduleAlreadyRunning')
 export class ScheduleAlreadyRunning extends Error {
   public readonly name: string = 'ScheduleAlreadyRunning';
 

--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -9,6 +9,7 @@ import {
 } from '@temporalio/common/lib/internal-non-workflow';
 import { temporal } from '@temporalio/proto';
 import { optionalDateToTs, optionalTsToDate, optionalTsToMs, tsToDate } from '@temporalio/common/lib/time';
+import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
 import { CreateScheduleInput, CreateScheduleOutput, ScheduleClientInterceptor } from './interceptors';
 import { WorkflowService } from './types';
 import { isGrpcServiceError, ServiceError } from './errors';
@@ -526,6 +527,7 @@ export class ScheduleClient extends BaseClient {
  *
  * @experimental
  */
+@symbolBasedInstanceOf('ScheduleAlreadyExistsError')
 export class ScheduleAlreadyRunning extends Error {
   public readonly name: string = 'ScheduleAlreadyRunning';
 
@@ -542,6 +544,7 @@ export class ScheduleAlreadyRunning extends Error {
  *
  * @experimental
  */
+@symbolBasedInstanceOf('ScheduleNotFoundError')
 export class ScheduleNotFoundError extends Error {
   public readonly name: string = 'ScheduleNotFoundError';
 

--- a/packages/client/src/task-queue-client.ts
+++ b/packages/client/src/task-queue-client.ts
@@ -1,6 +1,6 @@
 import { status } from '@grpc/grpc-js';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-non-workflow';
-import { assertNever, symbolBasedInstanceOf, RequireAtLeastOne } from '@temporalio/common/lib/type-helpers';
+import { assertNever, SymbolBasedInstanceOfError, RequireAtLeastOne } from '@temporalio/common/lib/type-helpers';
 import { temporal } from '@temporalio/proto';
 import { BaseClient, BaseClientOptions, defaultBaseClientOptions, LoadedWithDefaults } from './base-client';
 import { WorkflowService } from './types';
@@ -288,11 +288,5 @@ function reachabilityTypeFromProto(rtype: temporal.api.enums.v1.TaskReachability
  *
  * @experimental
  */
-@symbolBasedInstanceOf('BuildIdNotFoundError')
-export class BuildIdNotFoundError extends Error {
-  public readonly name: string = 'BuildIdNotFoundError';
-
-  constructor(message: string) {
-    super(message);
-  }
-}
+@SymbolBasedInstanceOfError('BuildIdNotFoundError')
+export class BuildIdNotFoundError extends Error {}

--- a/packages/client/src/task-queue-client.ts
+++ b/packages/client/src/task-queue-client.ts
@@ -1,6 +1,6 @@
 import { status } from '@grpc/grpc-js';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-non-workflow';
-import { assertNever, RequireAtLeastOne } from '@temporalio/common/lib/type-helpers';
+import { assertNever, symbolBasedInstanceOf, RequireAtLeastOne } from '@temporalio/common/lib/type-helpers';
 import { temporal } from '@temporalio/proto';
 import { BaseClient, BaseClientOptions, defaultBaseClientOptions, LoadedWithDefaults } from './base-client';
 import { WorkflowService } from './types';
@@ -288,6 +288,7 @@ function reachabilityTypeFromProto(rtype: temporal.api.enums.v1.TaskReachability
  *
  * @experimental
  */
+@symbolBasedInstanceOf('BuildIdNotFoundError')
 export class BuildIdNotFoundError extends Error {
   public readonly name: string = 'BuildIdNotFoundError';
 

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -22,7 +22,7 @@ import {
 } from '@temporalio/common';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import { History } from '@temporalio/common/lib/proto-utils';
-import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
+import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 import {
   decodeArrayFromPayloads,
   decodeFromPayloadsAtIndex,
@@ -993,17 +993,15 @@ export class WorkflowClient extends BaseClient {
   }
 }
 
-@symbolBasedInstanceOf('QueryRejectedError')
+@SymbolBasedInstanceOfError('QueryRejectedError')
 export class QueryRejectedError extends Error {
-  public readonly name: string = 'QueryRejectedError';
   constructor(public readonly status: temporal.api.enums.v1.WorkflowExecutionStatus) {
     super('Query rejected');
   }
 }
 
-@symbolBasedInstanceOf('QueryNotRegisteredError')
+@SymbolBasedInstanceOfError('QueryNotRegisteredError')
 export class QueryNotRegisteredError extends Error {
-  public readonly name: string = 'QueryNotRegisteredError';
   constructor(message: string, public readonly code: grpcStatus) {
     super(message);
   }

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -22,6 +22,7 @@ import {
 } from '@temporalio/common';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import { History } from '@temporalio/common/lib/proto-utils';
+import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
 import {
   decodeArrayFromPayloads,
   decodeFromPayloadsAtIndex,
@@ -992,6 +993,7 @@ export class WorkflowClient extends BaseClient {
   }
 }
 
+@symbolBasedInstanceOf('QueryRejectedError')
 export class QueryRejectedError extends Error {
   public readonly name: string = 'QueryRejectedError';
   constructor(public readonly status: temporal.api.enums.v1.WorkflowExecutionStatus) {
@@ -999,6 +1001,7 @@ export class QueryRejectedError extends Error {
   }
 }
 
+@symbolBasedInstanceOf('QueryNotRegisteredError')
 export class QueryNotRegisteredError extends Error {
   public readonly name: string = 'QueryNotRegisteredError';
   constructor(message: string, public readonly code: grpcStatus) {

--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -260,7 +260,7 @@ export class SearchAttributePayloadConverter implements PayloadConverter {
   validNonDateTypes = ['string', 'number', 'boolean'];
 
   public toPayload(values: unknown): Payload {
-    if (!(values instanceof Array)) {
+    if (!Array.isArray(values)) {
       throw new ValueError(`SearchAttribute value must be an array`);
     }
 
@@ -309,7 +309,7 @@ export class SearchAttributePayloadConverter implements PayloadConverter {
     }
 
     const value = this.jsonConverter.fromPayload(payload);
-    let arrayWrappedValue = value instanceof Array ? value : [value];
+    let arrayWrappedValue = Array.isArray(value) ? value : [value];
 
     const searchAttributeType = decode(payload.metadata.type);
     if (searchAttributeType === 'Datetime') {

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -1,8 +1,10 @@
 import { TemporalFailure } from './failure';
+import { symbolBasedInstanceOf } from './type-helpers';
 
 /**
  * Thrown from code that receives a value that is unexpected or that it's unable to handle.
  */
+@symbolBasedInstanceOf('ValueError')
 export class ValueError extends Error {
   public readonly name: string = 'ValueError';
 
@@ -14,6 +16,7 @@ export class ValueError extends Error {
 /**
  * Thrown when a Payload Converter is misconfigured.
  */
+@symbolBasedInstanceOf('PayloadConverterError')
 export class PayloadConverterError extends ValueError {
   public readonly name: string = 'PayloadConverterError';
 }
@@ -21,11 +24,10 @@ export class PayloadConverterError extends ValueError {
 /**
  * Used in different parts of the SDK to note that something unexpected has happened.
  */
+@symbolBasedInstanceOf('IllegalStateError')
 export class IllegalStateError extends Error {
   public readonly name: string = 'IllegalStateError';
 }
-
-const isWorkflowExecutionAlreadyStartedError = Symbol.for('__temporal_isWorkflowExecutionAlreadyStartedError');
 
 /**
  * This exception is thrown in the following cases:
@@ -35,26 +37,12 @@ const isWorkflowExecutionAlreadyStartedError = Symbol.for('__temporal_isWorkflow
  *  - There is closed Workflow in the `Completed` state with the same Workflow Id and the {@link WorkflowOptions.workflowIdReusePolicy}
  *    is `WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY`
  */
+@symbolBasedInstanceOf('WorkflowExecutionAlreadyStartedError')
 export class WorkflowExecutionAlreadyStartedError extends TemporalFailure {
   public readonly name: string = 'WorkflowExecutionAlreadyStartedError';
 
   constructor(message: string, public readonly workflowId: string, public readonly workflowType: string) {
     super(message);
-  }
-
-  /**
-   * Marker to determine whether an error is an instance of WorkflowExecutionAlreadyStartedError.
-   */
-  protected readonly [isWorkflowExecutionAlreadyStartedError] = true;
-
-  /**
-   * Instanceof check that works when multiple versions of @temporalio/common are installed.
-   */
-  static is(error: unknown): error is WorkflowExecutionAlreadyStartedError {
-    return (
-      error instanceof WorkflowExecutionAlreadyStartedError ||
-      (error instanceof Error && (error as any)[isWorkflowExecutionAlreadyStartedError])
-    );
   }
 }
 
@@ -65,6 +53,7 @@ export class WorkflowExecutionAlreadyStartedError extends TemporalFailure {
  * - Workflow is closed (for some calls, e.g. `terminate`)
  * - Workflow was deleted from the Server after reaching its retention limit
  */
+@symbolBasedInstanceOf('WorkflowNotFoundError')
 export class WorkflowNotFoundError extends Error {
   public readonly name: string = 'WorkflowNotFoundError';
 
@@ -76,6 +65,7 @@ export class WorkflowNotFoundError extends Error {
 /**
  * Thrown when the specified namespace is not known to Temporal Server.
  */
+@symbolBasedInstanceOf('NamespaceNotFoundError')
 export class NamespaceNotFoundError extends Error {
   public readonly name: string = 'NamespaceNotFoundError';
 

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -1,13 +1,11 @@
 import { TemporalFailure } from './failure';
-import { symbolBasedInstanceOf } from './type-helpers';
+import { SymbolBasedInstanceOfError } from './type-helpers';
 
 /**
  * Thrown from code that receives a value that is unexpected or that it's unable to handle.
  */
-@symbolBasedInstanceOf('ValueError')
+@SymbolBasedInstanceOfError('ValueError')
 export class ValueError extends Error {
-  public readonly name: string = 'ValueError';
-
   constructor(message: string | undefined, public readonly cause?: unknown) {
     super(message ?? undefined);
   }
@@ -16,18 +14,14 @@ export class ValueError extends Error {
 /**
  * Thrown when a Payload Converter is misconfigured.
  */
-@symbolBasedInstanceOf('PayloadConverterError')
-export class PayloadConverterError extends ValueError {
-  public readonly name: string = 'PayloadConverterError';
-}
+@SymbolBasedInstanceOfError('PayloadConverterError')
+export class PayloadConverterError extends ValueError {}
 
 /**
  * Used in different parts of the SDK to note that something unexpected has happened.
  */
-@symbolBasedInstanceOf('IllegalStateError')
-export class IllegalStateError extends Error {
-  public readonly name: string = 'IllegalStateError';
-}
+@SymbolBasedInstanceOfError('IllegalStateError')
+export class IllegalStateError extends Error {}
 
 /**
  * This exception is thrown in the following cases:
@@ -37,10 +31,8 @@ export class IllegalStateError extends Error {
  *  - There is closed Workflow in the `Completed` state with the same Workflow Id and the {@link WorkflowOptions.workflowIdReusePolicy}
  *    is `WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY`
  */
-@symbolBasedInstanceOf('WorkflowExecutionAlreadyStartedError')
+@SymbolBasedInstanceOfError('WorkflowExecutionAlreadyStartedError')
 export class WorkflowExecutionAlreadyStartedError extends TemporalFailure {
-  public readonly name: string = 'WorkflowExecutionAlreadyStartedError';
-
   constructor(message: string, public readonly workflowId: string, public readonly workflowType: string) {
     super(message);
   }
@@ -53,10 +45,8 @@ export class WorkflowExecutionAlreadyStartedError extends TemporalFailure {
  * - Workflow is closed (for some calls, e.g. `terminate`)
  * - Workflow was deleted from the Server after reaching its retention limit
  */
-@symbolBasedInstanceOf('WorkflowNotFoundError')
+@SymbolBasedInstanceOfError('WorkflowNotFoundError')
 export class WorkflowNotFoundError extends Error {
-  public readonly name: string = 'WorkflowNotFoundError';
-
   constructor(message: string, public readonly workflowId: string, public readonly runId: string | undefined) {
     super(message);
   }
@@ -65,10 +55,8 @@ export class WorkflowNotFoundError extends Error {
 /**
  * Thrown when the specified namespace is not known to Temporal Server.
  */
-@symbolBasedInstanceOf('NamespaceNotFoundError')
+@SymbolBasedInstanceOfError('NamespaceNotFoundError')
 export class NamespaceNotFoundError extends Error {
-  public readonly name: string = 'NamespaceNotFoundError';
-
   constructor(public readonly namespace: string) {
     super(`Namespace not found: '${namespace}'`);
   }

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -1,5 +1,5 @@
 import type { temporal } from '@temporalio/proto';
-import { checkExtends, errorMessage, isRecord, symbolBasedInstanceOf } from './type-helpers';
+import { checkExtends, errorMessage, isRecord, SymbolBasedInstanceOfError } from './type-helpers';
 
 export const FAILURE_SOURCE = 'TypeScriptSDK';
 export type ProtoFailure = temporal.api.failure.v1.IFailure;
@@ -42,9 +42,8 @@ export type WorkflowExecution = temporal.api.common.v1.IWorkflowExecution;
  *
  * The only child class you should ever throw from your code is {@link ApplicationFailure}.
  */
-@symbolBasedInstanceOf('TemporalFailure')
+@SymbolBasedInstanceOfError('TemporalFailure')
 export class TemporalFailure extends Error {
-  public readonly name: string = 'TemporalFailure';
   /**
    * The original failure that constructed this error.
    *
@@ -58,10 +57,8 @@ export class TemporalFailure extends Error {
 }
 
 /** Exceptions originated at the Temporal service. */
-@symbolBasedInstanceOf('ServerFailure')
+@SymbolBasedInstanceOfError('ServerFailure')
 export class ServerFailure extends TemporalFailure {
-  public readonly name: string = 'ServerFailure';
-
   constructor(message: string | undefined, public readonly nonRetryable: boolean, cause?: Error) {
     super(message, cause);
   }
@@ -89,10 +86,8 @@ export class ServerFailure extends TemporalFailure {
  * `ApplicationFailure` from the last Activity Task will be the `cause` of the {@link ActivityFailure} thrown in the
  * Workflow.
  */
-@symbolBasedInstanceOf('ApplicationFailure')
+@SymbolBasedInstanceOfError('ApplicationFailure')
 export class ApplicationFailure extends TemporalFailure {
-  public readonly name: string = 'ApplicationFailure';
-
   /**
    * Alternatively, use {@link fromError} or {@link create}.
    */
@@ -191,10 +186,8 @@ export interface ApplicationFailureOptions {
  *
  * When a Workflow or Activity has been successfully cancelled, a `CancelledFailure` will be the `cause`.
  */
-@symbolBasedInstanceOf('CancelledFailure')
+@SymbolBasedInstanceOfError('CancelledFailure')
 export class CancelledFailure extends TemporalFailure {
-  public readonly name: string = 'CancelledFailure';
-
   constructor(message: string | undefined, public readonly details: unknown[] = [], cause?: Error) {
     super(message, cause);
   }
@@ -203,10 +196,8 @@ export class CancelledFailure extends TemporalFailure {
 /**
  * Used as the `cause` when a Workflow has been terminated
  */
-@symbolBasedInstanceOf('TerminatedFailure')
+@SymbolBasedInstanceOfError('TerminatedFailure')
 export class TerminatedFailure extends TemporalFailure {
-  public readonly name: string = 'TerminatedFailure';
-
   constructor(message: string | undefined, cause?: Error) {
     super(message, cause);
   }
@@ -215,10 +206,8 @@ export class TerminatedFailure extends TemporalFailure {
 /**
  * Used to represent timeouts of Activities and Workflows
  */
-@symbolBasedInstanceOf('TimeoutFailure')
+@SymbolBasedInstanceOfError('TimeoutFailure')
 export class TimeoutFailure extends TemporalFailure {
-  public readonly name: string = 'TimeoutFailure';
-
   constructor(
     message: string | undefined,
     public readonly lastHeartbeatDetails: unknown,
@@ -234,10 +223,8 @@ export class TimeoutFailure extends TemporalFailure {
  *
  * This exception is expected to be thrown only by the framework code.
  */
-@symbolBasedInstanceOf('ActivityFailure')
+@SymbolBasedInstanceOfError('ActivityFailure')
 export class ActivityFailure extends TemporalFailure {
-  public readonly name: string = 'ActivityFailure';
-
   public constructor(
     message: string | undefined,
     public readonly activityType: string,
@@ -256,10 +243,8 @@ export class ActivityFailure extends TemporalFailure {
  *
  * This exception is expected to be thrown only by the framework code.
  */
-@symbolBasedInstanceOf('ChildWorkflowFailure')
+@SymbolBasedInstanceOfError('ChildWorkflowFailure')
 export class ChildWorkflowFailure extends TemporalFailure {
-  public readonly name: string = 'ChildWorkflowFailure';
-
   public constructor(
     public readonly namespace: string | undefined,
     public readonly execution: WorkflowExecution,

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -1,5 +1,5 @@
 import type { temporal } from '@temporalio/proto';
-import { checkExtends, isRecord } from './type-helpers';
+import { checkExtends, errorMessage, isRecord, symbolBasedInstanceOf } from './type-helpers';
 
 export const FAILURE_SOURCE = 'TypeScriptSDK';
 export type ProtoFailure = temporal.api.failure.v1.IFailure;
@@ -35,8 +35,6 @@ checkExtends<RetryState, temporal.api.enums.v1.RetryState>();
 
 export type WorkflowExecution = temporal.api.common.v1.IWorkflowExecution;
 
-const isTemporalFailure = Symbol.for('__temporal_isTemporalFailure');
-
 /**
  * Represents failures that can cross Workflow and Activity boundaries.
  *
@@ -44,6 +42,7 @@ const isTemporalFailure = Symbol.for('__temporal_isTemporalFailure');
  *
  * The only child class you should ever throw from your code is {@link ApplicationFailure}.
  */
+@symbolBasedInstanceOf('TemporalFailure')
 export class TemporalFailure extends Error {
   public readonly name: string = 'TemporalFailure';
   /**
@@ -56,44 +55,17 @@ export class TemporalFailure extends Error {
   constructor(message?: string | undefined | null, public readonly cause?: Error) {
     super(message ?? undefined);
   }
-
-  /**
-   * Marker to determine whether an error is an instance of TemporalFailure.
-   */
-  protected readonly [isTemporalFailure] = true;
-
-  /**
-   * Instanceof check that works when multiple versions of @temporalio/common are installed.
-   */
-  static is(error: unknown): error is TemporalFailure {
-    return error instanceof TemporalFailure || (error as any)?.[isTemporalFailure] === true;
-  }
 }
 
-const isServerFailure = Symbol.for('__temporal_isServerFailure');
-
 /** Exceptions originated at the Temporal service. */
+@symbolBasedInstanceOf('ServerFailure')
 export class ServerFailure extends TemporalFailure {
   public readonly name: string = 'ServerFailure';
 
   constructor(message: string | undefined, public readonly nonRetryable: boolean, cause?: Error) {
     super(message, cause);
   }
-
-  /**
-   * Marker to determine whether an error is an instance of ServerFailure.
-   */
-  protected readonly [isServerFailure] = true;
-
-  /**
-   * Instanceof check that works when multiple versions of @temporalio/common are installed.
-   */
-  static is(error: unknown): error is ServerFailure {
-    return error instanceof ServerFailure || (error as any)?.[isServerFailure] === true;
-  }
 }
-
-const isApplicationFailure = Symbol.for('__temporal_isApplicationFailure');
 
 /**
  * `ApplicationFailure`s are used to communicate application-specific failures in Workflows and Activities.
@@ -117,6 +89,7 @@ const isApplicationFailure = Symbol.for('__temporal_isApplicationFailure');
  * `ApplicationFailure` from the last Activity Task will be the `cause` of the {@link ActivityFailure} thrown in the
  * Workflow.
  */
+@symbolBasedInstanceOf('ApplicationFailure')
 export class ApplicationFailure extends TemporalFailure {
   public readonly name: string = 'ApplicationFailure';
 
@@ -131,18 +104,6 @@ export class ApplicationFailure extends TemporalFailure {
     cause?: Error
   ) {
     super(message, cause);
-  }
-
-  /**
-   * Marker to determine whether an error is an instance of ApplicationFailure.
-   */
-  protected readonly [isApplicationFailure] = true;
-
-  /**
-   * Instanceof check that works when multiple versions of @temporalio/common are installed.
-   */
-  static is(error: unknown): error is ApplicationFailure {
-    return error instanceof ApplicationFailure || (error as any)?.[isApplicationFailure] === true;
   }
 
   /**
@@ -223,8 +184,6 @@ export interface ApplicationFailureOptions {
   cause?: Error;
 }
 
-const isCancelledFailure = Symbol.for('__temporal_isCancelledFailure');
-
 /**
  * This error is thrown when Cancellation has been requested. To allow Cancellation to happen, let it propagate. To
  * ignore Cancellation, catch it and continue executing. Note that Cancellation can only be requested a single time, so
@@ -232,56 +191,31 @@ const isCancelledFailure = Symbol.for('__temporal_isCancelledFailure');
  *
  * When a Workflow or Activity has been successfully cancelled, a `CancelledFailure` will be the `cause`.
  */
+@symbolBasedInstanceOf('CancelledFailure')
 export class CancelledFailure extends TemporalFailure {
   public readonly name: string = 'CancelledFailure';
 
   constructor(message: string | undefined, public readonly details: unknown[] = [], cause?: Error) {
     super(message, cause);
   }
-
-  /**
-   * Marker to determine whether an error is an instance of CancelledFailure.
-   */
-  protected readonly [isCancelledFailure] = true;
-
-  /**
-   * Instanceof check that works when multiple versions of @temporalio/common are installed.
-   */
-  static is(error: unknown): error is CancelledFailure {
-    return error instanceof CancelledFailure || (error as any)?.[isCancelledFailure] === true;
-  }
 }
-
-const isTerminatedFailure = Symbol.for('__temporal_isTerminatedFailure');
 
 /**
  * Used as the `cause` when a Workflow has been terminated
  */
+@symbolBasedInstanceOf('TerminatedFailure')
 export class TerminatedFailure extends TemporalFailure {
   public readonly name: string = 'TerminatedFailure';
 
   constructor(message: string | undefined, cause?: Error) {
     super(message, cause);
   }
-
-  /**
-   * Marker to determine whether an error is an instance of TerminatedFailure.
-   */
-  protected readonly [isTerminatedFailure] = true;
-
-  /**
-   * Instanceof check that works when multiple versions of @temporalio/common are installed.
-   */
-  static is(error: unknown): error is TerminatedFailure {
-    return error instanceof TerminatedFailure || (error as any)?.[isTerminatedFailure] === true;
-  }
 }
-
-const isTimeoutFailure = Symbol.for('__temporal_isTimeoutFailure');
 
 /**
  * Used to represent timeouts of Activities and Workflows
  */
+@symbolBasedInstanceOf('TimeoutFailure')
 export class TimeoutFailure extends TemporalFailure {
   public readonly name: string = 'TimeoutFailure';
 
@@ -292,21 +226,7 @@ export class TimeoutFailure extends TemporalFailure {
   ) {
     super(message);
   }
-
-  /**
-   * Marker to determine whether an error is an instance of TimeoutFailure.
-   */
-  protected readonly [isTimeoutFailure] = true;
-
-  /**
-   * Instanceof check that works when multiple versions of @temporalio/common are installed.
-   */
-  static is(error: unknown): error is TimeoutFailure {
-    return error instanceof TimeoutFailure || (error as any)?.[isTimeoutFailure] === true;
-  }
 }
-
-const isActivityFailure = Symbol.for('__temporal_isActivityFailure');
 
 /**
  * Contains information about an Activity failure. Always contains the original reason for the failure as its `cause`.
@@ -314,6 +234,7 @@ const isActivityFailure = Symbol.for('__temporal_isActivityFailure');
  *
  * This exception is expected to be thrown only by the framework code.
  */
+@symbolBasedInstanceOf('ActivityFailure')
 export class ActivityFailure extends TemporalFailure {
   public readonly name: string = 'ActivityFailure';
 
@@ -327,21 +248,7 @@ export class ActivityFailure extends TemporalFailure {
   ) {
     super(message, cause);
   }
-
-  /**
-   * Marker to determine whether an error is an instance of ActivityFailure.
-   */
-  protected readonly [isActivityFailure] = true;
-
-  /**
-   * Instanceof check that works when multiple versions of @temporalio/common are installed.
-   */
-  static is(error: unknown): error is ActivityFailure {
-    return error instanceof ActivityFailure || (error as any)?.[isActivityFailure] === true;
-  }
 }
-
-const isChildWorkflowFailure = Symbol.for('__temporal_isChildWorkflowFailure');
 
 /**
  * Contains information about a Child Workflow failure. Always contains the reason for the failure as its {@link cause}.
@@ -349,6 +256,7 @@ const isChildWorkflowFailure = Symbol.for('__temporal_isChildWorkflowFailure');
  *
  * This exception is expected to be thrown only by the framework code.
  */
+@symbolBasedInstanceOf('ChildWorkflowFailure')
 export class ChildWorkflowFailure extends TemporalFailure {
   public readonly name: string = 'ChildWorkflowFailure';
 
@@ -360,18 +268,6 @@ export class ChildWorkflowFailure extends TemporalFailure {
     cause?: Error
   ) {
     super('Child Workflow execution failed', cause);
-  }
-
-  /**
-   * Marker to determine whether an error is an instance of ChildWorkflowFailure.
-   */
-  protected readonly [isChildWorkflowFailure] = true;
-
-  /**
-   * Instanceof check that works when multiple versions of @temporalio/common are installed.
-   */
-  static is(error: unknown): error is ChildWorkflowFailure {
-    return error instanceof ChildWorkflowFailure || (error as any)?.[isChildWorkflowFailure] === true;
   }
 }
 
@@ -385,7 +281,7 @@ export class ChildWorkflowFailure extends TemporalFailure {
  * - `stack`: `error.stack` or `''`
  */
 export function ensureApplicationFailure(error: unknown): ApplicationFailure {
-  if (ApplicationFailure.is(error)) {
+  if (error instanceof ApplicationFailure) {
     return error;
   }
 
@@ -404,7 +300,7 @@ export function ensureApplicationFailure(error: unknown): ApplicationFailure {
  * Otherwise returns an `ApplicationFailure` with `String(err)` as the message.
  */
 export function ensureTemporalFailure(err: unknown): TemporalFailure {
-  if (TemporalFailure.is(err)) {
+  if (err instanceof TemporalFailure) {
     return err;
   }
   return ensureApplicationFailure(err);
@@ -417,14 +313,8 @@ export function ensureTemporalFailure(err: unknown): TemporalFailure {
  * Otherwise, return `error.message`.
  */
 export function rootCause(error: unknown): string | undefined {
-  if (TemporalFailure.is(error)) {
+  if (error instanceof TemporalFailure) {
     return error.cause ? rootCause(error.cause) : error.message;
   }
-  if (error instanceof Error) {
-    return error.message;
-  }
-  if (typeof error === 'string') {
-    return error;
-  }
-  return undefined;
+  return errorMessage(error);
 }

--- a/packages/common/src/type-helpers.ts
+++ b/packages/common/src/type-helpers.ts
@@ -36,15 +36,27 @@ export function hasOwnProperties<X extends Record<string, unknown>, Y extends Pr
   return props.every((prop) => prop in record);
 }
 
+export function isError(error: unknown): error is Error {
+  return (
+    isRecord(error) &&
+    typeof error.name === 'string' &&
+    typeof error.message === 'string' &&
+    (error.stack == null || typeof error.stack === 'string')
+  );
+}
+
+export function isAbortError(error: unknown): error is Error & { name: 'AbortError' } {
+  return isError(error) && error.name === 'AbortError';
+}
+
 /**
  * Get `error.message` (or `undefined` if not present)
  */
 export function errorMessage(error: unknown): string | undefined {
-  if (typeof error === 'string') {
-    return error;
-  }
-  if (error instanceof Error) {
+  if (isError(error)) {
     return error.message;
+  } else if (typeof error === 'string') {
+    return error;
   }
   return undefined;
 }
@@ -52,16 +64,17 @@ export function errorMessage(error: unknown): string | undefined {
 interface ErrorWithCode {
   code: string;
 }
+
+function isErrorWithCode(error: unknown): error is ErrorWithCode {
+  return isRecord(error) && typeof error.code === 'string';
+}
+
 /**
  * Get `error.code` (or `undefined` if not present)
  */
 export function errorCode(error: unknown): string | undefined {
-  if (
-    typeof error === 'object' &&
-    (error as ErrorWithCode).code !== undefined &&
-    typeof (error as ErrorWithCode).code === 'string'
-  ) {
-    return (error as ErrorWithCode).code;
+  if (isErrorWithCode(error)) {
+    return error.code;
   }
 
   return undefined;
@@ -72,4 +85,53 @@ export function errorCode(error: unknown): string | undefined {
  */
 export function assertNever(msg: string, x: never): never {
   throw new TypeError(msg + ': ' + x);
+}
+
+export type Class = {
+  new (...args: any[]): any;
+  prototype: object;
+};
+
+/**
+ * According to the EcmaScript's spec, the default behavior of JavaScript's `x instanceof Y` operator is to walk up the
+ * prototype chain of object 'x', checking if any constructor in that hierarchy is _exactly the same object_ as the
+ * constructor function 'Y'.
+ *
+ * Unfortunately, it happens in various situations that different constructor function objects get created for what
+ * appears to be the very same class. This leads to surprising behavior where `instanceof` returns false though it is
+ * known that the object is indeed an instance of that class. One particular case where this happens is when constructor
+ * 'Y' belongs to a different realm than the constuctor with which 'x' was instantiated. Another case is when two copies
+ * of the same library gets loaded in the same realm.
+ *
+ * In practice, this tends to cause issues when crossing the workflow-sandboxing boundary (since Node's vm module
+ * really creates new execution realms), as well as when running tests using Jest (see https://github.com/jestjs/jest/issues/2549
+ * for some details on that one).
+ *
+ * This function injects a custom 'instanceof' handler into the prototype of 'clazz', which is both cross-realm safe and
+ * cross-copies-of-the-same-lib safe. It works by adding a special symbol property to the prototype of 'clazz', and then
+ * checking for the presence of that symbol.
+ */
+export function symbolBasedInstanceOf(markerName: string): (clazz: Class) => void {
+  return (clazz: Class): void => {
+    const marker = Symbol.for(`__temporal_is${markerName}`);
+
+    Object.defineProperty(clazz.prototype, marker, { value: true, enumerable: false });
+    Object.defineProperty(clazz, Symbol.hasInstance, {
+      // eslint-disable-next-line object-shorthand
+      value: function (this: any, error: object): boolean {
+        if (this === clazz) {
+          return isRecord(error) && (error as any)[marker] === true;
+        } else {
+          // 'this' must be a _subclass_ of clazz that doesn't redefined [Symbol.hasInstance], so that it inherited
+          // from clazz's [Symbol.hasInstance]. If we don't handle this particular situation, then
+          // `x instanceof SubclassOfParent` would return true for any instance of 'Parent', which is clearly wrong.
+          //
+          // Ideally, it'd be preferable to avoid this case entirely, by making sure that all subclasses of 'clazz'
+          // redefine [Symbol.hasInstance], but we can't enforce that. We therefore fallback to the default instanceof
+          // behavior (which is NOT cross-realm safe).
+          return this.prototype.isPrototypeOf(error); // eslint-disable-line no-prototype-builtins
+        }
+      },
+    });
+  };
 }

--- a/packages/common/src/type-helpers.ts
+++ b/packages/common/src/type-helpers.ts
@@ -21,7 +21,6 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-// ts-prune-ignore-next
 export function hasOwnProperty<X extends Record<string, unknown>, Y extends PropertyKey>(
   record: X,
   prop: Y

--- a/packages/core-bridge/ts/errors.ts
+++ b/packages/core-bridge/ts/errors.ts
@@ -1,30 +1,24 @@
 import { IllegalStateError } from '@temporalio/common';
-import { isError, symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
+import { isError, SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 
 /**
  * The worker has been shut down
  */
-@symbolBasedInstanceOf('ShutdownError')
-export class ShutdownError extends Error {
-  public readonly name = 'ShutdownError';
-}
+@SymbolBasedInstanceOfError('ShutdownError')
+export class ShutdownError extends Error {}
 
 /**
  * Thrown after shutdown was requested as a response to a poll function, JS should stop polling
  * once this error is encountered
  */
-@symbolBasedInstanceOf('TransportError')
-export class TransportError extends Error {
-  public readonly name = 'TransportError';
-}
+@SymbolBasedInstanceOfError('TransportError')
+export class TransportError extends Error {}
 
 /**
  * Something unexpected happened, considered fatal
  */
-@symbolBasedInstanceOf('UnexpectedError')
-export class UnexpectedError extends Error {
-  public readonly name = 'UnexpectedError';
-}
+@SymbolBasedInstanceOfError('UnexpectedError')
+export class UnexpectedError extends Error {}
 
 export { IllegalStateError };
 

--- a/packages/interceptors-opentelemetry/src/workflow/index.ts
+++ b/packages/interceptors-opentelemetry/src/workflow/index.ts
@@ -59,7 +59,7 @@ export class OpenTelemetryInboundInterceptor implements WorkflowInboundCallsInte
       spanName: `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}${workflowInfo().workflowType}`,
       fn: () => next(input),
       context,
-      acceptableErrors: ContinueAsNew.is,
+      acceptableErrors: (err) => err instanceof ContinueAsNew,
     });
   }
 }
@@ -120,7 +120,7 @@ export class OpenTelemetryOutboundInterceptor implements WorkflowOutboundCallsIn
           headers,
         });
       },
-      acceptableErrors: ContinueAsNew.is,
+      acceptableErrors: (err) => err instanceof ContinueAsNew,
     });
   }
 }

--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -713,7 +713,7 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
 
     const checksums = searchAttributePayloadConverter.fromPayload(encodedId);
     console.log(checksums);
-    t.true(checksums instanceof Array);
+    t.true(Array.isArray(checksums));
     t.regex((checksums as string[]).pop()!, /@temporalio\/worker@\d+\.\d+\.\d+/);
     t.is(execution.raw.executionConfig?.taskQueue?.name, 'test');
     t.is(

--- a/packages/test/src/test-type-helpers.ts
+++ b/packages/test/src/test-type-helpers.ts
@@ -125,7 +125,6 @@ test.serial(`instanceof is working as expected across realms with SymbolBasedIns
   t.false(cx1('new ClassC()') instanceof cx2('Object'));
 });
 
-// This test demonstrates that cross-realm instanceof is indeed broken by default.
 test.serial('SymbolBasedInstanceOfError doesnt break on non-object values', (t) => {
   const { cx1 } = t.context;
 

--- a/packages/test/src/test-type-helpers.ts
+++ b/packages/test/src/test-type-helpers.ts
@@ -1,0 +1,157 @@
+import vm from 'vm';
+import anyTest, { TestFn } from 'ava';
+import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
+
+interface Context {
+  cx1: (script: string) => any;
+  cx2: (script: string) => any;
+}
+const test = anyTest as TestFn<Context>;
+
+const script = new vm.Script(`
+  class ClassA {};
+  class ClassB extends ClassA {}
+  class ClassC extends ClassB {}
+`);
+
+test.beforeEach((t) => {
+  const cx1 = vm.createContext();
+  cx1.symbolBasedInstanceOf = symbolBasedInstanceOf;
+  script.runInContext(cx1);
+
+  const cx2 = vm.createContext();
+  cx2.symbolBasedInstanceOf = symbolBasedInstanceOf;
+  script.runInContext(cx2);
+
+  t.context = {
+    cx1: (script: string) => vm.runInContext(script, cx1),
+    cx2: (script: string) => vm.runInContext(script, cx2),
+  };
+});
+
+// This test is trivial and obvious. It is only meant to clearly establish a baseline for other tests.
+test.serial('BASELINE - instanceof works as expected in single realm, without symbolBasedInstanceOf', (t) => {
+  const { cx1 } = t.context;
+
+  t.true(cx1('new ClassA()') instanceof cx1('ClassA'));
+  t.true(cx1('new ClassB()') instanceof cx1('ClassA'));
+  t.true(cx1('new ClassC()') instanceof cx1('ClassA'));
+
+  t.false(cx1('new ClassA()') instanceof cx1('ClassB'));
+  t.true(cx1('new ClassB()') instanceof cx1('ClassB'));
+  t.true(cx1('new ClassC()') instanceof cx1('ClassB'));
+
+  t.false(cx1('new ClassA()') instanceof cx1('ClassC'));
+  t.false(cx1('new ClassB()') instanceof cx1('ClassC'));
+  t.true(cx1('new ClassC()') instanceof cx1('ClassC'));
+
+  t.true(cx1('new ClassA()') instanceof cx1('Object'));
+  t.true(cx1('new ClassB()') instanceof cx1('Object'));
+  t.true(cx1('new ClassC()') instanceof cx1('Object'));
+});
+
+// This test demonstrates that cross-realm instanceof is indeed broken by default.
+test.serial('BASELINE - instanceof is broken in cross realms, without symbolBasedInstanceOf', (t) => {
+  const { cx1, cx2 } = t.context;
+
+  t.false(cx1('new ClassA()') instanceof cx2('ClassA'));
+  t.false(cx1('new ClassB()') instanceof cx2('ClassA'));
+  t.false(cx1('new ClassC()') instanceof cx2('ClassA'));
+
+  t.false(cx1('new ClassA()') instanceof cx2('ClassB'));
+  t.false(cx1('new ClassB()') instanceof cx2('ClassB'));
+  t.false(cx1('new ClassC()') instanceof cx2('ClassB'));
+
+  t.false(cx1('new ClassA()') instanceof cx2('ClassC'));
+  t.false(cx1('new ClassB()') instanceof cx2('ClassC'));
+  t.false(cx1('new ClassC()') instanceof cx2('ClassC'));
+
+  t.false(cx1('new ClassA()') instanceof cx2('Object'));
+  t.false(cx1('new ClassB()') instanceof cx2('Object'));
+  t.false(cx1('new ClassC()') instanceof cx2('Object'));
+});
+
+test.serial(`symbolBasedInstanceOf doesn't break any default behaviour of instanceof in single realm`, (t) => {
+  const { cx1 } = t.context;
+
+  cx1(`symbolBasedInstanceOf('ClassA')(ClassA)`);
+  cx1(`symbolBasedInstanceOf('ClassB')(ClassB)`);
+
+  t.true(cx1('new ClassA()') instanceof cx1('ClassA'));
+  t.true(cx1('new ClassB()') instanceof cx1('ClassA'));
+  t.true(cx1('new ClassC()') instanceof cx1('ClassA'));
+
+  t.false(cx1('new ClassA()') instanceof cx1('ClassB'));
+  t.true(cx1('new ClassB()') instanceof cx1('ClassB'));
+  t.true(cx1('new ClassC()') instanceof cx1('ClassB'));
+
+  t.false(cx1('new ClassA()') instanceof cx1('ClassC'));
+  t.false(cx1('new ClassB()') instanceof cx1('ClassC'));
+  t.true(cx1('new ClassC()') instanceof cx1('ClassC'));
+
+  t.true(cx1('new ClassA()') instanceof cx1('Object'));
+  t.true(cx1('new ClassB()') instanceof cx1('Object'));
+  t.true(cx1('new ClassC()') instanceof cx1('Object'));
+});
+
+test.serial(`instanceof is working as expected across realms with symbolBasedInstanceOf`, (t) => {
+  const { cx1, cx2 } = t.context;
+
+  cx1(`symbolBasedInstanceOf('ClassA')(ClassA)`);
+  cx1(`symbolBasedInstanceOf('ClassB')(ClassB)`);
+
+  cx2(`symbolBasedInstanceOf('ClassA')(ClassA)`);
+  cx2(`symbolBasedInstanceOf('ClassB')(ClassB)`);
+
+  t.true(cx1('new ClassA()') instanceof cx2('ClassA'));
+  t.true(cx1('new ClassB()') instanceof cx2('ClassA'));
+  t.true(cx1('new ClassC()') instanceof cx2('ClassA'));
+
+  t.false(cx1('new ClassA()') instanceof cx2('ClassB'));
+  t.true(cx1('new ClassB()') instanceof cx2('ClassB'));
+  t.true(cx1('new ClassC()') instanceof cx2('ClassB'));
+
+  t.false(cx1('new ClassA()') instanceof cx2('ClassC'));
+  t.false(cx1('new ClassB()') instanceof cx2('ClassC'));
+
+  // This one is surprising but expected, as symbolBasedInstanceOf was never called on ClassC;
+  // it therefore reverts to the default behavior of instanceof, which is not cross-realm safe.
+  t.false(cx1('new ClassC()') instanceof cx2('ClassC'));
+
+  // The followings are surprising, but expected, as 'Object' differs between realms.
+  // symbolBasedInstanceOf doesn't help with that.
+  t.false(cx1('new ClassA()') instanceof cx2('Object'));
+  t.false(cx1('new ClassB()') instanceof cx2('Object'));
+  t.false(cx1('new ClassC()') instanceof cx2('Object'));
+});
+
+// This test demonstrates that cross-realm instanceof is indeed broken by default.
+test.serial('symbolBasedInstanceOf doesnt break on non-object values', (t) => {
+  const { cx1 } = t.context;
+
+  cx1(`symbolBasedInstanceOf('ClassA')(ClassA)`);
+
+  t.false((true as any) instanceof cx1('ClassA'));
+  t.false((12 as any) instanceof cx1('ClassA'));
+  t.false((NaN as any) instanceof cx1('ClassA'));
+  t.false(('string' as any) instanceof cx1('ClassA'));
+  t.false(([] as any) instanceof cx1('ClassA'));
+  t.false((undefined as any) instanceof cx1('ClassA'));
+  t.false((null as any) instanceof cx1('ClassA'));
+  t.false(((() => null) as any) instanceof cx1('ClassA'));
+  t.false((Symbol() as any) instanceof cx1('ClassA'));
+});
+
+test.serial('Same context with same symbolBasedInstanceOf calls also works', (t) => {
+  class ClassA {}
+  class ClassB {}
+
+  t.false(new ClassA() instanceof ClassB);
+  t.false(new ClassB() instanceof ClassA);
+
+  symbolBasedInstanceOf('Foo')(ClassA);
+  symbolBasedInstanceOf('Foo')(ClassB);
+
+  t.true(new ClassA() instanceof ClassB);
+  t.true(new ClassB() instanceof ClassA);
+});

--- a/packages/test/src/test-workflow-unhandled-rejection-crash.ts
+++ b/packages/test/src/test-workflow-unhandled-rejection-crash.ts
@@ -9,7 +9,7 @@ import { throwUnhandledRejection } from './workflows';
 if (RUN_INTEGRATION_TESTS) {
   test('Worker crashes if workflow throws unhandled rejection that cannot be associated with a workflow run', async (t) => {
     // To debug Workflows with this worker run the test with `ava debug` and add breakpoints to your Workflows
-    const taskQueue = 'unhandled-rejection-crash';
+    const taskQueue = `unhandled-rejection-crash-${uuid4()}`;
     const worker = await Worker.create({ ...defaultOptions, taskQueue });
     const client = new WorkflowClient();
     const handle = await client.start(throwUnhandledRejection, {

--- a/packages/worker/src/errors.ts
+++ b/packages/worker/src/errors.ts
@@ -1,9 +1,11 @@
 import { IllegalStateError } from '@temporalio/common';
+import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
 import { ShutdownError, TransportError, UnexpectedError } from '@temporalio/core-bridge';
 
 /**
  * Thrown from JS if Worker does not shutdown in configured period
  */
+@symbolBasedInstanceOf('GracefulShutdownPeriodExpiredError')
 export class GracefulShutdownPeriodExpiredError extends Error {
   public readonly name = 'GracefulShutdownPeriodExpiredError';
 }

--- a/packages/worker/src/errors.ts
+++ b/packages/worker/src/errors.ts
@@ -1,14 +1,12 @@
 import { IllegalStateError } from '@temporalio/common';
-import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
+import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 import { ShutdownError, TransportError, UnexpectedError } from '@temporalio/core-bridge';
 
 /**
  * Thrown from JS if Worker does not shutdown in configured period
  */
-@symbolBasedInstanceOf('GracefulShutdownPeriodExpiredError')
-export class GracefulShutdownPeriodExpiredError extends Error {
-  public readonly name = 'GracefulShutdownPeriodExpiredError';
-}
+@SymbolBasedInstanceOfError('GracefulShutdownPeriodExpiredError')
+export class GracefulShutdownPeriodExpiredError extends Error {}
 
 /**
  * @deprecated Import error classes directly

--- a/packages/worker/src/replay.ts
+++ b/packages/worker/src/replay.ts
@@ -1,5 +1,5 @@
 import { HistoryAndWorkflowId } from '@temporalio/client';
-import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
+import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 import { coresdk } from '@temporalio/proto';
 import { DeterminismViolationError } from '@temporalio/workflow';
 
@@ -10,10 +10,8 @@ export type RemoveFromCache = coresdk.workflow_activation.IRemoveFromCache;
 /**
  * Error thrown when using the Worker to replay Workflow(s).
  */
-@symbolBasedInstanceOf('ReplayError')
-export class ReplayError extends Error {
-  public readonly name = 'ReplayError';
-}
+@SymbolBasedInstanceOfError('ReplayError')
+export class ReplayError extends Error {}
 
 /**
  * Result of a single workflow replay

--- a/packages/worker/src/replay.ts
+++ b/packages/worker/src/replay.ts
@@ -1,4 +1,5 @@
 import { HistoryAndWorkflowId } from '@temporalio/client';
+import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
 import { coresdk } from '@temporalio/proto';
 import { DeterminismViolationError } from '@temporalio/workflow';
 
@@ -9,6 +10,7 @@ export type RemoveFromCache = coresdk.workflow_activation.IRemoveFromCache;
 /**
  * Error thrown when using the Worker to replay Workflow(s).
  */
+@symbolBasedInstanceOf('ReplayError')
 export class ReplayError extends Error {
   public readonly name = 'ReplayError';
 }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -50,7 +50,7 @@ import {
 } from '@temporalio/common/lib/otel';
 import { historyFromJSON } from '@temporalio/common/lib/proto-utils';
 import { optionalTsToDate, optionalTsToMs, tsToDate, tsToMs } from '@temporalio/common/lib/time';
-import { errorMessage } from '@temporalio/common/lib/type-helpers';
+import { errorMessage, isError, symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
 import * as native from '@temporalio/core-bridge';
 import { ShutdownError, UnexpectedError } from '@temporalio/core-bridge';
 import { coresdk, temporal } from '@temporalio/proto';
@@ -159,6 +159,7 @@ interface EvictionWithRunID {
 /**
  * Error thrown by {@link Worker.runUntil} and {@link Worker.runReplayHistories}
  */
+@symbolBasedInstanceOf('CombinedWorkerRunError')
 export class CombinedWorkerRunError extends Error {
   public readonly name = 'CombinedWorkerRunError';
   public readonly cause: CombinedWorkerRunErrorCause;
@@ -578,7 +579,7 @@ export class Worker {
         await runPromise;
       } catch (err) {
         /* eslint-disable no-unsafe-finally */
-        if (ShutdownError.is(err)) {
+        if (err instanceof ShutdownError) {
           if (innerError !== undefined) throw innerError;
           return;
         } else if (innerError === undefined) {
@@ -816,7 +817,7 @@ export class Worker {
           try {
             yield await pollFn();
           } catch (err) {
-            if (ShutdownError.is(err)) {
+            if (err instanceof ShutdownError) {
               break;
             }
             throw err;
@@ -901,7 +902,7 @@ export class Worker {
                                 err
                               )}`,
                               applicationFailureInfo: {
-                                type: err instanceof Error ? err.name : undefined,
+                                type: isError(err) ? err.name : undefined,
                                 nonRetryable: false,
                               },
                             },
@@ -1476,7 +1477,7 @@ export class Worker {
 
           return { activation, parentSpan };
         },
-        ShutdownError.is
+        (err) => err instanceof ShutdownError
       );
     }).pipe(
       tap({
@@ -1592,7 +1593,7 @@ export class Worker {
           }
           return { task, parentSpan, base64TaskToken };
         },
-        ShutdownError.is
+        (err) => err instanceof ShutdownError
       );
     }).pipe(
       tap({

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -50,7 +50,7 @@ import {
 } from '@temporalio/common/lib/otel';
 import { historyFromJSON } from '@temporalio/common/lib/proto-utils';
 import { optionalTsToDate, optionalTsToMs, tsToDate, tsToMs } from '@temporalio/common/lib/time';
-import { errorMessage, isError, symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
+import { errorMessage, isError, SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 import * as native from '@temporalio/core-bridge';
 import { ShutdownError, UnexpectedError } from '@temporalio/core-bridge';
 import { coresdk, temporal } from '@temporalio/proto';
@@ -159,9 +159,8 @@ interface EvictionWithRunID {
 /**
  * Error thrown by {@link Worker.runUntil} and {@link Worker.runReplayHistories}
  */
-@symbolBasedInstanceOf('CombinedWorkerRunError')
+@SymbolBasedInstanceOfError('CombinedWorkerRunError')
 export class CombinedWorkerRunError extends Error {
-  public readonly name = 'CombinedWorkerRunError';
   public readonly cause: CombinedWorkerRunErrorCause;
 
   constructor(message: string, { cause }: { cause: CombinedWorkerRunErrorCause }) {

--- a/packages/worker/src/workflow-log-interceptor.ts
+++ b/packages/worker/src/workflow-log-interceptor.ts
@@ -49,7 +49,7 @@ export class WorkflowLogInterceptor implements WorkflowInboundCallsInterceptor, 
           if (isCancellation(error)) {
             log.debug('Workflow completed as cancelled');
             throw error;
-          } else if (ContinueAsNew.is(error)) {
+          } else if (error instanceof ContinueAsNew) {
             log.debug('Workflow continued as new');
             throw error;
           }

--- a/packages/workflow/src/errors.ts
+++ b/packages/workflow/src/errors.ts
@@ -1,21 +1,17 @@
 import { ActivityFailure, CancelledFailure, ChildWorkflowFailure } from '@temporalio/common';
-import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
+import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 
 /**
  * Base class for all workflow errors
  */
-@symbolBasedInstanceOf('WorkflowError')
-export class WorkflowError extends Error {
-  public readonly name: string = 'WorkflowError';
-}
+@SymbolBasedInstanceOfError('WorkflowError')
+export class WorkflowError extends Error {}
 
 /**
  * Thrown in workflow when it tries to do something that non-deterministic such as construct a WeakRef()
  */
-@symbolBasedInstanceOf('DeterminismViolationError')
-export class DeterminismViolationError extends WorkflowError {
-  public readonly name: string = 'DeterminismViolationError';
-}
+@SymbolBasedInstanceOfError('DeterminismViolationError')
+export class DeterminismViolationError extends WorkflowError {}
 
 /**
  * Returns whether provided `err` is caused by cancellation

--- a/packages/workflow/src/errors.ts
+++ b/packages/workflow/src/errors.ts
@@ -1,7 +1,10 @@
 import { ActivityFailure, CancelledFailure, ChildWorkflowFailure } from '@temporalio/common';
+import { symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
+
 /**
  * Base class for all workflow errors
  */
+@symbolBasedInstanceOf('WorkflowError')
 export class WorkflowError extends Error {
   public readonly name: string = 'WorkflowError';
 }
@@ -9,6 +12,7 @@ export class WorkflowError extends Error {
 /**
  * Thrown in workflow when it tries to do something that non-deterministic such as construct a WeakRef()
  */
+@symbolBasedInstanceOf('DeterminismViolationError')
 export class DeterminismViolationError extends WorkflowError {
   public readonly name: string = 'DeterminismViolationError';
 }
@@ -18,7 +22,7 @@ export class DeterminismViolationError extends WorkflowError {
  */
 export function isCancellation(err: unknown): boolean {
   return (
-    CancelledFailure.is(err) ||
-    ((ActivityFailure.is(err) || ChildWorkflowFailure.is(err)) && CancelledFailure.is(err.cause))
+    err instanceof CancelledFailure ||
+    ((err instanceof ActivityFailure || err instanceof ChildWorkflowFailure) && err.cause instanceof CancelledFailure)
   );
 }

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -9,7 +9,7 @@ import {
   Duration,
   VersioningIntent,
 } from '@temporalio/common';
-import { checkExtends } from '@temporalio/common/lib/type-helpers';
+import { checkExtends, symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
 import type { coresdk } from '@temporalio/proto';
 
 /**
@@ -166,28 +166,15 @@ export interface ParentWorkflowInfo {
   namespace: string;
 }
 
-const isContinueAsNew = Symbol.for('__temporal_isContinueAsNew');
-
 /**
  * Not an actual error, used by the Workflow runtime to abort execution when {@link continueAsNew} is called
  */
+@symbolBasedInstanceOf('ContinueAsNew')
 export class ContinueAsNew extends Error {
   public readonly name = 'ContinueAsNew';
 
   constructor(public readonly command: coresdk.workflow_commands.IContinueAsNewWorkflowExecution) {
     super('Workflow continued as new');
-  }
-
-  /**
-   * Marker to determine whether an error is an instance of ContinueAsNew.
-   */
-  protected readonly [isContinueAsNew] = true;
-
-  /**
-   * Instanceof check that works when multiple versions of @temporalio/workflow are installed.
-   */
-  static is(error: unknown): error is ContinueAsNew {
-    return error instanceof ContinueAsNew || (error as any)?.[isContinueAsNew] === true;
   }
 }
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -9,7 +9,7 @@ import {
   Duration,
   VersioningIntent,
 } from '@temporalio/common';
-import { checkExtends, symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
+import { checkExtends, SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 import type { coresdk } from '@temporalio/proto';
 
 /**
@@ -169,10 +169,8 @@ export interface ParentWorkflowInfo {
 /**
  * Not an actual error, used by the Workflow runtime to abort execution when {@link continueAsNew} is called
  */
-@symbolBasedInstanceOf('ContinueAsNew')
+@SymbolBasedInstanceOfError('ContinueAsNew')
 export class ContinueAsNew extends Error {
-  public readonly name = 'ContinueAsNew';
-
   constructor(public readonly command: coresdk.workflow_commands.IContinueAsNewWorkflowExecution) {
     super('Workflow continued as new');
   }

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -15,7 +15,7 @@ import {
   ProtoFailure,
 } from '@temporalio/common';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
-import { checkExtends, symbolBasedInstanceOf } from '@temporalio/common/lib/type-helpers';
+import { checkExtends, SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 import type { coresdk } from '@temporalio/proto';
 import { alea, RNG } from './alea';
 import { RootCancellationScope } from './cancellation-scope';
@@ -70,10 +70,11 @@ export interface Condition {
 /**
  * A class that acts as a marker for this special result type
  */
-@symbolBasedInstanceOf('LocalActivityDoBackoff')
-export class LocalActivityDoBackoff {
-  public readonly name = 'LocalActivityDoBackoff';
-  constructor(public readonly backoff: coresdk.activity_result.IDoBackoff) {}
+@SymbolBasedInstanceOfError('LocalActivityDoBackoff')
+export class LocalActivityDoBackoff extends Error {
+  constructor(public readonly backoff: coresdk.activity_result.IDoBackoff) {
+    super();
+  }
 }
 
 export type ActivationHandlerFunction<K extends keyof coresdk.workflow_activation.IWorkflowActivationJob> = (

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "incremental": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "sourceMap": true
+    "sourceMap": true,
+    "experimentalDecorators": true
   }
 }

--- a/tsconfig.prune.json
+++ b/tsconfig.prune.json
@@ -9,7 +9,6 @@
     "./packages/activity/src/index.ts",
     "./packages/client/src/index.ts",
     "./packages/common/src/index.ts",
-    "./packages/common/src/type-helpers.ts",
     "./packages/create-project/src/index.ts",
     "./packages/interceptors-opentelemetry/src/index.ts",
     "./packages/nyc-test-coverage/src/index.ts",

--- a/tsconfig.prune.json
+++ b/tsconfig.prune.json
@@ -9,6 +9,7 @@
     "./packages/activity/src/index.ts",
     "./packages/client/src/index.ts",
     "./packages/common/src/index.ts",
+    "./packages/common/src/type-helpers.ts",
     "./packages/create-project/src/index.ts",
     "./packages/interceptors-opentelemetry/src/index.ts",
     "./packages/nyc-test-coverage/src/index.ts",


### PR DESCRIPTION
## Context

#1128 introduced a new strategy, based on presence of a symbol, for checking `instanceof` on Error classes defined by SDK. However this turned out to work incorrectly when running in Jest, because of the remaining `instanceof Error` check. #1162 tried to fix that one, but missed the particular case of converting errors thrown from Core.

## What changed

- Introduce a new decorator function `SymbolBasedInstanceOfError` that adds a custom `instanceof` handler to error classes. It does so by defining a `[Symbol.hasInstance]` function on the object constructor. That custom `instanceof` handler look for the presence of a specific symbol.
- Replace the recently introduced `.is(...)` function by the `.[Symbol.hasInstance]()` function, which makes it automatically used by the `instanceof` operator, in place of the default algorithm. That means that user code automatically benefit from this, without change to their easing code.
- Introduced a new internal helper function `isError`, which uses a duck-typing strategy. Fixed all remaining cases of `instanceof Error` by calling `isError` instead (except for the `create-project`, scripts, and tests, all of which are not meant to be used in contexts where that would matter).
- Similarly strengthened some other type checking helpers
- Apply this new `instanceof` mechanism on all Error and Failure objects. That certainly include some errors that are not meant to be exposed to users or to travel across the Workflow sandbox boundary; however, considering how Jest may also play us tricks, trying to pin point exactly which one are could be subject to instanceof issues seems like an unreasonable approach.
- Also replaced all `instanceof Array` by `isArray()`.

## Limitations

- We are not adding custom `instanceof` handlers for JavaScript's builtin objects (Object, Array, Map, Uint8Array, Date, Promise, etc.). I believe this would technically be possible, but it could likely cause other/unpredictable issues. We should instead use `isXxx` kind of helpers for these things.

## Future work

- We'll need to define isXxx helpers for all built-in objects on which we need to do `instanceof` checks (eg. Uint8Array, Date, Promise, etc). This will be covered in a different PR (don't want to delay 1.8.2 for this)