### PR TITLE
Throw WorkflowExecutionAlreadyStartedError on signalWithStart

### DIFF
--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -704,7 +704,7 @@ export class WorkflowClient extends BaseClient {
       if (err.code === grpcStatus.ALREADY_EXISTS) {
         throw new WorkflowExecutionAlreadyStartedError(
           'Workflow execution already started',
-          opts.workflowId,
+          options.workflowId,
           workflowType
         );
       }

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -700,7 +700,14 @@ export class WorkflowClient extends BaseClient {
     };
     try {
       return (await this.workflowService.signalWithStartWorkflowExecution(req)).runId;
-    } catch (err) {
+    } catch (err: any) {
+      if (err.code === grpcStatus.ALREADY_EXISTS) {
+        throw new WorkflowExecutionAlreadyStartedError(
+          'Workflow execution already started',
+          opts.workflowId,
+          workflowType
+        );
+      }
       this.rethrowGrpcError(err, 'Failed to signalWithStart Workflow', { workflowId: options.workflowId });
     }
   }

--- a/packages/test/src/integration-tests.ts
+++ b/packages/test/src/integration-tests.ts
@@ -30,6 +30,7 @@ import {
   TimeoutType,
   WorkflowExecution,
   WorkflowExecutionAlreadyStartedError,
+  WorkflowIdReusePolicy,
   WorkflowNotFoundError,
 } from '@temporalio/common';
 import { msToNumber, tsToMs } from '@temporalio/common/lib/time';
@@ -1141,27 +1142,23 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
   test('WorkflowClient.signalWithStart fails with WorkflowExecutionAlreadyStartedError', async (t) => {
     const { client } = t.context;
     const workflowId = uuid4();
-    const handle = await client.signalWithStart(workflows.sleeper, {
+    await client.execute(workflows.sleeper, {
       taskQueue: 'test',
       workflowId,
-      signal: 'unblock',
-      args: [10000000],
     });
-    try {
-      await t.throwsAsync(
-        client.signalWithStart(workflows.sleeper, {
-          taskQueue: 'test',
-          signal: 'unblock',
-          workflowId,
-        }),
-        {
-          instanceOf: WorkflowExecutionAlreadyStartedError,
-          message: 'Workflow execution already started',
-        }
-      );
-    } finally {
-      await handle.terminate();
-    }
+    await t.throwsAsync(
+      client.signalWithStart(workflows.sleeper, {
+        taskQueue: 'test',
+        workflowId,
+        signal: workflows.interruptSignal,
+        signalArgs: ['interrupted from signalWithStart'],
+        workflowIdReusePolicy: WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+      }),
+      {
+        instanceOf: WorkflowExecutionAlreadyStartedError,
+        message: 'Workflow execution already started',
+      }
+    );
   });
 
   test('Handle from WorkflowClient.start follows only own execution chain', async (t) => {


### PR DESCRIPTION
## What was changed

Throw `WorkflowExecutionAlreadyStartedError` in `signalWithStart()` just like `start()`.

## Why?

So that the both functions have consistent errors in this case.

## Checklist

1. Closes
N/A

3. How was this tested:
Unit tests

4. Any docs updates needed?
No
