### PR TITLE
fix(client): Make `action.workflowId` optional on Schedule update

### DIFF
--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -149,9 +149,6 @@ function assertRequiredScheduleOptions(
       if (!opts.action.taskQueue) {
         throw new TypeError(`Missing ${structureName}.action.taskQueue for 'startWorkflow' action`);
       }
-      if (!opts.action.workflowId && action === 'UPDATE') {
-        throw new TypeError(`Missing ${structureName}.action.workflowId for 'startWorkflow' action`);
-      }
       if (!opts.action.workflowType) {
         throw new TypeError(`Missing ${structureName}.action.workflowType for 'startWorkflow' action`);
       }
@@ -459,7 +456,11 @@ export class ScheduleClient extends BaseClient {
         const currentHeader: Headers = current.raw.schedule?.action?.startWorkflow?.header?.fields ?? {};
         const updated = updateFn(current);
         assertRequiredScheduleOptions(updated, 'UPDATE');
-        await this.client._updateSchedule(scheduleId, compileUpdatedScheduleOptions(updated), currentHeader);
+        await this.client._updateSchedule(
+          scheduleId,
+          compileUpdatedScheduleOptions(scheduleId, updated),
+          currentHeader
+        );
       },
 
       async delete(): Promise<void> {

--- a/packages/client/src/schedule-helpers.ts
+++ b/packages/client/src/schedule-helpers.ts
@@ -221,13 +221,17 @@ export function compileScheduleOptions(options: ScheduleOptions): CompiledSchedu
   };
 }
 
-export function compileUpdatedScheduleOptions(options: ScheduleUpdateOptions): CompiledScheduleUpdateOptions {
+export function compileUpdatedScheduleOptions(
+  scheduleId: string,
+  options: ScheduleUpdateOptions
+): CompiledScheduleUpdateOptions {
   const workflowTypeOrFunc = options.action.workflowType;
   const workflowType = extractWorkflowType(workflowTypeOrFunc);
   return {
     ...options,
     action: {
       ...options.action,
+      workflowId: options.action.workflowId ?? `${scheduleId}-workflow`,
       workflowType,
       args: (options.action.args ?? []) as unknown[],
     },

--- a/packages/client/src/schedule-types.ts
+++ b/packages/client/src/schedule-types.ts
@@ -135,13 +135,7 @@ export type CompiledScheduleOptions = Replace<
 export type ScheduleUpdateOptions<A extends ScheduleOptionsAction = ScheduleOptionsAction> = Replace<
   Omit<ScheduleOptions, 'scheduleId' | 'memo' | 'searchAttributes'>,
   {
-    action: Replace<
-      A,
-      {
-        // No default value on update
-        workflowId: string;
-      }
-    >;
+    action: A;
     state: Omit<ScheduleOptions['state'], 'triggerImmediately' | 'backfill'>;
   }
 >;

--- a/packages/test/src/test-schedules.ts
+++ b/packages/test/src/test-schedules.ts
@@ -396,7 +396,6 @@ if (RUN_INTEGRATION_TESTS) {
         ...x,
         action: {
           type: 'startWorkflow',
-          workflowId: `${scheduleId}-workflow-2`,
           workflowType: dummyWorkflowWith2Args,
           args: [3, 4],
           taskQueue,


### PR DESCRIPTION
## What changed

- Make `ScheduleUpdateOptions.action.workflowId` optional, just like it is on createSchedule
- Fix #1092