### PR TITLE
fix: Use `for … of` loop instead of `for … in`

### DIFF
--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -268,7 +268,7 @@ export class SearchAttributePayloadConverter implements PayloadConverter {
       const firstValue = values[0];
       const firstType = typeof firstValue;
       if (firstType === 'object') {
-        for (const idx in values) {
+        for (const idx of values) {
           const value = values[idx];
           if (!(value instanceof Date)) {
             throw new ValueError(
@@ -281,7 +281,7 @@ export class SearchAttributePayloadConverter implements PayloadConverter {
           throw new ValueError(`SearchAttribute array values must be: string | number | boolean | Date`);
         }
 
-        for (const idx in values) {
+        for (const idx of values) {
           const value = values[idx];
           if (typeof value !== firstType) {
             throw new ValueError(

--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -268,8 +268,7 @@ export class SearchAttributePayloadConverter implements PayloadConverter {
       const firstValue = values[0];
       const firstType = typeof firstValue;
       if (firstType === 'object') {
-        for (const idx of values) {
-          const value = values[idx];
+        for (const [idx, value] of values.entries()) {
           if (!(value instanceof Date)) {
             throw new ValueError(
               `SearchAttribute values must arrays of strings, numbers, booleans, or Dates. The value ${value} at index ${idx} is of type ${typeof value}`
@@ -281,8 +280,7 @@ export class SearchAttributePayloadConverter implements PayloadConverter {
           throw new ValueError(`SearchAttribute array values must be: string | number | boolean | Date`);
         }
 
-        for (const idx of values) {
-          const value = values[idx];
+        for (const [idx, value] of values.entries()) {
           if (typeof value !== firstType) {
             throw new ValueError(
               `All SearchAttribute array values must be of the same type. The first value ${firstValue} of type ${firstType} doesn't match value ${value} of type ${typeof value} at index ${idx}`

--- a/packages/create-project/src/helpers/install.ts
+++ b/packages/create-project/src/helpers/install.ts
@@ -62,7 +62,7 @@ export async function replaceSdkVersion({ root, sdkVersion }: InstallArgs): Prom
   const fileName = `${root}/package.json`;
 
   const packageJson = JSON.parse(await readFile(fileName, 'utf8'));
-  for (const packageName in packageJson.dependencies) {
+  for (const packageName of packageJson.dependencies) {
     if (packageName.startsWith('@temporalio/')) {
       packageJson.dependencies[packageName] = sdkVersion;
     }

--- a/packages/create-project/src/helpers/install.ts
+++ b/packages/create-project/src/helpers/install.ts
@@ -62,7 +62,7 @@ export async function replaceSdkVersion({ root, sdkVersion }: InstallArgs): Prom
   const fileName = `${root}/package.json`;
 
   const packageJson = JSON.parse(await readFile(fileName, 'utf8'));
-  for (const packageName of packageJson.dependencies) {
+  for (const packageName in packageJson.dependencies) {
     if (packageName.startsWith('@temporalio/')) {
       packageJson.dependencies[packageName] = sdkVersion;
     }

--- a/packages/test/src/test-payload-converter.ts
+++ b/packages/test/src/test-payload-converter.ts
@@ -10,6 +10,7 @@ import {
   METADATA_ENCODING_KEY,
   METADATA_MESSAGE_TYPE_KEY,
   PayloadConverterError,
+  SearchAttributePayloadConverter,
   UndefinedPayloadConverter,
   ValueError,
 } from '@temporalio/common';
@@ -169,6 +170,21 @@ test('ProtobufJSONPayloadConverter converts binary', (t) => {
 
   const testInstance = converter.fromPayload<root.BinaryMessage>(encoded!);
   t.deepEqual(testInstance.data, instance.data);
+});
+
+test(`SearchAttributePayloadConverter doesn't fail if Array.prototype contains enumerable properties`, (t) => {
+  try {
+    const converter = new SearchAttributePayloadConverter();
+    Object.defineProperty(Array.prototype, 'foo', {
+      configurable: true,
+      value: 123,
+      enumerable: true,
+    });
+    converter.toPayload(['test']);
+    t.pass();
+  } finally {
+    delete (Array.prototype as any).foo;
+  }
 });
 
 if (RUN_INTEGRATION_TESTS) {


### PR DESCRIPTION
## What changed

- Use `for … of` loop instead of `for … in` for iterating on array in payload converter.

## Why

- This avoids issues when enumerable properties have been added on `Array.prototype` (eg. some badly implemented polyfills; they should be using `Object.defineProperty(..., { enumerable: false })` instead).