### PR TITLE
feat(client): Add startDelay to workflow (signal) start options

### DIFF
--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -688,6 +688,7 @@ export class WorkflowClient extends BaseClient {
       workflowExecutionTimeout: options.workflowExecutionTimeout,
       workflowRunTimeout: options.workflowRunTimeout,
       workflowTaskTimeout: options.workflowTaskTimeout,
+      workflowStartDelay: options.startDelay,
       retryPolicy: options.retry ? compileRetryPolicy(options.retry) : undefined,
       memo: options.memo ? { fields: await encodeMapToPayloads(this.dataConverter, options.memo) } : undefined,
       searchAttributes: options.searchAttributes
@@ -735,6 +736,7 @@ export class WorkflowClient extends BaseClient {
       workflowExecutionTimeout: opts.workflowExecutionTimeout,
       workflowRunTimeout: opts.workflowRunTimeout,
       workflowTaskTimeout: opts.workflowTaskTimeout,
+      workflowStartDelay: opts.startDelay,
       retryPolicy: opts.retry ? compileRetryPolicy(opts.retry) : undefined,
       memo: opts.memo ? { fields: await encodeMapToPayloads(this.dataConverter, opts.memo) } : undefined,
       searchAttributes: opts.searchAttributes

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -1,10 +1,7 @@
-import {
-  CommonWorkflowOptions,
-  SignalDefinition,
-  WithCompiledWorkflowOptions,
-  WithWorkflowArgs,
-  Workflow,
-} from '@temporalio/common';
+import { CommonWorkflowOptions, SignalDefinition, WithWorkflowArgs, Workflow } from '@temporalio/common';
+import { Duration, msOptionalToTs } from '@temporalio/common/lib/time';
+import { Replace } from '@temporalio/common/lib/type-helpers';
+import { google } from '@temporalio/proto';
 
 export * from '@temporalio/common/lib/workflow-options';
 
@@ -37,6 +34,36 @@ export interface WorkflowOptions extends CommonWorkflowOptions {
    * @default true
    */
   followRuns?: boolean;
+
+  /**
+   * Amount of time to wait before starting the workflow.
+   * This is ignored within a Schedule, as expected by {@link ScheduleClient.create}.
+   *
+   * @experimental
+   */
+  startDelay?: Duration;
+}
+
+export type WithCompiledWorkflowOptions<T extends WorkflowOptions> = Replace<
+  T,
+  {
+    workflowExecutionTimeout?: google.protobuf.IDuration;
+    workflowRunTimeout?: google.protobuf.IDuration;
+    workflowTaskTimeout?: google.protobuf.IDuration;
+    startDelay?: google.protobuf.IDuration;
+  }
+>;
+
+export function compileWorkflowOptions<T extends WorkflowOptions>(options: T): WithCompiledWorkflowOptions<T> {
+  const { workflowExecutionTimeout, workflowRunTimeout, workflowTaskTimeout, startDelay, ...rest } = options;
+
+  return {
+    ...rest,
+    workflowExecutionTimeout: msOptionalToTs(workflowExecutionTimeout),
+    workflowRunTimeout: msOptionalToTs(workflowRunTimeout),
+    workflowTaskTimeout: msOptionalToTs(workflowTaskTimeout),
+    startDelay: msOptionalToTs(startDelay),
+  };
 }
 
 export type WorkflowSignalWithStartOptions<SignalArgs extends any[] = []> = SignalArgs extends [any, ...any[]]

--- a/packages/common/src/workflow-options.ts
+++ b/packages/common/src/workflow-options.ts
@@ -1,8 +1,8 @@
-import type { temporal, google } from '@temporalio/proto';
+import type { temporal } from '@temporalio/proto';
 import { SearchAttributes, Workflow } from './interfaces';
 import { RetryPolicy } from './retry-policy';
-import { Duration, msOptionalToTs } from './time';
-import { checkExtends, Replace } from './type-helpers';
+import { Duration } from './time';
+import { checkExtends } from './type-helpers';
 
 // Avoid importing the proto implementation to reduce workflow bundle size
 // Copied from temporal.api.enums.v1.WorkflowIdReusePolicy
@@ -134,26 +134,6 @@ export interface WorkflowDurationOptions {
 }
 
 export type CommonWorkflowOptions = BaseWorkflowOptions & WorkflowDurationOptions;
-
-export type WithCompiledWorkflowOptions<T extends CommonWorkflowOptions> = Replace<
-  T,
-  {
-    workflowExecutionTimeout?: google.protobuf.IDuration;
-    workflowRunTimeout?: google.protobuf.IDuration;
-    workflowTaskTimeout?: google.protobuf.IDuration;
-  }
->;
-
-export function compileWorkflowOptions<T extends CommonWorkflowOptions>(options: T): WithCompiledWorkflowOptions<T> {
-  const { workflowExecutionTimeout, workflowRunTimeout, workflowTaskTimeout, ...rest } = options;
-
-  return {
-    ...rest,
-    workflowExecutionTimeout: msOptionalToTs(workflowExecutionTimeout),
-    workflowRunTimeout: msOptionalToTs(workflowRunTimeout),
-    workflowTaskTimeout: msOptionalToTs(workflowTaskTimeout),
-  };
-}
 
 export function extractWorkflowType<T extends Workflow>(workflowTypeOrFunc: string | T): string {
   if (typeof workflowTypeOrFunc === 'string') return workflowTypeOrFunc as string;

--- a/packages/core-bridge/src/helpers.rs
+++ b/packages/core-bridge/src/helpers.rs
@@ -189,13 +189,16 @@ where
 }
 
 // Recursively convert a Serde value to a JS value
-pub fn serde_value_to_js_value<'a>(cx: &mut impl Context<'a>, val: serde_json::Value) -> JsResult<'a, JsValue> {
+pub fn serde_value_to_js_value<'a>(
+    cx: &mut impl Context<'a>,
+    val: serde_json::Value,
+) -> JsResult<'a, JsValue> {
     match val {
         serde_json::Value::String(s) => Ok(cx.string(s).upcast()),
         serde_json::Value::Number(n) => Ok(cx.number(n.as_f64().unwrap()).upcast()),
         serde_json::Value::Bool(b) => Ok(cx.boolean(b).upcast()),
         serde_json::Value::Null => Ok(cx.null().upcast()),
-        serde_json::Value::Array(vec    ) => {
+        serde_json::Value::Array(vec) => {
             let arr: Handle<'a, JsArray> = JsArray::new(cx, vec.len() as u32);
             for (i, v) in vec.into_iter().enumerate() {
                 let v = serde_value_to_js_value(cx, v)?;
@@ -203,13 +206,14 @@ pub fn serde_value_to_js_value<'a>(cx: &mut impl Context<'a>, val: serde_json::V
             }
             Ok(arr.upcast())
         }
-        serde_json::Value::Object(map) => {
-            hashmap_to_js_value(cx, map).map(|v| v.upcast())
-        }
+        serde_json::Value::Object(map) => hashmap_to_js_value(cx, map).map(|v| v.upcast()),
     }
 }
 
-pub fn hashmap_to_js_value<'a>(cx: &mut impl Context<'a>, map: impl IntoIterator<Item = (String, serde_json::Value)>) -> JsResult<'a, JsObject> {
+pub fn hashmap_to_js_value<'a>(
+    cx: &mut impl Context<'a>,
+    map: impl IntoIterator<Item = (String, serde_json::Value)>,
+) -> JsResult<'a, JsObject> {
     let obj: Handle<'a, JsObject> = cx.empty_object();
     for (k, v) in map {
         let k = cx.string(snake_to_camel(k));
@@ -228,7 +232,7 @@ fn snake_to_camel(input: String) -> String {
                 result.push_str(&input[..first]);
             }
             let mut capitalize = true;
-            for c in input[first+1..].chars() {
+            for c in input[first + 1..].chars() {
                 if c == '_' {
                     capitalize = true;
                 } else if capitalize {
@@ -251,6 +255,9 @@ mod tests {
     fn snake_to_camel_works() {
         assert_eq!(snake_to_camel("this_is_a_test".into()), "thisIsATest");
         assert_eq!(snake_to_camel("this___IS_a_TEST".into()), "thisIsATest");
-        assert_eq!(snake_to_camel("éàç_this_is_a_test".into()), "éàçThisIsATest");
+        assert_eq!(
+            snake_to_camel("éàç_this_is_a_test".into()),
+            "éàçThisIsATest"
+        );
     }
 }

--- a/packages/core-bridge/src/worker.rs
+++ b/packages/core-bridge/src/worker.rs
@@ -83,19 +83,11 @@ pub async fn start_worker_loop(
                         worker.initiate_shutdown();
                         send_result(channel, callback, |cx| Ok(cx.undefined()));
                     }
-                    WorkerRequest::PollWorkflowActivation {
-                        callback,
-                    } => {
-                        handle_poll_workflow_activation_request(
-                            worker, channel, callback,
-                        )
-                        .await
+                    WorkerRequest::PollWorkflowActivation { callback } => {
+                        handle_poll_workflow_activation_request(worker, channel, callback).await
                     }
-                    WorkerRequest::PollActivityTask {
-                        callback,
-                    } => {
-                        handle_poll_activity_task_request(worker, channel, callback)
-                            .await
+                    WorkerRequest::PollActivityTask { callback } => {
+                        handle_poll_activity_task_request(worker, channel, callback).await
                     }
                     WorkerRequest::CompleteWorkflowActivation {
                         completion,
@@ -104,11 +96,7 @@ pub async fn start_worker_loop(
                         void_future_to_js(
                             channel,
                             callback,
-                            async move {
-                                worker
-                                    .complete_workflow_activation(completion)
-                                    .await
-                            },
+                            async move { worker.complete_workflow_activation(completion).await },
                             |cx, err| -> JsResult<JsObject> {
                                 match err {
                                     CompleteWfError::MalformedWorkflowCompletion {
@@ -126,11 +114,7 @@ pub async fn start_worker_loop(
                         void_future_to_js(
                             channel,
                             callback,
-                            async move {
-                                worker
-                                    .complete_activity_task(completion)
-                                    .await
-                            },
+                            async move { worker.complete_activity_task(completion).await },
                             |cx, err| -> JsResult<JsObject> {
                                 match err {
                                     CompleteActivityError::MalformedActivityCompletion {
@@ -158,10 +142,7 @@ async fn handle_poll_workflow_activation_request(
     channel: Arc<Channel>,
     callback: Root<JsFunction>,
 ) {
-    match worker
-        .poll_workflow_activation()
-        .await
-    {
+    match worker.poll_workflow_activation().await {
         Ok(task) => {
             send_result(channel, callback, move |cx| {
                 let len = task.encoded_len();


### PR DESCRIPTION

## What was changed
 The Temporal server introduced the ability to delay the start of a workflow using the attribute `startDelay` in version 1.21. 

This PR enables it for the TypeScript SDK.  

There are also some format changes to Rust files in `core-bridge` after using `npm run format`. They were missing in previous commits because npm run lint.check does not validate Rust files with `cargo fmt`.

1. Closes <!-- add issue number here -->
#1262 
2. How was this tested:
  Two system tests added
