### PR TITLE
fix(workflow): Fix mutliple sinks oddities

### DIFF
--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -339,8 +339,8 @@ if (RUN_INTEGRATION_TESTS) {
         hl: 3,
       },
       {
-        message: 'Workflow execution completed, replaying: true, hl: 7',
-        isReplaying: true,
+        message: 'Workflow execution completed, replaying: false, hl: 7',
+        isReplaying: false,
         hl: 7,
       },
     ]);

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1095,7 +1095,6 @@ export class Worker {
                       } as EvictionWithRunID);
                     }
                   }
-
                   activation.jobs = jobs;
                   if (jobs.length === 0) {
                     this.log.trace('Disposing workflow', {


### PR DESCRIPTION
## What changed

- FIx incorrect values of `wokrflowInfo.historyLength` and `workflowInfo.unsafe.isReplaying` as reported in out-of-sandbox log messages and as argument of sink function implementations.
- Sink functions configured with `callDuringReplay = false` may no longer be invoked from a replay-only worker (ie. `Worker.runReplayHistories()`); it  could previously get called in some cases on the very last WFT.
- Sink functions are now called serially, rather than in parallel. This ensure correct ordering of sink calls, even when sink functions execute asynchronously. This may however increase total WFT execution time, with a very minor risk of causing WFT Timeout.