### PR TITLE
Flatten test directory structure

### DIFF
--- a/packages/test/src/helpers-integration.ts
+++ b/packages/test/src/helpers-integration.ts
@@ -15,8 +15,8 @@ import {
   bundleWorkflowCode,
 } from '@temporalio/worker';
 import * as workflow from '@temporalio/workflow';
-import { ConnectionInjectorInterceptor } from '../activities/interceptors';
-import { Worker, test as anyTest, bundlerOptions } from '../helpers';
+import { ConnectionInjectorInterceptor } from './activities/interceptors';
+import { Worker, test as anyTest, bundlerOptions } from './helpers';
 
 export interface Context {
   env: TestWorkflowEnvironment;

--- a/packages/test/src/integration-tests-old.ts
+++ b/packages/test/src/integration-tests-old.ts
@@ -1,9 +1,9 @@
 /* eslint @typescript-eslint/no-non-null-assertion: 0 */
 
 /**
- * Our most recent style of integration tests are those in the
- * integration-tests/ directory. This file has been given the suffix -old to
- * distinguish the different variants.
+ * This file has been given the suffix -old because it uses an older style of
+ * integration testing. New code should follow the style of integration tests in
+ * the files without this suffix.
  */
 import path from 'node:path';
 import v8 from 'node:v8';

--- a/packages/test/src/test-integration-codec-old.ts
+++ b/packages/test/src/test-integration-codec-old.ts
@@ -1,7 +1,7 @@
 /**
- * Our most recent style of integration tests are those in the
- * integration-tests/ directory. This file has been given the suffix -old to
- * distinguish the different variants.
+ * This file has been given the suffix -old because it uses an older style of
+ * integration testing. New code should follow the style of integration tests in
+ * the files without this suffix.
  */
 
 import { RUN_INTEGRATION_TESTS, ByteSkewerPayloadCodec } from './helpers';

--- a/packages/test/src/test-integration-old.ts
+++ b/packages/test/src/test-integration-old.ts
@@ -1,7 +1,7 @@
 /**
- * Our most recent style of integration tests are those in the
- * integration-tests/ directory. This file has been given the suffix -old to
- * distinguish the different variants.
+ * This file has been given the suffix -old because it uses an older style of
+ * integration testing. New code should follow the style of integration tests in
+ * the files without this suffix.
  */
 
 import { RUN_INTEGRATION_TESTS } from './helpers';

--- a/packages/test/src/test-integration-workflows.ts
+++ b/packages/test/src/test-integration-workflows.ts
@@ -4,9 +4,9 @@ import * as activity from '@temporalio/activity';
 import { tsToMs } from '@temporalio/common/lib/time';
 import { CancelReason } from '@temporalio/worker/lib/activity';
 import * as workflow from '@temporalio/workflow';
-import { signalSchedulingWorkflow } from '../activities/helpers';
-import { activityStartedSignal } from '../workflows/definitions';
-import { helpers, makeTestFunction } from './helpers';
+import { signalSchedulingWorkflow } from './activities/helpers';
+import { activityStartedSignal } from './workflows/definitions';
+import { helpers, makeTestFunction } from './helpers-integration';
 
 const test = makeTestFunction({ workflowsPath: __filename });
 


### PR DESCRIPTION
There was a mistake in https://github.com/temporalio/sdk-typescript/pull/1299: tests inside the `integration-tests` subdirectory were not being run.

But that mistake emphasizes that it's not really desirable to have the nested directory. So instead of modifying the `test` and `test.watch` command definitions in `package.json`, this PR flattens the directory structure as follows

```
helpers.ts
helpers-integration.ts     // helper boilerplate shared by the new-style integration tests 
test-integration-*.ts      // i.e. new style integration tests (i.e. not matching -old-*.ts)
test-integration-old-*.ts  // old-style integration tests
```
