### PR TITLE
Fix ProtobufJSONPayloadConverter to not require Buffer in the workflo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ packages/testing/generated-protos/
 packages/core-bridge/releases
 packages/*/package-lock.json
 /sdk-node.iml
+*~

--- a/packages/common/src/converter/protobuf-payload-converters.ts
+++ b/packages/common/src/converter/protobuf-payload-converters.ts
@@ -14,6 +14,8 @@ import {
 
 import { encodingTypes, METADATA_ENCODING_KEY, METADATA_MESSAGE_TYPE_KEY } from './types';
 
+const GLOBAL_BUFFER = globalThis.constructor.constructor('return globalThis.Buffer')();
+
 abstract class ProtobufPayloadConverter implements PayloadConverterWithEncoding {
   protected readonly root: Root | undefined;
   public abstract encodingType: string;
@@ -175,7 +177,7 @@ function replaceBuffers<X>(obj: X) {
 
 function setBufferInGlobal(): boolean {
   if (typeof globalThis.Buffer === 'undefined') {
-    globalThis.Buffer = globalThis.constructor.constructor('return globalThis.Buffer')();
+    globalThis.Buffer = GLOBAL_BUFFER;
     return true;
   }
   return false;

--- a/packages/common/src/converter/protobuf-payload-converters.ts
+++ b/packages/common/src/converter/protobuf-payload-converters.ts
@@ -139,6 +139,9 @@ export class ProtobufJsonPayloadConverter extends ProtobufPayloadConverter {
     try {
       const { messageType, data } = this.validatePayload(content);
       const res = protoJsonSerializer.fromProto3JSON(messageType, JSON.parse(decode(data))) as unknown as T;
+      if (Buffer.isBuffer(res)) {
+        return new Uint8Array(res) as any;
+      }
       replaceBuffers(res);
       return res;
     } finally {

--- a/packages/test/src/test-payload-converter.ts
+++ b/packages/test/src/test-payload-converter.ts
@@ -168,7 +168,7 @@ test('ProtobufJSONPayloadConverter converts binary', (t) => {
   });
 
   const testInstance = converter.fromPayload<root.BinaryMessage>(encoded!);
-  t.deepEqual(testInstance.data, Buffer.from(instance.data));
+  t.deepEqual(testInstance.data, instance.data);
 });
 
 if (RUN_INTEGRATION_TESTS) {

--- a/packages/test/src/workflows/echo-binary-protobuf.ts
+++ b/packages/test/src/workflows/echo-binary-protobuf.ts
@@ -1,5 +1,6 @@
-import type { BinaryMessage } from '../../protos/root';
 import { ApplicationFailure } from '@temporalio/common';
+import type { BinaryMessage } from '../../protos/root';
+
 export async function echoBinaryProtobuf(input: BinaryMessage): Promise<BinaryMessage> {
   if (input.data instanceof Uint8Array) {
     return input;

--- a/packages/test/src/workflows/echo-binary-protobuf.ts
+++ b/packages/test/src/workflows/echo-binary-protobuf.ts
@@ -1,0 +1,8 @@
+import type { BinaryMessage } from '../../protos/root';
+import { ApplicationFailure } from '@temporalio/common';
+export async function echoBinaryProtobuf(input: BinaryMessage): Promise<BinaryMessage> {
+  if (input.data instanceof Uint8Array) {
+    return input;
+  }
+  throw ApplicationFailure.nonRetryable('input.data is not a Uint8Array');
+}


### PR DESCRIPTION

## What was changed
<!-- Describe what has changed in this PR -->
This is a fix to #1169 

The ProtobufJsonPayloadConverter ensures that Buffer is globally available, and if it is not, it just adds it when needed, but leaving the global space untouched after that. 

It also needs to ensure that no Buffer objects are leaked, replacing them with Uint8Array objects. 

## Why?

Protobufs containing binary fields cannot be properly encoded/decoded with this converter without the Buffer class, and this class is not available by default in the workflow context.

## Checklist

1. Closes <!-- add issue number here -->
#1169 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added a system test

