### PR TITLE
core: Update SDK to 520040

### DIFF
--- a/packages/core-bridge/Cargo.lock
+++ b/packages/core-bridge/Cargo.lock
@@ -332,42 +332,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2382,7 +2350,8 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "base64",
- "crossbeam",
+ "crossbeam-channel",
+ "crossbeam-queue",
  "dashmap",
  "derive_builder",
  "derive_more",


### PR DESCRIPTION
## What changed

- Updated Core SDK to [520040](https://github.com/temporalio/sdk-core/commit/520040aba1b044dd2d120cb75ce303fca4d81091).
  - Fix deprecated patch removal when no subequent command (temporalio/sdk-core#671).
  - Fix incorrect ordering of a query execution that could happen if new workflow tasks came in while theere were buffered queries (temporalio/sdk-core#673).
  - Fix a possibility of sending local activity marker after the Workflow Task Complete command  (temporalio/sdk-core#678).
  - Wait for activity completes to reach server before shutdown (temporalio/sdk-core#681).
  - Update protobuf definitions to work with the new `EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REQUESTED` event (temporalio/sdk-core#677).
