### PR TITLE
fix: Fix flakes in Worker Tuner and Workflow Update tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ env:
             || startsWith(github.ref, 'refs/heads/releases'))
         && github.event_name != 'pull_request'
     }}
-  TESTS_CLI_VERSION: 'v0.12.0'
+  # Use these variables to force specific version of CLI/Time Skipping Server for SDK tests
+  # TESTS_CLI_VERSION: 'v0.13.2'
+  # TESTS_TIME_SKIPPING_SERVER_VERSION: 'v1.24.1'
 
 jobs:
   # Compile native bridge code for each target platform.
@@ -281,7 +283,7 @@ jobs:
         if: matrix.server == 'cli'
         shell: bash
         run: |
-          temporal server start-dev --headless &
+          temporal server start-dev --headless &> /tmp/devserver.log &
 
       - name: Run Tests
         run: npm test
@@ -289,12 +291,19 @@ jobs:
           RUN_INTEGRATION_TESTS: true
           REUSE_V8_CONTEXT: ${{ matrix.reuse-v8-context }}
 
-      - name: Upload logs
+      - name: Upload NPM logs
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: failure() || cancelled()
         with:
           name: integration-tests-${{ matrix.platform }}-node${{ matrix.node }}-${{ matrix.server }}-${{ matrix.reuse-v8-context && 'reuse' || 'noreuse' }}-logs
           path: ${{ startsWith(matrix.platform, 'windows') && 'C:\\npm\\_logs\\' || '~/.npm/_logs/' }}
+
+      - name: Upload Dev Server logs
+        uses: actions/upload-artifact@v4
+        if: failure() || cancelled()
+        with:
+          name: integration-tests-${{ matrix.platform }}-node${{ matrix.node }}-${{ matrix.server }}-${{ matrix.reuse-v8-context && 'reuse' || 'noreuse' }}-devserver-logs
+          path: /tmp/devserver.log
 
   # Tests that npm init @temporalio results in a working worker and client
   test-npm-init:

--- a/packages/test/src/test-worker-lifecycle.ts
+++ b/packages/test/src/test-worker-lifecycle.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-duplicate-imports */
-// ^ needed for lint passing in CI
 /**
  * Test the various states of a Worker.
  * Most tests use a mocked core, some tests run serially because they emit signals to the process
@@ -16,7 +14,7 @@ if (RUN_INTEGRATION_TESTS) {
   test.serial('Worker shuts down gracefully', async (t) => {
     const worker = await Worker.create({
       ...defaultOptions,
-      taskQueue: 'shutdown-test',
+      taskQueue: t.title.replace(/ /g, '_'),
     });
     t.is(worker.getState(), 'INITIALIZED');
     const p = worker.run();
@@ -33,7 +31,7 @@ if (RUN_INTEGRATION_TESTS) {
   test.serial('Worker shuts down gracefully if interrupted before running', async (t) => {
     const worker = await Worker.create({
       ...defaultOptions,
-      taskQueue: 'shutdown-test',
+      taskQueue: t.title.replace(/ /g, '_'),
     });
     t.is(worker.getState(), 'INITIALIZED');
     process.emit('SIGINT', 'SIGINT');
@@ -47,7 +45,7 @@ if (RUN_INTEGRATION_TESTS) {
     await t.throwsAsync(
       Worker.create({
         ...defaultOptions,
-        taskQueue: 'shutdown-test',
+        taskQueue: t.title.replace(/ /g, '_'),
         namespace: 'oogabooga',
       }),
       {
@@ -61,7 +59,7 @@ if (RUN_INTEGRATION_TESTS) {
 test.serial('Mocked run shuts down gracefully', async (t) => {
   try {
     const worker = isolateFreeWorker({
-      taskQueue: 'shutdown-test',
+      taskQueue: t.title.replace(/ /g, '_'),
     });
     t.is(worker.getState(), 'INITIALIZED');
     const p = worker.run();
@@ -78,7 +76,7 @@ test.serial('Mocked run shuts down gracefully', async (t) => {
 test.serial('Mocked run shuts down gracefully if interrupted before running', async (t) => {
   try {
     const worker = isolateFreeWorker({
-      taskQueue: 'shutdown-test',
+      taskQueue: t.title.replace(/ /g, '_'),
     });
     // worker.native.initiateShutdown = () => new Promise(() => undefined);
     t.is(worker.getState(), 'INITIALIZED');
@@ -95,7 +93,7 @@ test.serial('Mocked run shuts down gracefully if interrupted before running', as
 test.serial('Mocked run throws if not shut down gracefully', async (t) => {
   const worker = isolateFreeWorker({
     shutdownForceTime: '5ms',
-    taskQueue: 'shutdown-test',
+    taskQueue: t.title.replace(/ /g, '_'),
   });
   t.is(worker.getState(), 'INITIALIZED');
   const p = worker.run();
@@ -113,7 +111,7 @@ test.serial('Mocked run throws if not shut down gracefully', async (t) => {
 test.serial('Mocked throws combined error in runUntil', async (t) => {
   const worker = isolateFreeWorker({
     shutdownForceTime: '5ms',
-    taskQueue: 'shutdown-test',
+    taskQueue: t.title.replace(/ /g, '_'),
   });
   worker.native.initiateShutdown = () => new Promise(() => undefined);
   const err = await t.throwsAsync(

--- a/packages/test/src/test-worker-tuner.ts
+++ b/packages/test/src/test-worker-tuner.ts
@@ -1,154 +1,141 @@
-import test from 'ava';
-import { v4 as uuid4 } from 'uuid';
-import { Client } from '@temporalio/client';
 import { ResourceBasedTunerOptions } from '@temporalio/core-bridge';
-import { defaultOptions } from './mock-native-worker';
-import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
-import { successString } from './workflows';
+import { helpers, makeTestFunction } from './helpers-integration';
 
-if (RUN_INTEGRATION_TESTS) {
-  test('Worker can run with resource based tuner', async (t) => {
-    const taskQueue = 'test-resource-based';
-    const resourceBasedTunerOptions: ResourceBasedTunerOptions = {
-      targetCpuUsage: 0.6,
-      targetMemoryUsage: 0.6,
-    };
-    const worker = await Worker.create({
-      ...defaultOptions,
-      taskQueue,
-      tuner: {
-        tunerOptions: resourceBasedTunerOptions,
-        activityTaskSlotOptions: {
-          minimumSlots: 2,
-          maximumSlots: 10,
-          rampThrottle: 20,
-        },
-      },
-    });
-    const client = new Client();
-    const result = await worker.runUntil(
-      client.workflow.execute(successString, {
-        workflowId: uuid4(),
-        taskQueue,
-      })
-    );
-    t.is(result, 'success');
-  });
+const test = makeTestFunction({ workflowsPath: __filename });
 
-  test('Worker can run with mixed slot suppliers in tuner', async (t) => {
-    const taskQueue = 'test-resource-based-mixed-slots';
-    const resourceBasedTunerOptions: ResourceBasedTunerOptions = {
-      targetCpuUsage: 0.5,
-      targetMemoryUsage: 0.5,
-    };
-    const worker = await Worker.create({
-      ...defaultOptions,
-      taskQueue,
-      tuner: {
-        activityTaskSlotSupplier: {
-          type: 'resource-based',
-          minimumSlots: 2,
-          maximumSlots: 10,
-          rampThrottle: 20,
-          tunerOptions: resourceBasedTunerOptions,
-        },
-        workflowTaskSlotSupplier: {
-          type: 'fixed-size',
-          numSlots: 10,
-        },
-        localActivityTaskSlotSupplier: {
-          type: 'fixed-size',
-          numSlots: 10,
-        },
-      },
-    });
-    const client = new Client();
-    const result = await worker.runUntil(
-      client.workflow.execute(successString, {
-        workflowId: uuid4(),
-        taskQueue,
-      })
-    );
-    t.is(result, 'success');
-  });
-
-  test('Can assume defaults for resource based options', async (t) => {
-    const taskQueue = 'test-resource-based';
-    const resourceBasedTunerOptions: ResourceBasedTunerOptions = {
-      targetCpuUsage: 0.6,
-      targetMemoryUsage: 0.6,
-    };
-    // With explicit tuner type
-    await Worker.create({
-      ...defaultOptions,
-      taskQueue,
-      tuner: {
-        tunerOptions: resourceBasedTunerOptions,
-        activityTaskSlotOptions: {
-          minimumSlots: 1,
-        },
-        localActivityTaskSlotOptions: {
-          maximumSlots: 10,
-        },
-        workflowTaskSlotOptions: {
-          rampThrottle: 20,
-        },
-      },
-    });
-    // With mixed slot suppliers
-    await Worker.create({
-      ...defaultOptions,
-      taskQueue,
-      tuner: {
-        activityTaskSlotSupplier: {
-          type: 'resource-based',
-          tunerOptions: resourceBasedTunerOptions,
-          minimumSlots: 3,
-        },
-        workflowTaskSlotSupplier: {
-          type: 'fixed-size',
-          numSlots: 40,
-        },
-        localActivityTaskSlotSupplier: {
-          type: 'resource-based',
-          tunerOptions: resourceBasedTunerOptions,
-          maximumSlots: 50,
-        },
-      },
-    });
-    t.pass();
-  });
-
-  test('Cannot construct worker tuner with multiple different tuner options', async (t) => {
-    const taskQueue = 'test-resource-based-mixed-slots';
-    const tunerOptions1: ResourceBasedTunerOptions = {
-      targetCpuUsage: 0.5,
-      targetMemoryUsage: 0.5,
-    };
-    const tunerOptions2: ResourceBasedTunerOptions = {
-      targetCpuUsage: 0.9,
-      targetMemoryUsage: 0.9,
-    };
-    const error = await t.throwsAsync(() =>
-      Worker.create({
-        ...defaultOptions,
-        taskQueue,
-        tuner: {
-          activityTaskSlotSupplier: {
-            type: 'resource-based',
-            tunerOptions: tunerOptions1,
-          },
-          workflowTaskSlotSupplier: {
-            type: 'resource-based',
-            tunerOptions: tunerOptions2,
-          },
-          localActivityTaskSlotSupplier: {
-            type: 'fixed-size',
-            numSlots: 10,
-          },
-        },
-      })
-    );
-    t.is(error?.message, 'Cannot construct worker tuner with multiple different tuner options');
-  });
+export async function successString(): Promise<string> {
+  return 'success';
 }
+
+test('Worker can run with resource based tuner', async (t) => {
+  const { createWorker, executeWorkflow } = helpers(t);
+  const resourceBasedTunerOptions: ResourceBasedTunerOptions = {
+    targetCpuUsage: 0.6,
+    targetMemoryUsage: 0.6,
+  };
+  const worker = await createWorker({
+    tuner: {
+      tunerOptions: resourceBasedTunerOptions,
+      activityTaskSlotOptions: {
+        minimumSlots: 2,
+        maximumSlots: 10,
+        rampThrottle: 20,
+      },
+    },
+    // FIXME(JWH): Resource Based Tuner does not guarantee that at least one permit would be
+    // allocated to a non-sticky pollers, which means the worker may not be able to poll for a
+    // WFT from the normal TQ before this test times out. For now, let's completely disable usage
+    // of sticky TQ. Rmeove this once https://github.com/temporalio/sdk-core/issues/775 gets fixed.
+    maxCachedWorkflows: 0,
+  });
+  const result = await worker.runUntil(executeWorkflow(successString));
+  t.is(result, 'success');
+});
+
+test('Worker can run with mixed slot suppliers in tuner', async (t) => {
+  const { createWorker, executeWorkflow } = helpers(t);
+  const resourceBasedTunerOptions: ResourceBasedTunerOptions = {
+    targetCpuUsage: 0.5,
+    targetMemoryUsage: 0.5,
+  };
+  const worker = await createWorker({
+    tuner: {
+      activityTaskSlotSupplier: {
+        type: 'resource-based',
+        minimumSlots: 2,
+        maximumSlots: 10,
+        rampThrottle: 20,
+        tunerOptions: resourceBasedTunerOptions,
+      },
+      workflowTaskSlotSupplier: {
+        type: 'fixed-size',
+        numSlots: 10,
+      },
+      localActivityTaskSlotSupplier: {
+        type: 'fixed-size',
+        numSlots: 10,
+      },
+    },
+  });
+  const result = await worker.runUntil(executeWorkflow(successString));
+  t.is(result, 'success');
+});
+
+test('Can assume defaults for resource based options', async (t) => {
+  const { createWorker } = helpers(t);
+  const resourceBasedTunerOptions: ResourceBasedTunerOptions = {
+    targetCpuUsage: 0.6,
+    targetMemoryUsage: 0.6,
+  };
+
+  // With explicit tuner type
+  const worker1 = await createWorker({
+    tuner: {
+      tunerOptions: resourceBasedTunerOptions,
+      activityTaskSlotOptions: {
+        minimumSlots: 1,
+      },
+      localActivityTaskSlotOptions: {
+        maximumSlots: 10,
+      },
+      workflowTaskSlotOptions: {
+        rampThrottle: 20,
+      },
+    },
+  });
+  await worker1.runUntil(Promise.resolve());
+
+  // With mixed slot suppliers
+  const worker2 = await createWorker({
+    tuner: {
+      activityTaskSlotSupplier: {
+        type: 'resource-based',
+        tunerOptions: resourceBasedTunerOptions,
+        minimumSlots: 3,
+      },
+      workflowTaskSlotSupplier: {
+        type: 'fixed-size',
+        numSlots: 40,
+      },
+      localActivityTaskSlotSupplier: {
+        type: 'resource-based',
+        tunerOptions: resourceBasedTunerOptions,
+        maximumSlots: 50,
+      },
+    },
+  });
+  await worker2.runUntil(Promise.resolve());
+
+  t.pass();
+});
+
+test('Cannot construct worker tuner with multiple different tuner options', async (t) => {
+  const { createWorker } = helpers(t);
+  const tunerOptions1: ResourceBasedTunerOptions = {
+    targetCpuUsage: 0.5,
+    targetMemoryUsage: 0.5,
+  };
+  const tunerOptions2: ResourceBasedTunerOptions = {
+    targetCpuUsage: 0.9,
+    targetMemoryUsage: 0.9,
+  };
+  const error = await t.throwsAsync(() =>
+    createWorker({
+      tuner: {
+        activityTaskSlotSupplier: {
+          type: 'resource-based',
+          tunerOptions: tunerOptions1,
+        },
+        workflowTaskSlotSupplier: {
+          type: 'resource-based',
+          tunerOptions: tunerOptions2,
+        },
+        localActivityTaskSlotSupplier: {
+          type: 'fixed-size',
+          numSlots: 10,
+        },
+      },
+    })
+  );
+  t.is(error?.message, 'Cannot construct worker tuner with multiple different tuner options');
+});


### PR DESCRIPTION
## What was changed and Why?

- Remove CI's pinning on CLI 0.12.0.
  - This was causing multiple CI flakes due to bugs that had already been fixed in server.
- Capture Dev Server logs.
  - Hopefully, this may help understand some other flakes in the future.
- In SDK's internal tests, if using the `TEST_LOG_LEVEL` env variable, we now also set Core's logging to that same level.
- A few other very minor refactors and improvements here and there.
- In one of the Worker Tuner tests, disable the workflow cache, as the Resource Based Tuner seems not to prioritize allocation of permits to at least one non-sticky poller, which was causing flakes.