### PR TITLE
doc: fix sort order + snipsync examples issue

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -129,6 +129,9 @@ module.exports = {
         excludeProtected: true,
         hideGenerator: true,
         disableSources: true,
+        jsDocCompatibility: {
+          exampleTag: false,
+        },
         readme: 'none',
         watch,
         frontmatter: {

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -11,6 +11,7 @@ function titleCase(str) {
 
 function nestMarkdownFiles() {
   return markdownFiles()
+    .sort()
     .sort((a, b) => a.split('.').length - b.split('.').length)
     .reduce((acc, f) => {
       const url = path.relative(path.join(__dirname, 'docs'), f).replace(/\.md$/, '');
@@ -24,7 +25,7 @@ function nestMarkdownFiles() {
             type: 'category',
             label: basename,
             link: { type: 'doc', id: `api/namespaces/${basename}` },
-            items: [url],
+            items: [],
           },
         ];
       }
@@ -35,7 +36,12 @@ function nestMarkdownFiles() {
 
       // Insert new item
       if (category === 'Namespaces') {
-        items.push({ type: 'category', label: url.replace(/.*\./, ''), items: [url] });
+        items.push({
+          type: 'category',
+          label: url.replace(/.*\./, ''),
+          link: { type: 'doc', id: `api/namespaces/${basename}` },
+          items: [],
+        });
       } else {
         let item = items.find(({ label }) => label === category);
         if (item === undefined) {


### PR DESCRIPTION
## What was changed

Fixed multiple issues with published API docs:

- Using snipsync comment tags to import content from an `@example` TS Doc section results in an invalid markdown code block (fix #1339)
- Items in the sidebar are sorted in reverse-alphabetical order (see image)
- In sidebar, namespaces entries appears twice: once as the category, and another as the first entry in that list (see image)

<img width="315" alt="Screenshot 2024-01-15 at 17 03 58" src="https://github.com/temporalio/sdk-typescript/assets/6412169/5ac418e6-c8b1-494f-b6bd-e4c8f40243b0">