### PR TITLE
Update grpc-js to 1.10.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -605,15 +605,15 @@
       "dev": true
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.13",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.13.tgz",
-      "integrity": "sha512-OEZZu9v9AA+7/tghMDE8o5DAMD5THVnwSqDWuh7PPYO5287rTyqy0xEHT6/e4pbqSrhyLPdQFsam4TwFQVVIIw==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.6.tgz",
+      "integrity": "sha512-xP58G7wDQ4TCmN/cMUHh00DS7SRDv/+lC+xFLrTkMIN8h55X5NhZMLYbvy7dSELP15qlI6hPhNCRWVMtZMwqLA==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.8",
-        "@types/node": ">=12.12.47"
+        "@grpc/proto-loader": "^0.7.10",
+        "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
-        "node": "^8.13.0 || >=10.10.0"
+        "node": ">=12.10.0"
       }
     },
     "node_modules/@grpc/proto-loader": {
@@ -783,6 +783,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@jsdoc/salty": {
@@ -18791,7 +18800,7 @@
       "version": "1.9.3",
       "license": "MIT",
       "dependencies": {
-        "@grpc/grpc-js": "~1.7.3",
+        "@grpc/grpc-js": "~1.10.6",
         "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
         "abort-controller": "^3.0.0",
@@ -18800,18 +18809,6 @@
       },
       "devDependencies": {
         "protobufjs": "^7.2.5"
-      }
-    },
-    "packages/client/node_modules/@grpc/grpc-js": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
-      "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
-      "dependencies": {
-        "@grpc/proto-loader": "^0.7.0",
-        "@types/node": ">=12.12.47"
-      },
-      "engines": {
-        "node": "^8.13.0 || >=10.10.0"
       }
     },
     "packages/common": {
@@ -19002,7 +18999,7 @@
       "version": "1.9.3",
       "license": "MIT",
       "dependencies": {
-        "@grpc/grpc-js": "~1.7.3",
+        "@grpc/grpc-js": "~1.10.6",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/core": "^1.19.0",
@@ -19046,18 +19043,6 @@
         "pidusage": "^3.0.2"
       }
     },
-    "packages/test/node_modules/@grpc/grpc-js": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
-      "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
-      "dependencies": {
-        "@grpc/proto-loader": "^0.7.0",
-        "@types/node": ">=12.12.47"
-      },
-      "engines": {
-        "node": "^8.13.0 || >=10.10.0"
-      }
-    },
     "packages/test/node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -19082,7 +19067,6 @@
       "version": "1.9.3",
       "license": "MIT",
       "dependencies": {
-        "@grpc/grpc-js": "~1.7.3",
         "@temporalio/activity": "file:../activity",
         "@temporalio/client": "file:../client",
         "@temporalio/common": "file:../common",
@@ -19091,18 +19075,6 @@
         "@temporalio/worker": "file:../worker",
         "@temporalio/workflow": "file:../workflow",
         "abort-controller": "^3.0.0"
-      }
-    },
-    "packages/testing/node_modules/@grpc/grpc-js": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
-      "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
-      "dependencies": {
-        "@grpc/proto-loader": "^0.7.0",
-        "@types/node": ">=12.12.47"
-      },
-      "engines": {
-        "node": "^8.13.0 || >=10.10.0"
       }
     },
     "packages/worker": {
@@ -19580,12 +19552,12 @@
       "dev": true
     },
     "@grpc/grpc-js": {
-      "version": "1.9.13",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.13.tgz",
-      "integrity": "sha512-OEZZu9v9AA+7/tghMDE8o5DAMD5THVnwSqDWuh7PPYO5287rTyqy0xEHT6/e4pbqSrhyLPdQFsam4TwFQVVIIw==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.6.tgz",
+      "integrity": "sha512-xP58G7wDQ4TCmN/cMUHh00DS7SRDv/+lC+xFLrTkMIN8h55X5NhZMLYbvy7dSELP15qlI6hPhNCRWVMtZMwqLA==",
       "requires": {
-        "@grpc/proto-loader": "^0.7.8",
-        "@types/node": ">=12.12.47"
+        "@grpc/proto-loader": "^0.7.10",
+        "@js-sdsl/ordered-map": "^4.4.2"
       }
     },
     "@grpc/proto-loader": {
@@ -19715,6 +19687,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="
     },
     "@jsdoc/salty": {
       "version": "0.2.7",
@@ -21572,24 +21549,13 @@
     "@temporalio/client": {
       "version": "file:packages/client",
       "requires": {
-        "@grpc/grpc-js": "~1.7.3",
+        "@grpc/grpc-js": "~1.10.6",
         "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
         "abort-controller": "^3.0.0",
         "long": "^5.2.3",
         "protobufjs": "^7.2.5",
         "uuid": "^9.0.1"
-      },
-      "dependencies": {
-        "@grpc/grpc-js": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
-          "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
-          "requires": {
-            "@grpc/proto-loader": "^0.7.0",
-            "@types/node": ">=12.12.47"
-          }
-        }
       }
     },
     "@temporalio/common": {
@@ -21709,7 +21675,7 @@
     "@temporalio/test": {
       "version": "file:packages/test",
       "requires": {
-        "@grpc/grpc-js": "~1.7.3",
+        "@grpc/grpc-js": "~1.10.6",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/core": "^1.19.0",
@@ -21751,15 +21717,6 @@
         "uuid": "^9.0.1"
       },
       "dependencies": {
-        "@grpc/grpc-js": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
-          "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
-          "requires": {
-            "@grpc/proto-loader": "^0.7.0",
-            "@types/node": ">=12.12.47"
-          }
-        },
         "node-fetch": {
           "version": "2.7.0",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -21773,7 +21730,6 @@
     "@temporalio/testing": {
       "version": "file:packages/testing",
       "requires": {
-        "@grpc/grpc-js": "~1.7.3",
         "@temporalio/activity": "file:../activity",
         "@temporalio/client": "file:../client",
         "@temporalio/common": "file:../common",
@@ -21782,17 +21738,6 @@
         "@temporalio/worker": "file:../worker",
         "@temporalio/workflow": "file:../workflow",
         "abort-controller": "^3.0.0"
-      },
-      "dependencies": {
-        "@grpc/grpc-js": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
-          "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
-          "requires": {
-            "@grpc/proto-loader": "^0.7.0",
-            "@types/node": ">=12.12.47"
-          }
-        }
       }
     },
     "@temporalio/worker": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18800,7 +18800,7 @@
       "version": "1.9.3",
       "license": "MIT",
       "dependencies": {
-        "@grpc/grpc-js": "~1.10.6",
+        "@grpc/grpc-js": "^1.10.6",
         "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
         "abort-controller": "^3.0.0",
@@ -18999,7 +18999,7 @@
       "version": "1.9.3",
       "license": "MIT",
       "dependencies": {
-        "@grpc/grpc-js": "~1.10.6",
+        "@grpc/grpc-js": "^1.10.6",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/core": "^1.19.0",
@@ -21549,7 +21549,7 @@
     "@temporalio/client": {
       "version": "file:packages/client",
       "requires": {
-        "@grpc/grpc-js": "~1.10.6",
+        "@grpc/grpc-js": "^1.10.6",
         "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
         "abort-controller": "^3.0.0",
@@ -21675,7 +21675,7 @@
     "@temporalio/test": {
       "version": "file:packages/test",
       "requires": {
-        "@grpc/grpc-js": "~1.10.6",
+        "@grpc/grpc-js": "^1.10.6",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/core": "^1.19.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,7 +13,7 @@
   "author": "Temporal Technologies Inc. <sdk@temporal.io>",
   "license": "MIT",
   "dependencies": {
-    "@grpc/grpc-js": "~1.10.6",
+    "@grpc/grpc-js": "^1.10.6",
     "@temporalio/common": "file:../common",
     "@temporalio/proto": "file:../proto",
     "abort-controller": "^3.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,7 +13,7 @@
   "author": "Temporal Technologies Inc. <sdk@temporal.io>",
   "license": "MIT",
   "dependencies": {
-    "@grpc/grpc-js": "~1.7.3",
+    "@grpc/grpc-js": "~1.10.6",
     "@temporalio/common": "file:../common",
     "@temporalio/proto": "file:../proto",
     "abort-controller": "^3.0.0",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -26,7 +26,7 @@
   "author": "Temporal Technologies Inc. <sdk@temporal.io>",
   "license": "MIT",
   "dependencies": {
-    "@grpc/grpc-js": "~1.10.6",
+    "@grpc/grpc-js": "^1.10.6",
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/core": "^1.19.0",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -26,7 +26,7 @@
   "author": "Temporal Technologies Inc. <sdk@temporal.io>",
   "license": "MIT",
   "dependencies": {
-    "@grpc/grpc-js": "~1.7.3",
+    "@grpc/grpc-js": "~1.10.6",
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/core": "^1.19.0",

--- a/packages/test/src/test-client-connection.ts
+++ b/packages/test/src/test-client-connection.ts
@@ -415,7 +415,12 @@ test('No 10s delay on close due to grpc-js', async (t) => {
     const startTime = Date.now();
     await new Promise((resolve, reject) => {
       try {
-        const childProcess = fork('-e', [script]);
+        const childProcess = fork('-e', [script], {
+          env: {
+            GRPC_VERBOSITY: 'DEBUG',
+            GRPC_TRACE: 'all',
+          },
+        });
         childProcess.on('exit', resolve);
         childProcess.on('error', reject);
       } catch (e) {

--- a/packages/test/src/test-client-connection.ts
+++ b/packages/test/src/test-client-connection.ts
@@ -406,7 +406,17 @@ test('Can configure TLS + call credentials', async (t) => {
 test('No 10s delay on close due to grpc-js', async (t) => {
   const server = new grpc.Server();
   try {
-    server.addService(workflowServiceProtoDescriptor.temporal.api.workflowservice.v1.WorkflowService.service, {});
+    server.addService(workflowServiceProtoDescriptor.temporal.api.workflowservice.v1.WorkflowService.service, {
+      getSystemInfo(
+        call: grpc.ServerUnaryCall<
+          temporal.api.workflowservice.v1.IGetSystemInfoRequest,
+          temporal.api.workflowservice.v1.IGetSystemInfoResponse
+        >,
+        callback: grpc.sendUnaryData<temporal.api.workflowservice.v1.IGetSystemInfoResponse>
+      ) {
+        callback(null, { serverVersion: 'test', capabilities: undefined });
+      },
+    });
     const port = await bindLocalhostTls(server);
     const script = `
       const { Connection } = require("@temporalio/client");

--- a/packages/test/src/test-client-connection.ts
+++ b/packages/test/src/test-client-connection.ts
@@ -380,8 +380,9 @@ test('Can configure TLS + call credentials', async (t) => {
 
           const expectedMinDuration =
             (expectedAttempts - 1) * (grpcStatusCode === grpc.status.RESOURCE_EXHAUSTED ? 100 : 10);
-          // Allow an overhead of 30ms per request. Even on very busy CI, that should be more than enough.
-          const expectedMaxDuration = expectedMinDuration + expectedAttempts * 30;
+          // Allow an overhead of 100ms for the first attempt, then 40ms per retry.
+          // Even on very busy CI, that should be more than enough.
+          const expectedMaxDuration = expectedMinDuration + 100 + (expectedAttempts - 1) * 40;
           const actualDuration = Date.now() - startTime;
           t.true(
             actualDuration >= expectedMinDuration,

--- a/packages/test/src/test-client-connection.ts
+++ b/packages/test/src/test-client-connection.ts
@@ -380,9 +380,11 @@ test('Can configure TLS + call credentials', async (t) => {
 
           const expectedMinDuration =
             (expectedAttempts - 1) * (grpcStatusCode === grpc.status.RESOURCE_EXHAUSTED ? 100 : 10);
-          // Allow an overhead of 100ms for the first attempt, then 40ms per retry.
-          // Even on very busy CI, that should be more than enough.
-          const expectedMaxDuration = expectedMinDuration + 100 + (expectedAttempts - 1) * 40;
+          // Here, we really just want to confirm that gRPC is not playing tricks on us by adding
+          // extra wait time over our own retry policy's backoff. But being too strict may cause
+          // flakes on very busy CI. Hence, we allow for very generous overhead.
+          // Allow an overhead of 500ms for the first attempt, then 200ms per retry.
+          const expectedMaxDuration = expectedMinDuration + 500 + (expectedAttempts - 1) * 200;
           const actualDuration = Date.now() - startTime;
           t.true(
             actualDuration >= expectedMinDuration,

--- a/packages/test/src/test-native-connection-headers.ts
+++ b/packages/test/src/test-native-connection-headers.ts
@@ -66,8 +66,6 @@ test('NativeConnection passes headers provided in options', async (t) => {
     '127.0.0.1:0',
     grpc.ServerCredentials.createInsecure()
   );
-  server.start();
-
   const connection = await NativeConnection.connect({
     address: `127.0.0.1:${port}`,
     metadata: { initial: 'true' },

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -12,7 +12,6 @@
   "author": "Temporal Technologies Inc. <sdk@temporal.io>",
   "license": "MIT",
   "dependencies": {
-    "@grpc/grpc-js": "~1.7.3",
     "@temporalio/activity": "file:../activity",
     "@temporalio/client": "file:../client",
     "@temporalio/common": "file:../common",

--- a/packages/testing/src/connection.ts
+++ b/packages/testing/src/connection.ts
@@ -1,4 +1,3 @@
-import * as grpc from '@grpc/grpc-js';
 import { Connection as BaseConnection, ConnectionOptions } from '@temporalio/client';
 import { ConnectionCtorOptions as BaseConnectionCtorOptions } from '@temporalio/client/lib/connection';
 import { temporal } from '@temporalio/proto';
@@ -14,7 +13,6 @@ interface ConnectionCtorOptions extends BaseConnectionCtorOptions {
  * A Connection class that can be used to interact with both the test server's TestService and WorkflowService
  */
 export class Connection extends BaseConnection {
-  public static readonly TestServiceClient = grpc.makeGenericClientConstructor({}, 'TestService', {});
   public readonly testService: TestService;
 
   protected static createCtorOptions(options?: ConnectionOptions): ConnectionCtorOptions {


### PR DESCRIPTION
## What was changed

- Remove version pin on `@grpc/grpc-js`, and update it to 1.10.6.
- Added tests to assert that bugs and concerns regarding grpc-js 1.8+ are no longer pertinent.

## Why?

grpc-js had been pinned to 1.7.3 in #1073, as 1.8.x introduced multiple bugs, as well a built-in retry feature, which could possibly conflict with our own retry interceptor.

Recently, there's been security concerns regarding older releases of grpc-js, as well as report of a bug that has been presumably been resolved in recent grpc-js releases.

After more testing, it has been demonstrated that the built-in retry mechanism introduced in grpc-js 1.8 does not conflict with ours. Their retry mechanism is enabled by default, but will only perform so called "transparent retries" unless configured otherwise.

Transparent retries are cases where the gRPC library is able to determine that a request has not been received by the remote end (e.g. if the underlying HTTP/2 channel is being closed following a GOAWAY notification). Those cases are inherently safe to retry, but identifying those require connection level knowledge that is not exposed to our retry interceptor. Consequently, our own retry logic would simply fail to retry in those specific cases.

Resolves #1026.