### PR TITLE
fix(workflow): Fix isReplaying being incorrectly true due to query

### DIFF
--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -8,6 +8,7 @@ import {
   Runtime,
   LoggerSinks as DefaultLoggerSinks,
   InjectedSinkFunction,
+  WorkerOptions,
 } from '@temporalio/worker';
 import { SearchAttributes, WorkflowInfo } from '@temporalio/workflow';
 import { UnsafeWorkflowInfo } from '@temporalio/workflow/src/interfaces';
@@ -403,6 +404,58 @@ if (RUN_INTEGRATION_TESTS) {
           CustomDatetimeField: [date],
           CustomDoubleField: [3.14],
         },
+      },
+    ]);
+  });
+
+  test('Core issue 589', async (t) => {
+    const taskQueue = `${__filename}-${t.title}`;
+
+    const recordedMessages = Array<{ message: string; historyLength: number; isReplaying: boolean }>();
+    const sinks: InjectedSinks<workflows.CustomLoggerSinks> = {
+      customLogger: {
+        info: {
+          fn: async (info, message) => {
+            recordedMessages.push({
+              message,
+              historyLength: info.historyLength,
+              isReplaying: info.unsafe.isReplaying,
+            });
+          },
+          callDuringReplay: true,
+        },
+      },
+    };
+
+    const client = new WorkflowClient();
+    const handle = await client.start(workflows.coreIssue589, { taskQueue, workflowId: uuid4() });
+
+    const workerOptions: WorkerOptions = {
+      ...defaultOptions,
+      taskQueue,
+      sinks,
+      maxCachedWorkflows: 2,
+      maxConcurrentWorkflowTaskExecutions: 2,
+
+      // Cut down on execution time
+      stickyQueueScheduleToStartTimeout: 1,
+    };
+
+    await (await Worker.create(workerOptions)).runUntil(new Promise((resolve) => setTimeout(resolve, 1000)));
+    await (
+      await Worker.create(workerOptions)
+    ).runUntil(async () => {
+      await handle.query('q').catch(() => undefined);
+      await handle.signal(workflows.unblockSignal);
+      await handle.result();
+    });
+
+    const checkpointEntries = recordedMessages.filter((m) => m.message.startsWith('Checkpoint'));
+    t.deepEqual(checkpointEntries, [
+      {
+        message: 'Checkpoint, replaying: false, hl: 8',
+        historyLength: 8,
+        isReplaying: false,
       },
     ]);
   });

--- a/packages/test/src/workflows/core-issue-589.ts
+++ b/packages/test/src/workflows/core-issue-589.ts
@@ -1,0 +1,22 @@
+import * as wf from '@temporalio/workflow';
+import { CustomLoggerSinks } from './log-sink-tester';
+import { unblockSignal } from './definitions';
+
+const { customLogger } = wf.proxySinks<CustomLoggerSinks>();
+
+// Demo for https://github.com/temporalio/sdk-core/issues/589
+export async function coreIssue589(): Promise<void> {
+  wf.setHandler(wf.defineQuery('q'), () => {
+    return 'not important';
+  });
+
+  let unblocked = false;
+  wf.setHandler(unblockSignal, () => {
+    unblocked = true;
+  });
+  await wf.condition(() => unblocked, 10000);
+
+  customLogger.info(
+    `Checkpoint, replaying: ${wf.workflowInfo().unsafe.isReplaying}, hl: ${wf.workflowInfo().historyLength}`
+  );
+}

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -29,6 +29,7 @@ export * from './condition-completion-race';
 export * from './condition-timeout-0';
 export * from './continue-as-new-same-workflow';
 export * from './continue-as-new-to-different-workflow';
+export * from './core-issue-589';
 export * from './date';
 export * from './deferred-resolve';
 export * from './definitions';


### PR DESCRIPTION
## What was changed

- Updated core-sdk to include temporalio/sdk-core#597
- Added TS test for that issue

## Why

- This could notably cause situations where calls to sink functions not configured with `calledDuringReplay = true` would not be relayed, as well as situations where `patched(...)` would return false even though this part of the code was being executed for the first time.