### PR TITLE
fix(workflow): Fix isReplaying incorrectly true in signal-evict-query scenario

### DIFF
--- a/packages/test/src/test-signal-query-patch.ts
+++ b/packages/test/src/test-signal-query-patch.ts
@@ -1,0 +1,55 @@
+import crypto from 'node:crypto';
+import test from 'ava';
+import * as wf from '@temporalio/workflow';
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { Worker } from './helpers';
+import * as workflows from './workflows/signal-query-patch-pre-patch';
+
+test('Signal+Query+Patch does not cause non-determinism error on replay', async (t) => {
+  const env = await TestWorkflowEnvironment.createLocal();
+  try {
+    const workflowId = crypto.randomUUID();
+
+    // Create the first worker with pre-patched version of the workflow
+    const worker1 = await Worker.create({
+      connection: env.nativeConnection,
+      taskQueue: 'signal-query-patch',
+      workflowsPath: require.resolve('./workflows/signal-query-patch-pre-patch'),
+
+      // Avoid waiting for sticky execution timeout on worker transition
+      stickyQueueScheduleToStartTimeout: '1s',
+    });
+
+    // Start the workflow, wait for the first task to be processed, then send it a signal and wait for it to be completed
+    const handle = await worker1.runUntil(async () => {
+      const handle = await env.client.workflow.start(workflows.patchQuerySignal, {
+        taskQueue: 'signal-query-patch',
+        workflowId,
+      });
+      await handle.signal(wf.defineSignal('signal'));
+
+      // Make sure the signal got processed before we shutdown the worker
+      await handle.query('query');
+      return handle;
+    });
+
+    // Create the second worker with post-patched version of the workflow
+    const worker2 = await Worker.create({
+      connection: env.nativeConnection,
+      taskQueue: 'signal-query-patch',
+      workflowsPath: require.resolve('./workflows/signal-query-patch-post-patch'),
+    });
+
+    // Trigger a query and wait for it to be processed
+    const enteredPatchBlock = await worker2.runUntil(async () => {
+      await handle.query('query');
+      await handle.signal('unblock');
+
+      return await handle.result();
+    });
+
+    t.false(enteredPatchBlock);
+  } finally {
+    await env.teardown();
+  }
+});

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -444,11 +444,14 @@ if (RUN_INTEGRATION_TESTS) {
       stickyQueueScheduleToStartTimeout: 1,
     };
 
-    await (await Worker.create(workerOptions)).runUntil(new Promise((resolve) => setTimeout(resolve, 1000)));
+    // Start the first worker and wait for the first task to complete before shutdown that worker
+    await (await Worker.create(workerOptions)).runUntil(handle.query('q'));
+
+    // Start the second worker
     await (
       await Worker.create(workerOptions)
     ).runUntil(async () => {
-      await handle.query('q').catch(() => undefined);
+      await handle.query('q');
       await handle.signal(workflows.unblockSignal);
       await handle.result();
     });

--- a/packages/test/src/workflows/signal-query-patch-post-patch.ts
+++ b/packages/test/src/workflows/signal-query-patch-post-patch.ts
@@ -1,0 +1,26 @@
+/**
+ * Post-patched version of a workflow used to reproduce an issue with signal+query+patch
+ *
+ * @module
+ */
+import * as wf from '@temporalio/workflow';
+
+export async function patchQuerySignal(): Promise<boolean> {
+  let enteredPatchBlock = false;
+
+  wf.setHandler(wf.defineQuery<boolean, [string]>('query'), () => true);
+  wf.setHandler(wf.defineSignal('signal'), () => {
+    // This block should not execute, since the patch did not get registered when the signal was first handled.
+    if (wf.patched('should_never_be_set')) {
+      enteredPatchBlock = true;
+    }
+  });
+
+  let blocked = true;
+  wf.setHandler(wf.defineSignal('unblock'), () => {
+    blocked = false;
+  });
+  await wf.condition(() => !blocked);
+
+  return enteredPatchBlock;
+}

--- a/packages/test/src/workflows/signal-query-patch-pre-patch.ts
+++ b/packages/test/src/workflows/signal-query-patch-pre-patch.ts
@@ -1,0 +1,21 @@
+/**
+ * Pre-patched version of a workflow used to reproduce an issue with signal+query+patch
+ *
+ * @module
+ */
+import * as wf from '@temporalio/workflow';
+
+export async function patchQuerySignal(): Promise<boolean> {
+  wf.setHandler(wf.defineQuery<boolean, [string]>('query'), () => true);
+  wf.setHandler(wf.defineSignal('signal'), () => {
+    // Nothing. In post-patch version, there will be a block here, surrounded by a patch check.
+  });
+
+  let blocked = true;
+  wf.setHandler(wf.defineSignal('unblock'), () => {
+    blocked = false;
+  });
+  await wf.condition(() => !blocked);
+
+  throw new Error('Execution should not reach this point in pre-patch version');
+}

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -573,7 +573,7 @@ export function proxyLocalActivities<A = UntypedActivities>(options: LocalActivi
 
 // TODO: deprecate this patch after "enough" time has passed
 const EXTERNAL_WF_CANCEL_PATCH = '__temporal_internal_connect_external_handle_cancel_to_scope';
-// This generic name of this patch comes from an attempt to build a generic internal patching mechanism.
+// The name of this patch comes from an attempt to build a generic internal patching mechanism.
 // That effort has been abandoned in favor of a newer WorkflowTaskCompletedMetadata based mechanism.
 const CONDITION_0_PATCH = '__sdk_internal_patch_number:1';
 


### PR DESCRIPTION
## What was changed

- Fix a case where `isReplaying` is incorrectly `true` if a workflow receives a signal, then the workflow is evicted from cache (or worker is restarted), then a query is sent to that workflow. This may have caused `patched()` to succeed despite that patch not having been set on first execution, and NDE afterward when the workflow get replayed.

- Fix a flake in CI test