### PR TITLE
feat(worker): Set default webpack build configuration target to node

### DIFF
--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -238,6 +238,7 @@ exports.importInterceptors = function importInterceptors() {
       entry: [entry],
       mode: 'development',
       devtool: 'inline-source-map',
+      target: 'node',
       output: {
         path: distDir,
         filename: 'workflow-bundle-[fullhash].js',


### PR DESCRIPTION
## What was changed
This PR sets the default worker webpack build configuration target to `node`.

## Why?
Webpack default target is `web`, as described in [their docs](https://webpack.js.org/concepts/targets/), this brings some problems when running some packages i.e. [Prisma](https://github.com/prisma/prisma) that are unable to run with a web environment.

## Checklist

1. Closes: None, but happy to create if needed!

2. How was this tested:
While starting testing Temporal with our current codebase we found that we were unable to build workers given webpack default target is web, which is incompatible with Prisma way of executing.

3. Any docs updates needed?
As far as I saw, the current docs don't state the default config for webpack, but a link to the default configs could be added for possible future cases, to allow developers to dig into the problems faster.