### PR TITLE
feat(workflow): Unify GRPC::CANCELED and DEADLINE_EXCEEDED in an SDK Timeout exception for Update

### DIFF
--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -50,6 +50,20 @@ export class WorkflowUpdateFailedError extends Error {
 }
 
 /**
+ * Thrown by the client if the Update call timed out or was cancelled.
+ * This doesn't mean the update itself was timed out or cancelled.
+ */
+@SymbolBasedInstanceOfError('WorkflowUpdateRPCTimeoutOrCancelledError')
+export class WorkflowUpdateRPCTimeoutOrCancelledError extends Error {
+  public readonly cause?: Error;
+
+  public constructor(message: string, opts?: { cause: Error }) {
+    super(message);
+    this.cause = opts?.cause;
+  }
+}
+
+/**
  * Thrown the by client while waiting on Workflow execution result if Workflow
  * continues as new.
  *

--- a/packages/test/src/test-integration-update.ts
+++ b/packages/test/src/test-integration-update.ts
@@ -1,5 +1,4 @@
-import { status as grpcStatus } from '@grpc/grpc-js';
-import { isGrpcServiceError } from '@temporalio/client';
+import { WorkflowUpdateRPCTimeoutOrCancelledError } from '@temporalio/client';
 import * as wf from '@temporalio/workflow';
 import { helpers, makeTestFunction } from './helpers-integration';
 
@@ -108,7 +107,7 @@ test('Update handle can be created from identifiers and used to obtain result', 
     const workflowHandleWithIncorrectRunId = t.context.env.client.workflow.getHandle(wfHandle.workflowId, wf.uuid4());
     const updateHandle4 = workflowHandleWithIncorrectRunId.getUpdateHandle(updateId);
     const err = await t.throwsAsync(updateHandle4.result());
-    t.true(isGrpcServiceError(err) && err.code === grpcStatus.NOT_FOUND);
+    t.true(err instanceof wf.WorkflowNotFoundError);
   });
 });
 
@@ -459,5 +458,41 @@ test('Interruption of update by server long-poll timeout is invisible to client'
     await wfHandle.executeUpdate(doneUpdate);
     const wfResult = await wfHandle.result();
     t.deepEqual(wfResult, [arg, 'done', '$']);
+  });
+});
+
+test('startUpdate throws WorkflowUpdateRPCTimeoutOrCancelledError with no worker', async (t) => {
+  const { startWorkflow } = helpers(t);
+  const wfHandle = await startWorkflow(workflowWithUpdates);
+  await t.context.env.client.withDeadline(Date.now() + 100, async () => {
+    const err = await t.throwsAsync(wfHandle.startUpdate(update, { args: ['1'] }));
+    t.true(err instanceof WorkflowUpdateRPCTimeoutOrCancelledError);
+  });
+
+  const ctrl = new AbortController();
+  setTimeout(() => ctrl.abort(), 10);
+  await t.context.env.client.withAbortSignal(ctrl.signal, async () => {
+    const err = await t.throwsAsync(wfHandle.startUpdate(update, { args: ['1'] }));
+    t.true(err instanceof WorkflowUpdateRPCTimeoutOrCancelledError);
+  });
+});
+
+test('update result poll throws WorkflowUpdateRPCTimeoutOrCancelledError', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+  const worker = await createWorker();
+  await worker.runUntil(async () => {
+    const wfHandle = await startWorkflow(workflowWithUpdates);
+    const arg = 'wait-for-longer-than-server-long-poll-timeout';
+    await t.context.env.client.withDeadline(Date.now() + LONG_POLL_EXPIRATION_INTERVAL_SECONDS * 1000, async () => {
+      const err = await t.throwsAsync(wfHandle.executeUpdate(update, { args: [arg] }));
+      t.true(err instanceof WorkflowUpdateRPCTimeoutOrCancelledError);
+    });
+
+    const ctrl = new AbortController();
+    setTimeout(() => ctrl.abort(), LONG_POLL_EXPIRATION_INTERVAL_SECONDS * 1000);
+    await t.context.env.client.withAbortSignal(ctrl.signal, async () => {
+      const err = await t.throwsAsync(wfHandle.executeUpdate(update, { args: [arg] }));
+      t.true(err instanceof WorkflowUpdateRPCTimeoutOrCancelledError);
+    });
   });
 });


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Introduced a new exception `WorkflowUpdateRPCTimeoutOrCancelledError` that unifies grpc exceptions `DEADLINE_EXCEEDED` and `CANCELLED` during an update call for starting or polling for a result. 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#1422 
2. How was this tested:
Integration tests