### PR TITLE
Change error log of `Tried to cancel a non-existing activity` to debug

### DIFF
--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -939,7 +939,7 @@ export class Worker {
                 case 'cancel': {
                   output = { type: 'ignore' };
                   if (activity === undefined) {
-                    this.logger.error('Tried to cancel a non-existing activity', {
+                    this.logger.debug('Tried to cancel a non-existing activity', {
                       taskToken: base64TaskToken,
                     });
                     break;


### PR DESCRIPTION
## What was changed

This changes the severity of the logging of `Tried to cancel a non-existing activity` from error to debug.

## Why?

This is not an error condition, so it shouldn't be logged like one.  We have an alert on error logs and this one comes up every now and again and is a distraction.

See Slack discussion: https://temporalio.slack.com/archives/C01DKSMU94L/p1726925750497729?thread_ts=1678096035.562979&cid=C01DKSMU94L

## Checklist

2. How was this tested:

It wasn't.  I don't know how to reproduce the conditions that lead to this log.

3. Any docs updates needed?

I don't think so.