### PR TITLE
fix(activity): Add missing Activity Info fields

### DIFF
--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -165,6 +165,10 @@ export interface Info {
    */
   startToCloseTimeoutMs: number;
   /**
+   * Timestamp for when the current attempt of this Activity was scheduled in milliseconds
+   */
+  currentAttemptScheduledTimestampMs: number;
+  /**
    * Heartbeat timeout in milliseconds.
    * If this timeout is defined, the Activity must heartbeat before the timeout is reached.
    * The Activity must **not** heartbeat in case this timeout is not defined.

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -376,6 +376,7 @@ export const defaultActivityInfo: activity.Info = {
   activityType: 'unknown',
   workflowType: 'test',
   base64TaskToken: Buffer.from('test').toString('base64'),
+  heartbeatTimeoutMs: undefined,
   heartbeatDetails: undefined,
   activityNamespace: 'default',
   workflowNamespace: 'default',
@@ -383,6 +384,7 @@ export const defaultActivityInfo: activity.Info = {
   scheduledTimestampMs: 1,
   startToCloseTimeoutMs: 1000,
   scheduleToCloseTimeoutMs: 1000,
+  currentAttemptScheduledTimestampMs: 1,
 };
 
 /**

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1828,11 +1828,13 @@ async function extractActivityInfo(
     isLocal: start.isLocal,
     activityType: start.activityType,
     workflowType: start.workflowType,
+    heartbeatTimeoutMs: start.heartbeatTimeout ? tsToMs(start.heartbeatTimeout) : undefined,
     heartbeatDetails: await decodeFromPayloadsAtIndex(dataConverter, 0, start.heartbeatDetails),
     activityNamespace,
     workflowNamespace: start.workflowNamespace,
     scheduledTimestampMs: tsToMs(start.scheduledTime),
     startToCloseTimeoutMs: tsToMs(start.startToCloseTimeout),
     scheduleToCloseTimeoutMs: tsToMs(start.scheduleToCloseTimeout),
+    currentAttemptScheduledTimestampMs: tsToMs(start.currentAttemptScheduledTime),
   };
 }


### PR DESCRIPTION
## What changed

- Correctly set `heartbeatTimeoutMs` on `Context.current().info` (fix #1182)
- Also expose `currentAttemptScheduledTimestampMs`