### PR TITLE
Strengthen signal and query handler types to catch empty-argument signatures

### DIFF
--- a/packages/test/src/test-interface-type-safety.ts
+++ b/packages/test/src/test-interface-type-safety.ts
@@ -76,7 +76,7 @@ test('Signal handler type safety', (t) => {
   // @ts-expect-error signal handler must take string argument
   wf.setHandler(signal, (arg: number) => {});
 
-  // FIXME: @ts-expect-error signal handler must take string argument
+  // @ts-expect-error signal handler must take string argument
   wf.setHandler(signal, () => {});
 
   // @ts-expect-error signal handler must return void
@@ -93,7 +93,7 @@ test('Query handler type safety', (t) => {
   // @ts-expect-error query handler argument type must match
   wf.setHandler(query, (arg: number): string => '');
 
-  // FIXME: @ts-expect-error query handler argument type must match
+  // @ts-expect-error query handler argument type must match
   wf.setHandler(query, (): string => '');
 
   // @ts-expect-error query handler return type must match

--- a/packages/test/src/test-interface-type-safety.ts
+++ b/packages/test/src/test-interface-type-safety.ts
@@ -71,16 +71,16 @@ test('Can call signal on any WorkflowHandle', async (t) => {
 test('Signal handler type safety', (t) => {
   const signal = defineSignal<[string]>('a');
 
-  wf.setHandler(signal, (arg: string): void => {});
+  wf.setHandler(signal, (_arg: string): void => {});
 
   // @ts-expect-error signal handler must take string argument
-  wf.setHandler(signal, (arg: number) => {});
+  wf.setHandler(signal, (_arg: number) => {});
 
   // @ts-expect-error signal handler must take string argument
   wf.setHandler(signal, () => {});
 
   // @ts-expect-error signal handler must return void
-  wf.setHandler(signal, (arg: string): string => '');
+  wf.setHandler(signal, (_arg: string): string => '');
 
   t.pass();
 });
@@ -88,19 +88,19 @@ test('Signal handler type safety', (t) => {
 test('Query handler type safety', (t) => {
   const query = defineQuery<string, [string]>('a');
 
-  wf.setHandler(query, (arg: string): string => '');
+  wf.setHandler(query, (_arg: string): string => '');
 
   // @ts-expect-error query handler argument type must match
-  wf.setHandler(query, (arg: number): string => '');
+  wf.setHandler(query, (_arg: number): string => '');
 
   // @ts-expect-error query handler argument type must match
   wf.setHandler(query, (): string => '');
 
   // @ts-expect-error query handler return type must match
-  wf.setHandler(query, (arg: string): void => {});
+  wf.setHandler(query, (_arg: string): void => {});
 
   // @ts-expect-error query handler return type must match
-  wf.setHandler(query, (arg: string): number => 7);
+  wf.setHandler(query, (_arg: string): number => 7);
 
   t.pass();
 });

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -438,10 +438,10 @@ export type Handler<
   Ret,
   Args extends any[],
   T extends SignalDefinition<Args> | QueryDefinition<Ret, Args>
-> = T extends SignalDefinition<infer A>
-  ? (...args: A) => void | Promise<void>
-  : T extends QueryDefinition<infer R, infer A>
-  ? (...args: A) => R
+> = T extends SignalDefinition<Args>
+  ? (...args: Args) => void | Promise<void>
+  : T extends QueryDefinition<Ret, Args>
+  ? (...args: Args) => Ret
   : never;
 
 /**


### PR DESCRIPTION
These should both be type errors, but currently they are not:
```ts
  const signal = defineSignal<[string]>('a');
  wf.setHandler(signal, () => {});

  const query = defineQuery<string, [string]>('a');
  wf.setHandler(query, (): string => '');
```

I think that was unintentional, and this PR fixes it (but it is a breaking change).