### PR TITLE
changed the signal definition on ExternalWorkflowHandle

### DIFF
--- a/packages/workflow/src/workflow-handle.ts
+++ b/packages/workflow/src/workflow-handle.ts
@@ -17,7 +17,10 @@ export interface ExternalWorkflowHandle {
    * await handle.signal(incrementSignal, 3);
    * ```
    */
-  signal<Args extends any[] = []>(def: SignalDefinition<Args> | string, ...args: Args): Promise<void>;
+  signal<Args extends any[] = [], Name extends string = string>(
+    def: SignalDefinition<Args, Name> | string,
+    ...args: Args
+  ): Promise<void>;
 
   /**
    * Cancel the external Workflow execution.


### PR DESCRIPTION
changed the signal definition on ExternalWorkflowHandle so it matches the definition of BaseWorkflowHandle

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
the definition of signal was not the same in the interface ExternalWorkflowHandle and BaseWorkflowHandleClass

## Why?
<!-- Tell your future self why have you made these changes -->
Made sure the definition of Signal are the same because it causes problem where you have a typescript error when you call signal on an variable that was defined as ExternalWorkflowHandle | ChildWorkflowHandle.

## Checklist
ran test before: 222 passed  | 9 todo
build with no error
ran test after: 222 passed | 9 todo

2. How was this tested:
N/A


3. Any docs updates needed?
no docs updates should be needed
