### PR TITLE
fix(doc): Rectify the default workflowIdReusePolicy

### DIFF
--- a/packages/common/src/workflow-options.ts
+++ b/packages/common/src/workflow-options.ts
@@ -52,7 +52,7 @@ export interface BaseWorkflowOptions {
    *
    * *Note: A Workflow can never be started with a Workflow Id of a Running Workflow.*
    *
-   * @default {@link WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY}
+   * @default {@link WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE}
    */
   workflowIdReusePolicy?: WorkflowIdReusePolicy;
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
According to Maxim, this was changed from
`WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY` to `WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE` when forked from Cadence.

@cretz and I have also verified from other sources:

Go:
https://github.com/temporalio/sdk-go/blob/master/client/client.go#L281
Java:
https://github.com/temporalio/sdk-java/blob/master/temporal-sdk/src/main/java/io/temporal/client/WorkflowOptions.java#L146
.NET:
https://dotnet.temporal.io/api/Temporalio.Client.WorkflowOptions.html#Temporalio_Client_WorkflowOptions_IdReusePolicy
Python:
https://python.temporal.io/temporalio.client.Client.html#start_workflow
Server:
https://github.com/temporalio/temporal/blob/main/service/frontend/workflow_handler.go#L2004
https://github.com/temporalio/temporal/blob/main/common/enums/defaults.go#L33