### PR TITLE
chore: Deprecate `defaultSinks`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@temporalio/client": "file:packages/client",
         "@temporalio/common": "file:packages/common",
         "@temporalio/create": "file:packages/create-project",
+        "@temporalio/interceptors-opentelemetry": "file:packages/interceptors-opentelemetry",
         "@temporalio/nyc-test-coverage": "file:packages/nyc-test-coverage",
         "@temporalio/proto": "file:packages/proto",
         "@temporalio/test": "file:packages/test",
@@ -19,6 +20,9 @@
         "temporalio": "file:packages/meta"
       },
       "devDependencies": {
+        "@opentelemetry/api": "^1.4.1",
+        "@opentelemetry/core": "^1.12.0",
+        "@opentelemetry/sdk-node": "^0.38.0",
         "@tsconfig/node14": "^1.0.3",
         "@types/dedent": "^0.7.0",
         "@types/fs-extra": "^9.0.13",
@@ -18761,11 +18765,6 @@
         "@temporalio/common": "file:../common",
         "@temporalio/worker": "file:../worker",
         "@temporalio/workflow": "file:../workflow"
-      },
-      "devDependencies": {
-        "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/core": "^1.12.0",
-        "@opentelemetry/sdk-node": "^0.38.0"
       }
     },
     "packages/meta": {
@@ -21815,7 +21814,6 @@
         "@opentelemetry/api": "^1.4.1",
         "@opentelemetry/core": "^1.12.0",
         "@opentelemetry/resources": "^1.12.0",
-        "@opentelemetry/sdk-node": "^0.38.0",
         "@opentelemetry/sdk-trace-base": "^1.12.0",
         "@temporalio/activity": "file:../activity",
         "@temporalio/client": "file:../client",

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -10,7 +10,7 @@ import {
   WorkerOptions,
   LogEntry,
 } from '@temporalio/worker';
-import { LoggerSinks as DefaultLoggerSinks } from '@temporalio/workflow/lib/logs';
+import { LoggerSinksInternal as DefaultLoggerSinks } from '@temporalio/workflow/lib/logs';
 import { SearchAttributes, WorkflowInfo } from '@temporalio/workflow';
 import { UnsafeWorkflowInfo } from '@temporalio/workflow/src/interfaces';
 import { RUN_INTEGRATION_TESTS, Worker, registerDefaultCustomSearchAttributes } from './helpers';
@@ -23,12 +23,12 @@ class DependencyError extends Error {
   }
 }
 
-function asDefaultLoggerSink(
+function asSdkLoggerSink(
   fn: (info: WorkflowInfo, message: string, attrs?: Record<string, unknown>) => Promise<void>,
   opts?: Omit<InjectedSinkFunction<any>, 'fn'>
 ): InjectedSinks<DefaultLoggerSinks> {
   return {
-    defaultWorkerLogger: {
+    __temporal_logger: {
       trace: { fn, ...opts },
       debug: { fn, ...opts },
       info: { fn, ...opts },
@@ -375,7 +375,7 @@ if (RUN_INTEGRATION_TESTS) {
     const taskQueue = `${__filename}-${t.title}`;
 
     const recordedMessages = Array<{ message: string; searchAttributes: SearchAttributes }>();
-    const sinks = asDefaultLoggerSink(async (info, message, _attrs) => {
+    const sinks = asSdkLoggerSink(async (info, message, _attrs) => {
       recordedMessages.push({
         message,
         searchAttributes: info.searchAttributes,

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -1,18 +1,19 @@
 /* eslint @typescript-eslint/no-non-null-assertion: 0 */
 import test from 'ava';
 import { v4 as uuid4 } from 'uuid';
-import { WorkflowClient } from '@temporalio/client';
+import { Connection, WorkflowClient } from '@temporalio/client';
 import {
   DefaultLogger,
   InjectedSinks,
   Runtime,
-  LoggerSinks as DefaultLoggerSinks,
   InjectedSinkFunction,
   WorkerOptions,
+  LogEntry,
 } from '@temporalio/worker';
+import { LoggerSinks as DefaultLoggerSinks } from '@temporalio/workflow/lib/logs';
 import { SearchAttributes, WorkflowInfo } from '@temporalio/workflow';
 import { UnsafeWorkflowInfo } from '@temporalio/workflow/src/interfaces';
-import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { RUN_INTEGRATION_TESTS, Worker, registerDefaultCustomSearchAttributes } from './helpers';
 import { defaultOptions } from './mock-native-worker';
 import * as workflows from './workflows';
 
@@ -38,17 +39,20 @@ function asDefaultLoggerSink(
 }
 
 if (RUN_INTEGRATION_TESTS) {
-  const recordedLogs: any[] = [];
-  test.before((_) => {
+  const recordedLogs: { [workflowId: string]: LogEntry[] } = {};
+
+  test.before(async (_) => {
+    await registerDefaultCustomSearchAttributes(await Connection.connect({}));
     Runtime.install({
-      logger: new DefaultLogger('DEBUG', ({ level, message, meta }) => {
-        if (message === 'External sink function threw an error') recordedLogs.push({ level, message, meta });
+      logger: new DefaultLogger('DEBUG', (entry: LogEntry) => {
+        const workflowId = (entry.meta as any)?.workflowInfo?.workflowId;
+        recordedLogs[workflowId] ??= [];
+        recordedLogs[workflowId].push(entry);
       }),
     });
   });
 
-  // Must be serial because it uses the global Runtime to check for error messages
-  test.serial('Worker injects sinks', async (t) => {
+  test('Worker injects sinks', async (t) => {
     interface RecordedCall {
       info: WorkflowInfo;
       counter: number;
@@ -153,12 +157,13 @@ if (RUN_INTEGRATION_TESTS) {
     ]);
 
     t.deepEqual(
-      recordedLogs.map((x) => ({
+      recordedLogs[info.workflowId].map((x: LogEntry) => ({
         ...x,
         meta: {
           ...x.meta,
-          workflowInfo: fixWorkflowInfoDates(x.meta.workflowInfo),
+          workflowInfo: fixWorkflowInfoDates(x.meta?.workflowInfo),
         },
+        timestampNanos: undefined,
       })),
       thrownErrors.map((error) => ({
         level: 'ERROR',
@@ -169,6 +174,7 @@ if (RUN_INTEGRATION_TESTS) {
           fnName: error.fnName,
           workflowInfo: info,
         },
+        timestampNanos: undefined,
       }))
     );
   });

--- a/packages/test/src/test-workflow-log-interceptor.ts
+++ b/packages/test/src/test-workflow-log-interceptor.ts
@@ -1,7 +1,16 @@
 import anyTest, { TestFn, ExecutionContext } from 'ava';
 import { v4 as uuid4 } from 'uuid';
-import { DefaultLogger, LogEntry, Runtime, defaultSinks } from '@temporalio/worker';
+import {
+  DefaultLogger,
+  InjectedSinks,
+  LogEntry,
+  LogLevel,
+  LoggerSinks,
+  Runtime,
+  defaultSinks,
+} from '@temporalio/worker';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { WorkflowInfo } from '@temporalio/workflow';
 import * as workflows from './workflows';
 import { Worker } from './helpers';
 
@@ -119,6 +128,7 @@ test('(Legacy) defaultSinks(logger) can be used to customize where logs are sent
     connection: nativeConnection,
     taskQueue: t.context.taskQueue,
     workflowsPath: require.resolve('./workflows'),
+    // eslint-disable-next-line deprecation/deprecation
     sinks: defaultSinks(logger),
   });
   await worker.runUntil(
@@ -136,4 +146,56 @@ test('(Legacy) defaultSinks(logger) can be used to customize where logs are sent
   t.is(startLog.meta?.workflowType, 'successString');
   t.is(endLog.level, 'DEBUG');
   t.is(endLog.message, 'Workflow completed');
+});
+
+test('(Legacy) Can register defaultWorkerLogger sink to customize where logs are sent', async (t) => {
+  const { client } = t.context.testEnv;
+  const workflowId = uuid4();
+  const { nativeConnection } = t.context.testEnv;
+  const logs = Array<LogEntry>();
+  const fn = (level: LogLevel, _info: WorkflowInfo, message: string, attrs?: Record<string, unknown>) => {
+    logs.push({ level, message, meta: attrs, timestampNanos: 0n });
+  };
+  const worker = await Worker.create({
+    connection: nativeConnection,
+    taskQueue: t.context.taskQueue,
+    workflowsPath: require.resolve('./workflows'),
+    // eslint-disable-next-line deprecation/deprecation
+    sinks: <InjectedSinks<LoggerSinks>>{
+      defaultWorkerLogger: {
+        trace: { fn: fn.bind(undefined, 'TRACE') },
+        debug: { fn: fn.bind(undefined, 'DEBUG') },
+        info: { fn: fn.bind(undefined, 'INFO') },
+        warn: { fn: fn.bind(undefined, 'WARN') },
+        error: { fn: fn.bind(undefined, 'ERROR') },
+      },
+    },
+  });
+  await worker.runUntil(
+    client.workflow.execute(workflows.successString, { workflowId, taskQueue: t.context.taskQueue })
+  );
+  t.false(workflowId in recordedLogs);
+  t.true(logs.length >= 2);
+  const [startLog, endLog] = logs;
+  t.is(startLog.level, 'DEBUG');
+  t.is(startLog.message, 'Workflow started');
+  t.is(startLog.meta?.workflowId, workflowId);
+  t.true(typeof startLog.meta?.runId === 'string');
+  t.is(startLog.meta?.taskQueue, t.context.taskQueue);
+  t.is(startLog.meta?.namespace, 'default');
+  t.is(startLog.meta?.workflowType, 'successString');
+  t.is(endLog.level, 'DEBUG');
+  t.is(endLog.message, 'Workflow completed');
+});
+
+test('(Legacy) Can explicitly call defaultWorkerLogger sink to emit logs', async (t) => {
+  const { client } = t.context.testEnv;
+  const workflowId = uuid4();
+  const [_, midLog] = await withWorker(
+    t,
+    client.workflow.execute(workflows.useDepreatedLoggerSinkWorkflow, { workflowId, taskQueue: t.context.taskQueue }),
+    workflowId
+  );
+  t.is(midLog.level, 'INFO');
+  t.is(midLog.message, 'Log message from workflow');
 });

--- a/packages/test/src/test-workflow-log-interceptor.ts
+++ b/packages/test/src/test-workflow-log-interceptor.ts
@@ -1,6 +1,6 @@
 import anyTest, { TestFn, ExecutionContext } from 'ava';
 import { v4 as uuid4 } from 'uuid';
-import { DefaultLogger, LogEntry, defaultSinks } from '@temporalio/worker';
+import { DefaultLogger, LogEntry, Runtime, defaultSinks } from '@temporalio/worker';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
 import * as workflows from './workflows';
 import { Worker } from './helpers';
@@ -11,9 +11,19 @@ interface Context {
 }
 const test = anyTest as TestFn<Context>;
 
+const recordedLogs: { [workflowId: string]: LogEntry[] } = {};
+
 test.before(async (t) => {
+  Runtime.install({
+    logger: new DefaultLogger('DEBUG', (entry) => {
+      const workflowId = (entry.meta as any)?.workflowInfo?.workflowId ?? (entry.meta as any)?.workflowId;
+      recordedLogs[workflowId] ??= [];
+      recordedLogs[workflowId].push(entry);
+    }),
+  });
+
   t.context = {
-    testEnv: await TestWorkflowEnvironment.createTimeSkipping(),
+    testEnv: await TestWorkflowEnvironment.createLocal(),
     taskQueue: '', // Will be set in beforeEach
   };
 });
@@ -26,27 +36,30 @@ test.after.always(async (t) => {
   await t.context.testEnv?.teardown();
 });
 
-async function withWorker(t: ExecutionContext<Context>, p: Promise<any>): Promise<[LogEntry, LogEntry]> {
+async function withWorker(
+  t: ExecutionContext<Context>,
+  p: Promise<any>,
+  workflowId: string
+): Promise<[LogEntry, LogEntry]> {
   const { nativeConnection } = t.context.testEnv;
-  const logs = Array<LogEntry>();
-  const logger = new DefaultLogger('DEBUG', (entry) => logs.push(entry));
   const worker = await Worker.create({
     connection: nativeConnection,
     taskQueue: t.context.taskQueue,
     workflowsPath: require.resolve('./workflows'),
-    sinks: defaultSinks(logger),
   });
   await worker.runUntil(p);
+  const logs = recordedLogs[workflowId];
   t.true(logs.length >= 2);
   return logs as [LogEntry, LogEntry];
 }
 
-test.serial('WorkflowInboundLogInterceptor logs when workflow completes', async (t) => {
+test('WorkflowInboundLogInterceptor logs when workflow completes', async (t) => {
   const { client } = t.context.testEnv;
   const workflowId = uuid4();
   const [startLog, endLog] = await withWorker(
     t,
-    client.workflow.execute(workflows.successString, { workflowId, taskQueue: t.context.taskQueue })
+    client.workflow.execute(workflows.successString, { workflowId, taskQueue: t.context.taskQueue }),
+    workflowId
   );
   t.is(startLog.level, 'DEBUG');
   t.is(startLog.message, 'Workflow started');
@@ -59,35 +72,68 @@ test.serial('WorkflowInboundLogInterceptor logs when workflow completes', async 
   t.is(endLog.message, 'Workflow completed');
 });
 
-test.serial('WorkflowInboundLogInterceptor logs when workflow continues as new', async (t) => {
+test('WorkflowInboundLogInterceptor logs when workflow continues as new', async (t) => {
   const { client } = t.context.testEnv;
+  const workflowId = uuid4();
   const [_, endLog] = await withWorker(
     t,
     t.throwsAsync(
       client.workflow.execute(workflows.continueAsNewSameWorkflow, {
         args: ['execute', 'execute'],
-        workflowId: uuid4(),
+        workflowId,
         taskQueue: t.context.taskQueue,
         followRuns: false,
       })
-    )
+    ),
+    workflowId
   );
   t.is(endLog.level, 'DEBUG');
   t.is(endLog.message, 'Workflow continued as new');
 });
 
-test.serial('WorkflowInboundLogInterceptor logs warning when workflow fails', async (t) => {
+test('WorkflowInboundLogInterceptor logs warning when workflow fails', async (t) => {
   const { client } = t.context.testEnv;
+  const workflowId = uuid4();
   const [_, endLog] = await withWorker(
     t,
     t.throwsAsync(
       client.workflow.execute(workflows.throwAsync, {
-        workflowId: uuid4(),
+        workflowId,
         taskQueue: t.context.taskQueue,
         followRuns: false,
       })
-    )
+    ),
+    workflowId
   );
   t.is(endLog.level, 'WARN');
   t.is(endLog.message, 'Workflow failed');
+});
+
+test('(Legacy) defaultSinks(logger) can be used to customize where logs are sent', async (t) => {
+  const { client } = t.context.testEnv;
+  const workflowId = uuid4();
+  const { nativeConnection } = t.context.testEnv;
+  const logs = Array<LogEntry>();
+  const logger = new DefaultLogger('DEBUG', (entry) => logs.push(entry));
+  const worker = await Worker.create({
+    connection: nativeConnection,
+    taskQueue: t.context.taskQueue,
+    workflowsPath: require.resolve('./workflows'),
+    sinks: defaultSinks(logger),
+  });
+  await worker.runUntil(
+    client.workflow.execute(workflows.successString, { workflowId, taskQueue: t.context.taskQueue })
+  );
+  t.false(workflowId in recordedLogs);
+  t.true(logs.length >= 2);
+  const [startLog, endLog] = logs;
+  t.is(startLog.level, 'DEBUG');
+  t.is(startLog.message, 'Workflow started');
+  t.is(startLog.meta?.workflowId, workflowId);
+  t.true(typeof startLog.meta?.runId === 'string');
+  t.is(startLog.meta?.taskQueue, t.context.taskQueue);
+  t.is(startLog.meta?.namespace, 'default');
+  t.is(startLog.meta?.workflowType, 'successString');
+  t.is(endLog.level, 'DEBUG');
+  t.is(endLog.message, 'Workflow completed');
 });

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -1568,7 +1568,7 @@ test('logAndTimeout', async (t) => {
   });
   t.deepEqual(calls, [
     {
-      ifaceName: 'defaultWorkerLogger',
+      ifaceName: '__temporal_logger',
       fnName: 'debug',
       args: [
         'Workflow started',
@@ -1582,7 +1582,7 @@ test('logAndTimeout', async (t) => {
       ],
     },
     {
-      ifaceName: 'defaultWorkerLogger',
+      ifaceName: '__temporal_logger',
       fnName: 'info',
       args: [
         'logging before getting stuck',

--- a/packages/test/src/workflows/internals-interceptor-example.ts
+++ b/packages/test/src/workflows/internals-interceptor-example.ts
@@ -1,12 +1,12 @@
 import { proxySinks, WorkflowInterceptors, Sinks, sleep } from '@temporalio/workflow';
 
-export interface LoggerSinks extends Sinks {
+export interface MyLoggerSinks extends Sinks {
   logger: {
     log(event: string): void;
   };
 }
 
-const { logger } = proxySinks<LoggerSinks>();
+const { logger } = proxySinks<MyLoggerSinks>();
 
 export async function internalsInterceptorExample(): Promise<void> {
   await sleep(10);

--- a/packages/test/src/workflows/log-sink-tester.ts
+++ b/packages/test/src/workflows/log-sink-tester.ts
@@ -34,3 +34,10 @@ export async function logSinkTester(): Promise<void> {
     }`
   );
 }
+
+// eslint-disable-next-line deprecation/deprecation
+const { defaultWorkerLogger } = wf.proxySinks<wf.LoggerSinks>();
+
+export async function useDepreatedLoggerSinkWorkflow(): Promise<void> {
+  defaultWorkerLogger.info(`Log message from workflow`, { workflowId: wf.workflowInfo().workflowId });
+}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -77,5 +77,5 @@ export {
    * @deprecated Do not use `LoggerSinks` directly. To log from Workflow code, use the `log` object exported by the `@temporalio/workflow`
    *             package. To capture log messages emitted by Workflow code, set the {@see Runtime.logger} property.
    */
-  LoggerSinks,
+  LoggerSinks, // eslint-disable-line deprecation/deprecation
 } from '@temporalio/workflow';

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -17,7 +17,6 @@ export {
   PrometheusMetricsExporter,
   TelemetryOptions,
 } from '@temporalio/core-bridge';
-export { LoggerSinks } from '@temporalio/workflow';
 export { ActivityInboundLogInterceptor, activityLogAttributes } from './activity-log-interceptor';
 export { NativeConnection as NativeConnection } from './connection';
 export { NativeConnectionOptions, RequiredNativeConnectionOptions, TLSConfig } from './connection-options';
@@ -41,13 +40,11 @@ export {
 export {
   appendDefaultInterceptors,
   CompiledWorkerOptions,
-  defaultSinks,
   ReplayWorkerOptions,
   WorkerOptions,
   WorkflowBundle,
   WorkflowBundleOption,
   WorkflowBundlePath,
-  WorkflowBundlePathWithSourceMap, // eslint-disable-line deprecation/deprecation
 } from './worker-options';
 export { ReplayError, ReplayHistoriesIterable, ReplayResult } from './replay';
 export {
@@ -59,9 +56,26 @@ export {
   BundleOptions,
   bundleWorkflowCode,
   defaultWorkflowInterceptorModules,
-  /**
-   * @deprecated Use `defaultWorkflowInterceptorModules` instead
-   */
-  defaultWorkflowInterceptorModules as defaultWorflowInterceptorModules,
   WorkflowBundleWithSourceMap,
 } from './workflow/bundler';
+
+// Anything below this line is deprecated
+
+export {
+  /**
+   * @deprecated Including `defaultSinks()` in the worker options is no longer required. To configure
+   *             a custom logger, set the {@see Runtime.logger} property instead.
+   */
+  defaultSinks, // eslint-disable-line deprecation/deprecation
+  /**
+   * @deprecated This no longer contains a source map. Use {@see WorkflowBundlePath} instead.
+   */
+  WorkflowBundlePathWithSourceMap, // eslint-disable-line deprecation/deprecation
+} from './worker-options';
+export {
+  /**
+   * @deprecated Do not use `LoggerSinks` directly. To log from Workflow code, use the `log` object exported by the `@temporalio/workflow`
+   *             package. To capture log messages emitted by Workflow code, set the {@see Runtime.logger} property.
+   */
+  LoggerSinks,
+} from '@temporalio/workflow';

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -445,9 +445,9 @@ export interface WorkerOptions {
    * guarantees, please consider using local activities instead. For use cases that require
    * _exactly-once_ or _at-most-once_ execution guarantees, please consider using regular activities.
    *
-   * The SDK itself may register sinks functions required to support workflow features. The name,
-   * signature and semantic of these sinks functions is considered an internal detail and may change
-   * in the future without notice. Please do not use them directly nor override them.
+   * Sink names starting with `__temporal_` are reserved for use by the SDK itself. Do not register
+   * or use such sink. Registering a sink named `defaultWorkerLogger` to redirect workflow logs to a
+   * custom logger is deprecated. Register a custom logger through {@link Runtime.logger} instead.
    */
   sinks?: InjectedSinks<any>;
 
@@ -601,8 +601,14 @@ export interface ReplayWorkerOptions
  * @deprecated Calling `defaultSink()` is no longer required. To configure a custom logger, set the
  *             {@see Runtime.logger} property instead.
  */
+// eslint-disable-next-line deprecation/deprecation
 export function defaultSinks(logger?: Logger): InjectedSinks<LoggerSinks> {
-  return initLoggerSink(logger);
+  // initLoggerSink() returns a sink that complies to the new LoggerSinksInternal API (ie. named __temporal_logger), but
+  // code that is still calling defaultSinks() expects return type to match the deprecated LoggerSinks API. Silently
+  // cast just to mask type checking issues, even though we know this is wrong. Users shouldn't call functions directly
+  // on the returned object anyway.
+  // eslint-disable-next-line deprecation/deprecation
+  return initLoggerSink(logger) as unknown as InjectedSinks<LoggerSinks>;
 }
 
 /**
@@ -615,6 +621,7 @@ export function appendDefaultInterceptors(
   logger?: Logger | undefined
 ): WorkerInterceptors {
   return {
+    // eslint-disable-next-line deprecation/deprecation
     activityInbound: [...(interceptors.activityInbound ?? []), (ctx) => new ActivityInboundLogInterceptor(ctx, logger)],
     workflowModules: [...(interceptors.workflowModules ?? []), ...defaultWorkflowInterceptorModules],
   };
@@ -669,6 +676,8 @@ export function addDefaultWorkerOptions(options: WorkerOptions): WorkerOptionsWi
     nonStickyToStickyPollRatio: nonStickyToStickyPollRatio ?? 0.2,
     sinks: {
       ...initLoggerSink(Runtime.instance().logger),
+      // Fix deprecated registration of the 'defaultWorkerLogger' sink
+      ...(sinks?.defaultWorkerLogger ? { __temporal_logger: sinks.defaultWorkerLogger } : {}),
       ...sinks,
     },
     ...rest,

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1260,6 +1260,8 @@ export class Worker {
     const { sinks } = this.options;
 
     const filteredCalls = externalCalls
+      // Fix depreacted usage of the 'defaultWorkerLogger' sink
+      .map((call) => (call.ifaceName === 'defaultWorkerLogger' ? { ...call, ifaceName: '__temporal_logger' } : call))
       // Map sink call to the corresponding sink function definition
       .map((call) => ({ call, sink: sinks?.[call.ifaceName]?.[call.fnName] }))
       // Reject calls to undefined sink definitions

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -45,7 +45,7 @@ import { errorMessage, isError, SymbolBasedInstanceOfError } from '@temporalio/c
 import * as native from '@temporalio/core-bridge';
 import { ShutdownError, UnexpectedError } from '@temporalio/core-bridge';
 import { coresdk, temporal } from '@temporalio/proto';
-import { SinkCall, WorkflowInfo } from '@temporalio/workflow';
+import { type SinkCall, type WorkflowInfo } from '@temporalio/workflow';
 import { Activity, CancelReason } from './activity';
 import { activityLogAttributes } from './activity-log-interceptor';
 import { extractNativeClient, extractReferenceHolders, InternalNativeConnection, NativeConnection } from './connection';

--- a/packages/worker/src/workflow/interface.ts
+++ b/packages/worker/src/workflow/interface.ts
@@ -1,6 +1,6 @@
-import { coresdk } from '@temporalio/proto';
-import { SinkCall } from '@temporalio/workflow';
-import { WorkflowCreateOptions } from '@temporalio/workflow/lib/interfaces';
+import { type coresdk } from '@temporalio/proto';
+import { type SinkCall } from '@temporalio/workflow';
+import { type WorkflowCreateOptions } from '@temporalio/workflow/lib/interfaces';
 
 export { WorkflowCreateOptions };
 

--- a/packages/worker/src/workflow/logger.ts
+++ b/packages/worker/src/workflow/logger.ts
@@ -1,0 +1,44 @@
+import { type LoggerSinks } from '@temporalio/workflow/lib/logs';
+import { type InjectedSinks } from '../sinks';
+import { Runtime } from '../runtime';
+import { type Logger } from '../logger';
+
+/**
+ * Injects a logger sink that forwards to the worker's logger
+ */
+export function initLoggerSink(logger?: Logger): InjectedSinks<LoggerSinks> {
+  return {
+    defaultWorkerLogger: {
+      trace: {
+        fn(_, message, attrs) {
+          logger ??= Runtime.instance().logger;
+          logger.trace(message, attrs);
+        },
+      },
+      debug: {
+        fn(_, message, attrs) {
+          logger ??= Runtime.instance().logger;
+          logger.debug(message, attrs);
+        },
+      },
+      info: {
+        fn(_, message, attrs) {
+          logger ??= Runtime.instance().logger;
+          logger.info(message, attrs);
+        },
+      },
+      warn: {
+        fn(_, message, attrs) {
+          logger ??= Runtime.instance().logger;
+          logger.warn(message, attrs);
+        },
+      },
+      error: {
+        fn(_, message, attrs) {
+          logger ??= Runtime.instance().logger;
+          logger.error(message, attrs);
+        },
+      },
+    },
+  };
+}

--- a/packages/worker/src/workflow/logger.ts
+++ b/packages/worker/src/workflow/logger.ts
@@ -1,4 +1,4 @@
-import { type LoggerSinks } from '@temporalio/workflow/lib/logs';
+import { type LoggerSinksInternal } from '@temporalio/workflow/lib/logs';
 import { type InjectedSinks } from '../sinks';
 import { Runtime } from '../runtime';
 import { type Logger } from '../logger';
@@ -6,9 +6,9 @@ import { type Logger } from '../logger';
 /**
  * Injects a logger sink that forwards to the worker's logger
  */
-export function initLoggerSink(logger?: Logger): InjectedSinks<LoggerSinks> {
+export function initLoggerSink(logger?: Logger): InjectedSinks<LoggerSinksInternal> {
   return {
-    defaultWorkerLogger: {
+    __temporal_logger: {
       trace: {
         fn(_, message, attrs) {
           logger ??= Runtime.instance().logger;

--- a/packages/worker/src/workflow/threaded-vm.ts
+++ b/packages/worker/src/workflow/threaded-vm.ts
@@ -11,7 +11,7 @@
 
 import { Worker as NodeWorker } from 'node:worker_threads';
 import { coresdk } from '@temporalio/proto';
-import { IllegalStateError, SinkCall } from '@temporalio/workflow';
+import { IllegalStateError, type SinkCall } from '@temporalio/workflow';
 import { UnexpectedError } from '@temporalio/core-bridge';
 import {
   WorkflowBundleWithSourceMapAndFilename,

--- a/packages/worker/src/workflow/vm-shared.ts
+++ b/packages/worker/src/workflow/vm-shared.ts
@@ -4,7 +4,7 @@ import { SourceMapConsumer } from 'source-map';
 import { cutoffStackTrace, IllegalStateError } from '@temporalio/common';
 import { coresdk } from '@temporalio/proto';
 import type { WorkflowInfo, FileLocation } from '@temporalio/workflow';
-import { SinkCall } from '@temporalio/workflow/lib/sinks';
+import { type SinkCall } from '@temporalio/workflow/lib/sinks';
 import * as internals from '@temporalio/workflow/lib/worker-interface';
 import { Activator } from '@temporalio/workflow/lib/internals';
 import { partition } from '../utils';

--- a/packages/worker/src/workflow/workflow-worker-thread/output.ts
+++ b/packages/worker/src/workflow/workflow-worker-thread/output.ts
@@ -1,5 +1,5 @@
-import { coresdk } from '@temporalio/proto';
-import { SinkCall } from '@temporalio/workflow/lib/sinks';
+import { type coresdk } from '@temporalio/proto';
+import { type SinkCall } from '@temporalio/workflow/lib/sinks';
 
 /**
  * An activation completion.

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -112,5 +112,6 @@ export {
    *             exported by the `@temporalio/workflow` package. To capture log messages emitted
    *             by Workflow code, set the {@see Runtime.logger} property.
    */
-  LoggerSinks,
+  // eslint-disable-next-line deprecation/deprecation
+  LoggerSinksDeprecated as LoggerSinks,
 } from './logs';

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -98,7 +98,19 @@ export {
   UnsafeWorkflowInfo,
   WorkflowInfo,
 } from './interfaces';
-export { LoggerSinks, Sink, SinkCall, SinkFunction, Sinks } from './sinks';
+export { proxySinks, Sink, SinkCall, SinkFunction, Sinks } from './sinks';
+export { log } from './logs';
 export { Trigger } from './trigger';
 export * from './workflow';
 export { ChildWorkflowHandle, ExternalWorkflowHandle } from './workflow-handle';
+
+// Anything below this line is deprecated
+
+export {
+  /**
+   * @deprecated Do not use LoggerSinks directly. To log from Workflow code, use the `log` object
+   *             exported by the `@temporalio/workflow` package. To capture log messages emitted
+   *             by Workflow code, set the {@see Runtime.logger} property.
+   */
+  LoggerSinks,
+} from './logs';

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -31,7 +31,7 @@ import {
   WorkflowInfo,
   WorkflowCreateOptionsInternal,
 } from './interfaces';
-import { SinkCall } from './sinks';
+import { type SinkCall } from './sinks';
 import { untrackPromise } from './stack-helpers';
 import pkg from './pkg';
 import { maybeGetActivatorUntyped } from './global-attributes';
@@ -385,6 +385,7 @@ export class Activator implements ActivationHandler {
 
   public startWorkflow(activation: coresdk.workflow_activation.IStartWorkflow): void {
     const execute = composeInterceptors(this.interceptors.inbound, 'execute', this.startWorkflowNextHandler.bind(this));
+
     untrackPromise(
       execute({
         headers: activation.headers ?? {},
@@ -700,6 +701,12 @@ export class Activator implements ActivationHandler {
   failureToError(failure: ProtoFailure): Error {
     return this.failureConverter.failureToError(failure, this.payloadConverter);
   }
+}
+
+export function assertInWorkflowContext(message: string): Activator {
+  const activator = maybeGetActivator();
+  if (activator == null) throw new IllegalStateError(message);
+  return activator;
 }
 
 export function maybeGetActivator(): Activator | undefined {

--- a/packages/workflow/src/logs.ts
+++ b/packages/workflow/src/logs.ts
@@ -12,12 +12,28 @@ export interface WorkflowLogger extends Sink {
 
 /**
  * Sink interface for forwarding logs from the Workflow sandbox to the Worker
+ *
+ * @deprecated Do not use LoggerSinks directly. To log from Workflow code, use the `log` object
+ *             exported by the `@temporalio/workflow` package. To capture log messages emitted
+ *             by Workflow code, set the {@see Runtime.logger} property.
  */
-export interface LoggerSinks extends Sinks {
+export interface LoggerSinksDeprecated extends Sinks {
+  /**
+   * @deprecated Do not use LoggerSinks directly. To log from Workflow code, use the `log` object
+   *             exported by the `@temporalio/workflow` package. To capture log messages emitted
+   *             by Workflow code, set the {@link Runtime.logger} property.
+   */
   defaultWorkerLogger: WorkflowLogger;
 }
 
-const loggerSink = proxySinks<LoggerSinks>().defaultWorkerLogger;
+/**
+ * Sink interface for forwarding logs from the Workflow sandbox to the Worker
+ */
+export interface LoggerSinksInternal extends Sinks {
+  __temporal_logger: WorkflowLogger;
+}
+
+const loggerSink = proxySinks<LoggerSinksInternal>().__temporal_logger;
 
 /**
  * Symbol used by the SDK logger to extract a timestamp from log attributes.

--- a/packages/workflow/src/logs.ts
+++ b/packages/workflow/src/logs.ts
@@ -1,0 +1,57 @@
+import { composeInterceptors } from '@temporalio/common/lib/interceptors';
+import { Sink, Sinks, proxySinks } from './sinks';
+import { assertInWorkflowContext } from './internals';
+
+export interface WorkflowLogger extends Sink {
+  trace(message: string, attrs?: Record<string, unknown>): void;
+  debug(message: string, attrs?: Record<string, unknown>): void;
+  info(message: string, attrs?: Record<string, unknown>): void;
+  warn(message: string, attrs?: Record<string, unknown>): void;
+  error(message: string, attrs?: Record<string, unknown>): void;
+}
+
+/**
+ * Sink interface for forwarding logs from the Workflow sandbox to the Worker
+ */
+export interface LoggerSinks extends Sinks {
+  defaultWorkerLogger: WorkflowLogger;
+}
+
+const loggerSink = proxySinks<LoggerSinks>().defaultWorkerLogger;
+
+/**
+ * Symbol used by the SDK logger to extract a timestamp from log attributes.
+ * Also defined in `worker/logger.ts` - intentionally not shared.
+ */
+const LogTimestamp = Symbol.for('log_timestamp');
+
+/**
+ * Default workflow logger.
+ *
+ * This logger is replay-aware and will omit log messages on workflow replay. Messages emitted by this logger are
+ * funnelled through a sink that forwards them to the logger registered on {@link Runtime.logger}.
+ *
+ * Notice that since sinks are used to power this logger, any log attributes must be transferable via the
+ * {@link https://nodejs.org/api/worker_threads.html#worker_threads_port_postmessage_value_transferlist | postMessage}
+ * API.
+ *
+ * NOTE: Specifying a custom logger through {@link defaultSink} or by manually registering a sink named
+ * `defaultWorkerLogger` has been deprecated. Please use {@link Runtime.logger} instead.
+ */
+export const log: WorkflowLogger = Object.fromEntries(
+  (['trace', 'debug', 'info', 'warn', 'error'] as Array<keyof WorkflowLogger>).map((level) => {
+    return [
+      level,
+      (message: string, attrs?: Record<string, unknown>) => {
+        const activator = assertInWorkflowContext('Workflow.log(...) may only be used from workflow context.');
+        const getLogAttributes = composeInterceptors(activator.interceptors.outbound, 'getLogAttributes', (a) => a);
+        return loggerSink[level](message, {
+          // Inject the call time in nanosecond resolution as expected by the worker logger.
+          [LogTimestamp]: activator.getTimeOfDay(),
+          ...getLogAttributes({}),
+          ...attrs,
+        });
+      },
+    ];
+  })
+) as any;

--- a/packages/workflow/src/sinks.ts
+++ b/packages/workflow/src/sinks.ts
@@ -15,6 +15,7 @@
  */
 
 import { WorkflowInfo } from './interfaces';
+import { assertInWorkflowContext } from './internals';
 
 /**
  * Any function signature can be used for Sink functions as long as the return type is `void`.
@@ -44,14 +45,64 @@ export interface SinkCall {
 }
 
 /**
- * Sink interface for forwarding logs from the Workflow sandbox to the Worker
+ * Get a reference to Sinks for exporting data out of the Workflow.
+ *
+ * These Sinks **must** be registered with the Worker in order for this
+ * mechanism to work.
+ *
+ * @example
+ * ```ts
+ * import { proxySinks, Sinks } from '@temporalio/workflow';
+ *
+ * interface MySinks extends Sinks {
+ *   logger: {
+ *     info(message: string): void;
+ *     error(message: string): void;
+ *   };
+ * }
+ *
+ * const { logger } = proxySinks<MyDependencies>();
+ * logger.info('setting up');
+ *
+ * export function myWorkflow() {
+ *   return {
+ *     async execute() {
+ *       logger.info("hey ho");
+ *       logger.error("lets go");
+ *     }
+ *   };
+ * }
+ * ```
  */
-export interface LoggerSinks extends Sinks {
-  defaultWorkerLogger: {
-    trace(message: string, attrs?: Record<string, unknown>): void;
-    debug(message: string, attrs?: Record<string, unknown>): void;
-    info(message: string, attrs?: Record<string, unknown>): void;
-    warn(message: string, attrs?: Record<string, unknown>): void;
-    error(message: string, attrs?: Record<string, unknown>): void;
-  };
+export function proxySinks<T extends Sinks>(): T {
+  return new Proxy(
+    {},
+    {
+      get(_, ifaceName) {
+        return new Proxy(
+          {},
+          {
+            get(_, fnName) {
+              return (...args: any[]) => {
+                const activator = assertInWorkflowContext(
+                  'Proxied sinks functions may only be used from a Workflow Execution.'
+                );
+                activator.sinkCalls.push({
+                  ifaceName: ifaceName as string,
+                  fnName: fnName as string,
+                  // Sink function don't get called immediately. Make a clone of sink's args, so that further mutations
+                  // to these objects don't corrupt the args that the sink function will receive. Only available from node 17.
+                  args: (globalThis as any).structuredClone ? (globalThis as any).structuredClone(args) : args,
+                  // activator.info is internally copy-on-write. This ensure that any further mutations
+                  // to the workflow state in the context of the present activation will not corrupt the
+                  // workflowInfo state that gets passed when the sink function actually gets called.
+                  workflowInfo: activator.info,
+                });
+              };
+            },
+          }
+        );
+      },
+    }
+  ) as any;
 }

--- a/packages/workflow/src/sinks.ts
+++ b/packages/workflow/src/sinks.ts
@@ -90,7 +90,7 @@ export function proxySinks<T extends Sinks>(): T {
                 activator.sinkCalls.push({
                   ifaceName: ifaceName as string,
                   fnName: fnName as string,
-                  // Sink function don't get called immediately. Make a clone of sink's args, so that further mutations
+                  // Sink function doesn't get called immediately. Make a clone of the sink's args, so that further mutations
                   // to these objects don't corrupt the args that the sink function will receive. Only available from node 17.
                   args: (globalThis as any).structuredClone ? (globalThis as any).structuredClone(args) : args,
                   // activator.info is internally copy-on-write. This ensure that any further mutations

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -12,7 +12,7 @@ import { DeterminismViolationError } from './errors';
 import { WorkflowInterceptorsFactory } from './interceptors';
 import { WorkflowCreateOptionsInternal } from './interfaces';
 import { Activator, getActivator } from './internals';
-import { SinkCall } from './sinks';
+import { type SinkCall } from './sinks';
 import { setActivatorUntyped } from './global-attributes';
 
 // Export the type for use on the "worker" side


### PR DESCRIPTION
## What changed

- Deprecate `defaultSink()` and `LoggerSinks`. SDK's logger sink is now forcibly injected. Registering a custom logger sink named `defaultWorkerLogger` is still supported, but discouraged and deprecated.
- Refactored sink code internally.

## Why

- These changes adds up to better DX, notably by:
  - Promoting clear usage patterns regarding Workflow logging that works out-of-the-box;
  - Discourage the use of insufficiently documented features (eg. possibility of redirecting workflow logs by registering a custom `defaultWorkerLogger` sink);
  - Remove the requirement that users should call `defaultSinks()` if they were to add custom sinks, which was error prone and a recurring source of support question.
- Prepare the code base for other, similar upcoming refactors and some features (eg. custom metrics, context forwarding, etc).