### PR TITLE
Update webpack error doc link in worker/bundler.ts

### DIFF
--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -269,7 +269,7 @@ exports.importInterceptors = function importInterceptors() {
             if (hasError) {
               reject(
                 new Error(
-                  "Webpack finished with errors, if you're unsure what went wrong, visit our troubleshooting page at https://docs.temporal.io/typescript/troubleshooting#webpack-errors"
+                  "Webpack finished with errors, if you're unsure what went wrong, visit our troubleshooting page at https://docs.temporal.io/dev-guide/typescript/debugging#webpack-errors"
                 )
               );
             }


### PR DESCRIPTION
## What was changed
Outdated link to docs in the bundler script when there is a Webpack error

## Why?
To link users to the right documentation page.
