### PR TITLE
doc: Avoid doctype reexports canonicalization issue

### DIFF
--- a/packages/meta/src/index.ts
+++ b/packages/meta/src/index.ts
@@ -1,9 +1,11 @@
-export * as worker from '@temporalio/worker';
-export * as client from '@temporalio/client';
+// ORDER IS IMPORTANT! When a type is re-exported, TypeDoc will keep the first
+// one it encountered as canonical, and mark others as references to that one.
+export * as protobufs from '@temporalio/common/lib/protobufs';
 export * as proto from '@temporalio/proto';
 export * as common from '@temporalio/common';
-export * as protobufs from '@temporalio/common/lib/protobufs';
 export * as workflow from '@temporalio/workflow';
 export * as activity from '@temporalio/activity';
+export * as worker from '@temporalio/worker';
+export * as client from '@temporalio/client';
 export * as testing from '@temporalio/testing';
 export * as opentelemetry from '@temporalio/interceptors-opentelemetry';

--- a/scripts/prepublish.mjs
+++ b/scripts/prepublish.mjs
@@ -12,9 +12,11 @@ const packages = await fs.readdir(packagesPath);
 for (const dir of packages) {
   const packageJsonPath = path.join(packagesPath, dir, 'package.json');
   const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
-  for (const dep of Object.keys(packageJson.dependencies)) {
-    if (dep.startsWith('@temporalio/')) {
-      packageJson.dependencies[dep] = `${version}`;
+  for (const depType of ['dependencies', 'devDependencies', 'peerDependencies']) {
+    for (const dep of Object.keys(packageJson[depType] ?? {})) {
+      if (dep.startsWith('@temporalio/')) {
+        packageJson[depType][dep] = `${version}`;
+      }
     }
   }
   const replacedContent = JSON.stringify(packageJson, null, 2);


### PR DESCRIPTION
## What was changed and why?

- Change the order in which packages are visited by the TypeDoc exporter.
  - When types are reexported, TypeDoc canonicalize references to that type to the first public export it encountered. Given the previous package ordering, that means that, for example, ` ApplicationFailure` would appear under the `activity` package, rather than the `common` package.
- Updated our prepublish script to also update `devDependecies` and `peerDependencies`.
  - Some users have faced issues with this using the 1.9.0 release. 1.9.1 fixed the invalid dependencies, but the change to the script had not been comited.