### PR TITLE
Normalize construction of user facing enums

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,10 +1,9 @@
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-non-workflow';
-import { temporal } from '@temporalio/proto';
 import { AsyncCompletionClient } from './async-completion-client';
 import { BaseClient, BaseClientOptions, defaultBaseClientOptions, LoadedWithDefaults } from './base-client';
 import { ClientInterceptors } from './interceptors';
 import { ScheduleClient } from './schedule-client';
-import { WorkflowService } from './types';
+import { QueryRejectCondition, WorkflowService } from './types';
 import { WorkflowClient } from './workflow-client';
 import { TaskQueueClient } from './task-queue-client';
 
@@ -20,9 +19,9 @@ export interface ClientOptions extends BaseClientOptions {
     /**
      * Should a query be rejected by closed and failed workflows
      *
-     * @default QUERY_REJECT_CONDITION_UNSPECIFIED which means that closed and failed workflows are still queryable
+     * @default `undefined`, which means that closed and failed workflows are still queryable
      */
-    queryRejectCondition?: temporal.api.enums.v1.QueryRejectCondition;
+    queryRejectCondition?: QueryRejectCondition;
   };
 }
 
@@ -63,6 +62,7 @@ export class Client extends BaseClient {
       connection: this.connection,
       dataConverter: this.dataConverter,
       interceptors: interceptors?.workflow,
+      queryRejectCondition: workflow?.queryRejectCondition,
     });
 
     this.activity = new AsyncCompletionClient({

--- a/packages/client/src/schedule-helpers.ts
+++ b/packages/client/src/schedule-helpers.ts
@@ -32,7 +32,6 @@ import {
   CompiledScheduleUpdateOptions,
   Range,
   ScheduleOptions,
-  ScheduleOverlapPolicy,
   ScheduleUpdateOptions,
   DayOfWeek,
   DAYS_OF_WEEK,
@@ -47,6 +46,7 @@ import {
   ScheduleExecutionActionResult,
   ScheduleExecutionResult,
   ScheduleExecutionStartWorkflowActionResult,
+  encodeScheduleOverlapPolicy,
 } from './schedule-types';
 
 const [encodeSecond, decodeSecond] = makeCalendarSpecFieldCoders(
@@ -192,21 +192,6 @@ export function decodeOptionalStructuredCalendarSpecs(
   );
 }
 
-export function encodeOverlapPolicy(input: ScheduleOverlapPolicy): temporal.api.enums.v1.ScheduleOverlapPolicy {
-  return temporal.api.enums.v1.ScheduleOverlapPolicy[
-    `SCHEDULE_OVERLAP_POLICY_${ScheduleOverlapPolicy[input] as keyof typeof ScheduleOverlapPolicy}`
-  ];
-}
-
-export function decodeOverlapPolicy(input?: temporal.api.enums.v1.ScheduleOverlapPolicy | null): ScheduleOverlapPolicy {
-  if (!input) return ScheduleOverlapPolicy.UNSPECIFIED;
-  const encodedPolicyName = temporal.api.enums.v1.ScheduleOverlapPolicy[input];
-  const decodedPolicyName = encodedPolicyName.substring(
-    'SCHEDULE_OVERLAP_POLICY_'.length
-  ) as keyof typeof ScheduleOverlapPolicy;
-  return ScheduleOverlapPolicy[decodedPolicyName];
-}
-
 export function compileScheduleOptions(options: ScheduleOptions): CompiledScheduleOptions {
   const workflowTypeOrFunc = options.action.workflowType;
   const workflowType = extractWorkflowType(workflowTypeOrFunc);
@@ -290,7 +275,7 @@ export function encodeSchedulePolicies(
 ): temporal.api.schedule.v1.ISchedulePolicies {
   return {
     catchupWindow: msOptionalToTs(policies?.catchupWindow),
-    overlapPolicy: policies?.overlap ? encodeOverlapPolicy(policies.overlap) : undefined,
+    overlapPolicy: policies?.overlap ? encodeScheduleOverlapPolicy(policies.overlap) : undefined,
     pauseOnFailure: policies?.pauseOnFailure,
   };
 }

--- a/packages/client/src/task-queue-client.ts
+++ b/packages/client/src/task-queue-client.ts
@@ -1,6 +1,7 @@
 import { status } from '@grpc/grpc-js';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-non-workflow';
 import { assertNever, SymbolBasedInstanceOfError, RequireAtLeastOne } from '@temporalio/common/lib/type-helpers';
+import { makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow';
 import { temporal } from '@temporalio/proto';
 import { BaseClient, BaseClientOptions, defaultBaseClientOptions, LoadedWithDefaults } from './base-client';
 import { WorkflowService } from './types';
@@ -148,7 +149,7 @@ export class TaskQueueClient extends BaseClient {
         namespace: this.options.namespace,
         taskQueues: options.taskQueues,
         buildIds,
-        reachability: reachabilityTypeToProto(options.reachability),
+        reachability: encodeTaskReachability(options.reachability),
       });
     } catch (e) {
       this.rethrowGrpcError(e, 'Unexpected error fetching Build Id reachability');
@@ -173,6 +174,20 @@ export class TaskQueueClient extends BaseClient {
  */
 export type ReachabilityOptions = RequireAtLeastOne<BaseReachabilityOptions, 'buildIds' | 'taskQueues'>;
 
+export const ReachabilityType = {
+  /** The Build Id might be used by new workflows. */
+  NEW_WORKFLOWS: 'NEW_WORKFLOWS',
+
+  /** The Build Id might be used by open workflows and/or closed workflows. */
+  EXISTING_WORKFLOWS: 'EXISTING_WORKFLOWS',
+
+  /** The Build Id might be used by open workflows. */
+  OPEN_WORKFLOWS: 'OPEN_WORKFLOWS',
+
+  /** The Build Id might be used by closed workflows. */
+  CLOSED_WORKFLOWS: 'CLOSED_WORKFLOWS',
+} as const;
+
 /**
  * There are different types of reachability:
  *   - `NEW_WORKFLOWS`: The Build Id might be used by new workflows
@@ -180,7 +195,24 @@ export type ReachabilityOptions = RequireAtLeastOne<BaseReachabilityOptions, 'bu
  *   - `OPEN_WORKFLOWS` The Build Id might be used by open workflows
  *   - `CLOSED_WORKFLOWS` The Build Id might be used by closed workflows
  */
-export type ReachabilityType = 'NEW_WORKFLOWS' | 'EXISTING_WORKFLOWS' | 'OPEN_WORKFLOWS' | 'CLOSED_WORKFLOWS';
+export type ReachabilityType = (typeof ReachabilityType)[keyof typeof ReachabilityType];
+
+export const [encodeTaskReachability, decodeTaskReachability] = makeProtoEnumConverters<
+  temporal.api.enums.v1.TaskReachability,
+  typeof temporal.api.enums.v1.TaskReachability,
+  keyof typeof temporal.api.enums.v1.TaskReachability,
+  typeof ReachabilityType,
+  'TASK_REACHABILITY_'
+>(
+  {
+    [ReachabilityType.NEW_WORKFLOWS]: 1,
+    [ReachabilityType.EXISTING_WORKFLOWS]: 2,
+    [ReachabilityType.OPEN_WORKFLOWS]: 3,
+    [ReachabilityType.CLOSED_WORKFLOWS]: 4,
+    UNSPECIFIED: 0,
+  } as const,
+  'TASK_REACHABILITY_'
+);
 
 /**
  * See {@link ReachabilityOptions}
@@ -215,24 +247,6 @@ export interface BuildIdReachability {
   taskQueueReachability: Record<string, ReachabilityTypeResponse[]>;
 }
 
-function reachabilityTypeToProto(type: ReachabilityType | undefined | null): temporal.api.enums.v1.TaskReachability {
-  switch (type) {
-    case null:
-    case undefined:
-      return temporal.api.enums.v1.TaskReachability.TASK_REACHABILITY_UNSPECIFIED;
-    case 'NEW_WORKFLOWS':
-      return temporal.api.enums.v1.TaskReachability.TASK_REACHABILITY_NEW_WORKFLOWS;
-    case 'EXISTING_WORKFLOWS':
-      return temporal.api.enums.v1.TaskReachability.TASK_REACHABILITY_EXISTING_WORKFLOWS;
-    case 'OPEN_WORKFLOWS':
-      return temporal.api.enums.v1.TaskReachability.TASK_REACHABILITY_OPEN_WORKFLOWS;
-    case 'CLOSED_WORKFLOWS':
-      return temporal.api.enums.v1.TaskReachability.TASK_REACHABILITY_CLOSED_WORKFLOWS;
-    default:
-      assertNever('Unknown Build Id reachability operation', type);
-  }
-}
-
 export function reachabilityResponseFromProto(resp: GetWorkerTaskReachabilityResponse): ReachabilityResponse {
   return {
     buildIdReachability: Object.fromEntries(
@@ -247,7 +261,9 @@ export function reachabilityResponseFromProto(resp: GetWorkerTaskReachabilityRes
               taskQueueReachability[tqr.taskQueue] = [];
               continue;
             }
-            taskQueueReachability[tqr.taskQueue] = tqr.reachability.map(reachabilityTypeFromProto);
+            taskQueueReachability[tqr.taskQueue] = tqr.reachability.map(
+              (x) => decodeTaskReachability(x) ?? 'NOT_FETCHED'
+            );
           }
         }
         let bid: string | UnversionedBuildIdType;
@@ -260,23 +276,6 @@ export function reachabilityResponseFromProto(resp: GetWorkerTaskReachabilityRes
       })
     ) as Record<string | UnversionedBuildIdType, BuildIdReachability>,
   };
-}
-
-function reachabilityTypeFromProto(rtype: temporal.api.enums.v1.TaskReachability): ReachabilityTypeResponse {
-  switch (rtype) {
-    case temporal.api.enums.v1.TaskReachability.TASK_REACHABILITY_UNSPECIFIED:
-      return 'NOT_FETCHED';
-    case temporal.api.enums.v1.TaskReachability.TASK_REACHABILITY_NEW_WORKFLOWS:
-      return 'NEW_WORKFLOWS';
-    case temporal.api.enums.v1.TaskReachability.TASK_REACHABILITY_EXISTING_WORKFLOWS:
-      return 'EXISTING_WORKFLOWS';
-    case temporal.api.enums.v1.TaskReachability.TASK_REACHABILITY_OPEN_WORKFLOWS:
-      return 'OPEN_WORKFLOWS';
-    case temporal.api.enums.v1.TaskReachability.TASK_REACHABILITY_CLOSED_WORKFLOWS:
-      return 'CLOSED_WORKFLOWS';
-    default:
-      return assertNever('Unknown Build Id reachability operation', rtype);
-  }
 }
 
 /**

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,5 +1,6 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { SearchAttributes } from '@temporalio/common';
+import { makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow';
 import * as proto from '@temporalio/proto';
 import { Replace } from '@temporalio/common/lib/type-helpers';
 
@@ -135,3 +136,38 @@ export interface ConnectionLike {
    */
   withAbortSignal<R>(abortSignal: AbortSignal, fn: () => Promise<R>): Promise<R>;
 }
+
+export const QueryRejectCondition = {
+  NONE: 'NONE',
+  NOT_OPEN: 'NOT_OPEN',
+  NOT_COMPLETED_CLEANLY: 'NOT_COMPLETED_CLEANLY',
+
+  /** @deprecated Use {@link NONE} instead. */
+  QUERY_REJECT_CONDITION_NONE: 'NONE', // eslint-disable-line deprecation/deprecation
+
+  /** @deprecated Use {@link NOT_OPEN} instead. */
+  QUERY_REJECT_CONDITION_NOT_OPEN: 'NOT_OPEN', // eslint-disable-line deprecation/deprecation
+
+  /** @deprecated Use {@link NOT_COMPLETED_CLEANLY} instead. */
+  QUERY_REJECT_CONDITION_NOT_COMPLETED_CLEANLY: 'NOT_COMPLETED_CLEANLY', // eslint-disable-line deprecation/deprecation
+
+  /** @deprecated Use `undefined` instead. */
+  QUERY_REJECT_CONDITION_UNSPECIFIED: undefined, // eslint-disable-line deprecation/deprecation
+} as const;
+export type QueryRejectCondition = (typeof QueryRejectCondition)[keyof typeof QueryRejectCondition];
+
+export const [encodeQueryRejectCondition, decodeQueryRejectCondition] = makeProtoEnumConverters<
+  proto.temporal.api.enums.v1.QueryRejectCondition,
+  typeof proto.temporal.api.enums.v1.QueryRejectCondition,
+  keyof typeof proto.temporal.api.enums.v1.QueryRejectCondition,
+  typeof QueryRejectCondition,
+  'QUERY_REJECT_CONDITION_'
+>(
+  {
+    [QueryRejectCondition.NONE]: 1,
+    [QueryRejectCondition.NOT_OPEN]: 2,
+    [QueryRejectCondition.NOT_COMPLETED_CLEANLY]: 3,
+    UNSPECIFIED: 0,
+  } as const,
+  'QUERY_REJECT_CONDITION_'
+);

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -20,6 +20,9 @@ import {
   WorkflowNotFoundError,
   WorkflowResultType,
   extractWorkflowType,
+  encodeWorkflowIdReusePolicy,
+  decodeRetryState,
+  encodeWorkflowIdConflictPolicy,
 } from '@temporalio/common';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import { History } from '@temporalio/common/lib/proto-utils';
@@ -56,7 +59,9 @@ import {
 } from './interceptors';
 import {
   DescribeWorkflowExecutionResponse,
+  encodeQueryRejectCondition,
   GetWorkflowExecutionHistoryRequest,
+  QueryRejectCondition,
   RequestCancelWorkflowExecutionResponse,
   StartWorkflowExecutionRequest,
   TerminateWorkflowExecutionResponse,
@@ -81,8 +86,9 @@ import {
   WithDefaults,
 } from './base-client';
 import { mapAsyncIterable } from './iterators-utils';
-import { WorkflowUpdateStage } from './workflow-update-stage';
-import * as workflowUpdateStage from './workflow-update-stage';
+import { WorkflowUpdateStage, encodeWorkflowUpdateStage } from './workflow-update-stage';
+
+const UpdateWorkflowExecutionLifecycleStage = temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage;
 
 /**
  * A client side handle to a single Workflow instance.
@@ -168,7 +174,7 @@ export interface WorkflowHandle<T extends Workflow = Workflow> extends BaseWorkf
    * ```ts
    * const updateHandle = await handle.startUpdate(incrementAndGetValueUpdate, {
    *   args: [2],
-   *   waitForStage: WorkflowUpdateStage.ACCEPTED,
+   *   waitForStage: 'ACCEPTED',
    * });
    * const updateResult = await updateHandle.result();
    * ```
@@ -177,7 +183,7 @@ export interface WorkflowHandle<T extends Workflow = Workflow> extends BaseWorkf
     def: UpdateDefinition<Ret, Args, Name> | string,
     options: WorkflowUpdateOptions & {
       args: Args;
-      waitForStage: WorkflowUpdateStage.ACCEPTED;
+      waitForStage: 'ACCEPTED';
     }
   ): Promise<WorkflowUpdateHandle<Ret>>;
 
@@ -185,7 +191,7 @@ export interface WorkflowHandle<T extends Workflow = Workflow> extends BaseWorkf
     def: UpdateDefinition<Ret, Args, Name> | string,
     options: WorkflowUpdateOptions & {
       args?: Args;
-      waitForStage: WorkflowUpdateStage.ACCEPTED;
+      waitForStage: typeof WorkflowUpdateStage.ACCEPTED;
     }
   ): Promise<WorkflowUpdateHandle<Ret>>;
 
@@ -280,9 +286,9 @@ export interface WorkflowClientOptions extends BaseClientOptions {
   /**
    * Should a query be rejected by closed and failed workflows
    *
-   * @default QUERY_REJECT_CONDITION_UNSPECIFIED which means that closed and failed workflows are still queryable
+   * @default `undefined` which means that closed and failed workflows are still queryable
    */
-  queryRejectCondition?: temporal.api.enums.v1.QueryRejectCondition;
+  queryRejectCondition?: QueryRejectCondition;
 }
 
 export type LoadedWorkflowClientOptions = LoadedWithDefaults<WorkflowClientOptions>;
@@ -291,7 +297,7 @@ function defaultWorkflowClientOptions(): WithDefaults<WorkflowClientOptions> {
   return {
     ...defaultBaseClientOptions(),
     interceptors: [],
-    queryRejectCondition: temporal.api.enums.v1.QueryRejectCondition.QUERY_REJECT_CONDITION_UNSPECIFIED,
+    queryRejectCondition: 'NONE',
   };
 }
 
@@ -659,7 +665,7 @@ export class WorkflowClient extends BaseClient {
         throw new WorkflowFailedError(
           'Workflow execution failed',
           await decodeOptionalFailureToOptionalError(this.dataConverter, failure),
-          retryState ?? RetryState.RETRY_STATE_UNSPECIFIED
+          decodeRetryState(retryState)
         );
       } else if (ev.workflowExecutionCanceledEventAttributes) {
         const failure = new CancelledFailure(
@@ -670,11 +676,7 @@ export class WorkflowClient extends BaseClient {
           )
         );
         failure.stack = '';
-        throw new WorkflowFailedError(
-          'Workflow execution cancelled',
-          failure,
-          RetryState.RETRY_STATE_NON_RETRYABLE_FAILURE
-        );
+        throw new WorkflowFailedError('Workflow execution cancelled', failure, RetryState.NON_RETRYABLE_FAILURE);
       } else if (ev.workflowExecutionTerminatedEventAttributes) {
         const failure = new TerminatedFailure(
           ev.workflowExecutionTerminatedEventAttributes.reason || 'Workflow execution terminated'
@@ -683,7 +685,7 @@ export class WorkflowClient extends BaseClient {
         throw new WorkflowFailedError(
           ev.workflowExecutionTerminatedEventAttributes.reason || 'Workflow execution terminated',
           failure,
-          RetryState.RETRY_STATE_NON_RETRYABLE_FAILURE
+          RetryState.NON_RETRYABLE_FAILURE
         );
       } else if (ev.workflowExecutionTimedOutEventAttributes) {
         if (followRuns && ev.workflowExecutionTimedOutEventAttributes.newExecutionRunId) {
@@ -691,16 +693,12 @@ export class WorkflowClient extends BaseClient {
           req.nextPageToken = undefined;
           continue;
         }
-        const failure = new TimeoutFailure(
-          'Workflow execution timed out',
-          undefined,
-          TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE
-        );
+        const failure = new TimeoutFailure('Workflow execution timed out', undefined, TimeoutType.START_TO_CLOSE);
         failure.stack = '';
         throw new WorkflowFailedError(
           'Workflow execution timed out',
           failure,
-          ev.workflowExecutionTimedOutEventAttributes.retryState || 0
+          decodeRetryState(ev.workflowExecutionTimedOutEventAttributes.retryState)
         );
       } else if (ev.workflowExecutionContinuedAsNewEventAttributes) {
         const { newExecutionRunId } = ev.workflowExecutionContinuedAsNewEventAttributes;
@@ -806,8 +804,15 @@ export class WorkflowClient extends BaseClient {
     waitForStage: WorkflowUpdateStage,
     input: WorkflowStartUpdateInput
   ): Promise<WorkflowStartUpdateOutput> {
-    waitForStage = waitForStage >= WorkflowUpdateStage.ACCEPTED ? waitForStage : WorkflowUpdateStage.ACCEPTED;
-    const waitForStageProto = workflowUpdateStage.toProtoEnum(waitForStage);
+    let waitForStageProto: temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage =
+      encodeWorkflowUpdateStage(waitForStage) ??
+      UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED;
+
+    waitForStageProto =
+      waitForStageProto >= UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED
+        ? waitForStageProto
+        : UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED;
+
     const updateId = input.options?.updateId ?? uuid4();
     const req: temporal.api.workflowservice.v1.IUpdateWorkflowExecutionRequest = {
       namespace: this.options.namespace,
@@ -886,7 +891,7 @@ export class WorkflowClient extends BaseClient {
       updateRef: { workflowExecution, updateId },
       identity: this.options.identity,
       waitPolicy: {
-        lifecycleStage: workflowUpdateStage.toProtoEnum(WorkflowUpdateStage.COMPLETED),
+        lifecycleStage: encodeWorkflowUpdateStage(WorkflowUpdateStage.COMPLETED),
       },
     };
     for (;;) {
@@ -938,8 +943,8 @@ export class WorkflowClient extends BaseClient {
       identity,
       requestId: uuid4(),
       workflowId: options.workflowId,
-      workflowIdReusePolicy: options.workflowIdReusePolicy,
-      workflowIdConflictPolicy: options.workflowIdConflictPolicy,
+      workflowIdReusePolicy: encodeWorkflowIdReusePolicy(options.workflowIdReusePolicy),
+      workflowIdConflictPolicy: encodeWorkflowIdConflictPolicy(options.workflowIdConflictPolicy),
       workflowType: { name: workflowType },
       input: { payloads: await encodeToPayloads(this.dataConverter, ...options.args) },
       signalName,
@@ -989,8 +994,8 @@ export class WorkflowClient extends BaseClient {
       identity,
       requestId: uuid4(),
       workflowId: opts.workflowId,
-      workflowIdReusePolicy: opts.workflowIdReusePolicy,
-      workflowIdConflictPolicy: opts.workflowIdConflictPolicy,
+      workflowIdReusePolicy: encodeWorkflowIdReusePolicy(opts.workflowIdReusePolicy),
+      workflowIdConflictPolicy: encodeWorkflowIdConflictPolicy(opts.workflowIdConflictPolicy),
       workflowType: { name: workflowType },
       input: { payloads: await encodeToPayloads(this.dataConverter, ...opts.args) },
       taskQueue: {
@@ -1180,7 +1185,7 @@ export class WorkflowClient extends BaseClient {
         def: UpdateDefinition<Ret, Args> | string,
         options: WorkflowUpdateOptions & {
           args?: Args;
-          waitForStage: WorkflowUpdateStage.ACCEPTED;
+          waitForStage: typeof WorkflowUpdateStage.ACCEPTED;
         }
       ): Promise<WorkflowUpdateHandle<Ret>> {
         return await _startUpdate(def, options.waitForStage, options);
@@ -1210,7 +1215,7 @@ export class WorkflowClient extends BaseClient {
         const fn = composeInterceptors(interceptors, 'query', next);
         return fn({
           workflowExecution: { workflowId, runId },
-          queryRejectCondition: this.client.options.queryRejectCondition,
+          queryRejectCondition: encodeQueryRejectCondition(this.client.options.queryRejectCondition),
           queryType: typeof def === 'string' ? def : def.name,
           args,
           headers: {},

--- a/packages/client/src/workflow-update-stage.ts
+++ b/packages/client/src/workflow-update-stage.ts
@@ -1,33 +1,41 @@
 import { temporal } from '@temporalio/proto';
-import { checkExtends } from '@temporalio/common/lib/type-helpers';
+import { makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow';
 
-export enum WorkflowUpdateStage {
-  /** This is not an allowed value. */
-  UNSPECIFIED = 0,
+export const WorkflowUpdateStage = {
   /** Admitted stage. This stage is reached when the server accepts the update request. It is not
    * allowed to wait for this stage when using startUpdate, since the update request has not yet
    * been durably persisted at this stage. */
-  ADMITTED = 1,
+  ADMITTED: 'ADMITTED',
+
   /** Accepted stage. This stage is reached when a workflow has received the update and either
    * accepted it (i.e. it has passed validation, or there was no validator configured on the update
    * handler) or rejected it. This is currently the only allowed value when using startUpdate. */
-  ACCEPTED = 2,
+  ACCEPTED: 'ACCEPTED',
+
   /** Completed stage. This stage is reached when a workflow has completed processing the
    * update with either a success or failure. */
-  COMPLETED = 3,
-}
+  COMPLETED: 'COMPLETED',
 
-checkExtends<
-  `UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_${keyof typeof WorkflowUpdateStage}`,
-  keyof typeof temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage
->();
-checkExtends<
+  /**
+   * This is not an allowed value.
+   * @deprecated
+   */
+  UNSPECIFIED: undefined, // eslint-disable-line deprecation/deprecation
+} as const;
+export type WorkflowUpdateStage = (typeof WorkflowUpdateStage)[keyof typeof WorkflowUpdateStage];
+
+export const [encodeWorkflowUpdateStage] = makeProtoEnumConverters<
+  temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage,
+  typeof temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage,
   keyof typeof temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage,
-  `UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_${keyof typeof WorkflowUpdateStage}`
->();
-
-export function toProtoEnum(stage: WorkflowUpdateStage): temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage {
-  return temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage[
-    `UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_${WorkflowUpdateStage[stage] as keyof typeof WorkflowUpdateStage}`
-  ];
-}
+  typeof WorkflowUpdateStage,
+  'UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_'
+>(
+  {
+    [WorkflowUpdateStage.ADMITTED]: 1,
+    [WorkflowUpdateStage.ACCEPTED]: 2,
+    [WorkflowUpdateStage.COMPLETED]: 3,
+    UNSPECIFIED: 0,
+  } as const,
+  'UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_'
+);

--- a/packages/common/src/activity-options.ts
+++ b/packages/common/src/activity-options.ts
@@ -1,19 +1,30 @@
 import type { coresdk } from '@temporalio/proto';
 import { RetryPolicy } from './retry-policy';
-import { checkExtends } from './type-helpers';
 import { Duration } from './time';
 import { VersioningIntent } from './versioning-intent';
+import { makeProtoEnumConverters } from './internal-workflow';
 
-// Avoid importing the proto implementation to reduce workflow bundle size
-// Copied from coresdk.workflow_commands.ActivityCancellationType
-export enum ActivityCancellationType {
-  TRY_CANCEL = 0,
-  WAIT_CANCELLATION_COMPLETED = 1,
-  ABANDON = 2,
-}
+export const ActivityCancellationType = {
+  TRY_CANCEL: 'TRY_CANCEL',
+  WAIT_CANCELLATION_COMPLETED: 'WAIT_CANCELLATION_COMPLETED',
+  ABANDON: 'ABANDON',
+} as const;
+export type ActivityCancellationType = (typeof ActivityCancellationType)[keyof typeof ActivityCancellationType];
 
-checkExtends<coresdk.workflow_commands.ActivityCancellationType, ActivityCancellationType>();
-checkExtends<ActivityCancellationType, coresdk.workflow_commands.ActivityCancellationType>();
+export const [encodeActivityCancellationType, decodeActivityCancellationType] = makeProtoEnumConverters<
+  coresdk.workflow_commands.ActivityCancellationType,
+  typeof coresdk.workflow_commands.ActivityCancellationType,
+  keyof typeof coresdk.workflow_commands.ActivityCancellationType,
+  typeof ActivityCancellationType,
+  ''
+>(
+  {
+    [ActivityCancellationType.TRY_CANCEL]: 0,
+    [ActivityCancellationType.WAIT_CANCELLATION_COMPLETED]: 1,
+    [ActivityCancellationType.ABANDON]: 2,
+  } as const,
+  ''
+);
 
 /**
  * Options for remote activity invocation
@@ -174,5 +185,5 @@ export interface LocalActivityOptions {
    *   heartbeat or chooses to ignore the cancellation request.
    * - `ABANDON` - Do not request cancellation of the activity and immediately report cancellation to the workflow.
    */
-  cancellationType?: coresdk.workflow_commands.ActivityCancellationType;
+  cancellationType?: ActivityCancellationType;
 }

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -1,38 +1,105 @@
 import type { temporal } from '@temporalio/proto';
-import { checkExtends, errorMessage, isRecord, SymbolBasedInstanceOfError } from './type-helpers';
+import { errorMessage, isRecord, SymbolBasedInstanceOfError } from './type-helpers';
 import { Duration } from './time';
+import { makeProtoEnumConverters } from './internal-workflow';
 
 export const FAILURE_SOURCE = 'TypeScriptSDK';
 export type ProtoFailure = temporal.api.failure.v1.IFailure;
 
-// Avoid importing the proto implementation to reduce workflow bundle size
-// Copied from temporal.api.enums.v1.TimeoutType
-export enum TimeoutType {
-  TIMEOUT_TYPE_UNSPECIFIED = 0,
-  TIMEOUT_TYPE_START_TO_CLOSE = 1,
-  TIMEOUT_TYPE_SCHEDULE_TO_START = 2,
-  TIMEOUT_TYPE_SCHEDULE_TO_CLOSE = 3,
-  TIMEOUT_TYPE_HEARTBEAT = 4,
-}
+export const TimeoutType = {
+  START_TO_CLOSE: 'START_TO_CLOSE',
+  SCHEDULE_TO_START: 'SCHEDULE_TO_START',
+  SCHEDULE_TO_CLOSE: 'SCHEDULE_TO_CLOSE',
+  HEARTBEAT: 'HEARTBEAT',
 
-checkExtends<temporal.api.enums.v1.TimeoutType, TimeoutType>();
-checkExtends<TimeoutType, temporal.api.enums.v1.TimeoutType>();
+  /** @deprecated Use {@link START_TO_CLOSE} instead. */
+  TIMEOUT_TYPE_START_TO_CLOSE: 'START_TO_CLOSE', // eslint-disable-line deprecation/deprecation
 
-// Avoid importing the proto implementation to reduce workflow bundle size
-// Copied from temporal.api.enums.v1.RetryState
-export enum RetryState {
-  RETRY_STATE_UNSPECIFIED = 0,
-  RETRY_STATE_IN_PROGRESS = 1,
-  RETRY_STATE_NON_RETRYABLE_FAILURE = 2,
-  RETRY_STATE_TIMEOUT = 3,
-  RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED = 4,
-  RETRY_STATE_RETRY_POLICY_NOT_SET = 5,
-  RETRY_STATE_INTERNAL_SERVER_ERROR = 6,
-  RETRY_STATE_CANCEL_REQUESTED = 7,
-}
+  /** @deprecated Use {@link SCHEDULE_TO_START} instead. */
+  TIMEOUT_TYPE_SCHEDULE_TO_START: 'SCHEDULE_TO_START', // eslint-disable-line deprecation/deprecation
 
-checkExtends<temporal.api.enums.v1.RetryState, RetryState>();
-checkExtends<RetryState, temporal.api.enums.v1.RetryState>();
+  /** @deprecated Use {@link SCHEDULE_TO_CLOSE} instead. */
+  TIMEOUT_TYPE_SCHEDULE_TO_CLOSE: 'SCHEDULE_TO_CLOSE', // eslint-disable-line deprecation/deprecation
+
+  /** @deprecated Use {@link HEARTBEAT} instead. */
+  TIMEOUT_TYPE_HEARTBEAT: 'HEARTBEAT', // eslint-disable-line deprecation/deprecation
+
+  /** @deprecated Use `undefined` instead. */
+  TIMEOUT_TYPE_UNSPECIFIED: undefined, // eslint-disable-line deprecation/deprecation
+} as const;
+export type TimeoutType = (typeof TimeoutType)[keyof typeof TimeoutType];
+
+export const [encodeTimeoutType, decodeTimeoutType] = makeProtoEnumConverters<
+  temporal.api.enums.v1.TimeoutType,
+  typeof temporal.api.enums.v1.TimeoutType,
+  keyof typeof temporal.api.enums.v1.TimeoutType,
+  typeof TimeoutType,
+  'TIMEOUT_TYPE_'
+>(
+  {
+    [TimeoutType.START_TO_CLOSE]: 1,
+    [TimeoutType.SCHEDULE_TO_START]: 2,
+    [TimeoutType.SCHEDULE_TO_CLOSE]: 3,
+    [TimeoutType.HEARTBEAT]: 4,
+    UNSPECIFIED: 0,
+  } as const,
+  'TIMEOUT_TYPE_'
+);
+
+export const RetryState = {
+  IN_PROGRESS: 'IN_PROGRESS',
+  NON_RETRYABLE_FAILURE: 'NON_RETRYABLE_FAILURE',
+  TIMEOUT: 'TIMEOUT',
+  MAXIMUM_ATTEMPTS_REACHED: 'MAXIMUM_ATTEMPTS_REACHED',
+  RETRY_POLICY_NOT_SET: 'RETRY_POLICY_NOT_SET',
+  INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
+  CANCEL_REQUESTED: 'CANCEL_REQUESTED',
+
+  /** @deprecated Use {@link IN_PROGRESS} instead. */
+  RETRY_STATE_IN_PROGRESS: 'IN_PROGRESS', // eslint-disable-line deprecation/deprecation
+
+  /** @deprecated Use {@link NON_RETRYABLE_FAILURE} instead. */
+  RETRY_STATE_NON_RETRYABLE_FAILURE: 'NON_RETRYABLE_FAILURE', // eslint-disable-line deprecation/deprecation
+
+  /** @deprecated Use {@link TIMEOUT} instead. */
+  RETRY_STATE_TIMEOUT: 'TIMEOUT', // eslint-disable-line deprecation/deprecation
+
+  /** @deprecated Use {@link MAXIMUM_ATTEMPTS_REACHED} instead. */
+  RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED: 'MAXIMUM_ATTEMPTS_REACHED', // eslint-disable-line deprecation/deprecation
+
+  /** @deprecated Use {@link RETRY_POLICY_NOT_SET} instead. */
+  RETRY_STATE_RETRY_POLICY_NOT_SET: 'RETRY_POLICY_NOT_SET', // eslint-disable-line deprecation/deprecation
+
+  /** @deprecated Use {@link INTERNAL_SERVER_ERROR} instead. */
+  RETRY_STATE_INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR', // eslint-disable-line deprecation/deprecation
+
+  /** @deprecated Use {@link CANCEL_REQUESTED} instead. */
+  RETRY_STATE_CANCEL_REQUESTED: 'CANCEL_REQUESTED', // eslint-disable-line deprecation/deprecation
+
+  /** @deprecated Use `undefined` instead. */
+  RETRY_STATE_UNSPECIFIED: undefined, // eslint-disable-line deprecation/deprecation
+} as const;
+export type RetryState = (typeof RetryState)[keyof typeof RetryState];
+
+export const [encodeRetryState, decodeRetryState] = makeProtoEnumConverters<
+  temporal.api.enums.v1.RetryState,
+  typeof temporal.api.enums.v1.RetryState,
+  keyof typeof temporal.api.enums.v1.RetryState,
+  typeof RetryState,
+  'RETRY_STATE_'
+>(
+  {
+    [RetryState.IN_PROGRESS]: 1,
+    [RetryState.NON_RETRYABLE_FAILURE]: 2,
+    [RetryState.TIMEOUT]: 3,
+    [RetryState.MAXIMUM_ATTEMPTS_REACHED]: 4,
+    [RetryState.RETRY_POLICY_NOT_SET]: 5,
+    [RetryState.INTERNAL_SERVER_ERROR]: 6,
+    [RetryState.CANCEL_REQUESTED]: 7,
+    UNSPECIFIED: 0,
+  } as const,
+  'RETRY_STATE_'
+);
 
 export type WorkflowExecution = temporal.api.common.v1.IWorkflowExecution;
 

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -128,11 +128,11 @@ export interface HistoryAndWorkflowId {
  * Policy defining actions taken when a workflow exits while update or signal handlers are running.
  * The workflow exit may be due to successful return, failure, cancellation, or continue-as-new.
  */
-export enum HandlerUnfinishedPolicy {
+export const HandlerUnfinishedPolicy = {
   /**
    * Issue a warning in addition to abandoning the handler execution. The warning will not be issued if the workflow fails.
    */
-  WARN_AND_ABANDON = 1,
+  WARN_AND_ABANDON: 'WARN_AND_ABANDON',
 
   /**
    * Abandon the handler execution.
@@ -140,5 +140,6 @@ export enum HandlerUnfinishedPolicy {
    * In the case of an update handler this means that the client will receive an error rather than
    * the update result.
    */
-  ABANDON = 2,
-}
+  ABANDON: 'ABANDON',
+} as const;
+export type HandlerUnfinishedPolicy = (typeof HandlerUnfinishedPolicy)[keyof typeof HandlerUnfinishedPolicy];

--- a/packages/common/src/internal-workflow/enums-helpers.ts
+++ b/packages/common/src/internal-workflow/enums-helpers.ts
@@ -158,6 +158,7 @@ export function makeProtoEnumConverters<
   const reverseTable: Record<ProtoEnumValue, ShortStringEnumKey> = Object.fromEntries(
     Object.entries(mapTable).map(([k, v]) => [v, k])
   );
+  const hasUnspecified = (mapTable as any)['UNSPECIFIED'] === 0 || (mapTable as any)[`${prefix}UNSPECIFIED`] === 0;
 
   function isShortStringEnumKeys(x: unknown): x is ShortStringEnumKey {
     return typeof x === 'string' && x in mapTable;
@@ -192,6 +193,10 @@ export function makeProtoEnumConverters<
     if (input == null) {
       return undefined;
     } else if (typeof input === 'number') {
+      if (hasUnspecified && input === 0) {
+        return undefined;
+      }
+
       if (isNumericEnumValue(input)) {
         return reverseTable[input];
       }

--- a/packages/common/src/internal-workflow/enums-helpers.ts
+++ b/packages/common/src/internal-workflow/enums-helpers.ts
@@ -1,0 +1,289 @@
+import { Exact, RemovePrefix, UnionToIntersection } from '../type-helpers';
+
+/**
+ * Create encoding and decoding functions to convert between the numeric `enum` types produced by our
+ * Protobuf compiler and "const object of strings" enum values that we expose in our public APIs.
+ *
+ * ### Usage
+ *
+ * Newly introduced enums should follow the following pattern:
+ *
+ * ```ts
+ *     type ParentClosePolicy = (typeof ParentClosePolicy)[keyof typeof ParentClosePolicy];
+ *     const ParentClosePolicy = {
+ *       TERMINATE: 'TERMINATE',
+ *       ABANDON: 'ABANDON',
+ *       REQUEST_CANCEL: 'REQUEST_CANCEL',
+ *     } as const;
+ *
+ *     const [encodeParentClosePolicy, decodeParentClosePolicy] = //
+ *       makeProtoEnumConverters<
+ *         coresdk.child_workflow.ParentClosePolicy,
+ *         typeof coresdk.child_workflow.ParentClosePolicy,
+ *         keyof typeof coresdk.child_workflow.ParentClosePolicy,
+ *         typeof ParentClosePolicy,
+ *         'PARENT_CLOSE_POLICY_'  // This may be an empty string if the proto enum doesn't add a repeated prefix on values
+ *       >(
+ *         {
+ *           [ParentClosePolicy.TERMINATE]: 1, // These numbers must match the ones in the proto enum
+ *           [ParentClosePolicy.ABANDON]: 2,
+ *           [ParentClosePolicy.REQUEST_CANCEL]: 3,
+ *
+ *           UNSPECIFIED: 0,
+ *         } as const,
+ *         'PARENT_CLOSE_POLICY_'
+ *       );
+ * ```
+ *
+ * `makeProtoEnumConverters` supports other usage patterns, but they are only meant for
+ * backward compatibility with former enum definitions and should not be used for new enums.
+ *
+ * ### Context
+ *
+ * Temporal's Protobuf APIs define several `enum` types; our Protobuf compiler transforms these to
+ * traditional (i.e. non-const) [TypeScript numeric `enum`s](https://www.typescriptlang.org/docs/handbook/enums.html#numeric-enums).
+ *
+ * For various reasons, this is far from ideal:
+ *
+ *  - Due to the dual nature of non-const TypeScript `enum`s (they are both a type and a value),
+ *    it is not possible to refer to an enum value from code without a "real" import of the enum type
+ *    (i.e. can't simply do `import type ...`). In Workflow code, such an import would result in
+ *    loading our entire Protobuf definitions into the workflow sandbox, adding several megabytes to
+ *    the per-workflow memory footprint, which is unacceptable; to avoid that, we need to maintain
+ *    a mirror copy of each enum types used by in-workflow APIs, and export these from either
+ *    `@temporalio/common` or `@temporalio/workflow`.
+ *  - It is not desirable for users to need an explicit dependency on `@temporalio/proto` just to
+ *    get access to these enum types; we therefore made it a common practice to reexport these enums
+ *    from our public facing packages. However, experience demontrated that these reexports effectively
+ *    resulted in poor and inconsistent documentation coverage compared to mirrored enums types.
+ *  - Our Protobuf enum types tend to follow a verbose and redundant naming convention, which feels
+ *    unatural and excessive according to most TypeScript style guides; e.g. instead of
+ *    `workflowIdReusePolicy: WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE`,
+ *    a TypeScript developer would generally expect to be able to write something similar to
+ *    `workflowIdReusePolicy: 'REJECT_DUPLICATE'`.
+ *  - Because of the way Protobuf works, many of our enum types contain an `UNSPECIFIED` value, which
+ *    is used to explicitly identify a value that is unset. In TypeScript code, the `undefined` value
+ *    already serves that purpose, and is definitely more idiomatic to TS developers, whereas these
+ *    `UNSPECIFIED` values create noise and confusion in our APIs.
+ *  - TypeScript editors generally do a very bad job at providing autocompletion that implies reaching
+ *    for values of a TypeScript enum type, forcing developers to explicitly type in at least part
+ *    of the name of the enum type before they can get autocompletion for its values. On the other
+ *    hand, all TS editors immediately provide autocompletion for string union types.
+ *  - The [TypeScript's official documentation](https://www.typescriptlang.org/docs/handbook/enums.html#objects-vs-enums)
+ *    itself suggests that, in modern TypeScript, the use of `as const` objects may generally suffice
+ *    and may be advantageous over the use of `enum` types.
+ *
+ * A const object of strings, combined with a union type of possible string values, provides a much
+ * more idomatic syntax and a better DX for TypeScript developers. This however requires a way to
+ * convert back and forth between the `enum` values produced by the Protobuf compiler and the
+ * equivalent string values.
+ *
+ * This helper dynamicaly creates these conversion functions for a given Protobuf enum type,
+ * strongly building upon specific conventions that we have adopted in our Protobuf definitions.
+ *
+ * ### Validations
+ *
+ * The complex type signature of this helper is there to prevent most potential incoherenties
+ * that could result from having to manually synchronize the const object of strings enum and the
+ * conversion table with the proto enum, while not requiring a regular import on the Protobuf enum
+ * itself (so it can be used safely for enums meant to be used from workflow code).
+ *
+ * In particular, failing any of the following invariants will result in build time errors:
+ *
+ * - For every key of the form `PREFIX_KEY: number` in the proto enum, excluding the `UNSPECIFIED` key:
+ *   - There MUST be a corresponding `KEY: 'KEY'` entry in the const object of strings enum;
+ *   - There MAY be a corresponding `PREFIX_KEY: 'KEY'` in the const object of strings enum
+ *     (this is meant to preserve backward compatibility with the former syntax; such aliases should
+ *     not be added for new enums and enum entries introduced going forward);
+ *   - There MUST be a corresponding `KEY: number` in the mapping table.
+ * - If the proto enum contains a `PREFIX_UNSPECIFIED` entry, then:
+ *   - There MAY be a corresponding `PREFIX_UNSPECIFIED: undefined` and/or `UNSPECIFIED: undefined`
+ *     entries in the const object of strings enum — this is meant to preserve backward compatibility
+ *     with the former syntax; this alias should not be added for new enums introduced going forward;
+ *   - There MUST be an `UNSPECIFIED: 0` in the mapping table.
+ * - The const object of strings enum MUST NOT contain any other keys than the ones mandated or
+ *   optionally allowed be the preceeding rules.
+ * - The mapping table MUST NOT contain any other keys than the ones mandated above.
+ *
+ * These rules notably ensure that whenever a new value is added to an existing Proto enum, the code
+ * will fail to compile until the corresponding entry is added on the const object of strings enum
+ * and the mapping table.
+ *
+ * @internal
+ */
+export function makeProtoEnumConverters<
+  ProtoEnumValue extends number,
+  ProtoEnum extends { [k in ProtoEnumKey]: ProtoEnumValue },
+  ProtoEnumKey extends `${Prefix}${string}`,
+  StringEnumTypeActual extends Exact<StringEnumType, StringEnumTypeActual>,
+  Prefix extends string,
+  //
+  // Parameters after this point will be inferred; they're not meant not to be specified by developers
+  Unspecified = ProtoEnumKey extends `${Prefix}UNSPECIFIED` ? 'UNSPECIFIED' : never,
+  ShortStringEnumKey extends RemovePrefix<Prefix, ProtoEnumKey> = Exclude<
+    RemovePrefix<Prefix, ProtoEnumKey>,
+    Unspecified
+  >,
+  StringEnumType extends ProtoConstObjectOfStringsEnum<
+    ShortStringEnumKey,
+    Prefix,
+    Unspecified
+  > = ProtoConstObjectOfStringsEnum<ShortStringEnumKey, Prefix, Unspecified>,
+  MapTable extends ProtoEnumToConstObjectOfStringMapTable<
+    StringEnumType,
+    ProtoEnumValue,
+    ProtoEnum,
+    ProtoEnumKey,
+    Prefix,
+    Unspecified,
+    ShortStringEnumKey
+  > = ProtoEnumToConstObjectOfStringMapTable<
+    StringEnumType,
+    ProtoEnumValue,
+    ProtoEnum,
+    ProtoEnumKey,
+    Prefix,
+    Unspecified,
+    ShortStringEnumKey
+  >,
+>(
+  mapTable: MapTable,
+  prefix: Prefix
+): [
+  (
+    input: ShortStringEnumKey | `${Prefix}${ShortStringEnumKey}` | ProtoEnumValue | null | undefined
+  ) => ProtoEnumValue | undefined, //
+  (input: ProtoEnumValue | null | undefined) => ShortStringEnumKey | undefined, //
+] {
+  const reverseTable: Record<ProtoEnumValue, ShortStringEnumKey> = Object.fromEntries(
+    Object.entries(mapTable).map(([k, v]) => [v, k])
+  );
+
+  function isShortStringEnumKeys(x: unknown): x is ShortStringEnumKey {
+    return typeof x === 'string' && x in mapTable;
+  }
+
+  function isNumericEnumValue(x: unknown): x is ProtoEnum[keyof ProtoEnum] {
+    return typeof x === 'number' && x in reverseTable;
+  }
+
+  function encode(
+    input: ShortStringEnumKey | `${Prefix}${ShortStringEnumKey}` | ProtoEnumValue | null | undefined
+  ): ProtoEnumValue | undefined {
+    if (input == null) {
+      return undefined;
+    } else if (typeof input === 'string') {
+      let shorten: string = input;
+      if (shorten.startsWith(prefix)) {
+        shorten = shorten.slice(prefix.length);
+      }
+      if (isShortStringEnumKeys(shorten)) {
+        return mapTable[shorten];
+      }
+      throw new TypeError(`Invalid enum value: '${input}'`);
+    } else if (typeof input === 'number') {
+      return input;
+    } else {
+      throw new TypeError(`Invalid enum value: '${input}' of type ${typeof input}`);
+    }
+  }
+
+  function decode(input: ProtoEnumValue | null | undefined): ShortStringEnumKey | undefined {
+    if (input == null) {
+      return undefined;
+    } else if (typeof input === 'number') {
+      if (isNumericEnumValue(input)) {
+        return reverseTable[input];
+      }
+
+      // FIXME: What should we do with unknown values?
+      // Throwing may end up causing more problems than it would solve if the decoded values
+      // would actually never get read anwyay. An alternative would be to return a string value
+      // containing the numeric value, something like "unknown_23"...
+    }
+
+    throw new TypeError(`Invalid proto enum value: '${input}' of type ${typeof input}`);
+  }
+
+  return [encode, decode] as const;
+}
+
+/**
+ * Given the exploded parameters of a proto enum (i.e. short keys, prefix, and short key of the
+ * unspecified value), make a type that _exactly_ correspond to the const object of strings enum,
+ * e.g. the type that the developer is expected to write.
+ *
+ * For example, for coresdk.child_workflow.ParentClosePolicy, this evaluates to:
+ *
+ * {
+ *   TERMINATE: "TERMINATE";
+ *   ABANDON: "ABANDON";
+ *   REQUEST_CANCEL: "REQUEST_CANCEL";
+ *
+ *   PARENT_CLOSE_POLICY_TERMINATE?: "TERMINATE";
+ *   PARENT_CLOSE_POLICY_ABANDON?: "ABANDON";
+ *   PARENT_CLOSE_POLICY_REQUEST_CANCEL?: "REQUEST_CANCEL";
+ *
+ *   PARENT_CLOSE_POLICY_UNSPECIFIED?: undefined;
+ * }
+ */
+type ProtoConstObjectOfStringsEnum<
+  ShortStringEnumKey extends string,
+  Prefix extends string,
+  Unspecified, // e.g. 'UNSPECIFIED'
+> = UnionToIntersection<
+  | {
+      // e.g.: "TERMINATE": "TERMINATE"
+      readonly [k in ShortStringEnumKey]: k;
+    }
+  | {
+      [k in ShortStringEnumKey]: Prefix extends ''
+        ? object
+        : {
+            // e.g.: "PARENT_CLOSE_POLICY_TERMINATE"?: "TERMINATE"
+            readonly [kk in `${Prefix}${k}`]?: k;
+          };
+    }[ShortStringEnumKey]
+  | (Unspecified extends string
+      ? {
+          // e.g.: "PARENT_CLOSE_POLICY_UNSPECIFIED"?: undefined
+          [k in `${Prefix}${Unspecified}`]?: undefined;
+        }
+      : object)
+  | (Unspecified extends string
+      ? {
+          // e.g.: "UNSPECIFIED"?: undefined
+          [k in `${Unspecified}`]?: undefined;
+        }
+      : object)
+>;
+
+/**
+ * Given the exploded parameters of a proto enum (i.e. short keys, prefix, and short key of the
+ * unspecified value), make a type that _exactly_ correspond to the mapping table that the user is
+ * expected to provide.
+ *
+ * For example, for coresdk.child_workflow.ParentClosePolicy, this evaluates to:
+ *
+ * {
+ *  UNSPECIFIED: 0,
+ *  TERMINATE: 1,
+ *  ABANDON: 2,
+ *  REQUEST_CANCEL: 3,
+ * }
+ */
+type ProtoEnumToConstObjectOfStringMapTable<
+  _StringEnum extends ProtoConstObjectOfStringsEnum<ShortStringEnumKey, Prefix, Unspecified>,
+  ProtoEnumValue extends number,
+  ProtoEnum extends { [k in ProtoEnumKey]: ProtoEnumValue },
+  ProtoEnumKey extends `${Prefix}${string}`,
+  Prefix extends string,
+  Unspecified,
+  ShortStringEnumKey extends RemovePrefix<Prefix, ProtoEnumKey>,
+> = UnionToIntersection<
+  {
+    [k in ProtoEnumKey]: {
+      [kk in RemovePrefix<Prefix, k>]: ProtoEnum[k] extends number ? ProtoEnum[k] : never;
+    };
+  }[ProtoEnumKey]
+>;

--- a/packages/common/src/internal-workflow/index.ts
+++ b/packages/common/src/internal-workflow/index.ts
@@ -1,0 +1,1 @@
+export * from './enums-helpers';

--- a/packages/common/src/type-helpers.ts
+++ b/packages/common/src/type-helpers.ts
@@ -17,6 +17,84 @@ export function checkExtends<_Orig, _Copy extends _Orig>(): void {
 
 export type Replace<Base, New> = Omit<Base, keyof New> & New;
 
+// From https://github.com/sindresorhus/type-fest/blob/main/source/union-to-intersection.d.ts
+// MIT or CC0-1.0 — It is meant to be copied into your codebase rather than being used as a dependency.
+export type UnionToIntersection<Union> =
+  // `extends unknown` is always going to be the case and is used to convert the `Union` into a
+  // [distributive conditional type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
+  (
+    Union extends unknown
+      ? // The union type is used as the only argument to a function since the union
+        // of function arguments is an intersection.
+        (distributedUnion: Union) => void
+      : // This won't happen.
+        never
+  ) extends // Infer the `Intersection` type since TypeScript represents the positional
+  // arguments of unions of functions as an intersection of the union.
+  (mergedIntersection: infer Intersection) => void
+    ? // The `& Union` is to allow indexing by the resulting type
+      Intersection & Union
+    : never;
+
+type IsEqual<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false;
+
+type Primitive = null | undefined | string | number | boolean | symbol | bigint;
+
+type IsNull<T> = [T] extends [null] ? true : false;
+
+type IsUnknown<T> = unknown extends T // `T` can be `unknown` or `any`
+  ? IsNull<T> extends false // `any` can be `null`, but `unknown` can't be
+    ? true
+    : false
+  : false;
+
+type ObjectValue<T, K> = K extends keyof T
+  ? T[K]
+  : ToString<K> extends keyof T
+    ? T[ToString<K>]
+    : K extends `${infer NumberK extends number}`
+      ? NumberK extends keyof T
+        ? T[NumberK]
+        : never
+      : never;
+
+type ToString<T> = T extends string | number ? `${T}` : never;
+
+type KeysOfUnion<ObjectType> = ObjectType extends unknown ? keyof ObjectType : never;
+
+type ArrayElement<T> = T extends readonly unknown[] ? T[0] : never;
+
+type ExactObject<ParameterType, InputType> = {
+  [Key in keyof ParameterType]: Exact<ParameterType[Key], ObjectValue<InputType, Key>>;
+} & Record<Exclude<keyof InputType, KeysOfUnion<ParameterType>>, never>;
+
+export type Exact<ParameterType, InputType> =
+  // Before distributing, check if the two types are equal and if so, return the parameter type immediately
+  IsEqual<ParameterType, InputType> extends true
+    ? ParameterType
+    : // If the parameter is a primitive, return it as is immediately to avoid it being converted to a complex type
+      ParameterType extends Primitive
+      ? ParameterType
+      : // If the parameter is an unknown, return it as is immediately to avoid it being converted to a complex type
+        IsUnknown<ParameterType> extends true
+        ? unknown
+        : // If the parameter is a Function, return it as is because this type is not capable of handling function, leave it to TypeScript
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+          ParameterType extends Function
+          ? ParameterType
+          : // Convert union of array to array of union: A[] & B[] => (A & B)[]
+            ParameterType extends unknown[]
+            ? Array<Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>>
+            : // In TypeScript, Array is a subtype of ReadonlyArray, so always test Array before ReadonlyArray.
+              ParameterType extends readonly unknown[]
+              ? ReadonlyArray<Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>>
+              : ExactObject<ParameterType, InputType>;
+// End of borrow from  https://github.com/sindresorhus/type-fest/blob/main/source/union-to-intersection.d.ts
+
+export type RemovePrefix<Prefix extends string, Keys extends string> = {
+  [k in Keys]: k extends `${Prefix}${infer Suffix}` ? Suffix : never;
+}[Keys];
+
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }

--- a/packages/test/src/integration-tests-old.ts
+++ b/packages/test/src/integration-tests-old.ts
@@ -36,7 +36,6 @@ import {
   TimeoutType,
   WorkflowExecution,
   WorkflowExecutionAlreadyStartedError,
-  WorkflowIdReusePolicy,
   WorkflowNotFoundError,
 } from '@temporalio/common';
 import { msToNumber, tsToMs } from '@temporalio/common/lib/time';
@@ -330,7 +329,7 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
     if (!(err?.cause instanceof ChildWorkflowFailure)) {
       return t.fail('Expected err.cause to be an instance of ChildWorkflowFailure');
     }
-    t.is(err.cause.retryState, RetryState.RETRY_STATE_NON_RETRYABLE_FAILURE);
+    t.is(err.cause.retryState, RetryState.NON_RETRYABLE_FAILURE);
     if (!(err.cause.cause instanceof TerminatedFailure)) {
       return t.fail('Expected err.cause.cause to be an instance of TerminatedFailure');
     }
@@ -350,11 +349,11 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
     if (!(err?.cause instanceof ChildWorkflowFailure)) {
       return t.fail('Expected err.cause to be an instance of ChildWorkflowFailure');
     }
-    t.is(err.cause.retryState, RetryState.RETRY_STATE_TIMEOUT);
+    t.is(err.cause.retryState, RetryState.TIMEOUT);
     if (!(err.cause.cause instanceof TimeoutFailure)) {
       return t.fail('Expected err.cause.cause to be an instance of TimeoutFailure');
     }
-    t.is(err.cause.cause.timeoutType, TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE);
+    t.is(err.cause.cause.timeoutType, TimeoutType.START_TO_CLOSE);
   });
 
   test('child-workflow-start-fail', async (t) => {
@@ -1165,7 +1164,7 @@ export function runIntegrationTests(codec?: PayloadCodec): void {
         workflowId,
         signal: workflows.interruptSignal,
         signalArgs: ['interrupted from signalWithStart'],
-        workflowIdReusePolicy: WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+        workflowIdReusePolicy: 'REJECT_DUPLICATE',
       }),
       {
         instanceOf: WorkflowExecutionAlreadyStartedError,

--- a/packages/test/src/test-enums-helpers.ts
+++ b/packages/test/src/test-enums-helpers.ts
@@ -448,7 +448,7 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
 
   test('Protobuf Enum to Const Object of Strings conversion works', (t) => {
     t.is(encodeParentClosePolicy(undefined), undefined);
-    t.is(encodeParentClosePolicy(ParentClosePolicy.PARENT_CLOSE_POLICY_UNSPECIFIED), 0);
+    t.is(encodeParentClosePolicy(ParentClosePolicy.PARENT_CLOSE_POLICY_UNSPECIFIED), undefined);
 
     t.is(
       encodeParentClosePolicy(ParentClosePolicy.TERMINATE),

--- a/packages/test/src/test-enums-helpers.ts
+++ b/packages/test/src/test-enums-helpers.ts
@@ -1,0 +1,494 @@
+import test from 'ava';
+import { coresdk } from '@temporalio/proto';
+import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow/enums-helpers';
+
+// ASSERTION: There MUST be a corresponding `KEY: 'KEY'` in the const object of strings enum (must be present)
+{
+  type ParentClosePolicyMissingEntry =
+    (typeof ParentClosePolicyMissingEntry)[keyof typeof ParentClosePolicyMissingEntry];
+  const ParentClosePolicyMissingEntry = {
+    TERMINATE: 'TERMINATE',
+    // ABANDON: 'ABANDON',  // Missing entry!
+    REQUEST_CANCEL: 'REQUEST_CANCEL',
+  } as const;
+
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    // @ts-expect-error 2344  Property 'ABANDON' is missing in type '{...}' but required in type '...'
+    typeof ParentClosePolicyMissingEntry,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    {
+      [ParentClosePolicyMissingEntry.TERMINATE]: 1,
+      [ParentClosePolicyMissingEntry.REQUEST_CANCEL]: 3,
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+}
+
+// ASSERTION: There MUST be a corresponding `KEY: 'KEY'` in the const object of strings enum (must have correct value)
+{
+  type ParentClosePolicyIncorectEntry =
+    (typeof ParentClosePolicyIncorectEntry)[keyof typeof ParentClosePolicyIncorectEntry];
+  const ParentClosePolicyIncorectEntry = {
+    TERMINATE: 'TERMINATE',
+    ABANDON: 'INCORRECT', // Incorrect entry!
+    REQUEST_CANCEL: 'REQUEST_CANCEL',
+  } as const;
+
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    // @ts-expect-error 2344 Type '"INCORRECT"' is not assignable to type '"ABANDON"'
+    typeof ParentClosePolicyIncorectEntry,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    {
+      [ParentClosePolicyIncorectEntry.TERMINATE]: 1,
+      [ParentClosePolicyIncorectEntry.ABANDON]: 2,
+      [ParentClosePolicyIncorectEntry.REQUEST_CANCEL]: 3,
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+}
+
+// ASSERTION: There MAY be a corresponding `PREFIX_KEY: 'KEY'` in the const object of strings enum (may be present)
+{
+  type ParentClosePolicyWithPrefixedEntries =
+    (typeof ParentClosePolicyWithPrefixedEntries)[keyof typeof ParentClosePolicyWithPrefixedEntries];
+  const ParentClosePolicyWithPrefixedEntries = {
+    TERMINATE: 'TERMINATE',
+    ABANDON: 'ABANDON',
+    REQUEST_CANCEL: 'REQUEST_CANCEL',
+
+    PARENT_CLOSE_POLICY_TERMINATE: 'TERMINATE',
+    PARENT_CLOSE_POLICY_ABANDON: 'ABANDON',
+    PARENT_CLOSE_POLICY_REQUEST_CANCEL: 'REQUEST_CANCEL',
+  } as const;
+
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    typeof ParentClosePolicyWithPrefixedEntries,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    {
+      [ParentClosePolicyWithPrefixedEntries.TERMINATE]: 1,
+      [ParentClosePolicyWithPrefixedEntries.ABANDON]: 2,
+      [ParentClosePolicyWithPrefixedEntries.REQUEST_CANCEL]: 3,
+      UNSPECIFIED: 0,
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+}
+
+// ASSERTION: There MAY be a corresponding `PREFIX_KEY: 'KEY'` in the const object of strings enum (may not be present)
+{
+  type ParentClosePolicyWithoutPrefixedEntries =
+    (typeof ParentClosePolicyWithoutPrefixedEntries)[keyof typeof ParentClosePolicyWithoutPrefixedEntries];
+  const ParentClosePolicyWithoutPrefixedEntries = {
+    TERMINATE: 'TERMINATE',
+    ABANDON: 'ABANDON',
+    REQUEST_CANCEL: 'REQUEST_CANCEL',
+  } as const;
+
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    typeof ParentClosePolicyWithoutPrefixedEntries,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    {
+      [ParentClosePolicyWithoutPrefixedEntries.TERMINATE]: 1,
+      [ParentClosePolicyWithoutPrefixedEntries.ABANDON]: 2,
+      [ParentClosePolicyWithoutPrefixedEntries.REQUEST_CANCEL]: 3,
+      UNSPECIFIED: 0,
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+}
+
+// ASSERTION: There MAY be a corresponding `PREFIX_KEY: 'KEY'` in the const object of strings enum (if present, must have correct value)
+{
+  type ParentClosePolicyWithPrefixedEntries =
+    (typeof ParentClosePolicyWithPrefixedEntries)[keyof typeof ParentClosePolicyWithPrefixedEntries];
+  const ParentClosePolicyWithPrefixedEntries = {
+    TERMINATE: 'TERMINATE',
+    ABANDON: 'ABANDON',
+    REQUEST_CANCEL: 'REQUEST_CANCEL',
+
+    PARENT_CLOSE_POLICY_TERMINATE: 'TERMINATE',
+    PARENT_CLOSE_POLICY_ABANDON: 'ABANDON',
+    PARENT_CLOSE_POLICY_REQUEST_CANCEL: 'INCORRECT', // Incorrect entry!
+  } as const;
+
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    // @ts-expect-error 2344 Type '"INCORRECT"' is not assignable to type '"REQUEST_CANCEL"'
+    typeof ParentClosePolicyWithPrefixedEntries,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    {
+      [ParentClosePolicyWithPrefixedEntries.TERMINATE]: 1,
+      [ParentClosePolicyWithPrefixedEntries.ABANDON]: 2,
+      [ParentClosePolicyWithPrefixedEntries.REQUEST_CANCEL]: 3,
+      UNSPECIFIED: 0,
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+}
+
+{
+  type ParentClosePolicy = (typeof ParentClosePolicy)[keyof typeof ParentClosePolicy];
+  const ParentClosePolicy = {
+    TERMINATE: 'TERMINATE',
+    ABANDON: 'ABANDON',
+    REQUEST_CANCEL: 'REQUEST_CANCEL',
+
+    PARENT_CLOSE_POLICY_UNSPECIFIED: undefined,
+    PARENT_CLOSE_POLICY_TERMINATE: 'TERMINATE',
+    PARENT_CLOSE_POLICY_ABANDON: 'ABANDON',
+    PARENT_CLOSE_POLICY_REQUEST_CANCEL: 'REQUEST_CANCEL',
+  } as const;
+
+  // ASSERTION: There MUST be a corresponding `KEY: number` in the mapping table (must be there)
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    typeof ParentClosePolicy,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    // @ts-expect-error 2345  Property '...' is missing in type '{...}' but required in type '...'
+    {
+      [ParentClosePolicy.TERMINATE]: 1,
+      // [ParentClosePolicy.ABANDON]: 2, // Missing entry!
+      [ParentClosePolicy.REQUEST_CANCEL]: 3,
+      UNSPECIFIED: 0,
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+
+  // ASSERTION: There MUST be a corresponding `KEY: number` in the mapping table (must be correct)
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    typeof ParentClosePolicy,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    {
+      [ParentClosePolicy.TERMINATE]: 1,
+      // @ts-expect-error 2418 Type of computed property's value is '...', which is not assignable to type '...'
+      [ParentClosePolicy.ABANDON]: 4, // Incorrect value!
+      [ParentClosePolicy.REQUEST_CANCEL]: 3,
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+}
+
+// ASSERTION: There MAY be a corresponding `PREFIX_UNSPECIFIED: undefined` in the const object of strings enum (may be there)
+{
+  const ParentClosePolicyWithUnspecified = {
+    TERMINATE: 'TERMINATE',
+    ABANDON: 'ABANDON',
+    REQUEST_CANCEL: 'REQUEST_CANCEL',
+    PARENT_CLOSE_POLICY_UNSPECIFIED: undefined,
+  } as const;
+
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    typeof ParentClosePolicyWithUnspecified,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    {
+      [ParentClosePolicyWithUnspecified.TERMINATE]: 1,
+      [ParentClosePolicyWithUnspecified.ABANDON]: 2,
+      [ParentClosePolicyWithUnspecified.REQUEST_CANCEL]: 3,
+      UNSPECIFIED: 0,
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+}
+
+// ASSERTION: There MAY be a corresponding `PREFIX_UNSPECIFIED: undefined` in the const object of strings enum (may not be there)
+{
+  const ParentClosePolicyWithoutUnspecified = {
+    TERMINATE: 'TERMINATE',
+    ABANDON: 'ABANDON',
+    REQUEST_CANCEL: 'REQUEST_CANCEL',
+  } as const;
+
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    typeof ParentClosePolicyWithoutUnspecified,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    {
+      [ParentClosePolicyWithoutUnspecified.TERMINATE]: 1,
+      [ParentClosePolicyWithoutUnspecified.ABANDON]: 2,
+      [ParentClosePolicyWithoutUnspecified.REQUEST_CANCEL]: 3,
+      UNSPECIFIED: 0,
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+}
+
+// ASSERTION: There MAY be a corresponding `PREFIX_UNSPECIFIED: undefined` in the const object of strings enum (if present, must have correct value)
+{
+  const ParentClosePolicyWithUnspecifiedIncorrectValue = {
+    TERMINATE: 'TERMINATE',
+    ABANDON: 'ABANDON',
+    REQUEST_CANCEL: 'REQUEST_CANCEL',
+    PARENT_CLOSE_POLICY_UNSPECIFIED: 'UNSPECIFIED', // Incorrect value!
+  } as const;
+
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    // @ts-expect-error 2344 Type '"UNSPECIFIED"' is not assignable to type 'undefined'
+    typeof ParentClosePolicyWithUnspecifiedIncorrectValue,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    {
+      [ParentClosePolicyWithUnspecifiedIncorrectValue.TERMINATE]: 1,
+      [ParentClosePolicyWithUnspecifiedIncorrectValue.ABANDON]: 2,
+      [ParentClosePolicyWithUnspecifiedIncorrectValue.REQUEST_CANCEL]: 3,
+      UNSPECIFIED: 0,
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+}
+
+// ASSERTION: There MUST be an `UNSPECIFIED: 0` in the mapping table
+{
+  const ParentClosePolicyWithoutUnspecified = {
+    TERMINATE: 'TERMINATE',
+    ABANDON: 'ABANDON',
+    REQUEST_CANCEL: 'REQUEST_CANCEL',
+  } as const;
+
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    typeof ParentClosePolicyWithoutUnspecified,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    // @ts-expect-error 2345 Property 'UNSPECIFIED' is missing in type '{...}' but required in type '...'
+    {
+      [ParentClosePolicyWithoutUnspecified.TERMINATE]: 1,
+      [ParentClosePolicyWithoutUnspecified.ABANDON]: 2,
+      [ParentClosePolicyWithoutUnspecified.REQUEST_CANCEL]: 3,
+      // UNSPECIFIED: 0, // Missing UNSPECIFIED entry!
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+}
+
+// ASSERTION: The const object of strings enum MUST NOT contain any other keys than the ones mandated or optionally allowed above.
+{
+  type ParentClosePolicyWithExtra = (typeof ParentClosePolicyWithExtra)[keyof typeof ParentClosePolicyWithExtra];
+  const ParentClosePolicyWithExtra = {
+    TERMINATE: 'TERMINATE',
+    ABANDON: 'ABANDON',
+    REQUEST_CANCEL: 'REQUEST_CANCEL',
+    EXTRA: 'EXTRA', // Extra entry!
+  } as const;
+
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    // @ts-expect-error 2344 Types of property 'EXTRA' are incompatible — Type 'string' is not assignable to type 'never'
+    typeof ParentClosePolicyWithExtra,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    {
+      [ParentClosePolicyWithExtra.TERMINATE]: 1,
+      [ParentClosePolicyWithExtra.ABANDON]: 2,
+      [ParentClosePolicyWithExtra.REQUEST_CANCEL]: 3,
+      UNSPECIFIED: 0,
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+}
+
+{
+  type ParentClosePolicy = (typeof ParentClosePolicy)[keyof typeof ParentClosePolicy];
+  const ParentClosePolicy = {
+    TERMINATE: 'TERMINATE',
+    ABANDON: 'ABANDON',
+    REQUEST_CANCEL: 'REQUEST_CANCEL',
+
+    PARENT_CLOSE_POLICY_UNSPECIFIED: undefined,
+    PARENT_CLOSE_POLICY_TERMINATE: 'TERMINATE',
+    PARENT_CLOSE_POLICY_ABANDON: 'ABANDON',
+    PARENT_CLOSE_POLICY_REQUEST_CANCEL: 'REQUEST_CANCEL',
+  } as const;
+
+  // ASSERTION: The mapping table MUST NOT contain any other keys than the ones mandated above
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    typeof ParentClosePolicy,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    {
+      [ParentClosePolicy.TERMINATE]: 1,
+      [ParentClosePolicy.ABANDON]: 2,
+      // @ts-expect-error 2353 Object literal may only specify known properties, and '...' does not exist in type
+      extraEntry: 1,
+      [ParentClosePolicy.REQUEST_CANCEL]: 3,
+      UNSPECIFIED: 0,
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+
+  // ASSERTION: The mapping table MUST NOT contain any other keys than the ones mandated above (duplicate entry using prefixed key)
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    typeof ParentClosePolicy,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    {
+      [ParentClosePolicy.TERMINATE]: 1,
+      [ParentClosePolicy.ABANDON]: 2,
+      //@ts-expect-error 1117 An object literal cannot have multiple properties with the same name
+      [ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON]: 2, // Duplicate entry using prefixed key!
+      [ParentClosePolicy.REQUEST_CANCEL]: 3,
+      UNSPECIFIED: 0,
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+
+  // ASSERTION: The mapping table MUST NOT contain any other keys than the ones mandated above (duplicate entry using prefixewd key as raw string)
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    typeof ParentClosePolicy,
+    'PARENT_CLOSE_POLICY_'
+  >(
+    {
+      [ParentClosePolicy.TERMINATE]: 1,
+      [ParentClosePolicy.ABANDON]: 2,
+      // @ts-expect-error 2353 Object literal may only specify known properties, and '...' does not exist in type
+      PARENT_CLOSE_POLICY_ABANDON: 2, // Duplicate entry using prefixed key!
+      [ParentClosePolicy.REQUEST_CANCEL]: 3,
+      UNSPECIFIED: 0,
+    } as const,
+    'PARENT_CLOSE_POLICY_'
+  );
+
+  // ASSERTION: If a prefix is provided, then all values in the proto enum MUST start with that prefix
+  makeProtoEnumConverters<
+    coresdk.child_workflow.ParentClosePolicy,
+    typeof coresdk.child_workflow.ParentClosePolicy,
+    // @ts-expect-error 2344 Type '...' does not satisfy the constraint '...'.
+    keyof typeof coresdk.child_workflow.ParentClosePolicy,
+    typeof ParentClosePolicy,
+    'INVALID_PREFIX_' // Incorrect prefix!
+  >(
+    {
+      [ParentClosePolicy.TERMINATE]: 1,
+      [ParentClosePolicy.ABANDON]: 2,
+      [ParentClosePolicy.REQUEST_CANCEL]: 3,
+    } as const,
+    'INVALID_PREFIX_'
+  );
+}
+
+// Functionnal tests
+{
+  type ParentClosePolicy = (typeof ParentClosePolicy)[keyof typeof ParentClosePolicy];
+  const ParentClosePolicy = {
+    TERMINATE: 'TERMINATE',
+    ABANDON: 'ABANDON',
+    REQUEST_CANCEL: 'REQUEST_CANCEL',
+
+    PARENT_CLOSE_POLICY_UNSPECIFIED: undefined,
+    PARENT_CLOSE_POLICY_TERMINATE: 'TERMINATE',
+    PARENT_CLOSE_POLICY_ABANDON: 'ABANDON',
+    PARENT_CLOSE_POLICY_REQUEST_CANCEL: 'REQUEST_CANCEL',
+  } as const;
+
+  const [encodeParentClosePolicy, decodeParentClosePolicy] = //
+    makeProtoEnumConverters<
+      coresdk.child_workflow.ParentClosePolicy,
+      typeof coresdk.child_workflow.ParentClosePolicy,
+      keyof typeof coresdk.child_workflow.ParentClosePolicy,
+      typeof ParentClosePolicy,
+      'PARENT_CLOSE_POLICY_'
+    >(
+      {
+        [ParentClosePolicy.TERMINATE]: 1,
+        [ParentClosePolicy.ABANDON]: 2,
+        [ParentClosePolicy.REQUEST_CANCEL]: 3,
+
+        UNSPECIFIED: 0,
+      } as const,
+      'PARENT_CLOSE_POLICY_'
+    );
+
+  test('Protobuf Enum to Const Object of Strings conversion works', (t) => {
+    t.is(encodeParentClosePolicy(undefined), undefined);
+    t.is(encodeParentClosePolicy(ParentClosePolicy.PARENT_CLOSE_POLICY_UNSPECIFIED), 0);
+
+    t.is(
+      encodeParentClosePolicy(ParentClosePolicy.TERMINATE),
+      coresdk.child_workflow.ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE
+    );
+    t.is(
+      encodeParentClosePolicy(ParentClosePolicy.ABANDON),
+      coresdk.child_workflow.ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON
+    );
+    t.is(
+      encodeParentClosePolicy(ParentClosePolicy.REQUEST_CANCEL),
+      coresdk.child_workflow.ParentClosePolicy.PARENT_CLOSE_POLICY_REQUEST_CANCEL
+    );
+
+    t.is(
+      encodeParentClosePolicy(ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON),
+      coresdk.child_workflow.ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON
+    );
+    t.is(
+      encodeParentClosePolicy(ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE),
+      coresdk.child_workflow.ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE
+    );
+    t.is(
+      encodeParentClosePolicy(ParentClosePolicy.PARENT_CLOSE_POLICY_REQUEST_CANCEL),
+      coresdk.child_workflow.ParentClosePolicy.PARENT_CLOSE_POLICY_REQUEST_CANCEL
+    );
+  });
+
+  test('Const Object of Strings to Protobuf Enum conversion works', (t) => {
+    t.is(
+      decodeParentClosePolicy(coresdk.child_workflow.ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE),
+      ParentClosePolicy.TERMINATE
+    );
+    t.is(
+      decodeParentClosePolicy(coresdk.child_workflow.ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON),
+      ParentClosePolicy.ABANDON
+    );
+    t.is(
+      decodeParentClosePolicy(coresdk.child_workflow.ParentClosePolicy.PARENT_CLOSE_POLICY_REQUEST_CANCEL),
+      ParentClosePolicy.REQUEST_CANCEL
+    );
+  });
+}

--- a/packages/test/src/test-integration-workflows.ts
+++ b/packages/test/src/test-integration-workflows.ts
@@ -7,7 +7,7 @@ import { msToNumber, tsToMs } from '@temporalio/common/lib/time';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
 import { CancelReason } from '@temporalio/worker/lib/activity';
 import * as workflow from '@temporalio/workflow';
-import { defineQuery, defineSignal, WorkflowIdConflictPolicy } from '@temporalio/workflow';
+import { defineQuery, defineSignal } from '@temporalio/workflow';
 import { SdkFlags } from '@temporalio/workflow/lib/flags';
 import { ActivityCancellationType, ApplicationFailure, WorkflowExecutionAlreadyStartedError } from '@temporalio/common';
 import { signalSchedulingWorkflow } from './activities/helpers';
@@ -251,7 +251,7 @@ test('Start of workflow respects workflow id conflict policy', async (t) => {
       client.workflow.start(conflictId, {
         taskQueue,
         workflowId: wfid,
-        workflowIdConflictPolicy: WorkflowIdConflictPolicy.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
+        workflowIdConflictPolicy: 'FAIL',
       }),
       {
         instanceOf: WorkflowExecutionAlreadyStartedError,
@@ -264,7 +264,7 @@ test('Start of workflow respects workflow id conflict policy', async (t) => {
     const handle2 = await client.workflow.start(conflictId, {
       taskQueue,
       workflowId: wfid,
-      workflowIdConflictPolicy: WorkflowIdConflictPolicy.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+      workflowIdConflictPolicy: 'USE_EXISTING',
     });
 
     const desc = await handleWithRunId.describe();
@@ -278,7 +278,7 @@ test('Start of workflow respects workflow id conflict policy', async (t) => {
     const handle3 = await client.workflow.start(conflictId, {
       taskQueue,
       workflowId: wfid,
-      workflowIdConflictPolicy: WorkflowIdConflictPolicy.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING,
+      workflowIdConflictPolicy: 'TERMINATE_EXISTING',
     });
 
     const descWithRunId = await handleWithRunId.describe();
@@ -321,7 +321,7 @@ test('Start of workflow with signal respects conflict id policy', async (t) => {
       workflowId: wfid,
       signal: workflows.argsTestSignal,
       signalArgs: [123, 'kid'],
-      workflowIdConflictPolicy: WorkflowIdConflictPolicy.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING,
+      workflowIdConflictPolicy: 'TERMINATE_EXISTING',
     });
 
     const descWithRunId = await handleWithRunId.describe();

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -10,11 +10,10 @@ import {
   defaultPayloadConverter,
   SdkComponent,
   Payload,
-  RetryState,
   toPayloads,
 } from '@temporalio/common';
 import { msToTs } from '@temporalio/common/lib/time';
-import { coresdk } from '@temporalio/proto';
+import { coresdk, temporal } from '@temporalio/proto';
 import { LogTimestamp } from '@temporalio/worker';
 import { WorkflowCodeBundler } from '@temporalio/worker/lib/workflow/bundler';
 import { VMWorkflow, VMWorkflowCreator } from '@temporalio/worker/lib/workflow/vm';
@@ -210,7 +209,7 @@ function makeActivityCancelledFailure(activityId: string, activityType: string) 
       activityId,
       identity: 'test',
       activityType: { name: activityType },
-      retryState: RetryState.RETRY_STATE_CANCEL_REQUESTED,
+      retryState: temporal.api.enums.v1.RetryState.RETRY_STATE_CANCEL_REQUESTED,
     },
   };
 }

--- a/packages/test/src/workflows/activity-failures.ts
+++ b/packages/test/src/workflows/activity-failures.ts
@@ -57,17 +57,17 @@ function assertRetryState(err: ActivityFailure, retryState: RetryState) {
 export async function activityFailures(): Promise<void> {
   {
     const err = await assertThrows(throwSpecificError('RetryableError', '1'), ActivityFailure);
-    assertRetryState(err, RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED);
+    assertRetryState(err, RetryState.MAXIMUM_ATTEMPTS_REACHED);
     assertApplicationFailure(err.cause, 'RetryableError', false, '1');
   }
   {
     const err = await assertThrows(throwSpecificError('NonRetryableError', '2'), ActivityFailure);
-    assertRetryState(err, RetryState.RETRY_STATE_NON_RETRYABLE_FAILURE);
+    assertRetryState(err, RetryState.NON_RETRYABLE_FAILURE);
     assertApplicationFailure(err.cause, 'NonRetryableError', false, '2');
   }
   {
     const err = await assertThrows(throwSpecificError('CustomError', '2'), ActivityFailure);
-    assertRetryState(err, RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED);
+    assertRetryState(err, RetryState.MAXIMUM_ATTEMPTS_REACHED);
     assertApplicationFailure(err.cause, 'CustomError', false, '2');
   }
   {
@@ -75,7 +75,7 @@ export async function activityFailures(): Promise<void> {
       throwSpecificError('RetryableApplicationFailureWithRetryableFlag', '3'),
       ActivityFailure
     );
-    assertRetryState(err, RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED);
+    assertRetryState(err, RetryState.MAXIMUM_ATTEMPTS_REACHED);
     assertApplicationFailure(err.cause, 'RetryableError', false, '3');
   }
   {
@@ -83,7 +83,7 @@ export async function activityFailures(): Promise<void> {
       throwSpecificError('RetryableApplicationFailureWithNonRetryableFlag', '4'),
       ActivityFailure
     );
-    assertRetryState(err, RetryState.RETRY_STATE_NON_RETRYABLE_FAILURE);
+    assertRetryState(err, RetryState.NON_RETRYABLE_FAILURE);
     assertApplicationFailure(err.cause, 'RetryableError', true, '4');
   }
   {
@@ -91,7 +91,7 @@ export async function activityFailures(): Promise<void> {
       throwSpecificError('NonRetryableApplicationFailureWithRetryableFlag', '5'),
       ActivityFailure
     );
-    assertRetryState(err, RetryState.RETRY_STATE_NON_RETRYABLE_FAILURE);
+    assertRetryState(err, RetryState.NON_RETRYABLE_FAILURE);
     assertApplicationFailure(err.cause, 'NonRetryableError', false, '5');
   }
   {
@@ -99,12 +99,12 @@ export async function activityFailures(): Promise<void> {
       throwSpecificError('NonRetryableApplicationFailureWithNonRetryableFlag', '6'),
       ActivityFailure
     );
-    assertRetryState(err, RetryState.RETRY_STATE_NON_RETRYABLE_FAILURE);
+    assertRetryState(err, RetryState.NON_RETRYABLE_FAILURE);
     assertApplicationFailure(err.cause, 'NonRetryableError', true, '6');
   }
   {
     const err = await assertThrows(throwSpecificError('RetryableApplicationFailureWithDetails', '7'), ActivityFailure);
-    assertRetryState(err, RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED);
+    assertRetryState(err, RetryState.MAXIMUM_ATTEMPTS_REACHED);
     assertApplicationFailure(err.cause, 'RetryableError', false, '7');
     const [detail1, detail2] = err.cause.details as [string, string];
     if (!(detail1 === 'detail1' && detail2 === 'detail2')) {

--- a/packages/test/src/workflows/child-workflow-start-fail.ts
+++ b/packages/test/src/workflows/child-workflow-start-fail.ts
@@ -3,14 +3,14 @@
  * @module
  */
 
-import { startChild, WorkflowIdReusePolicy } from '@temporalio/workflow';
+import { startChild } from '@temporalio/workflow';
 import { WorkflowExecutionAlreadyStartedError } from '@temporalio/common';
 import { successString } from './success-string';
 
 export async function childWorkflowStartFail(): Promise<void> {
   const child = await startChild(successString, {
     taskQueue: 'test',
-    workflowIdReusePolicy: WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+    workflowIdReusePolicy: 'REJECT_DUPLICATE',
   });
   await child.result();
 
@@ -18,7 +18,7 @@ export async function childWorkflowStartFail(): Promise<void> {
     await startChild(successString, {
       taskQueue: 'test',
       workflowId: child.workflowId, // duplicate
-      workflowIdReusePolicy: WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+      workflowIdReusePolicy: 'REJECT_DUPLICATE',
     });
     throw new Error('Managed to start a Workflow with duplicate workflowId');
   } catch (err) {

--- a/packages/test/src/workflows/testenv-test-workflows.ts
+++ b/packages/test/src/workflows/testenv-test-workflows.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert';
-import { sleep, proxyActivities, defineSignal, setHandler, startChild, ParentClosePolicy } from '@temporalio/workflow';
+import { sleep, proxyActivities, defineSignal, setHandler, startChild } from '@temporalio/workflow';
 
 // Export sleep to be invoked as a workflow
 export { sleep };
@@ -45,6 +45,6 @@ export async function asyncChildStarter(childWorkflowId: string): Promise<void> 
   await startChild(sleep, {
     args: ['1 day'],
     workflowId: childWorkflowId,
-    parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON,
+    parentClosePolicy: 'ABANDON',
   });
 }

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -11,7 +11,8 @@ import {
   Duration,
   VersioningIntent,
 } from '@temporalio/common';
-import { checkExtends, SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
+import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
+import { makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow/enums-helpers';
 import type { coresdk } from '@temporalio/proto';
 
 /**
@@ -273,16 +274,18 @@ export interface ContinueAsNewOptions {
  *
  * @default {@link ChildWorkflowCancellationType.WAIT_CANCELLATION_COMPLETED}
  */
-export enum ChildWorkflowCancellationType {
+export type ChildWorkflowCancellationType =
+  (typeof ChildWorkflowCancellationType)[keyof typeof ChildWorkflowCancellationType];
+export const ChildWorkflowCancellationType = {
   /**
    * Don't send a cancellation request to the Child.
    */
-  ABANDON = 0,
+  ABANDON: 'ABANDON',
 
   /**
    * Send a cancellation request to the Child. Immediately throw the error.
    */
-  TRY_CANCEL = 1,
+  TRY_CANCEL: 'TRY_CANCEL',
 
   /**
    * Send a cancellation request to the Child. The Child may respect cancellation, in which case an error will be thrown
@@ -292,48 +295,102 @@ export enum ChildWorkflowCancellationType {
    *
    * @default
    */
-  WAIT_CANCELLATION_COMPLETED = 2,
+  WAIT_CANCELLATION_COMPLETED: 'WAIT_CANCELLATION_COMPLETED',
 
   /**
    * Send a cancellation request to the Child. Throw the error once the Server receives the Child cancellation request.
    */
-  WAIT_CANCELLATION_REQUESTED = 3,
-}
+  WAIT_CANCELLATION_REQUESTED: 'WAIT_CANCELLATION_REQUESTED',
+} as const;
 
-checkExtends<coresdk.child_workflow.ChildWorkflowCancellationType, ChildWorkflowCancellationType>();
-checkExtends<ChildWorkflowCancellationType, coresdk.child_workflow.ChildWorkflowCancellationType>();
+// ts-prune-ignore-next
+export const [encodeChildWorkflowCancellationType, decodeChildWorkflowCancellationType] = makeProtoEnumConverters<
+  coresdk.child_workflow.ChildWorkflowCancellationType,
+  typeof coresdk.child_workflow.ChildWorkflowCancellationType,
+  keyof typeof coresdk.child_workflow.ChildWorkflowCancellationType,
+  typeof ChildWorkflowCancellationType,
+  ''
+>(
+  {
+    [ChildWorkflowCancellationType.ABANDON]: 0,
+    [ChildWorkflowCancellationType.TRY_CANCEL]: 1,
+    [ChildWorkflowCancellationType.WAIT_CANCELLATION_COMPLETED]: 2,
+    [ChildWorkflowCancellationType.WAIT_CANCELLATION_REQUESTED]: 3,
+  } as const,
+  ''
+);
 
 /**
  * How a Child Workflow reacts to the Parent Workflow reaching a Closed state.
  *
  * @see {@link https://docs.temporal.io/concepts/what-is-a-parent-close-policy/ | Parent Close Policy}
  */
-export enum ParentClosePolicy {
-  /**
-   * If a `ParentClosePolicy` is set to this, or is not set at all, the server default value will be used.
-   */
-  PARENT_CLOSE_POLICY_UNSPECIFIED = 0,
-
+export type ParentClosePolicy = (typeof ParentClosePolicy)[keyof typeof ParentClosePolicy];
+export const ParentClosePolicy = {
   /**
    * When the Parent is Closed, the Child is Terminated.
    *
    * @default
    */
-  PARENT_CLOSE_POLICY_TERMINATE = 1,
+  TERMINATE: 'TERMINATE',
 
   /**
    * When the Parent is Closed, nothing is done to the Child.
    */
-  PARENT_CLOSE_POLICY_ABANDON = 2,
+  ABANDON: 'ABANDON',
 
   /**
    * When the Parent is Closed, the Child is Cancelled.
    */
-  PARENT_CLOSE_POLICY_REQUEST_CANCEL = 3,
-}
+  REQUEST_CANCEL: 'REQUEST_CANCEL',
 
-checkExtends<coresdk.child_workflow.ParentClosePolicy, ParentClosePolicy>();
-checkExtends<ParentClosePolicy, coresdk.child_workflow.ParentClosePolicy>();
+  /// Anything below this line has been deprecated
+
+  /**
+   * If a `ParentClosePolicy` is set to this, or is not set at all, the server default value will be used.
+   *
+   * @deprecated Either leave property `undefined`, or set an explicit policy instead.
+   */
+  PARENT_CLOSE_POLICY_UNSPECIFIED: undefined, // eslint-disable-line deprecation/deprecation
+
+  /**
+   * When the Parent is Closed, the Child is Terminated.
+   *
+   * @deprecated Use {@link ParentClosePolicy.TERMINATE} instead.
+   */
+  PARENT_CLOSE_POLICY_TERMINATE: 'TERMINATE', // eslint-disable-line deprecation/deprecation
+
+  /**
+   * When the Parent is Closed, nothing is done to the Child.
+   *
+   * @deprecated Use {@link ParentClosePolicy.ABANDON} instead.
+   */
+  PARENT_CLOSE_POLICY_ABANDON: 'ABANDON', // eslint-disable-line deprecation/deprecation
+
+  /**
+   * When the Parent is Closed, the Child is Cancelled.
+   *
+   * @deprecated Use {@link ParentClosePolicy.REQUEST_CANCEL} instead.
+   */
+  PARENT_CLOSE_POLICY_REQUEST_CANCEL: 'REQUEST_CANCEL', // eslint-disable-line deprecation/deprecation
+} as const;
+
+// ts-prune-ignore-next
+export const [encodeParentClosePolicy, decodeParentClosePolicy] = makeProtoEnumConverters<
+  coresdk.child_workflow.ParentClosePolicy,
+  typeof coresdk.child_workflow.ParentClosePolicy,
+  keyof typeof coresdk.child_workflow.ParentClosePolicy,
+  typeof ParentClosePolicy,
+  'PARENT_CLOSE_POLICY_'
+>(
+  {
+    [ParentClosePolicy.TERMINATE]: 1,
+    [ParentClosePolicy.ABANDON]: 2,
+    [ParentClosePolicy.REQUEST_CANCEL]: 3,
+    UNSPECIFIED: 0,
+  } as const,
+  'PARENT_CLOSE_POLICY_'
+);
 
 export interface ChildWorkflowOptions extends CommonWorkflowOptions {
   /**

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -2,6 +2,8 @@ import {
   ActivityFunction,
   ActivityOptions,
   compileRetryPolicy,
+  encodeActivityCancellationType,
+  encodeWorkflowIdReusePolicy,
   extractWorkflowType,
   HandlerUnfinishedPolicy,
   LocalActivityOptions,
@@ -46,6 +48,8 @@ import {
   UpdateHandlerOptions,
   WorkflowInfo,
   UpdateInfo,
+  encodeChildWorkflowCancellationType,
+  encodeParentClosePolicy,
 } from './interfaces';
 import { LocalActivityDoBackoff } from './errors';
 import { assertInWorkflowContext, getActivator, maybeGetActivator } from './global-attributes';
@@ -179,7 +183,7 @@ function scheduleActivityNextHandler({ options, args, headers, seq, activityType
         startToCloseTimeout: msOptionalToTs(options.startToCloseTimeout),
         scheduleToStartTimeout: msOptionalToTs(options.scheduleToStartTimeout),
         headers,
-        cancellationType: options.cancellationType,
+        cancellationType: encodeActivityCancellationType(options.cancellationType),
         doNotEagerlyExecute: !(options.allowEagerDispatch ?? true),
         versioningIntent: versioningIntentToProto(options.versioningIntent),
       },
@@ -246,7 +250,7 @@ async function scheduleLocalActivityNextHandler({
         scheduleToStartTimeout: msOptionalToTs(options.scheduleToStartTimeout),
         localRetryThreshold: msOptionalToTs(options.localRetryThreshold),
         headers,
-        cancellationType: options.cancellationType,
+        cancellationType: encodeActivityCancellationType(options.cancellationType),
       },
     });
     activator.completions.activity.set(seq, {
@@ -372,9 +376,9 @@ function startChildWorkflowExecutionNextHandler({
         workflowTaskTimeout: msOptionalToTs(options.workflowTaskTimeout),
         namespace: activator.info.namespace, // Not configurable
         headers,
-        cancellationType: options.cancellationType,
-        workflowIdReusePolicy: options.workflowIdReusePolicy,
-        parentClosePolicy: options.parentClosePolicy,
+        cancellationType: encodeChildWorkflowCancellationType(options.cancellationType),
+        workflowIdReusePolicy: encodeWorkflowIdReusePolicy(options.workflowIdReusePolicy),
+        parentClosePolicy: encodeParentClosePolicy(options.parentClosePolicy),
         cronSchedule: options.cronSchedule,
         searchAttributes: options.searchAttributes
           ? mapToPayloads(searchAttributePayloadConverter, options.searchAttributes)


### PR DESCRIPTION
## What was changed

- This PR normalizes conventions around user facing `enums` in the TS SDK.

- More specifically, it features the following conventions:

  - No more redundant prefixes on enum values.
  
    For example:
    ```diff
      await startChild(sleep, {
    -   parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON,
    +   parentClosePolicy: ParentClosePolicy.ABANDON,
      });
    ```

  - No more 'UNSPECIFIED' values in user facing enums; TypeScript's `undefined` already means that.
  
  - "Enum values" are now of type string, and the "enum" themselves are now implemented using `const` objects, with a string union type defined from all values of the const object. That makes it possible for users to simply pass the string representation of an enum value, without having to import and refer to the enum definition object. That's much more TS idiomatic and is better supported by TS code editors.

    The preceding example can therefore be further reduced down to:
    ```diff
      await startChild(sleep, {
    -   parentClosePolicy: ParentClosePolicy.ABANDON,
    +   parentClosePolicy: 'ABANDON',
      });
    ```

  - The const object is preserved (i.e not completely replaced by the union of strings type), for backward compatibility reasons, but also because it plays better in regard to documentation of each enum values.

  - We preserve build-time backward compatibility for enum values that existed before.

    For example, the following code will still compile, but will report a deprecation on `ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON`.

    ```typescript
      await startChild(sleep, {
        parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON,
      });
    ```

  - We maintain the SCREAMING_SNAKE_CASE format for enum values

  - For "user facing enums" to/from "proto enums" conversions, we normalize on a `encodeEnumName(string): ProtoEnumValue` and a `decodeEnumName(ProtoEnumValue): string` functions, where `ProtoEnumValue` really is the _numerical value_ of the proto enum value. This ensures uniformity for all enum types, without risk of getting the proto definitions imported in the Workflow sandbox (which would significantly increase the per-workflow memory footprint).
