### PR TITLE
fix(workflow): make ExternalWorkflowHandle.signal signature match that of BaseWorkflowHandle.signal

### DIFF
--- a/packages/test/src/test-interface-type-safety.ts
+++ b/packages/test/src/test-interface-type-safety.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
-import { defineSignal, defineQuery } from '@temporalio/workflow';
+import { defineSignal, defineQuery, ExternalWorkflowHandle, ChildWorkflowHandle, Workflow } from '@temporalio/workflow';
+import { WorkflowHandle } from '@temporalio/client';
 
 test('SignalDefinition Name type safety', (t) => {
   // @ts-expect-error Assert expect a type error when generic and concrete names do not match
@@ -51,5 +52,15 @@ test('QueryDefinition Args and Ret type safety', (t) => {
   type ArgTypeAssertion = typeof argVariantB extends typeof argVariantA ? 'intermixable' : 'not-intermixable';
 
   const _argAssertion: ArgTypeAssertion = 'not-intermixable';
+  t.pass();
+});
+
+test('Can call signal on any WorkflowHandle', async (t) => {
+  // This function definition is an assertion by itself. TSC will throw a compile time error if
+  // the signature of the signal function is not compatible across all WorkflowHandle variants.
+  function _assertion<T extends Workflow>(handle: WorkflowHandle<T> | ChildWorkflowHandle<T> | ExternalWorkflowHandle) {
+    handle.signal(defineSignal('signal'));
+  }
+
   t.pass();
 });

--- a/packages/workflow/src/workflow-handle.ts
+++ b/packages/workflow/src/workflow-handle.ts
@@ -17,7 +17,10 @@ export interface ExternalWorkflowHandle {
    * await handle.signal(incrementSignal, 3);
    * ```
    */
-  signal<Args extends any[] = []>(def: SignalDefinition<Args> | string, ...args: Args): Promise<void>;
+  signal<Args extends any[] = [], Name extends string = string>(
+    def: SignalDefinition<Args, Name> | string,
+    ...args: Args
+  ): Promise<void>;
 
   /**
    * Cancel the external Workflow execution.


### PR DESCRIPTION
## What was changed

- `ExternalWorkflowHandle.signal` signature was changed to match that of `BaseWorkflowHandle.signal`

## Note

- This change was originally contributed in #1236 by @gabrielsantosblanchet. It was moved to a new PR so that I could add tests (OP's branch did not allowed edits by maintainers).