### PR TITLE
fix: Fix race in TestEnvironment test causing flakes

### DIFF
--- a/packages/test/src/test-testenvironment.ts
+++ b/packages/test/src/test-testenvironment.ts
@@ -2,7 +2,6 @@ import anyTest, { TestFn } from 'ava';
 import { v4 as uuid4 } from 'uuid';
 import { WorkflowFailedError } from '@temporalio/client';
 import { TestWorkflowEnvironment, workflowInterceptorModules } from '@temporalio/testing';
-import { Connection } from '@temporalio/testing/lib/connection';
 import { bundleWorkflowCode, WorkflowBundleWithSourceMap } from '@temporalio/worker';
 import {
   assertFromWorkflow,
@@ -79,11 +78,6 @@ test.serial('TestEnvironment can toggle between normal and skipped time', async 
 });
 
 test.serial('TestEnvironment sleep can be used to delay activity completion', async (t) => {
-  // TODO: check why this fails on windows
-  if (process.platform === 'win32') {
-    t.pass();
-    return;
-  }
   const { client, nativeConnection, sleep } = t.context.testEnv;
 
   const worker = await Worker.create({
@@ -106,10 +100,6 @@ test.serial('TestEnvironment sleep can be used to delay activity completion', as
     t.is(winner, expectedWinner);
   };
   await worker.runUntil(async () => {
-    // TODO: there's an issue with the Java test server where if an activity
-    // does not complete before its scheduling workflow, time skipping stays
-    // locked.
-    // If the order of the below 2 statements is reversed, this test will hang.
     await run('activity');
     await run('timer');
   });
@@ -117,15 +107,7 @@ test.serial('TestEnvironment sleep can be used to delay activity completion', as
 });
 
 test.serial('TestEnvironment sleep can be used to delay sending a signal', async (t) => {
-  // TODO: check why this fails on windows
-  if (process.platform === 'win32') {
-    t.pass();
-    return;
-  }
   const { client, nativeConnection, sleep } = t.context.testEnv;
-  // TODO: due to the test server issue mentioned in the test avove we need to manually unlock time skipping
-  // for the current test to balance out the time skipping lock counter.
-  await (t.context.testEnv.connection as Connection).testService.unlockTimeSkipping({});
 
   const worker = await Worker.create({
     connection: nativeConnection,

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -765,7 +765,7 @@ export class Worker {
    */
   shutdown(): void {
     if (this.state !== 'RUNNING') {
-      throw new IllegalStateError('Not running');
+      throw new IllegalStateError(`Not running. Current state: ${this.state}`);
     }
     this.state = 'STOPPING';
     this.nativeWorker


### PR DESCRIPTION
## What changed

- Slightly modify the `raceActivityAndTimer` test so that we wait for activity completion before actually completing the workflow. This avoid bug described in https://github.com/temporalio/sdk-java/issues/1138. The previous workaround was failing on Windows and causing some rare CI flakes.