### PR TITLE
docs: Tell versioning users to call updateBuildIdCompatibility

### DIFF
--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -88,6 +88,9 @@ export interface WorkerOptions {
    *
    * ℹ️ Required if {@link useVersioning} is `true`.
    *
+   * :warning: NOTE: When used with versioning, you must call {@link updateBuildIdCompatibility}.
+   * Otherwise, this Worker will not pick up any tasks.
+   *
    * @default `@temporalio/worker` package name and version + checksum of workflow bundle's code
    *
    * @experimental

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -88,7 +88,7 @@ export interface WorkerOptions {
    *
    * ℹ️ Required if {@link useVersioning} is `true`.
    *
-   * :warning: NOTE: When used with versioning, you must call {@link updateBuildIdCompatibility}.
+   * :warning: NOTE: When used with versioning, you must pass this build ID to {@link updateBuildIdCompatibility}.
    * Otherwise, this Worker will not pick up any tasks.
    *
    * @default `@temporalio/worker` package name and version + checksum of workflow bundle's code


### PR DESCRIPTION
So they know to do so. Without doing so, they may not realize why their Workers aren't picking up tasks.

Could put note under `useVersioning` instead, but imagine `buildId` is more often looked at.