### PR TITLE
Fix argument name in executeChild signature

### DIFF
--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -774,7 +774,7 @@ export async function executeChild<T extends Workflow>(
  * @return The result of the child Workflow.
  */
 export async function executeChild<T extends Workflow>(
-  workflowType: T,
+  workflowFunc: T,
   options: WithWorkflowArgs<T, ChildWorkflowOptions>
 ): Promise<WorkflowResultType<T>>;
 


### PR DESCRIPTION
## What was changed
An argument name in a function type signature.

## Why?
The semantics implied by the name were incorrect. 

## Checklist

2. How was this tested:
`npm run test`

4. Any docs updates needed?
I believe that the API reference docs at https://typescript.temporal.io/api/namespaces/workflow#executechild will update automatically although I haven't researched exactly how that happens.

I believe that this change should not have any backwards compatibility problems, although it is technically possible that something could be introspecting on the argument name.