### PR TITLE
feat: mark run activity span as consumer span

### DIFF
--- a/packages/interceptors-opentelemetry/src/instrumentation.ts
+++ b/packages/interceptors-opentelemetry/src/instrumentation.ts
@@ -58,6 +58,7 @@ async function wrapWithSpan<T>(
 export interface InstrumentOptions<T> {
   tracer: otel.Tracer;
   spanName: string;
+  spanOptions?: otel.SpanOptions;
   fn: (span: otel.Span) => Promise<T>;
   context?: otel.Context;
   acceptableErrors?: (err: unknown) => boolean;
@@ -69,14 +70,23 @@ export interface InstrumentOptions<T> {
 export async function instrument<T>({
   tracer,
   spanName,
+  spanOptions = {},
   fn,
   context,
   acceptableErrors,
 }: InstrumentOptions<T>): Promise<T> {
   if (context) {
     return await otel.context.with(context, async () => {
-      return await tracer.startActiveSpan(spanName, async (span) => await wrapWithSpan(span, fn, acceptableErrors));
+      return await tracer.startActiveSpan(
+        spanName,
+        spanOptions,
+        async (span) => await wrapWithSpan(span, fn, acceptableErrors)
+      );
     });
   }
-  return await tracer.startActiveSpan(spanName, async (span) => await wrapWithSpan(span, fn, acceptableErrors));
+  return await tracer.startActiveSpan(
+    spanName,
+    spanOptions,
+    async (span) => await wrapWithSpan(span, fn, acceptableErrors)
+  );
 }

--- a/packages/interceptors-opentelemetry/src/worker/index.ts
+++ b/packages/interceptors-opentelemetry/src/worker/index.ts
@@ -29,7 +29,13 @@ export class OpenTelemetryActivityInboundInterceptor implements ActivityInboundC
   async execute(input: ActivityExecuteInput, next: Next<ActivityInboundCallsInterceptor, 'execute'>): Promise<unknown> {
     const context = await extractContextFromHeaders(input.headers);
     const spanName = `${SpanName.ACTIVITY_EXECUTE}${SPAN_DELIMITER}${this.ctx.info.activityType}`;
-    return await instrument({ tracer: this.tracer, spanName, fn: () => next(input), context });
+    return await instrument({
+      tracer: this.tracer,
+      spanName,
+      spanOptions: { attributes: { 'messaging.system': 'temporal' }, kind: otel.SpanKind.CONSUMER },
+      fn: () => next(input),
+      context,
+    });
   }
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
the arguments passed to `instrument` function in OpenTelemetryActivityInboundInterceptor's execute method has been expended which would be passed to the Open Telemetry `startActiveSpan` method.

## Why?
<!-- Tell your future self why have you made these changes -->
this marks the run activity spans as [consumer spans](https://opentelemetry.io/docs/concepts/signals/traces/#consumer) and adds a value to the [messaging system field](https://opentelemetry.io/docs/specs/semconv/attributes-registry/messaging/).
the information in itself is useful and it's needed in some cases for observability software such as Elastic Observability when [apm-agent-nodejs](https://github.com/elastic/apm-agent-nodejs) is used with [OpenTelemetry bridge](https://www.elastic.co/guide/en/apm/agent/nodejs/current/opentelemetry-bridge.html) where those fields are checked to properly [map the span](https://github.com/elastic/apm-agent-nodejs/blob/2031a263befadc16f00e3584f26932f03b4e7d92/lib/opentelemetry-bridge/OTelSpan.js#L212) to a [messaging transaction](https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-messaging.md).