### PR TITLE
Add support for URL/URLSearchParams inside the workflow sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ packages/testing/generated-protos/
 packages/core-bridge/releases
 packages/*/package-lock.json
 /sdk-node.iml
+*~

--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -163,6 +163,16 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
     t.is(res, 'Hello, world!');
   });
 
+  test('url-whatwg', async (t) => {
+    const { client } = t.context;
+    const res = await client.execute(workflows.urlEcho, {
+      taskQueue: 'test',
+      workflowId: uuid4(),
+      args: ['http://foo.com'],
+    });
+    t.is(res, 'http://foo.com/?counter=1');
+  });
+
   test('cancel-fake-progress', async (t) => {
     const { client } = t.context;
     await client.execute(workflows.cancelFakeProgress, {

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -91,5 +91,6 @@ export * from './two-strings';
 export { isBlockedQuery, unblockOrCancel } from './unblock-or-cancel';
 export * from './unhandled-rejection';
 export * from './upsert-and-read-search-attributes';
+export * from './url-whatwg';
 export * from './wait-on-user';
 export * from './workflow-cancellation-scenarios';

--- a/packages/test/src/workflows/url-whatwg.ts
+++ b/packages/test/src/workflows/url-whatwg.ts
@@ -1,0 +1,9 @@
+// import URL but use directly from global URLSearchParams
+import { URL } from 'url';
+
+export async function urlEcho(url: string): Promise<string> {
+  const parsedURL = new URL(url);
+  const searchParams = new URLSearchParams({ counter: '1' });
+  parsedURL.search = searchParams.toString();
+  return parsedURL.toString();
+}

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -10,7 +10,7 @@ import { toMB } from '../utils';
 
 export const defaultWorflowInterceptorModules = [require.resolve('../workflow-log-interceptor')];
 
-export const allowedBuiltinModules = ['assert'];
+export const allowedBuiltinModules = ['assert', 'url'];
 export const disallowedBuiltinModules = builtinModules.filter((module) => !allowedBuiltinModules.includes(module));
 export const disallowedModules = [
   ...disallowedBuiltinModules,

--- a/packages/worker/src/workflow/module-overrides/url.ts
+++ b/packages/worker/src/workflow/module-overrides/url.ts
@@ -1,0 +1,2 @@
+// Only expose the WHATWG URL API
+module.exports = { URL, URLSearchParams };

--- a/packages/worker/src/workflow/module-overrides/url.ts
+++ b/packages/worker/src/workflow/module-overrides/url.ts
@@ -1,2 +1,3 @@
+/* eslint-disable import/unambiguous */
 // Only expose the WHATWG URL API
 module.exports = { URL, URLSearchParams };

--- a/packages/worker/src/workflow/reusable-vm.ts
+++ b/packages/worker/src/workflow/reusable-vm.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { URL, URLSearchParams } from 'node:url';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import vm from 'node:vm';
 import * as internals from '@temporalio/workflow/lib/worker-interface';
@@ -90,7 +91,7 @@ export class ReusableVMWorkflowCreator implements WorkflowCreator {
         },
       }
     );
-    const globals = { AsyncLocalStorage, assert, __webpack_module_cache__ };
+    const globals = { AsyncLocalStorage, URL, URLSearchParams, assert, __webpack_module_cache__ };
     this._context = vm.createContext(globals, { microtaskMode: 'afterEvaluate' });
     this.injectConsole();
     script.runInContext(this.context);

--- a/packages/worker/src/workflow/vm.ts
+++ b/packages/worker/src/workflow/vm.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { URL, URLSearchParams } from 'node:url';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import vm from 'node:vm';
 import { IllegalStateError } from '@temporalio/common';
@@ -76,7 +77,7 @@ export class VMWorkflowCreator implements WorkflowCreator {
     if (this.script === undefined) {
       throw new IllegalStateError('Isolate context provider was destroyed');
     }
-    const globals = { AsyncLocalStorage, assert, __webpack_module_cache__: {} };
+    const globals = { AsyncLocalStorage, URL, URLSearchParams, assert, __webpack_module_cache__: {} };
     const context = vm.createContext(globals, { microtaskMode: 'afterEvaluate' });
     this.script.runInContext(context);
     return context;


### PR DESCRIPTION

## What was changed
<!-- Describe what has changed in this PR -->

Enable access to URL and URLSearchParams inside the workflow sandbox either using globals or with
an import of the 'url' module.

## Why?

See #981 

<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#981 
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added a system test case
