### PR TITLE
fix(ci): Enable file-based persistence on dev server for stress tests

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Run Temporal CLI
         shell: bash
         run: |
-          temporal server start-dev --headless &
+          temporal server start-dev --headless &> /tmp/devserver.log &
 
       - name: Run tests
         run: |
@@ -139,6 +139,13 @@ jobs:
         with:
           name: worker-mem-logs-${{ inputs.reuse-v8-context && 'reuse-v8' || 'no-reuse-v8' }}
           path: ${{ env.TEMPORAL_TESTING_MEM_LOG_DIR }}
+
+      - name: Upload Dev Server logs
+        uses: actions/upload-artifact@v4
+        if: failure() || cancelled()
+        with:
+          name: integration-tests-${{ inputs.reuse-v8-context && 'reuse' || 'noreuse' }}-devserver-logs
+          path: /tmp/devserver.log
 
       # TODO: set up alerting
       # TODO: record test durations and other metrics like memory usage / cache utilization / CPU

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Run Temporal CLI
         shell: bash
         run: |
-          temporal server start-dev --headless &> /tmp/devserver.log &
+          temporal server start-dev --headless --db-filename /tmp/temporal.sqlite3 &> /tmp/devserver.log &
 
       - name: Run tests
         run: |


### PR DESCRIPTION
## What changed

- Enabled file-based persistence on dev server for stress tests. This should hopefully resolve the consistent failure of nightly stress tests we have been observing since the workflow was modified to use CLI rather a Docker-based server (#1479)
- Also, persist server-side logs to a job artifact in case of failure to facilitate diagnosing eventual issues.