### PR TITLE
fix(core): build native libs against glibc 2.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,14 @@ jobs:
         include:
           # For Linux targets, use Buildjet's builders to get the oldest supported glibc version
           - platform: linux-x64
-            runner: buildjet-4vcpu-ubuntu-2004
+            runner: buildjet-4vcpu-ubuntu-2204
             target: x86_64-unknown-linux-gnu
-            container: quay.io/pypa/manylinux_2_28_x86_64
+            container: quay.io/pypa/manylinux_2_24_x86_64
             out-file: libtemporal_sdk_typescript_bridge.so
           - platform: linux-arm
             runner: buildjet-4vcpu-ubuntu-2204-arm
             target: aarch64-unknown-linux-gnu
+            container: quay.io/pypa/manylinux_2_24_aarch64
             out-file: libtemporal_sdk_typescript_bridge.so
           - platform: macos-x64
             runner: macos-12
@@ -63,14 +64,12 @@ jobs:
         with:
           submodules: recursive
 
-      # FIXME: Temporarily disable caching to properly test buildeing in containers
       - name: 'Cache index.node'
         id: cached-artifact
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v4
         with:
           path: ./packages/core-bridge/releases
-          key: disabled-corebridge-artifactcache-${{ matrix.platform }}-${{ hashFiles('./packages/core-bridge/**/Cargo.lock', './packages/core-bridge/**/*.rs') }}
-
+          key: corebridge-artifactcache-${{ matrix.platform }}-${{ hashFiles('./packages/core-bridge/**/Cargo.lock', './packages/core-bridge/**/*.rs') }}
 
       - name: Install Rust
         if: steps.cached-artifact.outputs.cache-hit != 'true'
@@ -110,10 +109,7 @@ jobs:
         working-directory: ./packages/core-bridge
         run: |
           objdump -T ./releases/${{ matrix.target }}/index.node |
-              grep GLIBC |
-              sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' |
-              sort -Vu |
-              tail -1
+              grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -V | tail -1
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,19 +55,27 @@ jobs:
     name: Compile Native Binaries (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.container }}
+    env:
+      # This is required to allow continuing usage of Node 16 for actions,
+      # as Node 20 won't run on the docker image we use for linux builds
+      # (Node 20 require glibc 2.28+, but container image has glibc 2.24).
+      # https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     defaults:
       run:
         shell: bash
     steps:
       - name: 'Checkout code'
-        uses: actions/checkout@v4
+        # v4+ requires Node 20
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
       # FIXME: Temporarily disable caching to properly test buildeing in containers
       - name: 'Cache index.node'
         id: cached-artifact
-        uses: actions/cache/restore@v4
+        # v4+ requires Node 20
+        uses: actions/cache/restore@v3
         with:
           path: ./packages/core-bridge/releases
           key: corebridge-artifactcache-${{ matrix.platform }}-${{ hashFiles('./packages/core-bridge/**/Cargo.lock', './packages/core-bridge/**/*.rs') }}
@@ -80,7 +88,8 @@ jobs:
 
       - name: Install protoc
         if: steps.cached-artifact.outputs.cache-hit != 'true'
-        uses: arduino/setup-protoc@v3
+        # v3+ requires Node 20
+        uses: arduino/setup-protoc@v2
         with:
           # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
           version: '23.x'
@@ -88,7 +97,8 @@ jobs:
 
       - name: Rust Cargo and Build cache
         if: steps.cached-artifact.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@v2
+        # v2.7.2+ requires Node 20
+        uses: Swatinem/rust-cache@v2.7.1
         with:
           workspaces: packages/core-bridge -> target
           prefix-key: corebridge-buildcache
@@ -112,7 +122,8 @@ jobs:
           objdump -T ./releases/${{ matrix.target }}/index.node |
               grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -V | tail -1
 
-      - uses: actions/upload-artifact@v4
+      # v4+ requires Node 20
+      - uses: actions/upload-artifact@v3
         with:
           name: corebridge-native-${{ matrix.platform }}
           # Actual file will be named ${{ matrix.target }}/index.node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,10 @@ jobs:
         with:
           submodules: recursive
 
-      # FIXME: Temporarily disable caching to properly test buildeing in containers
       - name: 'Cache index.node'
         id: cached-artifact
         # FIXME: v4+ requires Node 20
-        uses: actions/cache/restore@v3
+        uses: actions/cache@v3
         with:
           path: ./packages/core-bridge/releases
           key: corebridge-artifactcache-${{ matrix.platform }}-${{ hashFiles('./packages/core-bridge/**/Cargo.lock', './packages/core-bridge/**/*.rs') }}
@@ -88,7 +87,7 @@ jobs:
 
       - name: Install protoc
         if: steps.cached-artifact.outputs.cache-hit != 'true'
-        # v3+ requires Node 20
+        # FIXME: v3+ requires Node 20
         uses: arduino/setup-protoc@v2
         with:
           # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
@@ -97,7 +96,7 @@ jobs:
 
       - name: Rust Cargo and Build cache
         if: steps.cached-artifact.outputs.cache-hit != 'true'
-        # v2.7.2+ requires Node 20
+        # FIXME: v2.7.2+ requires Node 20
         uses: Swatinem/rust-cache@v2.7.1
         with:
           workspaces: packages/core-bridge -> target
@@ -122,7 +121,7 @@ jobs:
           objdump -T ./releases/${{ matrix.target }}/index.node |
               grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -V | tail -1
 
-      # v4+ requires Node 20
+      # FIXME: v4+ requires Node 20
       - uses: actions/upload-artifact@v3
         with:
           name: corebridge-native-${{ matrix.platform }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,23 +34,23 @@ jobs:
             runner: buildjet-4vcpu-ubuntu-2004
             target: x86_64-unknown-linux-gnu
             container: quay.io/pypa/manylinux_2_28_x86_64
-            out-file: libtemporal_sdk_bridge.so
+            out-file: libtemporal_sdk_typescript_bridge.so
           - platform: linux-arm
             runner: buildjet-4vcpu-ubuntu-2204-arm
             target: aarch64-unknown-linux-gnu
-            out-file: libtemporal_sdk_bridge.so
+            out-file: libtemporal_sdk_typescript_bridge.so
           - platform: macos-x64
             runner: macos-12
             target: x86_64-apple-darwin
-            out-file: libtemporal_sdk_bridge.dylib
+            out-file: libtemporal_sdk_typescript_bridge.dylib
           - platform: macos-arm
             runner: macos-14
             target: aarch64-apple-darwin
-            out-file: libtemporal_sdk_bridge.dylib
+            out-file: libtemporal_sdk_typescript_bridge.dylib
           - platform: windows-x64
             runner: windows-latest
             target: x86_64-pc-windows-msvc
-            out-file: temporal_sdk_bridge.dll
+            out-file: temporal_sdk_typescript_bridge.dll
     name: Compile Native Binaries (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.container }}
@@ -555,7 +555,9 @@ jobs:
         if: env.IS_MAIN_OR_RELEASE == 'true'
         run: npx vercel deploy packages/docs/build -t ${{ secrets.VERCEL_TOKEN }} --name typescript --scope temporal --prod --yes
 
-      - name: Deploy draft docs
-        # Don't run on forks, since secrets won't be available, and command will fail
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.ref != 'refs/heads/main'
-        run: npx vercel deploy packages/docs/build -t ${{ secrets.VERCEL_TOKEN }} --name typescript --scope temporal --yes
+      # FIXME: This is not working properly, and should probably be done only from the main branch anyway
+      # (and "Deploy prod docs" should only be done when we publish a new release)
+      # - name: Deploy draft docs
+      #   # Don't run on forks, since secrets won't be available, and command will fail
+      #   if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.ref != 'refs/heads/main'
+      #   run: npx vercel deploy packages/docs/build -t ${{ secrets.VERCEL_TOKEN }} --name typescript --scope temporal --yes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
 
       - name: Print required GLIBC version
         if: startsWith(matrix.platform, 'linux')
+        working-directory: ./packages/core-bridge
         run: |
           objdump -T ./releases/${{ matrix.target }}/index.node |
               grep GLIBC |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         shell: bash
     steps:
       - name: 'Checkout code'
-        # v4+ requires Node 20
+        # FIXME: v4+ requires Node 20
         uses: actions/checkout@v3
         with:
           submodules: recursive
@@ -74,7 +74,7 @@ jobs:
       # FIXME: Temporarily disable caching to properly test buildeing in containers
       - name: 'Cache index.node'
         id: cached-artifact
-        # v4+ requires Node 20
+        # FIXME: v4+ requires Node 20
         uses: actions/cache/restore@v3
         with:
           path: ./packages/core-bridge/releases
@@ -154,7 +154,8 @@ jobs:
           submodules: recursive
 
       - name: Download core-bridge native libraries
-        uses: actions/download-artifact@v4
+        # Need v3 here to stay compatible with the compile-native-binaries job.
+        uses: actions/download-artifact@v3-node20
         with:
           path: ./packages/core-bridge/releases/tmp
 
@@ -241,7 +242,8 @@ jobs:
           submodules: recursive
 
       - name: Download core-bridge native libraries
-        uses: actions/download-artifact@v4
+        # Need v3 here to stay compatible with the compile-native-binaries job.
+        uses: actions/download-artifact@v3-node20
         with:
           name: corebridge-native-${{ matrix.platform }}
           path: ./packages/core-bridge/releases

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ./packages/core-bridge/releases
-          key: corebridge-artifactcache-${{ matrix.platform }}-${{ hashFiles('./packages/core-bridge/**/Cargo.lock', './packages/core-bridge/**/*.rs') }}
+          key: disabled-corebridge-artifactcache-${{ matrix.platform }}-${{ hashFiles('./packages/core-bridge/**/Cargo.lock', './packages/core-bridge/**/*.rs') }}
 
 
       - name: Install Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,20 +33,27 @@ jobs:
           - platform: linux-x64
             runner: buildjet-4vcpu-ubuntu-2004
             target: x86_64-unknown-linux-gnu
+            container: quay.io/pypa/manylinux_2_28_x86_64
+            out-file: libtemporal_sdk_bridge.so
           - platform: linux-arm
             runner: buildjet-4vcpu-ubuntu-2204-arm
             target: aarch64-unknown-linux-gnu
+            out-file: libtemporal_sdk_bridge.so
           - platform: macos-x64
             runner: macos-12
             target: x86_64-apple-darwin
+            out-file: libtemporal_sdk_bridge.dylib
           - platform: macos-arm
             runner: macos-14
             target: aarch64-apple-darwin
+            out-file: libtemporal_sdk_bridge.dylib
           - platform: windows-x64
             runner: windows-latest
             target: x86_64-pc-windows-msvc
+            out-file: temporal_sdk_bridge.dll
     name: Compile Native Binaries (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
     defaults:
       run:
         shell: bash
@@ -56,12 +63,14 @@ jobs:
         with:
           submodules: recursive
 
+      # FIXME: Temporarily disable caching to properly test buildeing in containers
       - name: 'Cache index.node'
         id: cached-artifact
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ./packages/core-bridge/releases
           key: corebridge-artifactcache-${{ matrix.platform }}-${{ hashFiles('./packages/core-bridge/**/Cargo.lock', './packages/core-bridge/**/*.rs') }}
+
 
       - name: Install Rust
         if: steps.cached-artifact.outputs.cache-hit != 'true'
@@ -76,10 +85,6 @@ jobs:
           # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
           version: '23.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Print libc version
-        if: (steps.cached-artifact.outputs.cache-hit != 'true') && startsWith(matrix.platform, 'linux')
-        run: ldd --version
 
       - name: Rust Cargo and Build cache
         if: steps.cached-artifact.outputs.cache-hit != 'true'
@@ -98,11 +103,16 @@ jobs:
           set -x
           cargo build --release --target ${{ matrix.target }}
           mkdir -p ./releases/${{ matrix.target }}
-          # FIXME: This is aweful. Surely there's a better way, but I'm out of ideas.
-          native_lib_file=$(
-            ls target/${{ matrix.target }}/release/{lib,}temporal_sdk_typescript_bridge.{dylib,so,dll} 2>/dev/null || true
-          )
-          cp $native_lib_file ./releases/${{ matrix.target }}/index.node
+          cp target/${{ matrix.target }}/release/${{ matrix.out-file }} ./releases/${{ matrix.target }}/index.node
+
+      - name: Print required GLIBC version
+        if: startsWith(matrix.platform, 'linux')
+        run: |
+          objdump -T ./releases/${{ matrix.target }}/index.node |
+              grep GLIBC |
+              sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' |
+              sort -Vu |
+              tail -1
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,10 @@ jobs:
         with:
           submodules: recursive
 
+      # FIXME: Temporarily disable caching to properly test buildeing in containers
       - name: 'Cache index.node'
         id: cached-artifact
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ./packages/core-bridge/releases
           key: corebridge-artifactcache-${{ matrix.platform }}-${{ hashFiles('./packages/core-bridge/**/Cargo.lock', './packages/core-bridge/**/*.rs') }}

--- a/packages/core-bridge/scripts/build.js
+++ b/packages/core-bridge/scripts/build.js
@@ -55,6 +55,10 @@ const forceBuild = args['--force'];
 const buildRelease = args['--release'] || process.env.BUILD_CORE_RELEASE !== undefined;
 
 function compile(requestedTarget) {
+  if (!fs.existsSync('sdk-core/Cargo.toml')) {
+    throw new Error('Missing sdk-core/Cargo.toml. Did you forget to run `git submodule update --init --recursive`?');
+  }
+
   const target = requestedTarget ?? getPrebuiltTargetName();
   console.log('Compiling bridge', { target, buildRelease });
 


### PR DESCRIPTION
## What changed

- In CI, build native artifacts for Linux targets in Docker containers, using the `manylinux-2.24` image; this effectively brings the required glibc version down to 2.18 (we're technically building against glibc 2.24, but it appears that the resulting library file is only binding to 2.18 and older symbols).

## Context

- In the recent CI refactor, we stopped using Buildjet's Ubuntu 18.04 runners, as they are incompatible with some recent and upcoming GHA changes. This resulted in increasing the required glibc version from 2.17 (in 1.9) to 2.29 (in 1.10 on x64) and 2.35 (on arm64). This jump is problematic to several users who have internal requirements of using specific base images (e.g. RHE8).

- Some of the GHA changes that are making this more complicated: Node 16 actions will automatically be updated to use Node 20 in June, but Node 20 require at least glibc 2.28, so older runners will no longer be usable; there's an environment variable that can be set to prevent auto-update, but only til October; at the same time, `actions/*-artifact` v1 and v2 are being completely retired in June, and v3 (which is the last version compatible with Node 16) is being retired in October.

- Our Python and .NET SDKs are already built against manylinux images.