### PR TITLE
fix(activity): Change to arrow function notation so class context is not lost

### DIFF
--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -285,7 +285,7 @@ export class Context {
    */
   public heartbeat = (details?: unknown): void => {
     this.heartbeatFn(details);
-  }
+  };
 
   /**
    * Gets the context of the current Activity.
@@ -311,5 +311,5 @@ export class Context {
       handle = setTimeout(resolve, msToNumber(ms));
     });
     return Promise.race([this.cancelled.finally(() => clearTimeout(handle)), timer]);
-  }
+  };
 }

--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -297,6 +297,8 @@ export class Context {
     if (store === undefined) {
       throw new Error('Activity context not initialized');
     }
+    store.sleep = store.sleep.bind(store);
+    store.heartbeat = store.heartbeat.bind(store);
     return store;
   }
 

--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -283,7 +283,7 @@ export class Context {
    * :warning: Cancellation is not propagated from this function, use {@link cancelled} or {@link cancellationSignal} to
    * subscribe to cancellation notifications.
    */
-  public heartbeat(details?: unknown): void {
+  public heartbeat = (details?: unknown): void => {
     this.heartbeatFn(details);
   }
 
@@ -297,8 +297,6 @@ export class Context {
     if (store === undefined) {
       throw new Error('Activity context not initialized');
     }
-    store.sleep = store.sleep.bind(store);
-    store.heartbeat = store.heartbeat.bind(store);
     return store;
   }
 
@@ -307,7 +305,7 @@ export class Context {
    * @param ms Sleep duration: number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    * @returns A Promise that either resolves when `ms` is reached or rejects when the Activity is cancelled
    */
-  public sleep(ms: Duration): Promise<void> {
+  public sleep = (ms: Duration): Promise<void> => {
     let handle: NodeJS.Timeout;
     const timer = new Promise<void>((resolve) => {
       handle = setTimeout(resolve, msToNumber(ms));


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added missing bindings on activity context class.

## Why?
<!-- Tell your future self why have you made these changes -->
Since we are restoring the `Context` class from `AsyncLocalStorage`. Class scope is missing and thus rebinding is necessary. Attempting to use `Context.current().heartbeat()` or `Context.current().sleep()` would result on `this` property is undefined error.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
I tested it with the `activities-cancellation-heartbeating` SDK example.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Since it addresses a current bug, no doc changes are necessary.
