### PR TITLE
chore: Update Core to a8150d5c (+job ordering update)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,10 @@ We welcome contributions from the community. To contribute, please start by open
 
 The current maintainers are:
 
-- [Roey `bergundy`](https://github.com/bergundy)
-- [James `mjameswh`](https://github.com/mjameswh)
+- [James Waktins-Harvey](https://github.com/mjameswh)
+- [Antonio Lain](https://github.com/antlai-temporal)
 
-If you'd like to join us, [email Roey](mailto:roey@temporal.io). We'd be happy to have help with any of these things:
+If you'd like to give a hand, pelase reach us on our [community Slack workspace](https://temporalio.slack.com/channels/typescript-sdk). We'd be happy to have help with any of these things:
 
 - Triaging issues
 - Reviewing PRs

--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -87,8 +87,8 @@ export function arrayFromPayloads(converter: PayloadConverter, payloads?: Payloa
 export function mapFromPayloads<K extends string>(
   converter: PayloadConverter,
   map?: Record<K, Payload> | null | undefined
-): Record<K, unknown> | undefined | null {
-  if (map == null) return map;
+): Record<K, unknown> | undefined {
+  if (map == null) return undefined;
   return Object.fromEntries(
     Object.entries(map).map(([k, payload]): [K, unknown] => {
       const value = converter.fromPayload(payload as Payload);

--- a/packages/common/src/internal-non-workflow/codec-helpers.ts
+++ b/packages/common/src/internal-non-workflow/codec-helpers.ts
@@ -122,7 +122,7 @@ export async function decodeOptionalMap(
 ): Promise<Record<string, DecodedPayload> | null | undefined> {
   if (payloads == null) return payloads;
   return Object.fromEntries(
-    await Promise.all(Object.entries(payloads).map(async ([k, v]) => [k, await decode(codecs, [v])]))
+    await Promise.all(Object.entries(payloads).map(async ([k, v]) => [k, (await decode(codecs, [v]))[0]]))
   );
 }
 

--- a/packages/core-bridge/Cargo.lock
+++ b/packages/core-bridge/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper 1.0.1",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
 ]
@@ -303,12 +303,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,25 +356,6 @@ name = "crossbeam-channel"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -531,15 +506,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "convert_case",
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version",
  "syn 2.0.72",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1017,7 +1000,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -1240,14 +1223,13 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
 dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
- "lazy_static",
  "mockall_derive",
  "predicates",
  "predicates-tree",
@@ -1255,9 +1237,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -1280,7 +1262,7 @@ dependencies = [
  "neon-build",
  "neon-macros",
  "neon-runtime",
- "semver 0.9.0",
+ "semver",
  "smallvec",
 ]
 
@@ -1871,26 +1853,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,15 +1993,6 @@ name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver 1.0.23",
-]
 
 [[package]]
 name = "rustfsm"
@@ -2190,12 +2143,6 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "semver-parser"
@@ -2396,16 +2343,14 @@ checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
 dependencies = [
- "cfg-if",
  "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
- "rayon",
  "windows",
 ]
 
@@ -2458,7 +2403,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
- "tower",
+ "tower 0.5.1",
  "tracing",
  "url",
  "uuid",
@@ -2742,7 +2687,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2782,16 +2727,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-layer"
-version = "0.3.2"
+name = "tower"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2799,7 +2758,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2918,6 +2876,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
 
 [[package]]
 name = "untrusted"
@@ -3094,9 +3058,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core",
  "windows-targets 0.52.6",
@@ -3104,9 +3068,43 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -115,7 +115,7 @@ if (RUN_INTEGRATION_TESTS) {
       workflowType: 'sinksWorkflow',
       lastFailure: undefined,
       lastResult: undefined,
-      memo: undefined,
+      memo: {},
       parent: undefined,
       searchAttributes: {},
       historyLength: 3,

--- a/packages/worker/src/workflow/vm-shared.ts
+++ b/packages/worker/src/workflow/vm-shared.ts
@@ -328,6 +328,11 @@ export abstract class BaseVMWorkflow implements Workflow {
     }));
     this.activator.addKnownFlags(activation.availableInternalFlags ?? []);
 
+    // Initialization of the workflow must happens before anything else. Yet, keep the init job in
+    // place in the list as we'll use it as a marker to know when to start the workflow function.
+    const initWorkflowJob = activation.jobs.find((job) => job.initializeWorkflow != null)?.initializeWorkflow;
+    if (initWorkflowJob) this.workflowModule.initialize(initWorkflowJob);
+
     const hasSignals = activation.jobs.some(({ signalWorkflow }) => signalWorkflow != null);
     const doSingleBatch = !hasSignals || this.activator.hasFlag(SdkFlags.ProcessWorkflowActivationJobsAsSingleBatch);
 
@@ -338,16 +343,14 @@ export abstract class BaseVMWorkflow implements Workflow {
     }
 
     if (doSingleBatch) {
-      // updateRandomSeed require the same special handling as patches (before anything else, and don't
+      // updateRandomSeed requires the same special handling as patches (before anything else, and don't
       // unblock conditions after each job). Unfortunately, prior to ProcessWorkflowActivationJobsAsSingleBatch,
       // they were handled as regular jobs, making it unsafe to properly handle that job above, with patches.
-      const [updateRandomSeed, rest] = partition(activation.jobs, ({ updateRandomSeed }) => updateRandomSeed != null);
+      const [updateRandomSeed, rest] = partition(nonPatches, ({ updateRandomSeed }) => updateRandomSeed != null);
       if (updateRandomSeed.length > 0)
         this.activator.updateRandomSeed(updateRandomSeed[updateRandomSeed.length - 1].updateRandomSeed!);
-
       this.workflowModule.activate(
-        coresdk.workflow_activation.WorkflowActivation.fromObject({ ...activation, jobs: rest }),
-        0
+        coresdk.workflow_activation.WorkflowActivation.fromObject({ ...activation, jobs: rest })
       );
       this.tryUnblockConditionsAndMicrotasks();
     } else {
@@ -396,7 +399,7 @@ export abstract class BaseVMWorkflow implements Workflow {
         isReplaying: true,
       },
     }));
-    this.workflowModule.activate(activation, 0);
+    this.workflowModule.activate(activation);
     return this.workflowModule.concludeActivation();
   }
 

--- a/packages/worker/src/workflow/vm-shared.ts
+++ b/packages/worker/src/workflow/vm-shared.ts
@@ -328,7 +328,7 @@ export abstract class BaseVMWorkflow implements Workflow {
     }));
     this.activator.addKnownFlags(activation.availableInternalFlags ?? []);
 
-    // Initialization of the workflow must happens before anything else. Yet, keep the init job in
+    // Initialization of the workflow must happen before anything else. Yet, keep the init job in
     // place in the list as we'll use it as a marker to know when to start the workflow function.
     const initWorkflowJob = activation.jobs.find((job) => job.initializeWorkflow != null)?.initializeWorkflow;
     if (initWorkflowJob) this.workflowModule.initialize(initWorkflowJob);

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -452,8 +452,6 @@ export interface WorkflowCreateOptions {
   info: WorkflowInfo;
   randomnessSeed: number[];
   now: number;
-  patches: string[];
-  sdkFlags: number[];
   showStackTraceSources: boolean;
 }
 

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -108,14 +108,24 @@ function fixPrototypes<X>(obj: X): X {
 }
 
 /**
+ * Initialize the workflow. Or to be exact, _complete_ initialization, as most part has been done in constructor).
+ */
+export function initialize(initializeWorkflowJob: coresdk.workflow_activation.IInitializeWorkflow): void {
+  getActivator().initializeWorkflow(initializeWorkflowJob);
+}
+
+/**
  * Run a chunk of activation jobs
  */
-export function activate(activation: coresdk.workflow_activation.IWorkflowActivation, batchIndex: number): void {
+export function activate(activation: coresdk.workflow_activation.IWorkflowActivation, batchIndex = 0): void {
   const activator = getActivator();
   const intercept = composeInterceptors(activator.interceptors.internals, 'activate', ({ activation }) => {
     // Cast from the interface to the class which has the `variant` attribute.
     // This is safe because we know that activation is a proto class.
     const jobs = activation.jobs as coresdk.workflow_activation.WorkflowActivationJob[];
+
+    // Initialization will have been handled already, but we might still need to start the workflow function
+    const startWorkflowJob = jobs[0].variant === 'initializeWorkflow' ? jobs.shift()?.initializeWorkflow : undefined;
 
     for (const job of jobs) {
       if (job.variant === undefined) throw new TypeError('Expected job.variant to be defined');
@@ -126,6 +136,25 @@ export function activate(activation: coresdk.workflow_activation.IWorkflowActiva
       activator[job.variant](variant as any /* TS can't infer this type */);
 
       if (job.variant !== 'queryWorkflow') tryUnblockConditions();
+    }
+
+    if (startWorkflowJob) {
+      const safeJobTypes: coresdk.workflow_activation.WorkflowActivationJob['variant'][] = [
+        'initializeWorkflow',
+        'signalWorkflow',
+        'doUpdate',
+        'cancelWorkflow',
+        'updateRandomSeed',
+      ];
+      if (jobs.some((job) => !safeJobTypes.includes(job.variant))) {
+        throw new TypeError(
+          'Received both initializeWorkflow and non-signal/non-update jobs in the same activation: ' +
+            JSON.stringify(jobs.map((job) => job.variant))
+        );
+      }
+
+      activator.startWorkflow(startWorkflowJob);
+      tryUnblockConditions();
     }
   });
   intercept({ activation, batchIndex });


### PR DESCRIPTION
## What was changed

- Update Core to a8150d5c.
- Updated Workflow Activation handling to expect `InitializeWorkflow` jobs, instead of `StartWorkflow` (fix #1511).
- Delay payload conversion of workflow's memo/SA/lastfailure/etc until we're inside the sandbox, as there's no guarantee that converted payloads are safe to transfer through the V8 message port to the worker thread.

