### PR TITLE
chore: Remove experimental flags on Schedules, Failure Converters, Local Activities and Replay Histories

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -43,8 +43,6 @@ export class Client extends BaseClient {
   public readonly activity: AsyncCompletionClient;
   /**
    * Schedule sub-client - use to start and interact with Schedules
-   *
-   * @experimental
    */
   public readonly schedule: ScheduleClient;
   /**

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -145,8 +145,6 @@ export interface WorkflowClientInterceptors {
 
 /**
  * Implement any of these methods to intercept ScheduleClient outbound calls
- *
- * @experimental
  */
 export interface ScheduleClientInterceptor {
   /**
@@ -157,8 +155,6 @@ export interface ScheduleClientInterceptor {
 
 /**
  * Input for {@link ScheduleClientInterceptor.create}
- *
- * @experimental
  */
 export interface CreateScheduleInput {
   readonly headers: Headers;
@@ -178,8 +174,5 @@ export interface ClientInterceptors {
   // eslint-disable-next-line deprecation/deprecation
   workflow?: WorkflowClientInterceptors | WorkflowClientInterceptor[];
 
-  /**
-   * @experimental
-   */
   schedule?: ScheduleClientInterceptor[];
 }

--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -50,8 +50,6 @@ import { rethrowKnownErrorTypes } from './helpers';
 
 /**
  * Handle to a single Schedule
- *
- * @experimental
  */
 export interface ScheduleHandle {
   /**
@@ -113,9 +111,6 @@ export interface ScheduleHandle {
   readonly client: ScheduleClient;
 }
 
-/**
- * @experimental
- */
 export interface ScheduleClientOptions extends BaseClientOptions {
   /**
    * Used to override and extend default Connection functionality
@@ -125,7 +120,6 @@ export interface ScheduleClientOptions extends BaseClientOptions {
   interceptors?: ScheduleClientInterceptor[];
 }
 
-/** @experimental */
 export type LoadedScheduleClientOptions = LoadedWithDefaults<ScheduleClientOptions>;
 
 function defaultScheduleClientOptions(): WithDefaults<ScheduleClientOptions> {
@@ -156,7 +150,6 @@ function assertRequiredScheduleOptions(
   }
 }
 
-/** @experimental */
 export interface ListScheduleOptions {
   /**
    * How many results to fetch from the Server at a time.
@@ -167,8 +160,6 @@ export interface ListScheduleOptions {
 
 /**
  * Client for starting Workflow executions and creating Workflow handles
- *
- * @experimental
  */
 export class ScheduleClient extends BaseClient {
   public readonly options: LoadedScheduleClientOptions;
@@ -525,8 +516,6 @@ export class ScheduleClient extends BaseClient {
 
 /**
  * Thrown from {@link ScheduleClient.create} if there's a running (not deleted) Schedule with the given `id`.
- *
- * @experimental
  */
 @SymbolBasedInstanceOfError('ScheduleAlreadyRunning')
 export class ScheduleAlreadyRunning extends Error {
@@ -540,8 +529,6 @@ export class ScheduleAlreadyRunning extends Error {
  * It could be because:
  * - Id passed is incorrect
  * - Schedule was deleted
- *
- * @experimental
  */
 @SymbolBasedInstanceOfError('ScheduleNotFoundError')
 export class ScheduleNotFoundError extends Error {

--- a/packages/client/src/schedule-types.ts
+++ b/packages/client/src/schedule-types.ts
@@ -5,8 +5,6 @@ import { WorkflowStartOptions } from './workflow-options';
 
 /**
  * The specification of a Schedule to be created, as expected by {@link ScheduleClient.create}.
- *
- * @experimental
  */
 export interface ScheduleOptions<A extends ScheduleOptionsAction = ScheduleOptionsAction> {
   /**
@@ -119,7 +117,6 @@ export interface ScheduleOptions<A extends ScheduleOptionsAction = ScheduleOptio
   };
 }
 
-/** @experimental */
 export type CompiledScheduleOptions = Replace<
   ScheduleOptions,
   {
@@ -129,8 +126,6 @@ export type CompiledScheduleOptions = Replace<
 
 /**
  * The specification of an updated Schedule, as expected by {@link ScheduleHandle.update}.
- *
- * @experimental
  */
 export type ScheduleUpdateOptions<A extends ScheduleOptionsAction = ScheduleOptionsAction> = Replace<
   Omit<ScheduleOptions, 'scheduleId' | 'memo' | 'searchAttributes'>,
@@ -140,7 +135,6 @@ export type ScheduleUpdateOptions<A extends ScheduleOptionsAction = ScheduleOpti
   }
 >;
 
-/** @experimental */
 export type CompiledScheduleUpdateOptions = Replace<
   ScheduleUpdateOptions,
   {
@@ -153,8 +147,6 @@ export type CompiledScheduleUpdateOptions = Replace<
  *
  * Note that schedule listing is eventual consistent; some returned properties may therefore
  * be undefined or incorrect for some time after creating or modifying a schedule.
- *
- * @experimental
  */
 export interface ScheduleSummary {
   /**
@@ -212,7 +204,6 @@ export interface ScheduleSummary {
   };
 }
 
-/** @experimental */
 export interface ScheduleExecutionResult {
   /** Time that the Action was scheduled for, including jitter */
   scheduledAt: Date;
@@ -224,10 +215,8 @@ export interface ScheduleExecutionResult {
   action: ScheduleExecutionActionResult;
 }
 
-/** @experimental */
 export type ScheduleExecutionActionResult = ScheduleExecutionStartWorkflowActionResult;
 
-/** @experimental */
 export interface ScheduleExecutionStartWorkflowActionResult {
   type: 'startWorkflow';
   workflow: {
@@ -243,8 +232,6 @@ export interface ScheduleExecutionStartWorkflowActionResult {
 
 /**
  * A detailed description of an exisiting Schedule, as returned by {@link ScheduleHandle.describe}.
- *
- * @experimental
  */
 export type ScheduleDescription = {
   /**
@@ -378,8 +365,6 @@ checkExtends<ScheduleUpdateOptions, ScheduleDescription>();
  * The times are the union of `calendars`, `intervals`, and `cronExpressions`, minus the `skip` times. These times
  * never change, except that the definition of a time zone can change over time (most commonly, when daylight saving
  * time policy changes for an area). To create a totally self-contained `ScheduleSpec`, use UTC.
- *
- * @experimental
  */
 export interface ScheduleSpec {
   /** Calendar-based specifications of times. */
@@ -483,8 +468,6 @@ export interface ScheduleSpec {
 
 /**
  * The version of {@link ScheduleSpec} that you get back from {@link ScheduleHandle.describe} and {@link ScheduleClient.list}
- *
- * @experimental
  */
 export type ScheduleSpecDescription = Omit<
   ScheduleSpec,
@@ -515,8 +498,6 @@ checkExtends<ScheduleSpec, ScheduleSpecDescription>();
  * An event specification relative to the calendar, similar to a traditional cron specification.
  *
  * A second in time matches if all fields match. This includes `dayOfMonth` and `dayOfWeek`.
- *
- * @experimental
  */
 export interface CalendarSpec {
   /**
@@ -574,8 +555,6 @@ export interface CalendarSpec {
  * An event specification relative to the calendar, similar to a traditional cron specification.
  *
  * A second in time matches if all fields match. This includes `dayOfMonth` and `dayOfWeek`.
- *
- * @experimental
  */
 export interface CalendarSpecDescription {
   /**
@@ -644,8 +623,6 @@ export interface CalendarSpecDescription {
  * of 19 minutes would match every `xx:19:00`. An `every` of 28 days with `offset` zero would match `2022-02-17T00:00:00Z`
  * (among other times). The same `every` with `offset` of 3 days, 5 hours, and 23 minutes would match `2022-02-20T05:23:00Z`
  * instead.
- *
- * @experimental
  */
 export interface IntervalSpec {
   /**
@@ -677,8 +654,6 @@ export interface IntervalSpec {
  * instead.
  *
  * This is the version of {@link IntervalSpec} that you get back from {@link ScheduleHandle.describe} and {@link ScheduleClient.list}
- *
- * @experimental
  */
 export interface IntervalSpecDescription {
   /**
@@ -699,8 +674,6 @@ export interface IntervalSpecDescription {
 /**
  * Range represents a set of values, used to match fields of a calendar. If end < start, then end is
  * interpreted as equal to start. Similarly, if step is less than 1, then step is interpreted as 1.
- *
- * @experimental
  */
 export interface Range<Unit> {
   /**
@@ -733,15 +706,12 @@ export interface Range<Unit> {
  * { start: 2, end: 4 } ➡️ 2, 3, 4
  * { start: 2, end: 10, step: 3 } ➡️ 2, 5, 8
  * ```
- *
- * @experimental
  */
 export type LooseRange<Unit> =
   | Range<Unit>
   | { start: Range<Unit>['start']; end?: Range<Unit>['end']; step?: never }
   | Unit;
 
-/** @experimental */
 export const MONTHS = [
   'JANUARY',
   'FEBRUARY',
@@ -757,19 +727,14 @@ export const MONTHS = [
   'DECEMBER',
 ] as const;
 
-/** @experimental */
 export type Month = (typeof MONTHS)[number];
 
-/** @experimental */
 export const DAYS_OF_WEEK = ['SUNDAY', 'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY'] as const;
 
-/** @experimental */
 export type DayOfWeek = (typeof DAYS_OF_WEEK)[number];
 
-/** @experimental */
 export type ScheduleOptionsAction = ScheduleOptionsStartWorkflowAction<Workflow>;
 
-/** @experimental */
 export type ScheduleOptionsStartWorkflowAction<W extends Workflow> = {
   type: 'startWorkflow';
   workflowType: string | W;
@@ -793,18 +758,15 @@ export type ScheduleOptionsStartWorkflowAction<W extends Workflow> = {
     workflowId?: string;
   };
 
-/** @experimental */
 export type ScheduleSummaryAction = ScheduleSummaryStartWorkflowAction;
 
-/** @experimental */
 export interface ScheduleSummaryStartWorkflowAction {
   type: 'startWorkflow';
   workflowType: string;
 }
-/** @experimental */
+
 export type ScheduleDescriptionAction = ScheduleDescriptionStartWorkflowAction;
 
-/** @experimental */
 export type ScheduleDescriptionStartWorkflowAction = ScheduleSummaryStartWorkflowAction &
   Pick<
     WorkflowStartOptions<Workflow>,
@@ -822,7 +784,6 @@ export type ScheduleDescriptionStartWorkflowAction = ScheduleSummaryStartWorkflo
 // Invariant: an existing ScheduleDescriptionAction can be used as is to create or update a schedule
 checkExtends<ScheduleOptionsAction, ScheduleDescriptionAction>();
 
-/** @experimental */
 export type CompiledScheduleAction = Replace<
   ScheduleDescriptionAction,
   {
@@ -833,8 +794,6 @@ export type CompiledScheduleAction = Replace<
 
 /**
  * Policy for overlapping Actions.
- *
- * @experimental
  */
 export enum ScheduleOverlapPolicy {
   /**
@@ -888,7 +847,6 @@ checkExtends<
   keyof typeof temporal.api.enums.v1.ScheduleOverlapPolicy
 >();
 
-/** @experimental */
 export interface Backfill {
   /**
    * Start of the time range to evaluate Schedule in.

--- a/packages/common/src/converter/data-converter.ts
+++ b/packages/common/src/converter/data-converter.ts
@@ -38,8 +38,6 @@ export interface DataConverter {
    * Path of a file that has a `failureConverter` named export.
    * `failureConverter` should be an object that implements {@link FailureConverter}.
    * If no path is provided, {@link defaultFailureConverter} is used.
-   *
-   * @experimental
    */
   failureConverterPath?: string;
 

--- a/packages/common/src/converter/failure-converter.ts
+++ b/packages/common/src/converter/failure-converter.ts
@@ -47,8 +47,6 @@ export function cutoffStackTrace(stack?: string): string {
  *
  * We recommended using the {@link DefaultFailureConverter} instead of customizing the default implementation in order
  * to maintain cross-language Failure serialization compatibility.
- *
- * @experimental
  */
 export interface FailureConverter {
   /**
@@ -89,8 +87,6 @@ export interface DefaultFailureConverterOptions {
  * `encodeCommonAttributes` to `true` in the constructor options and use a {@link PayloadCodec} that can encrypt /
  * decrypt Payloads in your {@link WorkerOptions.dataConverter | Worker} and
  * {@link ClientOptions.dataConverter | Client options}.
- *
- * @experimental
  */
 export class DefaultFailureConverter implements FailureConverter {
   public readonly options: DefaultFailureConverterOptions;

--- a/packages/worker/src/replay.ts
+++ b/packages/worker/src/replay.ts
@@ -24,8 +24,6 @@ export interface ReplayResult {
 
 /**
  * An iterable on workflow histories and their IDs, used for batch replaying.
- *
- * @experimental - this API is not considered stable
  */
 export type ReplayHistoriesIterable = AsyncIterable<HistoryAndWorkflowId> | Iterable<HistoryAndWorkflowId>;
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -529,8 +529,6 @@ export class Worker {
    * Create a replay Worker, running all histories provided by the passed in iterable.
    *
    * Returns an async iterable of results for each history replayed.
-   *
-   * @experimental - this API is considered unstable
    */
   public static async *runReplayHistories(
     options: ReplayWorkerOptions,

--- a/packages/workflow/src/interceptors.ts
+++ b/packages/workflow/src/interceptors.ts
@@ -195,6 +195,8 @@ export interface DisposeInput {}
  * Interceptor for the internals of the Workflow runtime.
  *
  * Use to manipulate or trace Workflow activations.
+ *
+ * @experimental This API is for advanced use cases and may change in the future.
  */
 export interface WorkflowInternalsInterceptor {
   /**

--- a/packages/workflow/src/interceptors.ts
+++ b/packages/workflow/src/interceptors.ts
@@ -195,8 +195,6 @@ export interface DisposeInput {}
  * Interceptor for the internals of the Workflow runtime.
  *
  * Use to manipulate or trace Workflow activations.
- *
- * @experimental
  */
 export interface WorkflowInternalsInterceptor {
   /**

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -546,8 +546,6 @@ export function proxyActivities<A = UntypedActivities>(options: ActivityOptions)
  * @return a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy | Proxy}
  *         for which each attribute is a callable Activity function
  *
- * @experimental
- *
  * @see {@link proxyActivities} for examples
  */
 export function proxyLocalActivities<A = UntypedActivities>(options: LocalActivityOptions): ActivityInterfaceFor<A> {


### PR DESCRIPTION
## What was changed

The following APIs are no longer marked as experimental:

- Schedules
- Failure Converters
- Local Activities
- Replay Histories

For info, at this date, the following APIs are still marked as experimental:

- Versioning / TaskQueueClient (newly introduced)
- Client's gRPC retry options (not sure we want to commit to long time support on this, and for sure, not before we upgrade to grpc-js 1.8)
- All telemetry options (likely to change due to upcoming advanced metrics support)

This one is deemed to perpertual 'experimental'

- Workflow Internal Interceptors (this is for advanced use cases, and we don't want to commit to long term support)
