### PR TITLE
fix(bundler): Pass Webpack output to logger in a single record

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/ms": "^0.7.34",
         "@types/node": "^20.10.8",
         "@types/stack-utils": "^2.0.3",
+        "@types/supports-color": "^8.1.3",
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "@typescript-eslint/parser": "^6.18.1",
         "arg": "^5.0.2",
@@ -3691,6 +3692,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true
+    },
+    "node_modules/@types/supports-color": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.3.tgz",
+      "integrity": "sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg==",
       "dev": true
     },
     "node_modules/@types/tar": {
@@ -19172,9 +19179,13 @@
         "rxjs": "^7.8.1",
         "source-map": "^0.7.4",
         "source-map-loader": "^4.0.2",
+        "supports-color": "^8.1.1",
         "swc-loader": "^0.2.3",
         "unionfs": "^4.5.1",
         "webpack": "^5.89.0"
+      },
+      "devDependencies": {
+        "@types/supports-color": "^8.1.3"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -21827,12 +21838,14 @@
         "@temporalio/core-bridge": "file:../core-bridge",
         "@temporalio/proto": "file:../proto",
         "@temporalio/workflow": "file:../workflow",
+        "@types/supports-color": "^8.1.3",
         "abort-controller": "^3.0.0",
         "heap-js": "^2.3.0",
         "memfs": "^4.6.0",
         "rxjs": "^7.8.1",
         "source-map": "^0.7.4",
         "source-map-loader": "^4.0.2",
+        "supports-color": "^8.1.1",
         "swc-loader": "^0.2.3",
         "unionfs": "^4.5.1",
         "webpack": "^5.89.0"
@@ -22154,6 +22167,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true
+    },
+    "@types/supports-color": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.3.tgz",
+      "integrity": "sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg==",
       "dev": true
     },
     "@types/tar": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/ms": "^0.7.34",
     "@types/node": "^20.10.8",
     "@types/stack-utils": "^2.0.3",
+    "@types/supports-color": "^8.1.3",
     "@typescript-eslint/eslint-plugin": "^6.18.1",
     "@typescript-eslint/parser": "^6.18.1",
     "arg": "^5.0.2",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -26,9 +26,13 @@
     "rxjs": "^7.8.1",
     "source-map": "^0.7.4",
     "source-map-loader": "^4.0.2",
+    "supports-color": "^8.1.1",
     "swc-loader": "^0.2.3",
     "unionfs": "^4.5.1",
     "webpack": "^5.89.0"
+  },
+  "devDependencies": {
+    "@types/supports-color": "^8.1.3"
   },
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"

--- a/packages/worker/src/logger.ts
+++ b/packages/worker/src/logger.ts
@@ -14,12 +14,19 @@ export interface LogEntry {
   meta?: LogMetadata;
 }
 
+/**
+ * @internal
+ */
+interface LoggerWithColorSupport extends Logger {
+  [loggerHasColorsSymbol]?: boolean;
+}
+
 export const LogTimestamp = Symbol.for('log_timestamp');
 
 const severities: LogLevel[] = ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR'];
 
 /**
- * @experimental This is a temporary fix until
+ * @internal
  */
 const loggerHasColorsSymbol = Symbol.for('logger_has_colors');
 const stderrHasColors = !!supportsColor.stderr;
@@ -59,7 +66,8 @@ export class DefaultLogger implements Logger {
     protected readonly logFunction = defaultLogFunction
   ) {
     this.severity = severities.indexOf(this.level);
-    (this as any)[loggerHasColorsSymbol] = (logFunction === defaultLogFunction && stderrHasColors) ?? false;
+    (this as LoggerWithColorSupport)[loggerHasColorsSymbol] =
+      (logFunction === defaultLogFunction && stderrHasColors) ?? false;
   }
 
   log(level: LogLevel, message: string, meta?: LogMetadata): void {
@@ -99,7 +107,7 @@ export class DefaultLogger implements Logger {
  * @internal
  */
 export function hasColorSupport(logger: Logger): boolean {
-  return (logger as any)[loggerHasColorsSymbol] ?? false;
+  return (logger as LoggerWithColorSupport)[loggerHasColorsSymbol] ?? false;
 }
 
 export function withMetadata(logger: Logger, meta: LogMetadata | (() => LogMetadata)): Logger {
@@ -119,7 +127,7 @@ class LoggerWithMetadata implements Logger {
       this.parentLogger = parent;
       this.metaChain = [meta];
     }
-    (this as any)[loggerHasColorsSymbol] = hasColorSupport(parent);
+    (this as LoggerWithColorSupport)[loggerHasColorsSymbol] = hasColorSupport(parent);
   }
 
   log(level: LogLevel, message: string, meta?: LogMetadata): void {

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -262,10 +262,8 @@ exports.importInterceptors = function importInterceptors() {
             const hasError = stats.hasErrors();
             // To debug webpack build:
             // const lines = stats.toString({ preset: 'verbose' }).split('\n');
-            const lines = stats.toString({ chunks: false, colors: true, errorDetails: true }).split('\n');
-            for (const line of lines) {
-              this.logger[hasError ? 'error' : 'info'](line);
-            }
+            const webpackOutput = stats.toString({ chunks: false, colors: false, errorDetails: true });
+            this.logger[hasError ? 'error' : 'info'](webpackOutput);
             if (hasError) {
               reject(
                 new Error(

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -5,7 +5,7 @@ import util from 'node:util';
 import * as unionfs from 'unionfs';
 import * as memfs from 'memfs';
 import { Configuration, webpack } from 'webpack';
-import { DefaultLogger, Logger } from '../logger';
+import { DefaultLogger, Logger, hasColorSupport } from '../logger';
 import { toMB } from '../utils';
 
 export const defaultWorkflowInterceptorModules = [require.resolve('../workflow-log-interceptor')];
@@ -262,7 +262,11 @@ exports.importInterceptors = function importInterceptors() {
             const hasError = stats.hasErrors();
             // To debug webpack build:
             // const lines = stats.toString({ preset: 'verbose' }).split('\n');
-            const webpackOutput = stats.toString({ chunks: false, colors: false, errorDetails: true });
+            const webpackOutput = stats.toString({
+              chunks: false,
+              colors: hasColorSupport(this.logger),
+              errorDetails: true,
+            });
             this.logger[hasError ? 'error' : 'info'](webpackOutput);
             if (hasError) {
               reject(


### PR DESCRIPTION
## What was changed

- Don't include color control characters when logging bundler output.
- Log bundler multi-line output as a single log record.

## Why?

Since we take this output and give it to a logging mechanism:
- Color should be omitted since the log message might not be written to a color-enabled console or encapsulated in JSON thus turning the control characters into a nuisance for reading.
- Multi-line message should be logged as a single record to maintain context.

## Checklist

1. Closes: n/a

2. How was this tested: Locally.

3. Any docs updates needed? None.
