### PR TITLE
docs: Change serverNameOverride to not be testing only

### DIFF
--- a/packages/common/src/internal-non-workflow/tls-config.ts
+++ b/packages/common/src/internal-non-workflow/tls-config.ts
@@ -3,7 +3,6 @@ export interface TLSConfig {
   /**
    * Overrides the target name used for SSL host name checking.
    * If this attribute is not specified, the name used for SSL host name checking will be the host from {@link ServerOptions.url}.
-   * This _should_ be used for testing only.
    */
   serverNameOverride?: string;
   /**

--- a/packages/common/src/internal-non-workflow/tls-config.ts
+++ b/packages/common/src/internal-non-workflow/tls-config.ts
@@ -1,8 +1,10 @@
 /** TLS configuration options. */
 export interface TLSConfig {
   /**
-   * Overrides the target name used for SSL host name checking.
-   * If this attribute is not specified, the name used for SSL host name checking will be the host from {@link ServerOptions.url}.
+   * Overrides the target name (SNI) used for TLS host name checking.
+   * If this attribute is not specified, the name used for TLS host name checking will be the host from {@link ServerOptions.url}.
+   * This can be useful when you have reverse proxy in front of temporal server, and you may want to override the SNI to
+   * direct traffic to the appropriate backend server based on custom routing rules.
    */
   serverNameOverride?: string;
   /**

--- a/packages/common/src/internal-non-workflow/tls-config.ts
+++ b/packages/common/src/internal-non-workflow/tls-config.ts
@@ -4,7 +4,8 @@ export interface TLSConfig {
    * Overrides the target name (SNI) used for TLS host name checking.
    * If this attribute is not specified, the name used for TLS host name checking will be the host from {@link ServerOptions.url}.
    * This can be useful when you have reverse proxy in front of temporal server, and you may want to override the SNI to
-   * direct traffic to the appropriate backend server based on custom routing rules.
+   * direct traffic to the appropriate backend server based on custom routing rules. Oppositely, connections could be refused
+   * if the provided SNI does not match the expected host. Adding this override should be done with care.
    */
   serverNameOverride?: string;
   /**


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Change serverNameOverride to not be testing only

## Why?
Using serverNameOverride is a legitimate use case in production cases

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
