### PR TITLE
fix: Remove accidental import of large protos into workflow library

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -20,7 +20,7 @@ export { Headers, Next } from './interceptors';
 export * from './interfaces';
 export * from './logger';
 export * from './retry-policy';
-export { type Timestamp, Duration, StringValue } from './time';
+export type { Timestamp, Duration, StringValue } from './time';
 export * from './workflow-handle';
 export * from './workflow-options';
 export * from './versioning-intent';

--- a/packages/common/src/versioning-intent-enum.ts
+++ b/packages/common/src/versioning-intent-enum.ts
@@ -1,0 +1,32 @@
+import type { coresdk } from '@temporalio/proto';
+import type { VersioningIntent as VersioningIntentString } from './versioning-intent';
+import { assertNever, checkExtends } from './type-helpers';
+
+// Avoid importing the proto implementation to reduce workflow bundle size
+// Copied from coresdk.common.VersioningIntent
+/**
+ * Protobuf enum representation of {@link VersioningIntentString}.
+ *
+ * @experimental
+ */
+export enum VersioningIntent {
+  UNSPECIFIED = 0,
+  COMPATIBLE = 1,
+  DEFAULT = 2,
+}
+
+checkExtends<coresdk.common.VersioningIntent, VersioningIntent>();
+checkExtends<VersioningIntent, coresdk.common.VersioningIntent>();
+
+export function versioningIntentToProto(intent: VersioningIntentString | undefined): VersioningIntent {
+  switch (intent) {
+    case 'DEFAULT':
+      return VersioningIntent.DEFAULT;
+    case 'COMPATIBLE':
+      return VersioningIntent.COMPATIBLE;
+    case undefined:
+      return VersioningIntent.UNSPECIFIED;
+    default:
+      assertNever('Unexpected VersioningIntent', intent);
+  }
+}

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -12,16 +12,14 @@ import {
   SignalDefinition,
   toPayloads,
   UntypedActivities,
-  VersioningIntent,
   WithWorkflowArgs,
   Workflow,
   WorkflowResultType,
   WorkflowReturnType,
 } from '@temporalio/common';
-import { assertNever } from '@temporalio/common/lib/type-helpers';
+import { versioningIntentToProto } from '@temporalio/common/lib/versioning-intent-enum';
 import { Duration, msOptionalToTs, msToNumber, msToTs, tsToMs } from '@temporalio/common/lib/time';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
-import { coresdk } from '@temporalio/proto';
 import { CancellationScope, registerSleepImplementation } from './cancellation-scope';
 import {
   ActivityInput,
@@ -1335,17 +1333,4 @@ function assertInWorkflowContext(message: string): Activator {
   const activator = maybeGetActivator();
   if (activator == null) throw new IllegalStateError(message);
   return activator;
-}
-
-function versioningIntentToProto(intent: VersioningIntent | undefined): coresdk.common.VersioningIntent {
-  switch (intent) {
-    case 'DEFAULT':
-      return coresdk.common.VersioningIntent.DEFAULT;
-    case 'COMPATIBLE':
-      return coresdk.common.VersioningIntent.COMPATIBLE;
-    case undefined:
-      return coresdk.common.VersioningIntent.UNSPECIFIED;
-    default:
-      assertNever('Unexpected VersioningIntent', intent);
-  }
 }


### PR DESCRIPTION
The import was added between 1.8.0 and 1.8.1.

Reduces the SDK test workflow bundle from 2.55MB to 1.04MB.