### PR TITLE
fix(worker): Fix prometheus and otel regressions

### DIFF
--- a/packages/test/src/helpers.ts
+++ b/packages/test/src/helpers.ts
@@ -1,3 +1,4 @@
+import * as net from 'net';
 import path from 'path';
 import StackUtils from 'stack-utils';
 import ava, { TestFn } from 'ava';
@@ -93,6 +94,7 @@ export const bundlerOptions = {
     '@grpc/grpc-js',
     'async-retry',
     'uuid',
+    'net',
   ],
 };
 
@@ -182,4 +184,19 @@ export async function registerDefaultCustomSearchAttributes(connection: Connecti
   );
   const timeTaken = Date.now() - startTime;
   console.log(`... Registered (took ${timeTaken / 1000} sec)!`);
+}
+
+export async function getRandomPort(fn = (_port: number) => Promise.resolve()): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen({ port: 0, host: '127.0.0.1' }, () => {
+      const addr = srv.address();
+      if (typeof addr === 'string' || addr === null) {
+        throw new Error('Unexpected server address type');
+      }
+      fn(addr.port)
+        .catch((e) => reject(e))
+        .finally(() => srv.close((_) => resolve(addr.port)));
+    });
+  });
 }

--- a/packages/test/src/test-otel.ts
+++ b/packages/test/src/test-otel.ts
@@ -2,6 +2,8 @@
 /**
  * Manual tests to inspect tracing output
  */
+import * as http2 from 'http2';
+import { setTimeout } from 'timers/promises';
 import { SpanStatusCode } from '@opentelemetry/api';
 import { ExportResultCode } from '@opentelemetry/core';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
@@ -17,10 +19,94 @@ import {
 } from '@temporalio/interceptors-opentelemetry/lib/worker';
 import { OpenTelemetrySinks, SpanName, SPAN_DELIMITER } from '@temporalio/interceptors-opentelemetry/lib/workflow';
 import { DefaultLogger, InjectedSinks, Runtime } from '@temporalio/worker';
+import { TestWorkflowEnvironment } from '@temporalio/testing';
 import * as activities from './activities';
 import { ConnectionInjectorInterceptor } from './activities/interceptors';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
 import * as workflows from './workflows';
+
+async function withHttp2Server(
+  fn: (port: number) => Promise<void>,
+  requestListener?: (request: http2.Http2ServerRequest, response: http2.Http2ServerResponse) => void
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const srv = http2.createServer();
+    srv.listen({ port: 0, host: '127.0.0.1' }, () => {
+      const addr = srv.address();
+      if (typeof addr === 'string' || addr === null) {
+        throw new Error('Unexpected server address type');
+      }
+      srv.on('request', async (req, res) => {
+        if (requestListener) await requestListener(req, res);
+        res.end();
+      });
+      fn(addr.port)
+        .catch((e) => reject(e))
+        .finally(() => srv.close((_) => resolve()));
+    });
+  });
+}
+
+test.serial('Runtime.install() throws meaningful error when passed invalid metrics.otel.url', async (t) => {
+  t.throws(() => Runtime.install({ telemetryOptions: { metrics: { otel: { url: ':invalid' } } } }), {
+    instanceOf: TypeError,
+    message: /Invalid telemetryOptions.metrics.otel.url/,
+  });
+});
+
+test.serial('Runtime.install() accepts metrics.otel.url without headers', async (t) => {
+  try {
+    Runtime.install({ telemetryOptions: { metrics: { otel: { url: 'http://127.0.0.1:1234' } } } });
+    t.pass();
+  } finally {
+    // Cleanup the runtime so that it doesn't interfere with other tests
+    await Runtime._instance?.shutdown();
+  }
+});
+
+test.serial('Exporting OTEL metrics from Core works', async (t) => {
+  let resolveCapturedRequest = (_req: http2.Http2ServerRequest) => undefined as void;
+  const capturedRequest = new Promise<http2.Http2ServerRequest>((r) => (resolveCapturedRequest = r));
+  await withHttp2Server(async (port: number) => {
+    Runtime.install({
+      telemetryOptions: {
+        metrics: {
+          otel: {
+            url: `http://127.0.0.1:${port}`,
+            headers: {
+              'x-test-header': 'test-value',
+            },
+            metricsExportInterval: 10,
+          },
+        },
+      },
+    });
+
+    const localEnv = await TestWorkflowEnvironment.createLocal();
+    try {
+      const worker = await Worker.create({
+        connection: localEnv.nativeConnection,
+        workflowsPath: require.resolve('./workflows'),
+        taskQueue: 'test-otel',
+      });
+      const client = new WorkflowClient({
+        connection: localEnv.connection,
+      });
+      await worker.runUntil(async () => {
+        await client.execute(workflows.successString, {
+          taskQueue: 'test-otel',
+          workflowId: uuid4(),
+        });
+        const req = await Promise.race([capturedRequest, setTimeout(1000).then(() => undefined)]);
+        t.truthy(req);
+        t.is(req?.url, '/opentelemetry.proto.collector.metrics.v1.MetricsService/Export');
+        t.is(req?.headers['x-test-header'], 'test-value');
+      });
+    } finally {
+      await localEnv.teardown();
+    }
+  }, resolveCapturedRequest);
+});
 
 if (RUN_INTEGRATION_TESTS) {
   test.serial('Otel interceptor spans are connected and complete', async (t) => {
@@ -178,7 +264,7 @@ if (RUN_INTEGRATION_TESTS) {
     });
     await worker.runUntil(client.execute(workflows.smorgasbord, { taskQueue: 'test-otel', workflowId: uuid4() }));
     // Allow some time to ensure spans are flushed out to collector
-    await new Promise((resolve) => setTimeout(resolve, 5000));
+    await setTimeout(5000);
     t.pass();
   });
 

--- a/packages/test/src/test-prometheus.ts
+++ b/packages/test/src/test-prometheus.ts
@@ -1,51 +1,57 @@
-import * as net from 'net';
 import test from 'ava';
 import { v4 as uuid4 } from 'uuid';
 import fetch from 'node-fetch';
 import { WorkflowClient } from '@temporalio/client';
-import { NativeConnection, Runtime } from '@temporalio/worker';
-import * as activities from './activities';
-import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { Runtime } from '@temporalio/worker';
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { Worker, getRandomPort } from './helpers';
 import * as workflows from './workflows';
 
-async function getRandomPort(): Promise<number> {
-  return new Promise<number>((res) => {
-    const srv = net.createServer();
-    srv.listen(0, () => {
-      const addr = srv.address();
-      if (typeof addr === 'string' || addr === null) {
-        throw new Error('Unexpected server address type');
-      }
-      srv.close((_) => res(addr.port));
-    });
+test.serial('Runtime.install() throws meaningful error when passed invalid metrics.prometheus.bindAddress', (t) => {
+  t.throws(() => Runtime.install({ telemetryOptions: { metrics: { prometheus: { bindAddress: ':invalid' } } } }), {
+    instanceOf: TypeError,
+    message: 'Invalid telemetryOptions.metrics.prometheus.bindAddress',
   });
-}
+});
 
-if (RUN_INTEGRATION_TESTS) {
-  test.serial('Prometheus metrics work', async (t) => {
-    const port = await getRandomPort();
-    Runtime.install({
-      telemetryOptions: {
-        metrics: {
-          prometheus: {
-            bindAddress: `127.0.0.1:${port}`,
-          },
+test.serial(
+  'Runtime.install() throws meaningful error when metrics.prometheus.bindAddress port is already taken',
+  async (t) => {
+    await getRandomPort(async (port: number) => {
+      t.throws(
+        () => Runtime.install({ telemetryOptions: { metrics: { prometheus: { bindAddress: `127.0.0.1:${port}` } } } }),
+        {
+          instanceOf: Error,
+          message: /Address already in use/,
+        }
+      );
+    });
+  }
+);
+
+test.serial('Exporting Prometheus metrics from Core works', async (t) => {
+  const port = await getRandomPort();
+  Runtime.install({
+    telemetryOptions: {
+      metrics: {
+        prometheus: {
+          bindAddress: `127.0.0.1:${port}`,
         },
       },
-    });
-    const connection = await NativeConnection.connect({
-      address: '127.0.0.1:7233',
-    });
+    },
+  });
+  const localEnv = await TestWorkflowEnvironment.createLocal();
+  try {
     const worker = await Worker.create({
-      connection,
+      connection: localEnv.nativeConnection,
       workflowsPath: require.resolve('./workflows'),
-      activities,
       taskQueue: 'test-prometheus',
     });
-
-    const client = new WorkflowClient();
+    const client = new WorkflowClient({
+      connection: localEnv.connection,
+    });
     await worker.runUntil(async () => {
-      await client.execute(workflows.cancelFakeProgress, {
+      await client.execute(workflows.successString, {
         taskQueue: 'test-prometheus',
         workflowId: uuid4(),
       });
@@ -54,7 +60,7 @@ if (RUN_INTEGRATION_TESTS) {
       const text = await resp.text();
       t.assert(text.includes('task_slots'));
     });
-
-    t.pass();
-  });
-}
+  } finally {
+    await localEnv.teardown();
+  }
+});

--- a/packages/test/src/test-prometheus.ts
+++ b/packages/test/src/test-prometheus.ts
@@ -22,7 +22,7 @@ test.serial(
         () => Runtime.install({ telemetryOptions: { metrics: { prometheus: { bindAddress: `127.0.0.1:${port}` } } } }),
         {
           instanceOf: Error,
-          message: /Address already in use/,
+          message: /(Address already in use|socket address)/,
         }
       );
     });

--- a/packages/test/src/test-runtime.ts
+++ b/packages/test/src/test-runtime.ts
@@ -53,7 +53,7 @@ if (RUN_INTEGRATION_TESTS) {
   // Stopping and starting Workers is probably not a common pattern but if we don't remember what
   // Runtime configuration was installed, creating a new Worker after Runtime shutdown we would fallback
   // to the default configuration (localhost) which is surprising behavior.
-  test.serial('Runtime.instance() remembers installed options after it has been shut down', async (t) => {
+  test.serial('Runtime.install() remembers installed options after it has been shut down', async (t) => {
     const logger = new DefaultLogger('DEBUG');
     Runtime.install({ logger });
     {
@@ -74,7 +74,7 @@ if (RUN_INTEGRATION_TESTS) {
     }
   });
 
-  test.serial('Runtime.instance() Core forwarded logs contains metadata', async (t) => {
+  test.serial('Runtime.install() Core forwarded logs contains metadata', async (t) => {
     const logEntries: LogEntry[] = [];
     const logger = new DefaultLogger('DEBUG', (entry) => logEntries.push(entry));
     Runtime.install({
@@ -118,21 +118,7 @@ if (RUN_INTEGRATION_TESTS) {
     }
   });
 
-  test.serial('Runtime.instance() throws meaningful error when passed invalid metrics.otel.url', (t) => {
-    t.throws(() => Runtime.install({ telemetryOptions: { metrics: { otel: { url: ':invalid' } } } }), {
-      instanceOf: TypeError,
-      message: 'Invalid telemetryOptions.metrics.otel.url',
-    });
-  });
-
-  test.serial('Runtime.instance() throws meaningful error when passed invalid metrics.prometheus.bindAddress', (t) => {
-    t.throws(() => Runtime.install({ telemetryOptions: { metrics: { prometheus: { bindAddress: ':invalid' } } } }), {
-      instanceOf: TypeError,
-      message: 'Invalid telemetryOptions.metrics.prometheus.bindAddress',
-    });
-  });
-
-  test.serial('Runtime.instance() throws meaningful error when passed invalid telemetryOptions.logging.filter', (t) => {
+  test.serial('Runtime.install() throws meaningful error when passed invalid telemetryOptions.logging.filter', (t) => {
     t.throws(() => Runtime.install({ telemetryOptions: { logging: { filter: 2 as any } } }), {
       instanceOf: TypeError,
       message: 'Invalid filter',

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -198,12 +198,12 @@ export class Runtime {
    * Factory function for creating a new Core instance, not exposed because Core is meant to be used as a singleton
    */
   protected static create(options: RuntimeOptions, instantiator: 'install' | 'instance'): Runtime {
+    const compiledOptions = this.compileOptions(options);
+    const runtime = newRuntime(compiledOptions.telemetryOptions);
+
     // Remember the provided options in case Core is reinstantiated after being shut down
     this.defaultOptions = options;
     this.instantiator = instantiator;
-
-    const compiledOptions = this.compileOptions(options);
-    const runtime = newRuntime(compiledOptions.telemetryOptions);
     this._instance = new this(runtime, compiledOptions);
     return this._instance;
   }
@@ -239,7 +239,7 @@ export class Runtime {
             ? {
                 otel: {
                   url: metrics.otel.url,
-                  headers: metrics.otel.headers,
+                  headers: metrics.otel.headers ?? {},
                   metricsExportInterval: msToNumber(metrics.otel.metricsExportInterval ?? '1s'),
                 },
               }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -630,9 +630,13 @@ export class Worker {
       if (compiledOptions.bundlerOptions) {
         logger.warn('Ignoring WorkerOptions.bundlerOptions because WorkerOptions.workflowBundle is set');
       }
-      const modules = compiledOptions.interceptors.workflowModules;
+      const modules = new Set(compiledOptions.interceptors.workflowModules);
       // Warn if user tries to customize the default set of workflow interceptor modules
-      if (modules && new Set([...modules, ...defaultWorkflowInterceptorModules]).size !== modules.length) {
+
+      if (
+        modules &&
+        new Set([...modules, ...defaultWorkflowInterceptorModules]).size !== defaultWorkflowInterceptorModules.length
+      ) {
         logger.warn(
           'Ignoring WorkerOptions.interceptors.workflowModules because WorkerOptions.workflowBundle is set.\n' +
             'To use workflow interceptors with a workflowBundle, pass them in the call to bundleWorkflowCode.'


### PR DESCRIPTION
## What changed

- Fix `Runtime.install()` failing with error `Failed to build otlp exporter options: UninitializedField("headers")` when configuring OTEL metric exporter is configured without specifying headers (fix #1342).
- Fix Rust panic + TS hanging when trying to create a Worker if `Runtime` has been configured with Prometheus metrics exporter, but the specified port is already taken.
- Add more TS side tests related to Prometheus and OTEL metric exports.

- Also fix incorrect reporting `Ignoring WorkerOptions.interceptors.workflowModules because WorkerOptions.workflowBundle is set. To use workflow interceptors with a workflowBundle, pass them in the call to bundleWorkflowCode.`