### PR TITLE
fix(worker): clarify activity cancellation after shutdownGraceTime

### DIFF
--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -746,7 +746,8 @@ export class Worker {
   }
 
   /**
-   * Start shutting down the Worker. The Worker stops polling for new tasks and sends
+   * Start shutting down the Worker. The Worker stops polling for new tasks and sends 
+   * shutdown signals. Any ongoing activities are canceled after the shutdownGraceTime.
    * {@link https://typescript.temporal.io/api/namespaces/activity#cancellation | cancellation} (via a
    * {@link CancelledFailure} with `message` set to `'WORKER_SHUTDOWN'`) to running Activities. Note: if the Activity
    * accepts cancellation (i.e. re-throws or allows the `CancelledFailure` to be thrown out of the Activity function),


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Updated the shutdown process description to mention that ongoing activities will be canceled after the shutdownGraceTime has passed. This ensures the behavior is clear in the worker shutdown flow.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> [#1309](https://github.com/temporalio/sdk-typescript/issues/1309)

3. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
