### PR TITLE
Silence webpack < WARN during integration tests

### DIFF
--- a/packages/test/src/helpers-integration.ts
+++ b/packages/test/src/helpers-integration.ts
@@ -57,6 +57,7 @@ export function makeTestFunction(opts: {
       ...bundlerOptions,
       workflowInterceptorModules: [...defaultWorkflowInterceptorModules, ...(opts.workflowInterceptorModules ?? [])],
       workflowsPath: opts.workflowsPath,
+      logger: new DefaultLogger('WARN'),
     });
     // Ignore invalid log levels
     Runtime.install({


### PR DESCRIPTION
The webpack bundler INFO-level logging obscures test output and isn't needed:

```
2024-08-02T18:02:09.564Z [INFO] asset workflow-bundle-cf9fb26ab6b116d88d4e.js 2.67 MiB [emitted] [immutable] (name: main)
runtime modules 221 bytes 1 module
modules by path ../ 916 KiB 88 modules
modules by path ./lib/ 38.3 KiB
  modules by path ./lib/*.js 35.8 KiB
    ./lib/test-integration-workflows-with-recorded-logs.js 17.9 KiB [built] [code generated]
    ./lib/helpers-integration.js 5.34 KiB [built] [code generated]
    ./lib/helpers.js 12.5 KiB [built] [code generated]
  ./lib/test-integration-workflows-with-recorded-logs-autogenerated-entrypoint.cjs 622 bytes [built] [code generated]
  ./lib/activities/interceptors.js 1.9 KiB [built] [code generated]
modules by path @temporalio/ 60 bytes
  @temporalio/client (ignored) 15 bytes [built] [code generated]
  @temporalio/testing (ignored) 15 bytes [built] [code generated]
  @temporalio/worker (ignored) 15 bytes [built] [code generated]
  @temporalio/activity (ignored) 15 bytes [built] [code generated]
+ 10 modules
webpack 5.89.0 compiled successfully in 360 ms
2024-08-02T18:02:09.569Z [INFO] Workflow bundle created { size: '2.67MB' }
```