### PR TITLE
fix(proto): protobuf exports may be incorrect if minimized

### DIFF
--- a/packages/common/src/converter/protobuf-payload-converters.ts
+++ b/packages/common/src/converter/protobuf-payload-converters.ts
@@ -193,7 +193,7 @@ function isProtobufType(type: unknown): type is Type {
   return (
     isRecord(type) &&
     // constructor.name may get mangled by minifiers; thanksfuly protobufjs also sets a className property
-    (type.constructor.name === 'Type' || (type.constructor as any).className === 'Type') &&
+    (type.constructor as any).className === 'Type') &&
     hasOwnProperties(type, ['parent', 'name', 'create', 'encode', 'decode']) &&
     typeof type.name === 'string' &&
     typeof type.create === 'function' &&
@@ -216,7 +216,7 @@ function getNamespacedTypeName(node: Type | Namespace): string {
 
 function isRoot(root: unknown): root is Root {
   // constructor.name may get mangled by minifiers; thanksfuly protobufjs also sets a className property
-  return isRecord(root) && (root.constructor.name === 'Root' || (root.constructor as any).className === 'Root');
+  return isRecord(root) && (root.constructor as any).className === 'Root');
 }
 
 export interface DefaultPayloadConverterWithProtobufsOptions {

--- a/packages/common/src/converter/protobuf-payload-converters.ts
+++ b/packages/common/src/converter/protobuf-payload-converters.ts
@@ -193,7 +193,7 @@ function isProtobufType(type: unknown): type is Type {
   return (
     isRecord(type) &&
     // constructor.name may get mangled by minifiers; thanksfuly protobufjs also sets a className property
-    (type.constructor as any).className === 'Type') &&
+    (type.constructor as any).className === 'Type' &&
     hasOwnProperties(type, ['parent', 'name', 'create', 'encode', 'decode']) &&
     typeof type.name === 'string' &&
     typeof type.create === 'function' &&
@@ -216,7 +216,7 @@ function getNamespacedTypeName(node: Type | Namespace): string {
 
 function isRoot(root: unknown): root is Root {
   // constructor.name may get mangled by minifiers; thanksfuly protobufjs also sets a className property
-  return isRecord(root) && (root.constructor as any).className === 'Root');
+  return isRecord(root) && (root.constructor as any).className === 'Root';
 }
 
 export interface DefaultPayloadConverterWithProtobufsOptions {

--- a/packages/common/src/converter/protobuf-payload-converters.ts
+++ b/packages/common/src/converter/protobuf-payload-converters.ts
@@ -192,7 +192,8 @@ function resetBufferInGlobal(hasChanged: boolean): void {
 function isProtobufType(type: unknown): type is Type {
   return (
     isRecord(type) &&
-    type.constructor.name === 'Type' &&
+    // constructor.name may get mangled by minifiers; thanksfuly protobufjs also sets a className property
+    (type.constructor.name === 'Type' || (type.constructor as any).className === 'Type') &&
     hasOwnProperties(type, ['parent', 'name', 'create', 'encode', 'decode']) &&
     typeof type.name === 'string' &&
     typeof type.create === 'function' &&
@@ -214,7 +215,8 @@ function getNamespacedTypeName(node: Type | Namespace): string {
 }
 
 function isRoot(root: unknown): root is Root {
-  return isRecord(root) && root.constructor.name === 'Root';
+  // constructor.name may get mangled by minifiers; thanksfuly protobufjs also sets a className property
+  return isRecord(root) && (root.constructor.name === 'Root' || (root.constructor as any).className === 'Root');
 }
 
 export interface DefaultPayloadConverterWithProtobufsOptions {

--- a/packages/proto/src/patch-protobuf-root.ts
+++ b/packages/proto/src/patch-protobuf-root.ts
@@ -53,11 +53,15 @@ type Type = Record<string, unknown>;
 type Namespace = { nested: Record<string, unknown> };
 
 function isType(value: unknown): value is Type {
-  return isRecord(value) && value.constructor.name === 'Type';
+  // constructor.name may get mangled by minifiers; thanksfuly protobufjs also sets a constructor.className property
+  return isRecord(value) && (value.constructor.name === 'Type' || (value.constructor as any).className === 'Type');
 }
 
 function isNamespace(value: unknown): value is Namespace {
-  return isRecord(value) && value.constructor.name === 'Namespace';
+  // constructor.name may get mangled by minifiers; thanksfuly protobufjs also sets a constructor.className property
+  return (
+    isRecord(value) && (value.constructor.name === 'Namespace' || (value.constructor as any).className === 'Namespace')
+  );
 }
 
 // Duplicate from type-helpers instead of importing in order to avoid circular dependency

--- a/packages/proto/src/patch-protobuf-root.ts
+++ b/packages/proto/src/patch-protobuf-root.ts
@@ -54,14 +54,12 @@ type Namespace = { nested: Record<string, unknown> };
 
 function isType(value: unknown): value is Type {
   // constructor.name may get mangled by minifiers; thanksfuly protobufjs also sets a constructor.className property
-  return isRecord(value) && (value.constructor.name === 'Type' || (value.constructor as any).className === 'Type');
+  return isRecord(value) && (value.constructor as any).className === 'Type';
 }
 
 function isNamespace(value: unknown): value is Namespace {
   // constructor.name may get mangled by minifiers; thanksfuly protobufjs also sets a constructor.className property
-  return (
-    isRecord(value) && (value.constructor.name === 'Namespace' || (value.constructor as any).className === 'Namespace')
-  );
+  return isRecord(value) && (value.constructor as any).className === 'Namespace';
 }
 
 // Duplicate from type-helpers instead of importing in order to avoid circular dependency

--- a/packages/test/src/test-patch-root.ts
+++ b/packages/test/src/test-patch-root.ts
@@ -23,6 +23,8 @@ test('patchRoot', (t) => {
 });
 
 class Namespace {
+  public static className = 'Namespace';
+
   constructor(props: Record<string, unknown>) {
     for (const key in props) {
       (this as any)[key] = props[key];
@@ -30,4 +32,6 @@ class Namespace {
   }
 }
 
-class Type {}
+class Type {
+  public static className = 'Type';
+}


### PR DESCRIPTION
## What changed

- In a few places, we reflectively visit and transform our protobuf definitions. To determine the type of node being visited (Root, Namespace or Type), we would previously check the object's `constructor.name`. However, that name could get mangled if the package was bundled and minimized, which would generally result in error messages such as:

  ```
  <app-dir>/node_modules/@temporalio/client/src/types.ts:62
  export const { WorkflowService } = proto.temporal.api.workflowservice.v1;
                                                    ^
  TypeError: Cannot read properties of undefined (reading 'api')
  ```

  We now check `constructor.className` instead, which is a convenient property added by the protobufjs library, specifically for the purpose of reflection.


## Note

- We provide no guarantee regarding the inclusion of `@temporalio/*` packages as part of bundled and/or minimized applications. We do not test such usage at this time. We strongly recommend configuring your bundler to treat these packages as external.