### PR TITLE
fix(worker): Dont deprecate non-reuseV8Context yet

### DIFF
--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -487,10 +487,11 @@ export interface WorkerOptions {
    * From running basic stress tests we've observed 2/3 reduction in memory usage and 1/3 to 1/2 in CPU usage with this
    * feature turned on.
    *
+   * NOTE: We strongly recommend enabling the Reuse V8 Context execution model, and there is currently no known reason
+   * not to use it. Support for the legacy execution model may get removed at some point in the future. Please report
+   * any issue that requires you to disable `reuseV8Context`.
+   *
    * @default true
-   * @deprecated There is currently no known reason to disable the Reuse V8 Context execution model.
-   * The legacy execution model will be completely removed at some point in the future (no earlier than 1.10.0).
-   * Please report any issue that requires you to disable `reuseV8Context`.
    */
   reuseV8Context?: boolean;
 
@@ -675,7 +676,6 @@ export function addDefaultWorkerOptions(options: WorkerOptions): WorkerOptionsWi
   const maxConcurrentWorkflowTaskExecutions = options.maxConcurrentWorkflowTaskExecutions ?? 40;
   const maxConcurrentActivityTaskExecutions = options.maxConcurrentActivityTaskExecutions ?? 100;
 
-  // eslint-disable-next-line deprecation/deprecation
   const reuseV8Context = options.reuseV8Context ?? true;
 
   const heapSizeMiB = v8.getHeapStatistics().heap_size_limit / MiB;

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -466,7 +466,6 @@ export class Worker {
     // This isn't required for vscode, only for Chrome Dev Tools which doesn't support debugging worker threads.
     // We also rely on this in debug-replayer where we inject a global variable to be read from workflow context.
     if (compiledOptions.debugMode) {
-      // eslint-disable-next-line deprecation/deprecation
       if (compiledOptions.reuseV8Context) {
         return await ReusableVMWorkflowCreator.create(
           workflowBundle,
@@ -484,7 +483,6 @@ export class Worker {
         workflowBundle,
         threadPoolSize: compiledOptions.workflowThreadPoolSize,
         isolateExecutionTimeoutMs: compiledOptions.isolateExecutionTimeoutMs,
-        // eslint-disable-next-line deprecation/deprecation
         reuseV8Context: compiledOptions.reuseV8Context ?? true,
         registeredActivityNames,
       });


### PR DESCRIPTION
## What was changed

- Rewrite doc comment on `WorkerOptions.reuseV8Context` to not make it deprecated, but only that it is strongly recommended not to disable that option.