### PR TITLE
fix: make it possible to omit port from connection address

### DIFF
--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -149,7 +149,7 @@ function normalizeGRPCConfig(options?: ConnectionOptions): ConnectionOptions {
     // eslint-disable-next-line prefer-const
     let [host, port] = rest.address.split(':', 2);
     port = port || '7233';
-    rest.address = `${host}:${port}`;
+    rest.address = port === "null" ? host : `${host}:${port}`;
   }
   const tls = normalizeTlsConfig(tlsFromConfig);
   if (tls) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Allows users to specify that they would like to omit the port entirely from the address used in the Connection constructor.
Users can now specify an address of the form `temporal.svc.mydomain.com:null` which will translate to the address `temporal.svc.mydomain.com`.

## Why?
Currently it is impossible to specify an address for use in the Connection constructor that omits the port entirely. As a user, if I try to specify the address `temporal.svc.mydomain.com`, it will translate to the address `temporal.svc.mydomain.com:7233` with the default port of 7233 set.

This can break network connectivity for load balancer & ingress configurations that rely on raw host names without ports.
> Note: The Temporal Python SDK does not have this behavior, and allows users to specify hosts without ports.

## Checklist
None

1. How was this tested:
I changed the code on a local copy, and saw that connectivity from my temporal client to my temporal server was restored. 

2. Any docs updates needed?

I'm not sure where to update documentation, but somewhere it should be documented that users can set the port to the string `"null"` to omit setting the port in the address for Connections.
