### PR TITLE
feat(workflow): Expose updateId to update handlers

### DIFF
--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -190,6 +190,21 @@ export interface UnsafeWorkflowInfo {
   readonly isReplaying: boolean;
 }
 
+/**
+ * Information about a workflow update.
+ */
+export interface UpdateInfo {
+  /**
+   *  A workflow-unique identifier for this update.
+   */
+  readonly id: string;
+
+  /**
+   *  The update type name.
+   */
+  readonly name: string;
+}
+
 export interface ParentWorkflowInfo {
   workflowId: string;
   runId: string;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -192,6 +192,8 @@ export interface UnsafeWorkflowInfo {
 
 /**
  * Information about a workflow update.
+ *
+ * @experimental
  */
 export interface UpdateInfo {
   /**

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -21,6 +21,7 @@ import { checkExtends } from '@temporalio/common/lib/type-helpers';
 import type { coresdk, temporal } from '@temporalio/proto';
 import { alea, RNG } from './alea';
 import { RootCancellationScope } from './cancellation-scope';
+import { UpdateScope } from './update-scope';
 import { DeterminismViolationError, LocalActivityDoBackoff, isCancellation } from './errors';
 import { QueryInput, SignalInput, UpdateInput, WorkflowExecuteInput, WorkflowInterceptors } from './interceptors';
 import {
@@ -624,25 +625,25 @@ export class Activator implements ActivationHandler {
     //
     // Note that there is a deliberately unhandled promise rejection below.
     // These are caught elsewhere and fail the corresponding activation.
-    let input: UpdateInput;
-    try {
-      if (runValidator && this.updateHandlers.get(name)?.validator) {
-        const validate = composeInterceptors(
-          this.interceptors.inbound,
-          'validateUpdate',
-          this.validateUpdateNextHandler.bind(this)
-        );
-        validate(makeInput());
+    const doUpdateImpl = async () => {
+      let input: UpdateInput;
+      try {
+        if (runValidator && this.updateHandlers.get(name)?.validator) {
+          const validate = composeInterceptors(
+            this.interceptors.inbound,
+            'validateUpdate',
+            this.validateUpdateNextHandler.bind(this)
+          );
+          validate(makeInput());
+        }
+        input = makeInput();
+      } catch (error) {
+        this.rejectUpdate(protocolInstanceId, error);
+        return;
       }
-      input = makeInput();
-    } catch (error) {
-      this.rejectUpdate(protocolInstanceId, error);
-      return;
-    }
-    const execute = composeInterceptors(this.interceptors.inbound, 'handleUpdate', this.updateNextHandler.bind(this));
-    this.acceptUpdate(protocolInstanceId);
-    untrackPromise(
-      execute(input)
+      const execute = composeInterceptors(this.interceptors.inbound, 'handleUpdate', this.updateNextHandler.bind(this));
+      this.acceptUpdate(protocolInstanceId);
+      const res = execute(input)
         .then((result) => this.completeUpdate(protocolInstanceId, result))
         .catch((error) => {
           if (error instanceof TemporalFailure) {
@@ -650,7 +651,14 @@ export class Activator implements ActivationHandler {
           } else {
             throw error;
           }
-        })
+        });
+      untrackPromise(res);
+      return res;
+    };
+    untrackPromise(
+      UpdateScope.updateWithInfo(updateId, name, doUpdateImpl).catch((error: any) => {
+        throw error;
+      })
     );
   }
 

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -660,9 +660,7 @@ export class Activator implements ActivationHandler {
       untrackPromise(res);
       return res;
     };
-    untrackPromise(
-      UpdateScope.updateWithInfo(updateId, name, doUpdateImpl)
-    );
+    untrackPromise(UpdateScope.updateWithInfo(updateId, name, doUpdateImpl));
   }
 
   protected async updateNextHandler({ name, args }: UpdateInput): Promise<unknown> {

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -661,9 +661,7 @@ export class Activator implements ActivationHandler {
       return res;
     };
     untrackPromise(
-      UpdateScope.updateWithInfo(updateId, name, doUpdateImpl).catch((error: any) => {
-        throw error;
-      })
+      UpdateScope.updateWithInfo(updateId, name, doUpdateImpl)
     );
   }
 

--- a/packages/workflow/src/update-scope.ts
+++ b/packages/workflow/src/update-scope.ts
@@ -1,0 +1,67 @@
+import type { AsyncLocalStorage as ALS } from 'node:async_hooks';
+
+/**
+ * Option for constructing a UpdateScope
+ */
+export interface UpdateScopeOptions {
+  /**
+   *  A workflow-unique identifier for this update.
+   */
+  id: string;
+
+  /**
+   *  The update type name.
+   */
+  name: string;
+}
+
+// AsyncLocalStorage is injected via vm module into global scope.
+// In case Workflow code is imported in Node.js context, replace with an empty class.
+export const AsyncLocalStorage: new <T>() => ALS<T> = (globalThis as any).AsyncLocalStorage ?? class {};
+
+export class UpdateScope {
+  /**
+   *  A workflow-unique identifier for this update.
+   */
+  public readonly id: string;
+
+  /**
+   *  The update type name.
+   */
+  public readonly name: string;
+
+  constructor(options: UpdateScopeOptions) {
+    this.id = options.id;
+    this.name = options.name;
+  }
+
+  /**
+   * Activate the scope as current and run the update handler `fn`.
+   *
+   * @return the result of `fn`
+   */
+  run<T>(fn: () => Promise<T>): Promise<T> {
+    return storage.run(this, fn);
+  }
+
+  /**
+   * Get the current "active" update scope.
+   */
+  static current(): UpdateScope | undefined {
+    return storage.getStore();
+  }
+
+  /** Alias to `new UpdateScope({ id, name }).run(fn)` */
+  static updateWithInfo<T>(id: string, name: string, fn: () => Promise<T>): Promise<T> {
+    return new this({ id, name }).run(fn);
+  }
+}
+
+const storage = new AsyncLocalStorage<UpdateScope>();
+
+/**
+ * Disable the async local storage for updates.
+ */
+export function disableUpdateStorage(): void {
+  storage.disable();
+}

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -8,6 +8,7 @@ import { msToTs, tsToMs } from '@temporalio/common/lib/time';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import { coresdk } from '@temporalio/proto';
 import { disableStorage } from './cancellation-scope';
+import { disableUpdateStorage } from './update-scope';
 import { DeterminismViolationError } from './errors';
 import { WorkflowInterceptorsFactory } from './interceptors';
 import { WorkflowCreateOptionsInternal } from './interfaces';
@@ -295,6 +296,7 @@ export function shouldUnblockConditions(job: coresdk.workflow_activation.IWorkfl
 export function dispose(): void {
   const dispose = composeInterceptors(getActivator().interceptors.internals, 'dispose', async () => {
     disableStorage();
+    disableUpdateStorage();
   });
   dispose({});
 }

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -24,6 +24,7 @@ import { Duration, msOptionalToTs, msToNumber, msToTs, tsToMs } from '@temporali
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import { temporal } from '@temporalio/proto';
 import { CancellationScope, registerSleepImplementation } from './cancellation-scope';
+import { UpdateScope } from './update-scope';
 import {
   ActivityInput,
   LocalActivityInput,
@@ -44,6 +45,7 @@ import {
   SignalHandlerOptions,
   UpdateHandlerOptions,
   WorkflowInfo,
+  UpdateInfo,
 } from './interfaces';
 import { LocalActivityDoBackoff } from './errors';
 import { assertInWorkflowContext, getActivator, maybeGetActivator } from './global-attributes';
@@ -866,6 +868,19 @@ export async function executeChild<T extends Workflow>(
 export function workflowInfo(): WorkflowInfo {
   const activator = assertInWorkflowContext('Workflow.workflowInfo(...) may only be used from a Workflow Execution.');
   return activator.info;
+}
+
+/**
+ * Get information about the current update if any.
+ *
+ * @return Info for the current update handler the code calling this is executing
+ * within if any.
+ *
+ * @experimental
+ */
+export function currentUpdateInfo(): UpdateInfo | undefined {
+  assertInWorkflowContext('Workflow.currentUpdateInfo(...) may only be used from a Workflow Execution.');
+  return UpdateScope.current();
 }
 
 /**


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
A method `currentUpdateInfo()` has been added to workflow to obtain the name and id of a currently executing update handler from within. The solution uses AsyncLocalStorage to propagate  this information across asynchronous invocations. Calling `currentUpdateInfo()` within a workflow, but outside the async scope of an update handler invocation, returns `undefined`.

## Why?
<!-- Tell your future self why have you made these changes -->

Facilitate deduplication of updates, particularly across CAN boundaries.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#1317 
