### PR TITLE
Bring gRPC retry options in line with other SDKs.

### DIFF
--- a/packages/client/src/grpc-retry.ts
+++ b/packages/client/src/grpc-retry.ts
@@ -26,7 +26,7 @@ export interface BackoffOptions {
   /**
    * Exponential backoff factor
    *
-   * @default 2
+   * @default 1.7
    */
   factor: number;
 
@@ -39,20 +39,20 @@ export interface BackoffOptions {
   /**
    * Maximum amount of jitter to apply
    *
-   * @default 0.1
+   * @default 0.2
    */
   maxJitter: number;
   /**
    * Function that returns the "initial" backoff interval based on the returned status.
    *
-   * The default is 1 second for RESOURCE_EXHAUSTED errors and 20 millis for other retryable errors.
+   * The default is 1 second for RESOURCE_EXHAUSTED errors and 100 millis for other retryable errors.
    */
   initialIntervalMs(status: StatusObject): number;
 
   /**
    * Function that returns the "maximum" backoff interval based on the returned status.
    *
-   * The default is 10 seconds regardless of the status.
+   * The default is 5 seconds regardless of the status.
    */
   maxIntervalMs(status: StatusObject): number;
 }
@@ -68,11 +68,11 @@ function withDefaultBackoffOptions({
 }: Partial<BackoffOptions>): BackoffOptions {
   return {
     maxAttempts: maxAttempts ?? 10,
-    factor: factor ?? 2,
-    maxJitter: maxJitter ?? 0.1,
+    factor: factor ?? 1.7,
+    maxJitter: maxJitter ?? 0.2,
     initialIntervalMs: initialIntervalMs ?? defaultInitialIntervalMs,
     maxIntervalMs() {
-      return 10_000;
+      return 5_000;
     },
   };
 }
@@ -125,7 +125,7 @@ function defaultInitialIntervalMs({ code }: StatusObject) {
   if (code === grpc.status.RESOURCE_EXHAUSTED) {
     return 1000;
   }
-  return 20;
+  return 100;
 }
 
 /**


### PR DESCRIPTION
## What was changed
* Raise initial interval to 100ms (from 20ms)
* Drop max interval to 5s (from 10s)
* Drop backoff factor to 1.7 (from 2.0)
* Raise jitter factor to 0.2 (from 0.1)

## Why?
The current retry options for the TypeScript SDK are a little wonky, as the existing initial interval is *by far* the most aggressive among all Temporal SDKs.  This brings the default parameters in line with the changes already made to the Java SDK and in flight for the Core SDK.

This also fixes a wart: the TypeScript SDK can exhaust all retries in 9.200 seconds, if the random jitters for each retry align in just the right way, and we want all SDKs to keep retrying for at least 10 seconds after the initial failure.

This advances progress on https://github.com/temporalio/features/issues/27 (aka SDK-118 in internal Jira).