### PR TITLE
Warn on unfinished handlers and provide `workflow.allHandlersFinished()` API

### DIFF
--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -39,9 +39,9 @@ export type WorkflowExecution = temporal.api.common.v1.IWorkflowExecution;
 /**
  * Represents failures that can cross Workflow and Activity boundaries.
  *
- * The only child class you should ever throw from your code is {@link ApplicationFailure}.
+ * **Never extend this class or any of its children.**
  *
- * **Never extend this class or any of its children other than {@link ApplicationFailure}.**
+ * The only child class you should ever throw from your code is {@link ApplicationFailure}.
  */
 @SymbolBasedInstanceOfError('TemporalFailure')
 export class TemporalFailure extends Error {

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -39,9 +39,9 @@ export type WorkflowExecution = temporal.api.common.v1.IWorkflowExecution;
 /**
  * Represents failures that can cross Workflow and Activity boundaries.
  *
- * **Never extend this class or any of its children.**
- *
  * The only child class you should ever throw from your code is {@link ApplicationFailure}.
+ *
+ * **Never extend this class or any of its children other than {@link ApplicationFailure}.**
  */
 @SymbolBasedInstanceOfError('TemporalFailure')
 export class TemporalFailure extends Error {

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -8,11 +8,16 @@ export type WorkflowUpdateType = (...args: any[]) => Promise<any> | any;
 export type WorkflowUpdateValidatorType = (...args: any[]) => void;
 export type WorkflowUpdateAnnotatedType = {
   handler: WorkflowUpdateType;
+  unfinishedPolicy: HandlerUnfinishedPolicy;
   validator?: WorkflowUpdateValidatorType;
   description?: string;
 };
 export type WorkflowSignalType = (...args: any[]) => Promise<void> | void;
-export type WorkflowSignalAnnotatedType = { handler: WorkflowSignalType; description?: string };
+export type WorkflowSignalAnnotatedType = {
+  handler: WorkflowSignalType;
+  unfinishedPolicy: HandlerUnfinishedPolicy;
+  description?: string;
+};
 export type WorkflowQueryType = (...args: any[]) => any;
 export type WorkflowQueryAnnotatedType = { handler: WorkflowQueryType; description?: string };
 
@@ -117,4 +122,23 @@ export type UntypedActivities = Record<string, ActivityFunction>;
 export interface HistoryAndWorkflowId {
   workflowId: string;
   history: temporal.api.history.v1.History | unknown | undefined;
+}
+
+/**
+ * Policy defining actions taken when a workflow exits while update or signal handlers are running.
+ * The workflow exit may be due to successful return, failure, cancellation, or continue-as-new.
+ */
+export enum HandlerUnfinishedPolicy {
+  /**
+   * Issue a warning in addition to abandoning the handler execution.
+   */
+  WARN_AND_ABANDON = 1,
+
+  /**
+   * Abandon the handler execution.
+   *
+   * In the case of an update handler this means that the client will receive an error rather than
+   * the update result.
+   */
+  ABANDON = 2,
 }

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -130,7 +130,7 @@ export interface HistoryAndWorkflowId {
  */
 export enum HandlerUnfinishedPolicy {
   /**
-   * Issue a warning in addition to abandoning the handler execution.
+   * Issue a warning in addition to abandoning the handler execution. The warning will not be issued if the workflow fails.
    */
   WARN_AND_ABANDON = 1,
 

--- a/packages/test/src/helpers.ts
+++ b/packages/test/src/helpers.ts
@@ -45,6 +45,23 @@ export async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export async function waitUntil(
+  condition: () => Promise<boolean>,
+  timeoutMs: number,
+  intervalMs: number = 100
+): Promise<void> {
+  const endTime = Date.now() + timeoutMs;
+  for (;;) {
+    if (await condition()) {
+      return;
+    } else if (Date.now() >= endTime) {
+      throw new Error('timed out waiting for condition');
+    } else {
+      await sleep(intervalMs);
+    }
+  }
+}
+
 export function cleanOptionalStackTrace(stackTrace: string | undefined | null): string | undefined {
   return stackTrace ? cleanStackTrace(stackTrace) : undefined;
 }

--- a/packages/test/src/test-integration-workflows-with-recorded-logs.ts
+++ b/packages/test/src/test-integration-workflows-with-recorded-logs.ts
@@ -284,23 +284,10 @@ class UnfinishedHandlersWorkflowTerminationTypeTest {
 
     return await worker.runUntil(async () => {
       if (this.handlerType === 'update') {
-        switch (this.workflowTerminationType) {
-          case 'cancellation': {
-            await this.assertWorkflowUpdateFailedError(executeUpdate);
-            break;
-          }
-          case 'continue-as-new': {
-            await this.assertWorkflowNotFoundError(executeUpdate);
-            break;
-          }
-          case 'failure': {
-            await this.assertWorkflowNotFoundError(executeUpdate);
-            break;
-          }
-          case 'return': {
-            await this.assertWorkflowNotFoundError(executeUpdate);
-            break;
-          }
+        if (this.workflowTerminationType === 'cancellation') {
+          await this.assertWorkflowUpdateFailedError(executeUpdate);
+        } else {
+          await this.assertWorkflowNotFoundError(executeUpdate);
         }
       }
 

--- a/packages/test/src/test-integration-workflows-with-recorded-logs.ts
+++ b/packages/test/src/test-integration-workflows-with-recorded-logs.ts
@@ -326,7 +326,7 @@ class UnfinishedHandlersWorkflowTerminationTypeTest {
     switch (this.handlerType) {
       case 'update':
         executeUpdate = w.executeUpdate(unfinishedHandlersWorkflowTerminationTypeUpdate, { updateId });
-        await waitUntil(() => workflowUpdateExists(w, updateId), 500);
+        await waitUntil(() => workflowUpdateExists(w, updateId), 2000);
         break;
       case 'signal':
         await w.signal(unfinishedHandlersWorkflowTerminationTypeSignal);

--- a/packages/test/src/test-integration-workflows-with-recorded-logs.ts
+++ b/packages/test/src/test-integration-workflows-with-recorded-logs.ts
@@ -201,19 +201,19 @@ export async function runUnfinishedHandlersWithCancellationOrFailureWorkflow(
 }
 
 test('unfinished update handler with workflow cancellation', async (t) => {
-  await new UnfinishedHandlersWithCancellationOrFailureTest(t, 'update', 'cancellation').testWarningIsIssued();
+  await new UnfinishedHandlersWithCancellationOrFailureTest(t, 'update', 'cancellation').testWarningIsIssued(false);
 });
 
 test('unfinished signal handler with workflow cancellation', async (t) => {
-  await new UnfinishedHandlersWithCancellationOrFailureTest(t, 'signal', 'cancellation').testWarningIsIssued();
+  await new UnfinishedHandlersWithCancellationOrFailureTest(t, 'signal', 'cancellation').testWarningIsIssued(false);
 });
 
 test('unfinished update handler with workflow failure', async (t) => {
-  await new UnfinishedHandlersWithCancellationOrFailureTest(t, 'update', 'failure').testWarningIsIssued();
+  await new UnfinishedHandlersWithCancellationOrFailureTest(t, 'update', 'failure').testWarningIsIssued(true);
 });
 
 test('unfinished signal handler with workflow failure', async (t) => {
-  await new UnfinishedHandlersWithCancellationOrFailureTest(t, 'signal', 'failure').testWarningIsIssued();
+  await new UnfinishedHandlersWithCancellationOrFailureTest(t, 'signal', 'failure').testWarningIsIssued(true);
 });
 
 class UnfinishedHandlersWithCancellationOrFailureTest {
@@ -223,8 +223,8 @@ class UnfinishedHandlersWithCancellationOrFailureTest {
     private readonly workflowTerminationType: 'cancellation' | 'failure'
   ) {}
 
-  async testWarningIsIssued() {
-    this.t.true(await this.runWorkflowAndGetWarning());
+  async testWarningIsIssued(expectWarning: boolean) {
+    this.t.is(await this.runWorkflowAndGetWarning(), expectWarning);
   }
 
   async runWorkflowAndGetWarning(): Promise<boolean> {

--- a/packages/test/src/test-integration-workflows-with-recorded-logs.ts
+++ b/packages/test/src/test-integration-workflows-with-recorded-logs.ts
@@ -168,7 +168,9 @@ class UnfinishedHandlersTest {
   isUnfinishedHandlerWarning(logEntry: LogEntry): boolean {
     return (
       logEntry.level === 'WARN' &&
-      new RegExp(`^Workflow finished while an? ${this.handlerType} handler was still running\\.`).test(logEntry.message)
+      new RegExp(`^\\[TMPRL1102\\] Workflow finished while an? ${this.handlerType} handler was still running\\.`).test(
+        logEntry.message
+      )
     );
   }
 }

--- a/packages/test/src/test-integration-workflows-with-recorded-logs.ts
+++ b/packages/test/src/test-integration-workflows-with-recorded-logs.ts
@@ -300,7 +300,7 @@ class UnfinishedHandlersWorkflowTerminationTypeTest {
       }
 
       const unfinishedHandlerWarningEmitted =
-        recordedLogs[handle.workflowId] &&
+        handle.workflowId in recordedLogs &&
         recordedLogs[handle.workflowId].findIndex((e) => this.isUnfinishedHandlerWarning(e)) >= 0;
       return unfinishedHandlerWarningEmitted;
     });

--- a/packages/test/src/test-integration-workflows-with-recorded-logs.ts
+++ b/packages/test/src/test-integration-workflows-with-recorded-logs.ts
@@ -175,22 +175,22 @@ class UnfinishedHandlersTest {
   }
 }
 
-export const unfinishedHandlersWithCancellationOrFailureOrCANUpdate = workflow.defineUpdate<void>(
-  'unfinishedHandlersWithCancellationOrFailureUpdate'
+export const unfinishedHandlersWorkflowTerminationTypeUpdate = workflow.defineUpdate<void>(
+  'unfinishedHandlersWorkflowTerminationTypeUpdate'
 );
-export const unfinishedHandlersWithCancellationOrFailureOrCANSignal = workflow.defineSignal(
-  'unfinishedHandlersWithCancellationOrFailureSignal'
+export const unfinishedHandlersWorkflowTerminationTypeSignal = workflow.defineSignal(
+  'unfinishedHandlersWorkflowTerminationTypeSignal'
 );
 
-export async function runUnfinishedHandlersWithCancellationOrFailureOrCANWorkflow(
+export async function runUnfinishedHandlersWorkflowTerminationTypeWorkflow(
   workflowTerminationType: 'cancellation' | 'continue-as-new' | 'failure'
 ): Promise<never> {
-  workflow.setHandler(unfinishedHandlersWithCancellationOrFailureOrCANUpdate, async () => {
+  workflow.setHandler(unfinishedHandlersWorkflowTerminationTypeUpdate, async () => {
     await workflow.condition(() => false);
     throw new Error('unreachable');
   });
 
-  workflow.setHandler(unfinishedHandlersWithCancellationOrFailureOrCANSignal, async () => {
+  workflow.setHandler(unfinishedHandlersWorkflowTerminationTypeSignal, async () => {
     await workflow.condition(() => false);
     throw new Error('unreachable');
   });
@@ -207,38 +207,30 @@ export async function runUnfinishedHandlersWithCancellationOrFailureOrCANWorkflo
 }
 
 test('unfinished update handler with workflow cancellation', async (t) => {
-  await new UnfinishedHandlersWithCancellationOrFailureOrCANTest(t, 'update', 'cancellation').testWarningIsIssued(
-    false
-  );
+  await new UnfinishedHandlersWorkflowTerminationTypeTest(t, 'update', 'cancellation').testWarningIsIssued(false);
 });
 
 test('unfinished signal handler with workflow cancellation', async (t) => {
-  await new UnfinishedHandlersWithCancellationOrFailureOrCANTest(t, 'signal', 'cancellation').testWarningIsIssued(
-    false
-  );
+  await new UnfinishedHandlersWorkflowTerminationTypeTest(t, 'signal', 'cancellation').testWarningIsIssued(false);
 });
 
 test('unfinished update handler with continue-as-new', async (t) => {
-  await new UnfinishedHandlersWithCancellationOrFailureOrCANTest(t, 'update', 'continue-as-new').testWarningIsIssued(
-    false
-  );
+  await new UnfinishedHandlersWorkflowTerminationTypeTest(t, 'update', 'continue-as-new').testWarningIsIssued(false);
 });
 
 test('unfinished signal handler with continue-as-new', async (t) => {
-  await new UnfinishedHandlersWithCancellationOrFailureOrCANTest(t, 'signal', 'continue-as-new').testWarningIsIssued(
-    false
-  );
+  await new UnfinishedHandlersWorkflowTerminationTypeTest(t, 'signal', 'continue-as-new').testWarningIsIssued(false);
 });
 
 test('unfinished update handler with workflow failure', async (t) => {
-  await new UnfinishedHandlersWithCancellationOrFailureOrCANTest(t, 'update', 'failure').testWarningIsIssued(false);
+  await new UnfinishedHandlersWorkflowTerminationTypeTest(t, 'update', 'failure').testWarningIsIssued(false);
 });
 
 test('unfinished signal handler with workflow failure', async (t) => {
-  await new UnfinishedHandlersWithCancellationOrFailureOrCANTest(t, 'signal', 'failure').testWarningIsIssued(false);
+  await new UnfinishedHandlersWorkflowTerminationTypeTest(t, 'signal', 'failure').testWarningIsIssued(false);
 });
 
-class UnfinishedHandlersWithCancellationOrFailureOrCANTest {
+class UnfinishedHandlersWorkflowTerminationTypeTest {
   constructor(
     private readonly t: ExecutionContext<Context>,
     private readonly handlerType: 'update' | 'signal',
@@ -257,7 +249,7 @@ class UnfinishedHandlersWithCancellationOrFailureOrCANTest {
     // they've all been accepted by the server.
     const updateId = 'update-id';
 
-    const handle = await startWorkflow(runUnfinishedHandlersWithCancellationOrFailureOrCANWorkflow, {
+    const handle = await startWorkflow(runUnfinishedHandlersWorkflowTerminationTypeWorkflow, {
       args: [this.workflowTerminationType],
     });
     if (this.workflowTerminationType === 'cancellation') {
@@ -267,11 +259,11 @@ class UnfinishedHandlersWithCancellationOrFailureOrCANTest {
 
     switch (this.handlerType) {
       case 'update':
-        executeUpdate = handle.executeUpdate(unfinishedHandlersWithCancellationOrFailureOrCANUpdate, { updateId });
+        executeUpdate = handle.executeUpdate(unfinishedHandlersWorkflowTerminationTypeUpdate, { updateId });
         await waitUntil(() => workflowUpdateExists(handle, updateId), 500);
         break;
       case 'signal':
-        await handle.signal(unfinishedHandlersWithCancellationOrFailureOrCANSignal);
+        await handle.signal(unfinishedHandlersWorkflowTerminationTypeSignal);
         break;
     }
 

--- a/packages/test/src/test-integration-workflows-with-recorded-logs.ts
+++ b/packages/test/src/test-integration-workflows-with-recorded-logs.ts
@@ -62,6 +62,8 @@ export async function unfinishedHandlersWorkflow(waitAllHandlersFinished: boolea
   return handlerFinished;
 }
 
+// These tests confirms that the unfinished-handler warning is issued, and respects the policy, and
+// can be avoided by waiting for the `allHandlersFinished` condition.
 test('unfinished update handler', async (t) => {
   await new UnfinishedHandlersTest(t, 'update').testWaitAllHandlersFinishedAndUnfinishedHandlersWarning();
 });
@@ -206,6 +208,8 @@ export async function runUnfinishedHandlersWorkflowTerminationTypeWorkflow(
   throw new Error('unreachable');
 }
 
+// These tests confirm that the warning is issued / not issued as appropriate for workflow
+// termination via cancellation, failure, and continue-as-new.
 test('unfinished update handler with workflow cancellation', async (t) => {
   await new UnfinishedHandlersWorkflowTerminationTypeTest(t, 'update', 'cancellation').testWarningIsIssued(false);
 });
@@ -215,11 +219,11 @@ test('unfinished signal handler with workflow cancellation', async (t) => {
 });
 
 test('unfinished update handler with continue-as-new', async (t) => {
-  await new UnfinishedHandlersWorkflowTerminationTypeTest(t, 'update', 'continue-as-new').testWarningIsIssued(false);
+  await new UnfinishedHandlersWorkflowTerminationTypeTest(t, 'update', 'continue-as-new').testWarningIsIssued(true);
 });
 
 test('unfinished signal handler with continue-as-new', async (t) => {
-  await new UnfinishedHandlersWorkflowTerminationTypeTest(t, 'signal', 'continue-as-new').testWarningIsIssued(false);
+  await new UnfinishedHandlersWorkflowTerminationTypeTest(t, 'signal', 'continue-as-new').testWarningIsIssued(true);
 });
 
 test('unfinished update handler with workflow failure', async (t) => {

--- a/packages/test/src/test-integration-workflows-with-recorded-logs.ts
+++ b/packages/test/src/test-integration-workflows-with-recorded-logs.ts
@@ -1,0 +1,172 @@
+import { ExecutionContext } from 'ava';
+import * as workflow from '@temporalio/workflow';
+import { HandlerUnfinishedPolicy } from '@temporalio/common';
+import { LogEntry } from '@temporalio/worker';
+import { Context, helpers, makeTestFunction } from './helpers-integration';
+
+const recordedLogs: { [workflowId: string]: LogEntry[] } = {};
+const test = makeTestFunction({
+  workflowsPath: __filename,
+  recordedLogs,
+});
+
+export const unfinishedHandlersUpdate = workflow.defineUpdate<void>('unfinished-handlers-update');
+export const unfinishedHandlersUpdate_ABANDON = workflow.defineUpdate<void>('unfinished-handlers-update-ABANDON');
+export const unfinishedHandlersUpdate_WARN_AND_ABANDON = workflow.defineUpdate<void>(
+  'unfinished-handlers-update-WARN_AND_ABANDON'
+);
+export const unfinishedHandlersSignal = workflow.defineSignal('unfinished-handlers-signal');
+export const unfinishedHandlersSignal_ABANDON = workflow.defineSignal('unfinished-handlers-signal-ABANDON');
+export const unfinishedHandlersSignal_WARN_AND_ABANDON = workflow.defineSignal(
+  'unfinished-handlers-signal-WARN_AND_ABANDON'
+);
+
+/**
+ * A workflow for testing `workflow.allHandlersFinished()` and control of
+ * warnings by HandlerUnfinishedPolicy.
+ */
+export async function unfinishedHandlersWorkflow(waitAllHandlersFinished: boolean): Promise<boolean> {
+  let startedHandler = false;
+  let handlerMayReturn = false;
+  let handlerFinished = false;
+
+  const doUpdateOrSignal = async (): Promise<void> => {
+    startedHandler = true;
+    await workflow.condition(() => handlerMayReturn);
+    handlerFinished = true;
+  };
+
+  workflow.setHandler(unfinishedHandlersUpdate, doUpdateOrSignal);
+  workflow.setHandler(unfinishedHandlersUpdate_ABANDON, doUpdateOrSignal, {
+    unfinishedPolicy: HandlerUnfinishedPolicy.ABANDON,
+  });
+  workflow.setHandler(unfinishedHandlersUpdate_WARN_AND_ABANDON, doUpdateOrSignal, {
+    unfinishedPolicy: HandlerUnfinishedPolicy.WARN_AND_ABANDON,
+  });
+  workflow.setHandler(unfinishedHandlersSignal, doUpdateOrSignal);
+  workflow.setHandler(unfinishedHandlersSignal_ABANDON, doUpdateOrSignal, {
+    unfinishedPolicy: HandlerUnfinishedPolicy.ABANDON,
+  });
+  workflow.setHandler(unfinishedHandlersSignal_WARN_AND_ABANDON, doUpdateOrSignal, {
+    unfinishedPolicy: HandlerUnfinishedPolicy.WARN_AND_ABANDON,
+  });
+  workflow.setDefaultSignalHandler(doUpdateOrSignal);
+
+  await workflow.condition(() => startedHandler);
+  if (waitAllHandlersFinished) {
+    handlerMayReturn = true;
+    await workflow.condition(() => workflow.allHandlersFinished());
+  }
+  return handlerFinished;
+}
+
+test('unfinished update handler', async (t) => {
+  await new UnfinishedHandlersTest(t, 'update').testWaitAllHandlersFinishedAndUnfinishedHandlersWarning();
+});
+
+test('unfinished signal handler', async (t) => {
+  await new UnfinishedHandlersTest(t, 'signal').testWaitAllHandlersFinishedAndUnfinishedHandlersWarning();
+});
+
+class UnfinishedHandlersTest {
+  constructor(
+    private readonly t: ExecutionContext<Context>,
+    private readonly handlerType: 'update' | 'signal'
+  ) {}
+
+  async testWaitAllHandlersFinishedAndUnfinishedHandlersWarning() {
+    // The unfinished handler warning is issued by default,
+    let [handlerFinished, warning] = await this.getWorkflowResultAndWarning(false);
+    this.t.false(handlerFinished);
+    this.t.true(warning);
+
+    // and when the workflow sets the unfinished_policy to WARN_AND_ABANDON,
+    [handlerFinished, warning] = await this.getWorkflowResultAndWarning(
+      false,
+      HandlerUnfinishedPolicy.WARN_AND_ABANDON
+    );
+    this.t.false(handlerFinished);
+    this.t.true(warning);
+
+    // and when a default (aka dynamic) handler is used
+    if (this.handlerType === 'signal') {
+      [handlerFinished, warning] = await this.getWorkflowResultAndWarning(false, undefined, true);
+      this.t.false(handlerFinished);
+      this.t.true(warning);
+    } else {
+      // default handlers not supported yet for update
+      // https://github.com/temporalio/sdk-typescript/issues/1460
+    }
+
+    // but not when the workflow waits for handlers to complete,
+    [handlerFinished, warning] = await this.getWorkflowResultAndWarning(true);
+    this.t.true(handlerFinished);
+    this.t.false(warning);
+
+    // TODO: make default handlers honor HandlerUnfinishedPolicy
+    // [handlerFinished, warning] = await this.getWorkflowResultAndWarning(true, undefined, true);
+    // this.t.true(handlerFinished);
+    // this.t.false(warning);
+
+    // nor when the silence-warnings policy is set on the handler.
+    [handlerFinished, warning] = await this.getWorkflowResultAndWarning(false, HandlerUnfinishedPolicy.ABANDON);
+    this.t.false(handlerFinished);
+    this.t.false(warning);
+  }
+
+  /**
+   * Run workflow and send signal/update. Return two booleans:
+   * - did the handler complete? (i.e. the workflow return value)
+   * - was an unfinished handler warning emitted?
+   */
+  async getWorkflowResultAndWarning(
+    waitAllHandlersFinished: boolean,
+    unfinishedPolicy?: HandlerUnfinishedPolicy,
+    useDefaultHandler?: boolean
+  ): Promise<[boolean, boolean]> {
+    const { createWorker, startWorkflow } = helpers(this.t);
+    const worker = await createWorker();
+    return await worker.runUntil(async () => {
+      const handle = await startWorkflow(unfinishedHandlersWorkflow, { args: [waitAllHandlersFinished] });
+      let messageType: string;
+      if (useDefaultHandler) {
+        messageType = '__no_registered_handler__';
+        this.t.falsy(unfinishedPolicy); // default handlers do not support setting the unfinished policy
+      } else {
+        messageType = `unfinished-handlers-${this.handlerType}`;
+        if (unfinishedPolicy) {
+          messageType += '-' + HandlerUnfinishedPolicy[unfinishedPolicy];
+        }
+      }
+      switch (this.handlerType) {
+        case 'signal':
+          await handle.signal(messageType);
+          break;
+        case 'update': {
+          const executeUpdate = handle.executeUpdate(messageType, { updateId: 'my-update-id' });
+          if (!waitAllHandlersFinished) {
+            const err: workflow.WorkflowNotFoundError = (await this.t.throwsAsync(executeUpdate, {
+              instanceOf: workflow.WorkflowNotFoundError,
+            })) as workflow.WorkflowNotFoundError;
+            this.t.is(err.message, 'workflow execution already completed');
+          } else {
+            await executeUpdate;
+          }
+          break;
+        }
+      }
+      const handlerFinished = await handle.result();
+      const unfinishedHandlerWarningEmitted =
+        recordedLogs[handle.workflowId] &&
+        recordedLogs[handle.workflowId].findIndex((e) => this.isUnfinishedHandlerWarning(e)) >= 0;
+      return [handlerFinished, unfinishedHandlerWarningEmitted];
+    });
+  }
+
+  isUnfinishedHandlerWarning(logEntry: LogEntry): boolean {
+    return (
+      logEntry.level === 'WARN' &&
+      new RegExp(`^Workflow finished while an? ${this.handlerType} handler was still running\\.`).test(logEntry.message)
+    );
+  }
+}

--- a/packages/test/src/test-integration-workflows-with-recorded-logs.ts
+++ b/packages/test/src/test-integration-workflows-with-recorded-logs.ts
@@ -185,8 +185,8 @@ export const unfinishedHandlersWorkflowTerminationTypeSignal = workflow.defineSi
 );
 
 export async function runUnfinishedHandlersWorkflowTerminationTypeWorkflow(
-  workflowTerminationType: 'cancellation' | 'continue-as-new' | 'failure'
-): Promise<never> {
+  workflowTerminationType: 'cancellation' | 'continue-as-new' | 'failure' | 'return'
+): Promise<void> {
   workflow.setHandler(unfinishedHandlersWorkflowTerminationTypeUpdate, async () => {
     await workflow.condition(() => false);
     throw new Error('unreachable');
@@ -201,11 +201,12 @@ export async function runUnfinishedHandlersWorkflowTerminationTypeWorkflow(
     case 'cancellation':
       await workflow.condition(() => false);
     case 'continue-as-new':
-      await workflow.continueAsNew();
+      await workflow.continueAsNew('return');
     case 'failure':
       throw new workflow.ApplicationFailure('Deliberately failing workflow with an unfinished handler');
+    case 'return':
+      break;
   }
-  throw new Error('unreachable');
 }
 
 // These tests confirm that the warning is issued / not issued as appropriate for workflow

--- a/packages/test/src/test-integration-workflows-with-recorded-logs.ts
+++ b/packages/test/src/test-integration-workflows-with-recorded-logs.ts
@@ -211,11 +211,11 @@ test('unfinished signal handler with workflow cancellation', async (t) => {
 });
 
 test('unfinished update handler with workflow failure', async (t) => {
-  await new UnfinishedHandlersWithCancellationOrFailureTest(t, 'update', 'failure').testWarningIsIssued(true);
+  await new UnfinishedHandlersWithCancellationOrFailureTest(t, 'update', 'failure').testWarningIsIssued(false);
 });
 
 test('unfinished signal handler with workflow failure', async (t) => {
-  await new UnfinishedHandlersWithCancellationOrFailureTest(t, 'signal', 'failure').testWarningIsIssued(true);
+  await new UnfinishedHandlersWithCancellationOrFailureTest(t, 'signal', 'failure').testWarningIsIssued(false);
 });
 
 class UnfinishedHandlersWithCancellationOrFailureTest {

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -3,6 +3,7 @@ import {
   RetryPolicy,
   TemporalFailure,
   CommonWorkflowOptions,
+  HandlerUnfinishedPolicy,
   SearchAttributes,
   SignalDefinition,
   UpdateDefinition,
@@ -494,12 +495,16 @@ export type QueryHandlerOptions = { description?: string };
 /**
  * A description of a signal handler.
  */
-export type SignalHandlerOptions = { description?: string };
+export type SignalHandlerOptions = { description?: string; unfinishedPolicy?: HandlerUnfinishedPolicy };
 
 /**
  * A validator and description of an update handler.
  */
-export type UpdateHandlerOptions<Args extends any[]> = { validator?: UpdateValidator<Args>; description?: string };
+export type UpdateHandlerOptions<Args extends any[]> = {
+  validator?: UpdateValidator<Args>;
+  description?: string;
+  unfinishedPolicy?: HandlerUnfinishedPolicy;
+};
 
 export interface ActivationCompletion {
   commands: coresdk.workflow_commands.IWorkflowCommand[];

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -1001,7 +1001,7 @@ function makeUnfinishedUpdateHandlerMessage(handlerExecutions: MessageHandlerExe
 [TMPRL1102] Workflow finished while an update handler was still running. This may have interrupted work that the
 update handler was doing, and the client that sent the update will receive a 'workflow execution
 already completed' RPCError instead of the update result. You can wait for all update and signal
-handlers to complete by using \`await workflow.condition(() => workflow.allHandlersFinished())\`.
+handlers to complete by using \`await workflow.condition(workflow.allHandlersFinished)\`.
 Alternatively, if both you and the clients sending the update are okay with interrupting running handlers
 when the workflow finishes, and causing clients to receive errors, then you can disable this warning by
 passing an option when setting the handler:
@@ -1018,7 +1018,7 @@ function makeUnfinishedSignalHandlerMessage(handlerExecutions: MessageHandlerExe
   const message = `
 [TMPRL1102] Workflow finished while a signal handler was still running. This may have interrupted work that the
 signal handler was doing. You can wait for all update and signal handlers to complete by using
-\`await workflow.condition(() => workflow.allHandlersFinished())\`. Alternatively, if both you and the
+\`await workflow.condition(workflow.allHandlersFinished)\`. Alternatively, if both you and the
 clients sending the update are okay with interrupting running handlers when the workflow finishes,
 then you can disable this warning by passing an option when setting the handler:
 \`workflow.setHandler(mySignal, mySignalHandler, {unfinishedPolicy: HandlerUnfinishedPolicy.ABANDON});\`.`

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -1004,7 +1004,7 @@ function getSeq<T extends { seq?: number | null }>(activation: T): number {
 
 function makeUnfinishedUpdateHandlerMessage(handlerExecutions: MessageHandlerExecution[]): string {
   const message = `
-Workflow finished while an update handler was still running. This may have interrupted work that the
+[TMPRL1102] Workflow finished while an update handler was still running. This may have interrupted work that the
 update handler was doing, and the client that sent the update will receive a 'workflow execution
 already completed' RPCError instead of the update result. You can wait for all update and signal
 handlers to complete by using \`await workflow.condition(() => workflow.allHandlersFinished())\`.
@@ -1022,12 +1022,11 @@ passing an option when setting the handler:
 
 function makeUnfinishedSignalHandlerMessage(handlerExecutions: MessageHandlerExecution[]): string {
   const message = `
-Workflow finished while a signal handler was still running. This may have interrupted work that the
+[TMPRL1102] Workflow finished while a signal handler was still running. This may have interrupted work that the
 signal handler was doing. You can wait for all update and signal handlers to complete by using
 \`await workflow.condition(() => workflow.allHandlersFinished())\`. Alternatively, if both you and the
-clients sending the update are okay with interrupting running handlers when the workflow finishes, and
-causing clients to receive errors, then you can disable this warning by passing an option when setting
-the handler:
+clients sending the update are okay with interrupting running handlers when the workflow finishes,
+then you can disable this warning by passing an option when setting the handler:
 \`workflow.setHandler(mySignal, mySignalHandler, {unfinishedPolicy: HandlerUnfinishedPolicy.ABANDON});\`.`
 
     .replace(/\n/g, ' ')

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -689,8 +689,7 @@ export class Activator implements ActivationHandler {
       const res = execute(input)
         .then((result) => this.completeUpdate(protocolInstanceId, result))
         .catch((error) => {
-          // is this failing updates on WFT failure?
-          if (error instanceof ApplicationFailure) {
+          if (error instanceof TemporalFailure) {
             this.rejectUpdate(protocolInstanceId, error);
           } else {
             throw error;

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -688,16 +688,14 @@ export class Activator implements ActivationHandler {
       this.inProgressUpdates.set(updateId, { name, unfinishedPolicy, id: updateId });
       const res = execute(input)
         .then((result) => this.completeUpdate(protocolInstanceId, result))
-        .then(() => {
-          this.inProgressUpdates.delete(updateId);
-        })
         .catch((error) => {
           if (error instanceof TemporalFailure) {
             this.rejectUpdate(protocolInstanceId, error);
           } else {
             throw error;
           }
-        });
+        })
+        .finally(() => this.inProgressUpdates.delete(updateId));
       untrackPromise(res);
       return res;
     };
@@ -786,8 +784,8 @@ export class Activator implements ActivationHandler {
       signalName,
       headers: headers ?? {},
     })
-      .then(() => this.inProgressSignals.delete(signalExecutionNum))
-      .catch(this.handleWorkflowFailure.bind(this));
+      .catch(this.handleWorkflowFailure.bind(this))
+      .finally(() => this.inProgressSignals.delete(signalExecutionNum));
   }
 
   public dispatchBufferedSignals(): void {

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -689,7 +689,8 @@ export class Activator implements ActivationHandler {
       const res = execute(input)
         .then((result) => this.completeUpdate(protocolInstanceId, result))
         .catch((error) => {
-          if (error instanceof TemporalFailure) {
+          // is this failing updates on WFT failure?
+          if (error instanceof ApplicationFailure) {
             this.rejectUpdate(protocolInstanceId, error);
           } else {
             throw error;

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -910,7 +910,10 @@ export class Activator implements ActivationHandler {
         // preventing it from completing.
         throw error;
       }
-
+      // Fail the workflow. We do not want to issue unfinishedHandlers warnings. To achieve that, we
+      // mark all handlers as completed now.
+      this.inProgressSignals.clear();
+      this.inProgressUpdates.clear();
       this.pushCommand(
         {
           failWorkflowExecution: {

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -186,6 +186,9 @@ export function concludeActivation(): coresdk.workflow_completion.IWorkflowActiv
   const { info } = activator;
   const activationCompletion = activator.concludeActivation();
   const { commands } = intercept({ commands: activationCompletion.commands });
+  if (activator.completed) {
+    activator.warnIfUnfinishedHandlers();
+  }
 
   return {
     runId: info.runId,

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1096,8 +1096,8 @@ function conditionInner(fn: () => boolean): Promise<void> {
 /**
  * Define an update method for a Workflow.
  *
- * Definitions are used to register handler in the Workflow via {@link setHandler} and to update Workflows using a {@link WorkflowHandle}, {@link ChildWorkflowHandle} or {@link ExternalWorkflowHandle}.
- * Definitions can be reused in multiple Workflows.
+ * A definition is used to register a handler in the Workflow via {@link setHandler} and to update a Workflow using a {@link WorkflowHandle}, {@link ChildWorkflowHandle} or {@link ExternalWorkflowHandle}.
+ * A definition can be reused in multiple Workflows.
  */
 export function defineUpdate<Ret, Args extends any[] = [], Name extends string = string>(
   name: Name
@@ -1111,8 +1111,8 @@ export function defineUpdate<Ret, Args extends any[] = [], Name extends string =
 /**
  * Define a signal method for a Workflow.
  *
- * Definitions are used to register handler in the Workflow via {@link setHandler} and to signal Workflows using a {@link WorkflowHandle}, {@link ChildWorkflowHandle} or {@link ExternalWorkflowHandle}.
- * Definitions can be reused in multiple Workflows.
+ * A definition is used to register a handler in the Workflow via {@link setHandler} and to signal a Workflow using a {@link WorkflowHandle}, {@link ChildWorkflowHandle} or {@link ExternalWorkflowHandle}.
+ * A definition can be reused in multiple Workflows.
  */
 export function defineSignal<Args extends any[] = [], Name extends string = string>(
   name: Name
@@ -1126,8 +1126,8 @@ export function defineSignal<Args extends any[] = [], Name extends string = stri
 /**
  * Define a query method for a Workflow.
  *
- * Definitions are used to register handler in the Workflow via {@link setHandler} and to query Workflows using a {@link WorkflowHandle}.
- * Definitions can be reused in multiple Workflows.
+ * A definition is used to register a handler in the Workflow via {@link setHandler} and to query a Workflow using a {@link WorkflowHandle}.
+ * A definition can be reused in multiple Workflows.
  */
 export function defineQuery<Ret, Args extends any[] = [], Name extends string = string>(
   name: Name
@@ -1194,7 +1194,7 @@ export function setHandler<Ret, Args extends any[], T extends UpdateDefinition<R
 // 1. sdk-core sorts Signal and Update jobs (and Patches) ahead of all other
 //    jobs. Thus if the handler is available at the start of the Activation then
 //    the Signal/Update will be executed before Workflow code is executed. If it
-//    is not, then the Signal/Update calls is pushed to a buffer.
+//    is not, then the Signal/Update calls are pushed to a buffer.
 //
 // 2. On each call to setHandler for a given Signal/Update, we make a pass
 //    through the buffer list. If a buffered job is associated with the just-set
@@ -1242,7 +1242,7 @@ export function setHandler<Ret, Args extends any[], T extends UpdateDefinition<R
 //    Worker polling until after they have verified that both requests have
 //    succeeded.)
 //
-// 5. If an Update has a validation function then it is executed immediately
+// 4. If an Update has a validation function then it is executed immediately
 //    prior to the handler. (Note that the validation function is required to be
 //    synchronous).
 export function setHandler<

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1439,6 +1439,18 @@ export function upsertMemo(memo: Record<string, unknown>): void {
   });
 }
 
+/**
+ * Whether update and signal handlers have finished executing.
+ *
+ * Consider waiting on this condition before workflow return or continue-as-new, to prevent
+ * interruption of in-progress handlers by workflow exit:
+ *
+ * ```ts
+ * await workflow.condition(workflow.allHandlersFinished)
+ * ```
+ *
+ * @returns true if there are no in-progress update or signal handler executions.
+ */
 export function allHandlersFinished(): boolean {
   const activator = assertInWorkflowContext('allHandlersFinished() may only be used from a Workflow Execution.');
   return activator.inProgressSignals.size === 0 && activator.inProgressUpdates.size === 0;


### PR DESCRIPTION
Fixes #1434 and #1435.

- new workflow API to wait for all signal and update handlers to be finished:
  `await workflow.condition(() => workflow.allHandlersFinished())`
- By default, warn when workflow exits with unfinished handlers, but not when a handler finishes due to workflow cancellation or workflow failure.
- Warnings controlled by `HandlerUnfinishedPolicy`