### PR TITLE
chore: bump GHA runner for stress tests

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -54,7 +54,7 @@ env:
 
 jobs:
   stress-test:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
       - name: Print build info
         run: 'echo test-type: ${{ inputs.test-type }}, test-timeout-minutes: ${{ inputs.test-timeout-minutes }}, reuse-v8-context: $REUSE_V8_CONTEXT'


### PR DESCRIPTION
## What was changed

- Changed GHA runner for stress tests from `buildjet-4vcpu-ubuntu-2204` to `buildjet-8vcpu-ubuntu-2204`

## Why?

- That test job has been failing recently with timeouts, and we suspect this might be due to runner's performance issues. If this is indeed the case, we will reevaluate at a later point.