### PR TITLE
Fix getUpdateHandle API

### DIFF
--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -167,7 +167,7 @@ export interface WorkflowHandle<T extends Workflow = Workflow> extends BaseWorkf
   /**
    * Get a handle to an Update of this Workflow.
    */
-  getUpdateHandle<Ret>(updateId: string, options?: GetWorkflowUpdateHandleOptions): WorkflowUpdateHandle<Ret>;
+  getUpdateHandle<Ret>(updateId: string): WorkflowUpdateHandle<Ret>;
 
   /**
    * Query a running or completed Workflow.
@@ -795,10 +795,9 @@ export class WorkflowClient extends BaseClient {
   protected createWorkflowUpdateHandle<Ret>(
     updateId: string,
     workflowId: string,
-    options?: GetWorkflowUpdateHandleOptions,
+    workflowRunId?: string,
     outcome?: temporal.api.update.v1.IOutcome
   ): WorkflowUpdateHandle<Ret> {
-    const workflowRunId = options?.workflowRunId;
     return {
       updateId,
       workflowId,
@@ -1073,7 +1072,7 @@ export class WorkflowClient extends BaseClient {
       return this.createWorkflowUpdateHandle<Ret>(
         output.updateId,
         input.workflowExecution.workflowId,
-        { workflowRunId: output.workflowRunId },
+        output.workflowRunId,
         output.outcome
       );
     };
@@ -1152,8 +1151,8 @@ export class WorkflowClient extends BaseClient {
         );
         return await handle.result();
       },
-      getUpdateHandle<Ret>(updateId: string, options?: GetWorkflowUpdateHandleOptions): WorkflowUpdateHandle<Ret> {
-        return this.client.createWorkflowUpdateHandle(updateId, workflowId, options);
+      getUpdateHandle<Ret>(updateId: string): WorkflowUpdateHandle<Ret> {
+        return this.client.createWorkflowUpdateHandle(updateId, workflowId, runId);
       },
       async signal<Args extends any[]>(def: SignalDefinition<Args> | string, ...args: Args): Promise<void> {
         const next = this.client._signalWorkflowHandler.bind(this.client);

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -472,7 +472,7 @@ export class WorkflowClient extends BaseClient {
 
   /**
    * Sends a signal to a running Workflow or starts a new one if not already running and immediately signals it.
-   * Useful when you're unsure of the Workflows' run state.
+   * Useful when you're unsure of the Workflow's run state.
    *
    * @returns the runId of the Workflow
    */

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -165,13 +165,9 @@ export interface WorkflowHandle<T extends Workflow = Workflow> extends BaseWorkf
   ): Promise<WorkflowUpdateHandle<Ret>>;
 
   /**
-   * Get a handle to an Update.
+   * Get a handle to an Update of this Workflow.
    */
-  getUpdateHandle<Ret>(
-    updateId: string,
-    workflowId: string,
-    options?: GetWorkflowUpdateHandleOptions
-  ): WorkflowUpdateHandle<Ret>;
+  getUpdateHandle<Ret>(updateId: string, options?: GetWorkflowUpdateHandleOptions): WorkflowUpdateHandle<Ret>;
 
   /**
    * Query a running or completed Workflow.
@@ -1156,11 +1152,7 @@ export class WorkflowClient extends BaseClient {
         );
         return await handle.result();
       },
-      getUpdateHandle<Ret>(
-        updateId: string,
-        workflowId: string,
-        options?: GetWorkflowUpdateHandleOptions
-      ): WorkflowUpdateHandle<Ret> {
+      getUpdateHandle<Ret>(updateId: string, options?: GetWorkflowUpdateHandleOptions): WorkflowUpdateHandle<Ret> {
         return this.client.createWorkflowUpdateHandle(updateId, workflowId, options);
       },
       async signal<Args extends any[]>(def: SignalDefinition<Args> | string, ...args: Args): Promise<void> {

--- a/packages/test/src/test-integration-update.ts
+++ b/packages/test/src/test-integration-update.ts
@@ -69,17 +69,17 @@ test('Update handle can be created from identifiers and used to obtain result', 
     const wfHandle = await startWorkflow(workflowWithUpdates);
     const updateHandleFromStartUpdate = await wfHandle.startUpdate(update, { args: ['1'], updateId });
 
-    const updateHandle = wfHandle.getUpdateHandle(updateId, wfHandle.workflowId);
+    const updateHandle = wfHandle.getUpdateHandle(updateId);
     t.deepEqual(await updateHandle.result(), ['1']);
 
     t.truthy(updateHandleFromStartUpdate.workflowRunId);
-    const updateHandle2 = wfHandle.getUpdateHandle(updateId, wfHandle.workflowId, {
+    const updateHandle2 = wfHandle.getUpdateHandle(updateId, {
       workflowRunId: updateHandleFromStartUpdate.workflowRunId,
     });
     t.deepEqual(await updateHandle2.result(), ['1']);
 
     const incorrectRunId = wf.uuid4();
-    const updateHandle3 = wfHandle.getUpdateHandle(updateId, wfHandle.workflowId, { workflowRunId: incorrectRunId });
+    const updateHandle3 = wfHandle.getUpdateHandle(updateId, { workflowRunId: incorrectRunId });
     const err = await t.throwsAsync(updateHandle3.result());
     t.true(isGrpcServiceError(err) && err.code === grpcStatus.NOT_FOUND);
   });


### PR DESCRIPTION
This PR fixes a mistake in the recently-introduced update `workflowHandle.getUpdateHandle(...)` API https://github.com/temporalio/sdk-typescript/pull/1312.  It should not take `workflowId` as an argument since the appropriate `workflowId` is the one on the `workflowHandle`. 