### PR TITLE
fix(worker): allow bundling typescript with .js extensions

### DIFF
--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -201,6 +201,7 @@ exports.importInterceptors = function importInterceptors() {
         // https://webpack.js.org/configuration/resolve/#resolvemodules
         modules: [path.resolve(__dirname, 'module-overrides'), 'node_modules'],
         extensions: ['.ts', '.js'],
+        extensionAlias: { '.js': ['.ts', '.js'] },
         alias: {
           __temporal_custom_payload_converter$: this.payloadConverterPath ?? false,
           __temporal_custom_failure_converter$: this.failureConverterPath ?? false,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Allow the bundler to understand `.js` imports in `.ts` executed with `tsx`, `jiti`, `ts-node` and similar Deno-like runtimes for node

Fix copied from https://github.com/softwareventures/resolve-typescript-plugin#obsolete

## Checklist
<!--- add/delete as needed --->

1. Closes #1185 

2. How was this tested: works on my machine :tm:
