### PR TITLE
fix(doc): Docs were no longer being built and deployed in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,13 @@ env:
   # Note: There will be an extra LF character at the end of this variable's value; when using it, just do
   # `if: env.IS_MAIN_OR_RELEASE`; string comparisons (e.g. `env.IS_MAIN_OR_RELEASE == 'true'`) will not work
   IS_MAIN_OR_RELEASE: |
-    '${{
+    ${{
       github.repository == 'temporalio/sdk-typescript'
         && (github.ref == 'refs/heads/main'
             || startsWith(github.ref, 'refs/tags/')
             || startsWith(github.ref, 'refs/heads/releases'))
         && github.event_name != 'pull_request'
-    }}'
-
+    }}
   # Use these variables to force specific version of CLI/Time Skipping Server for SDK tests
   # TESTS_CLI_VERSION: 'v0.13.2'
   # TESTS_TIME_SKIPPING_SERVER_VERSION: 'v1.24.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,9 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IS_OFFICIAL_REPO: ${{ github.repository == 'temporalio/sdk-typescript' }}
   # Is it the official main branch, or an official release branches?
-  # Note: There will be an extra LF character at the end of this variable's value; when using it, just do
-  # `if: env.IS_MAIN_OR_RELEASE`; string comparisons (e.g. `env.IS_MAIN_OR_RELEASE == 'true'`) will not work
-  IS_MAIN_OR_RELEASE: |
-    ${{
-      github.repository == 'temporalio/sdk-typescript'
-        && (github.ref == 'refs/heads/main'
-            || startsWith(github.ref, 'refs/tags/')
-            || startsWith(github.ref, 'refs/heads/releases'))
-        && github.event_name != 'pull_request'
-    }}
+  # AFAIK there's no way to break that line w/o introducing a trailing LF that breaks usage. Sorry.
+  IS_MAIN_OR_RELEASE: ${{ github.repository == 'temporalio/sdk-typescript' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/releases')) && github.event_name != 'pull_request' }}
+
   # Use these variables to force specific version of CLI/Time Skipping Server for SDK tests
   # TESTS_CLI_VERSION: 'v0.13.2'
   # TESTS_TIME_SKIPPING_SERVER_VERSION: 'v1.24.1'
@@ -107,7 +100,7 @@ jobs:
           prefix-key: corebridge-buildcache
           shared-key: ${{ matrix.platform }}
           env-vars: ''
-          save-if: env.IS_MAIN_OR_RELEASE
+          save-if: ${{ env.IS_MAIN_OR_RELEASE == 'true' }}
 
       - name: Compile rust code
         if: steps.cached-artifact.outputs.cache-hit != 'true'
@@ -205,7 +198,7 @@ jobs:
       - name: Save NPM cache
         uses: actions/cache/save@v4
         # Only saves NPM cache from the main branch, to reduce pressure on the cache (limited to 10GB).
-        if: env.IS_MAIN_OR_RELEASE
+        if: ${{ env.IS_MAIN_OR_RELEASE == 'true' }}
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: npm-main-${{ matrix.platform }}-${{ hashFiles('./package-lock.json') }}
@@ -573,7 +566,7 @@ jobs:
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
 
       - name: Deploy prod docs # TODO: only deploy prod docs when we publish a new version
-        if: env.IS_MAIN_OR_RELEASE
+        if: ${{ env.IS_MAIN_OR_RELEASE == 'true' }}
         run: npx vercel deploy packages/docs/build -t ${{ secrets.VERCEL_TOKEN }} --name typescript --scope temporal --prod --yes
 
       # FIXME: This is not working properly, and should probably be done only from the main branch anyway

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,16 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IS_OFFICIAL_REPO: ${{ github.repository == 'temporalio/sdk-typescript' }}
   # Is it the official main branch, or an official release branches?
+  # Note: There will be an extra LF character at the end of this variable's value; when using it, just do
+  # `if: env.IS_MAIN_OR_RELEASE`; string comparisons (e.g. `env.IS_MAIN_OR_RELEASE == 'true'`) will not work
   IS_MAIN_OR_RELEASE: |
-    "${{
+    '${{
       github.repository == 'temporalio/sdk-typescript'
         && (github.ref == 'refs/heads/main'
             || startsWith(github.ref, 'refs/tags/')
             || startsWith(github.ref, 'refs/heads/releases'))
         && github.event_name != 'pull_request'
-    }}"
+    }}'
 
   # Use these variables to force specific version of CLI/Time Skipping Server for SDK tests
   # TESTS_CLI_VERSION: 'v0.13.2'
@@ -106,7 +108,7 @@ jobs:
           prefix-key: corebridge-buildcache
           shared-key: ${{ matrix.platform }}
           env-vars: ''
-          save-if: env.IS_MAIN_OR_RELEASE == 'true'
+          save-if: env.IS_MAIN_OR_RELEASE
 
       - name: Compile rust code
         if: steps.cached-artifact.outputs.cache-hit != 'true'
@@ -204,7 +206,7 @@ jobs:
       - name: Save NPM cache
         uses: actions/cache/save@v4
         # Only saves NPM cache from the main branch, to reduce pressure on the cache (limited to 10GB).
-        if: env.IS_MAIN_OR_RELEASE == 'true'
+        if: env.IS_MAIN_OR_RELEASE
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: npm-main-${{ matrix.platform }}-${{ hashFiles('./package-lock.json') }}
@@ -572,7 +574,7 @@ jobs:
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
 
       - name: Deploy prod docs # TODO: only deploy prod docs when we publish a new version
-        if: env.IS_MAIN_OR_RELEASE == 'true'
+        if: env.IS_MAIN_OR_RELEASE
         run: npx vercel deploy packages/docs/build -t ${{ secrets.VERCEL_TOKEN }} --name typescript --scope temporal --prod --yes
 
       # FIXME: This is not working properly, and should probably be done only from the main branch anyway

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,14 @@ env:
   IS_OFFICIAL_REPO: ${{ github.repository == 'temporalio/sdk-typescript' }}
   # Is it the official main branch, or an official release branches?
   IS_MAIN_OR_RELEASE: |
-    ${{
+    "${{
       github.repository == 'temporalio/sdk-typescript'
         && (github.ref == 'refs/heads/main'
             || startsWith(github.ref, 'refs/tags/')
             || startsWith(github.ref, 'refs/heads/releases'))
         && github.event_name != 'pull_request'
-    }}
+    }}"
+
   # Use these variables to force specific version of CLI/Time Skipping Server for SDK tests
   # TESTS_CLI_VERSION: 'v0.13.2'
   # TESTS_TIME_SKIPPING_SERVER_VERSION: 'v1.24.1'

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: inputs.ref
+          ref: ${{ inputs.ref }}
 
       - name: Install Node
         uses: actions/setup-node@v4

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -43,7 +43,7 @@ env:
   TEMPORAL_TESTING_MEM_LOG_DIR: /tmp/worker-mem-logs
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   REUSE_V8_CONTEXT: ${{ inputs.reuse-v8-context }}
-  IS_MAIN_BRANCH: |
+  IS_MAIN_OR_RELEASE: |
     ${{
       github.repository == 'temporalio/sdk-typescript'
         && (github.ref == 'refs/heads/main'
@@ -62,6 +62,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          ref: inputs.ref
 
       - name: Install Node
         uses: actions/setup-node@v4
@@ -99,7 +100,7 @@ jobs:
           prefix-key: corebridge-buildcache
           shared-key: linux-intel
           env-vars: ''
-          save-if: env.IS_MAIN_BRANCH == 'true'
+          save-if: env.IS_MAIN_OR_RELEASE
 
       - name: Download dependencies
         # Make up to 3 attempts to install NPM dependencies, to work around transient NPM errors

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -43,14 +43,9 @@ env:
   TEMPORAL_TESTING_MEM_LOG_DIR: /tmp/worker-mem-logs
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   REUSE_V8_CONTEXT: ${{ inputs.reuse-v8-context }}
-  IS_MAIN_OR_RELEASE: |
-    ${{
-      github.repository == 'temporalio/sdk-typescript'
-        && (github.ref == 'refs/heads/main'
-            || startsWith(github.ref, 'refs/tags/')
-            || startsWith(github.ref, 'refs/heads/releases'))
-        && github.event_name != 'pull_request'
-    }}
+  # Is it the official main branch, or an official release branches?
+  # AFAIK there's no way to break that line w/o introducing a trailing LF that breaks usage. Sorry.
+  IS_MAIN_OR_RELEASE: ${{ github.repository == 'temporalio/sdk-typescript' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/releases')) && github.event_name != 'pull_request' }}
 
 jobs:
   stress-test:
@@ -100,7 +95,7 @@ jobs:
           prefix-key: corebridge-buildcache
           shared-key: linux-intel
           env-vars: ''
-          save-if: env.IS_MAIN_OR_RELEASE
+          save-if: ${{ env.IS_MAIN_OR_RELEASE == 'true' }}
 
       - name: Download dependencies
         # Make up to 3 attempts to install NPM dependencies, to work around transient NPM errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -4777,9 +4777,9 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.1.tgz",
-      "integrity": "sha512-+LV37nQcd1EpFalkXksWNBiA17NZ5m5/WspmHGmZmdx1qBOg/VNq/c4eRJiA9VQQHBOs+N0ZhhdU10h2TyNK7Q==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -22545,9 +22545,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.1.tgz",
-      "integrity": "sha512-+LV37nQcd1EpFalkXksWNBiA17NZ5m5/WspmHGmZmdx1qBOg/VNq/c4eRJiA9VQQHBOs+N0ZhhdU10h2TyNK7Q==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dev": true,
       "requires": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint.prune": "ts-prune --error -p tsconfig.prune.json --ignore \"used in module\" --skip \".d.ts\"",
     "format": "prettier --write . && lerna run --no-bail --stream format",
     "clean": "node ./scripts/clean.mjs",
-    "docs": "lerna run --stream maybe-install-deps-and-build-docs"
+    "docs": "cd packages/docs && npm run maybe-install-deps-and-build-docs"
   },
   "dependencies": {
     "@temporalio/client": "file:packages/client",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@temporalio/docs",
-  "version": "1.9.3",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## What was changed

- Don't use `lerna` to run the `maybe-install-deps-and-build-docs` task as `packages/docs` is no longer considered a workspace package.
- There was apparently a LF character at the end of the `IS_MAIN_OR_RELEASE` env variable, preventing the `env.IS_MAIN_OR_RELEASE == 'true'` condition to evaluates to true, which in turn prevented deployment of docs to vercel.
