### PR TITLE
Fix argument validation in WorkflowHandle for issue #1327

### DIFF
--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -308,6 +308,9 @@ function ensureArgs<W extends Workflow, T extends WorkflowStartOptions<W>>(
   opts: T
 ): Omit<T, 'args'> & { args: unknown[] } {
   const { args, ...rest } = opts;
+  if(args && !Array.isArray(args)) {
+    throw new Error("Invalid argument type: 'args' must be an array. Received " + typeof args + " instead.");
+  }
   return { args: args ?? [], ...rest };
 }
 


### PR DESCRIPTION
#1327 

**What was changed**
This PR fixes the argument validation for WorkflowHandle. It ensures that the args parameter is always validated as an array and throws an appropriate error if it is not.

**Why?**
To address issue #1327, improving error handling and clarity for users by ensuring the args passed to workflows are always arrays.
