### PR TITLE
Fix clients being created without prefixed metric meter

### DIFF
--- a/packages/core-bridge/src/runtime.rs
+++ b/packages/core-bridge/src/runtime.rs
@@ -22,7 +22,7 @@ use tokio::sync::{
 };
 use tokio_stream::wrappers::ReceiverStream;
 
-pub type RawClient = RetryClient<ConfiguredClient<TemporalServiceClientWithMetrics>>;
+pub type CoreClient = RetryClient<ConfiguredClient<TemporalServiceClientWithMetrics>>;
 
 #[derive(Clone)]
 pub struct EphemeralServer {
@@ -43,7 +43,7 @@ impl Finalize for RuntimeHandle {}
 #[derive(Clone)]
 pub struct Client {
     pub(crate) runtime: Arc<RuntimeHandle>,
-    pub(crate) core_client: Arc<RawClient>,
+    pub(crate) core_client: Arc<CoreClient>,
 }
 
 pub type BoxedClient = JsBox<RefCell<Option<Client>>>;
@@ -65,7 +65,7 @@ pub enum RuntimeRequest {
     },
     /// A request to update a client's HTTP request headers
     UpdateClientHeaders {
-        client: Arc<RawClient>,
+        client: Arc<CoreClient>,
         headers: HashMap<String, String>,
         /// Used to send the result back into JS
         callback: Root<JsFunction>,
@@ -75,7 +75,7 @@ pub enum RuntimeRequest {
         /// Worker configuration e.g. limits and task queue
         config: WorkerConfig,
         /// A client created with a [CreateClient] request
-        client: Arc<RawClient>,
+        client: Arc<CoreClient>,
         /// Used to send the result back into JS
         callback: Root<JsFunction>,
     },
@@ -107,7 +107,7 @@ pub enum RuntimeRequest {
         callback: Root<JsFunction>,
     },
     UpdateClientApiKey {
-        client: Arc<RawClient>,
+        client: Arc<CoreClient>,
         key: String,
         callback: Root<JsFunction>,
     },
@@ -168,7 +168,7 @@ pub fn start_bridge_loop(
                     options,
                     callback,
                 } => {
-                    let mm = core_runtime.telemetry().get_metric_meter();
+                    let mm = core_runtime.telemetry().get_temporal_metric_meter();
                     core_runtime.tokio_handle().spawn(async move {
                         match options
                             .connect_no_namespace(mm)
@@ -248,7 +248,7 @@ pub fn start_bridge_loop(
                     callback,
                 } => {
                     let client = (*client).clone();
-                    match init_worker(&core_runtime, config, client.into_inner()) {
+                    match init_worker(&core_runtime, config, client) {
                         Ok(worker) => {
                             let (tx, rx) = unbounded_channel();
                             core_runtime.tokio_handle().spawn(start_worker_loop(

--- a/packages/test/src/test-prometheus.ts
+++ b/packages/test/src/test-prometheus.ts
@@ -106,7 +106,6 @@ test.serial('Exporting Prometheus metrics from Core works with lots of options',
       // Verify 'total' suffix
       t.assert(text.includes('temporal_worker_start_total'));
       // Verify prefix exists on client request metrics
-      console.log(text);
       t.assert(text.includes('temporal_long_request'));
     });
   } finally {

--- a/packages/test/src/test-prometheus.ts
+++ b/packages/test/src/test-prometheus.ts
@@ -105,6 +105,9 @@ test.serial('Exporting Prometheus metrics from Core works with lots of options',
       );
       // Verify 'total' suffix
       t.assert(text.includes('temporal_worker_start_total'));
+      // Verify prefix exists on client request metrics
+      console.log(text);
+      t.assert(text.includes('temporal_long_request'));
     });
   } finally {
     await localEnv.teardown();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Client metrics were being emitted without the prefix

## Why?
Bug

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-typescript/issues/1440

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
