### PR TITLE
fix(client): Reexport WorkflowExecutionAlreadyStartedError from `@temporalio/client`

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -22,6 +22,7 @@ export {
   TemporalFailure,
   TerminatedFailure,
   TimeoutFailure,
+  WorkflowExecutionAlreadyStartedError,
 } from '@temporalio/common';
 export { TLSConfig } from '@temporalio/common/lib/internal-non-workflow';
 export * from '@temporalio/common/lib/errors';


### PR DESCRIPTION
## What was changed

- `WorkflowExecutionAlreadyStartedError` was previously in `@temporalio/client`, but got recently moved to `@temporalio/common`. Add a reexport to avoid build issues.