### PR TITLE
startUpdate require wait stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,7 +419,7 @@ jobs:
   # FIXME: Update this job to reuse native build artifacts from compile-native-binaries
   features-tests:
     name: Features Tests
-    uses: temporalio/features/.github/workflows/typescript.yaml@main
+    uses: temporalio/features/.github/workflows/typescript.yaml@sdk-1403-ts-startUpdate-require-wait-stage
     with:
       typescript-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,7 +419,7 @@ jobs:
   # FIXME: Update this job to reuse native build artifacts from compile-native-binaries
   features-tests:
     name: Features Tests
-    uses: temporalio/features/.github/workflows/typescript.yaml@sdk-1403-ts-startUpdate-require-wait-stage
+    uses: temporalio/features/.github/workflows/typescript.yaml@main
     with:
       typescript-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,7 @@ jobs:
       typescript-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
       version-is-repo-ref: true
+      features-repo-ref: sdk-1403-ts-startUpdate-require-wait-stage
 
   stress-tests-no-reuse-context:
     name: Stress Tests (No Reuse V8 Context)

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -39,6 +39,7 @@ export * from './workflow-options';
 export * from './schedule-types';
 export * from './schedule-client';
 export * from './task-queue-client';
+export { WorkflowUpdateStage } from './workflow-update-stage';
 export {
   WorkerBuildIdVersionSets,
   BuildIdVersionSet,

--- a/packages/client/src/workflow-update-stage.ts
+++ b/packages/client/src/workflow-update-stage.ts
@@ -1,0 +1,33 @@
+import { temporal } from '@temporalio/proto';
+import { checkExtends } from '@temporalio/common/lib/type-helpers';
+
+export enum WorkflowUpdateStage {
+  /** This is not an allowed value. */
+  UNSPECIFIED = 0,
+  /** Admitted stage. This stage is reached when the server accepts the update request. It is not
+   * allowed to wait for this stage when using startUpdate, since the update request has not yet
+   * been durably persisted at this stage. */
+  ADMITTED = 1,
+  /** Accepted stage. This stage is reached when a workflow has received the update and either
+   * accepted it (i.e. it has passed validation, or there was no validator configured on the update
+   * handler) or rejected it. This is currently the only allowed value when using startUpdate. */
+  ACCEPTED = 2,
+  /** Completed stage. This stage is reached when a workflow has completed processing the
+   * update with either a success or failure. */
+  COMPLETED = 3,
+}
+
+checkExtends<
+  `UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_${keyof typeof WorkflowUpdateStage}`,
+  keyof typeof temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage
+>();
+checkExtends<
+  keyof typeof temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage,
+  `UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_${keyof typeof WorkflowUpdateStage}`
+>();
+
+export function toProtoEnum(stage: WorkflowUpdateStage): temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage {
+  return temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage[
+    `UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_${WorkflowUpdateStage[stage] as keyof typeof WorkflowUpdateStage}`
+  ];
+}

--- a/packages/test/src/test-integration-update-interceptors.ts
+++ b/packages/test/src/test-integration-update-interceptors.ts
@@ -1,5 +1,4 @@
-import { WorkflowStartUpdateInput, WorkflowStartUpdateOutput } from '@temporalio/client';
-import { temporal } from '@temporalio/proto';
+import { WorkflowStartUpdateInput, WorkflowStartUpdateOutput, WorkflowUpdateStage } from '@temporalio/client';
 import * as wf from '@temporalio/workflow';
 import { Next, UpdateInput, WorkflowInboundCallsInterceptor, WorkflowInterceptors } from '@temporalio/workflow';
 import { helpers, makeTestFunction } from './helpers-integration';
@@ -69,8 +68,7 @@ test('Update client and inbound interceptors work for startUpdate', async (t) =>
 
     const updateHandle = await wfHandle.startUpdate(update, {
       args: ['1'],
-      waitForStage:
-        temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     const updateResult = await updateHandle.result();
     t.deepEqual(updateResult, '1-clientIntercepted-inboundIntercepted');

--- a/packages/test/src/test-integration-update-interceptors.ts
+++ b/packages/test/src/test-integration-update-interceptors.ts
@@ -1,4 +1,5 @@
 import { WorkflowStartUpdateInput, WorkflowStartUpdateOutput } from '@temporalio/client';
+import { temporal } from '@temporalio/proto';
 import * as wf from '@temporalio/workflow';
 import { Next, UpdateInput, WorkflowInboundCallsInterceptor, WorkflowInterceptors } from '@temporalio/workflow';
 import { helpers, makeTestFunction } from './helpers-integration';
@@ -66,7 +67,11 @@ test('Update client and inbound interceptors work for startUpdate', async (t) =>
   await worker.runUntil(async () => {
     const wfHandle = await startWorkflow(workflowWithUpdate);
 
-    const updateHandle = await wfHandle.startUpdate(update, { args: ['1'] });
+    const updateHandle = await wfHandle.startUpdate(update, {
+      args: ['1'],
+      waitForStage:
+        temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+    });
     const updateResult = await updateHandle.result();
     t.deepEqual(updateResult, '1-clientIntercepted-inboundIntercepted');
   });

--- a/packages/test/src/test-integration-update.ts
+++ b/packages/test/src/test-integration-update.ts
@@ -1,5 +1,4 @@
-import { WorkflowUpdateRPCTimeoutOrCancelledError } from '@temporalio/client';
-import { temporal } from '@temporalio/proto';
+import { WorkflowUpdateStage, WorkflowUpdateRPCTimeoutOrCancelledError } from '@temporalio/client';
 import * as wf from '@temporalio/workflow';
 import { helpers, makeTestFunction } from './helpers-integration';
 
@@ -67,15 +66,13 @@ test('Update can be executed via startUpdate() and handle.result()', async (t) =
 
     const updateHandle = await wfHandle.startUpdate(update, {
       args: ['1'],
-      waitForStage:
-        temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     const updateResult = await updateHandle.result();
     t.deepEqual(updateResult, ['1']);
 
     const doneUpdateHandle = await wfHandle.startUpdate(doneUpdate, {
-      waitForStage:
-        temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     const doneUpdateResult = await doneUpdateHandle.result();
     t.is(doneUpdateResult, undefined);
@@ -94,8 +91,7 @@ test('Update handle can be created from identifiers and used to obtain result', 
     const updateHandleFromStartUpdate = await wfHandle.startUpdate(update, {
       args: ['1'],
       updateId,
-      waitForStage:
-        temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
 
     // Obtain update handle on workflow handle from start update.
@@ -190,14 +186,12 @@ test('Update validator can reject when using handle.result() but handle can be o
     const wfHandle = await startWorkflow(workflowWithUpdateValidator);
     let updateHandle = await wfHandle.startUpdate(stringToStringUpdate, {
       args: ['arg'],
-      waitForStage:
-        temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     t.is(await updateHandle.result(), 'update-result');
     updateHandle = await wfHandle.startUpdate(stringToStringUpdate, {
       args: ['bad-arg'],
-      waitForStage:
-        temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     await assertWorkflowUpdateFailed(updateHandle.result(), wf.ApplicationFailure, 'Validation failed');
   });
@@ -269,8 +263,7 @@ test('Update id can be assigned and is present on returned handle', async (t) =>
     const wfHandle = await startWorkflow(workflowWithUpdates);
     const updateHandle = await wfHandle.startUpdate(doneUpdate, {
       updateId: 'my-update-id',
-      waitForStage:
-        temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     t.is(updateHandle.updateId, 'my-update-id');
   });
@@ -452,8 +445,7 @@ test('Update/Signal/Query example in WorkflowHandle docstrings works', async (t)
     t.is(updateResult, 6);
     const secondUpdateHandle = await wfHandle.startUpdate(incrementAndGetValueUpdate, {
       args: [2],
-      waitForStage:
-        temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     const secondUpdateResult = await secondUpdateHandle.result();
     t.is(secondUpdateResult, 8);
@@ -468,8 +460,7 @@ test('startUpdate does not return handle before update has reached requested sta
   const updatePromise = wfHandle
     .startUpdate(update, {
       args: ['1'],
-      waitForStage:
-        temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     })
     .then(() => 'update');
   const timeoutPromise = new Promise<string>((f) =>

--- a/packages/test/src/test-integration-update.ts
+++ b/packages/test/src/test-integration-update.ts
@@ -562,14 +562,18 @@ test('startUpdate throws WorkflowUpdateRPCTimeoutOrCancelledError with no worker
   const { startWorkflow } = helpers(t);
   const wfHandle = await startWorkflow(workflowWithUpdates);
   await t.context.env.client.withDeadline(Date.now() + 100, async () => {
-    const err = await t.throwsAsync(wfHandle.startUpdate(update, { args: ['1'] }));
+    const err = await t.throwsAsync(
+      wfHandle.startUpdate(update, { args: ['1'], waitForStage: WorkflowUpdateStage.ACCEPTED })
+    );
     t.true(err instanceof WorkflowUpdateRPCTimeoutOrCancelledError);
   });
 
   const ctrl = new AbortController();
   setTimeout(() => ctrl.abort(), 10);
   await t.context.env.client.withAbortSignal(ctrl.signal, async () => {
-    const err = await t.throwsAsync(wfHandle.startUpdate(update, { args: ['1'] }));
+    const err = await t.throwsAsync(
+      wfHandle.startUpdate(update, { args: ['1'], waitForStage: WorkflowUpdateStage.ACCEPTED })
+    );
     t.true(err instanceof WorkflowUpdateRPCTimeoutOrCancelledError);
   });
 });

--- a/packages/test/src/test-interface-type-safety.ts
+++ b/packages/test/src/test-interface-type-safety.ts
@@ -103,3 +103,30 @@ test('Can call signal on any WorkflowHandle', async (t) => {
 
   t.pass();
 });
+
+test('startUpdate and executeUpdate call signatures require `args` iff update takes args', async (t) => {
+  const nullaryUpdate = defineUpdate<string>('my-update');
+  const unaryUpdate = defineUpdate<string, [number]>('my-update');
+
+  async function _assertion<T extends Workflow>(handle: WorkflowHandle<T>) {
+    await handle.startUpdate(nullaryUpdate);
+    await handle.startUpdate(nullaryUpdate, {});
+    await handle.startUpdate(nullaryUpdate, { args: [] });
+    await handle.executeUpdate(nullaryUpdate);
+    await handle.executeUpdate(nullaryUpdate, {});
+    await handle.executeUpdate(nullaryUpdate, { args: [] });
+    // @ts-expect-error
+    await handle.startUpdate(unaryUpdate);
+    // @ts-expect-error
+    await handle.startUpdate(unaryUpdate, {});
+    // @ts-expect-error
+    await handle.startUpdate(unaryUpdate, { args: [] });
+    // @ts-expect-error
+    await handle.executeUpdate(unaryUpdate);
+    // @ts-expect-error
+    await handle.executeUpdate(unaryUpdate, {});
+    // @ts-expect-error
+    await handle.executeUpdate(unaryUpdate, { args: [] });
+  }
+  t.pass();
+});

--- a/packages/test/src/test-interface-type-safety.ts
+++ b/packages/test/src/test-interface-type-safety.ts
@@ -8,7 +8,6 @@ import {
   defineUpdate,
 } from '@temporalio/workflow';
 import { WorkflowHandle, WorkflowUpdateStage } from '@temporalio/client';
-import { temporal } from '@temporalio/proto';
 
 test('SignalDefinition Name type safety', (t) => {
   // @ts-expect-error Assert expect a type error when generic and concrete names do not match

--- a/packages/test/src/test-interface-type-safety.ts
+++ b/packages/test/src/test-interface-type-safety.ts
@@ -7,7 +7,7 @@ import {
   Workflow,
   defineUpdate,
 } from '@temporalio/workflow';
-import { WorkflowHandle } from '@temporalio/client';
+import { WorkflowHandle, WorkflowUpdateStage } from '@temporalio/client';
 import { temporal } from '@temporalio/proto';
 
 test('SignalDefinition Name type safety', (t) => {
@@ -111,7 +111,6 @@ test('startUpdate and executeUpdate call signatures', async (t) => {
   // executeUpdate does not accept `waitForStage`.
   const nullaryUpdate = defineUpdate<string>('my-nullary-update');
   const unaryUpdate = defineUpdate<string, [number]>('my-unary-update');
-  const UpdateWorkflowExecutionLifecycleStage = temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage;
 
   async function _assertion<T extends Workflow>(handle: WorkflowHandle<T>) {
     // @ts-expect-error: waitForStage required
@@ -122,36 +121,36 @@ test('startUpdate and executeUpdate call signatures', async (t) => {
     await handle.startUpdate(nullaryUpdate, { args: [] });
     // @ts-expect-error: waitForStage must be ACCEPTED
     await handle.startUpdate(nullaryUpdate, {
-      waitForStage: UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED,
+      waitForStage: WorkflowUpdateStage.ADMITTED,
     });
     // @ts-expect-error: waitForStage must be ACCEPTED
     await handle.startUpdate(nullaryUpdate, {
-      waitForStage: UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+      waitForStage: WorkflowUpdateStage.COMPLETED,
     });
     // @ts-expect-error: waitForStage must be ACCEPTED
     await handle.startUpdate(nullaryUpdate, {
-      waitForStage: UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED,
+      waitForStage: WorkflowUpdateStage.UNSPECIFIED,
     });
     // @ts-expect-error: args must be empty if present
     await handle.startUpdate(nullaryUpdate, {
       args: [1],
-      waitForStage: UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     // valid
     await handle.startUpdate(nullaryUpdate, {
-      waitForStage: UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     await handle.startUpdate(nullaryUpdate, {
       args: [],
-      waitForStage: UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     // @ts-expect-error:executeUpdate doesn't accept waitForStage
     await handle.executeUpdate(nullaryUpdate, {
-      waitForStage: UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     // @ts-expect-error:executeUpdate doesn't accept waitForStage
     await handle.executeUpdate(nullaryUpdate, {
-      waitForStage: UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+      waitForStage: WorkflowUpdateStage.COMPLETED,
     });
     // valid
     await handle.executeUpdate(nullaryUpdate, {});
@@ -159,22 +158,22 @@ test('startUpdate and executeUpdate call signatures', async (t) => {
 
     // @ts-expect-error: args required
     await handle.startUpdate(unaryUpdate, {
-      waitForStage: UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     // @ts-expect-error: args required
     await handle.startUpdate(unaryUpdate, {
       args: [],
-      waitForStage: UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     // valid
     await handle.startUpdate(unaryUpdate, {
       args: [1],
-      waitForStage: UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     // @ts-expect-error:executeUpdate doesn't accept waitForStage
     await handle.executeUpdate(unaryUpdate, {
       args: [1],
-      waitForStage: UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+      waitForStage: WorkflowUpdateStage.ACCEPTED,
     });
     // valid
     await handle.executeUpdate(unaryUpdate, { args: [1] });

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -56,7 +56,7 @@ import { ChildWorkflowHandle, ExternalWorkflowHandle } from './workflow-handle';
 registerSleepImplementation(sleep);
 
 /**
- * Adds default values to `workflowId` and `workflowIdReusePolicy` to given workflow options.
+ * Adds default values of `workflowId` and `cancellationType` to given workflow options.
  */
 export function addDefaultWorkflowOptions<T extends Workflow>(
   opts: WithWorkflowArgs<T, ChildWorkflowOptions>


### PR DESCRIPTION
Closes #1403

## What was changed
Make `startUpdate` require
```typescript
waitForStage: WorkflowUpdateStage.ACCEPTED
```

## Why?
We decided to require this to make it explicit that the call -- despite being named `startXXX` -- blocks until a worker is available and accepts/rejects the update.
