### PR TITLE
feat(Schedule): support query for listing schedules

### DIFF
--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -162,6 +162,10 @@ export interface ListScheduleOptions {
    * @default 1000
    */
   pageSize?: number;
+  /**
+   * Filter schedules by a query string.
+   */
+  query?: string;
 }
 
 /**
@@ -368,6 +372,7 @@ export class ScheduleClient extends BaseClient {
           nextPageToken,
           namespace: this.options.namespace,
           maximumPageSize: options?.pageSize,
+          query: options?.query,
         });
       } catch (e) {
         this.rethrowGrpcError(e, 'Failed to list schedules', undefined);

--- a/packages/test/src/test-schedules.ts
+++ b/packages/test/src/test-schedules.ts
@@ -549,11 +549,11 @@ if (RUN_INTEGRATION_TESTS) {
     const groupId = randomUUID();
     const createdScheduleHandlesPromises = [];
     const expectedIds: string[] = [];
-    for(let i = 0; i < 4; i++) {
-      const scheduleId = `test-query-${groupId}-${i + 1}`
+    for (let i = 0; i < 4; i++) {
+      const scheduleId = `test-query-${groupId}-${i + 1}`;
       const searchAttributes: SearchAttributes = {};
-      if(i < 2) {
-        searchAttributes["CustomKeywordField"] = ['some-value'];
+      if (i < 2) {
+        searchAttributes['CustomKeywordField'] = ['some-value'];
         expectedIds.push(scheduleId);
       }
       createdScheduleHandlesPromises.push(
@@ -575,7 +575,7 @@ if (RUN_INTEGRATION_TESTS) {
     const createdScheduleHandles: { [k: string]: ScheduleHandle } = Object.fromEntries(
       (await Promise.all(createdScheduleHandlesPromises)).map((x) => [x.scheduleId, x])
     );
-    
+
     try {
       // Wait for visibility to stabilize
       await asyncRetry(
@@ -583,16 +583,14 @@ if (RUN_INTEGRATION_TESTS) {
           const listedScheduleHandlesFromQuery: ScheduleSummary[] = []; // to list all the schedule handles from the query string provided
           const query = `CustomKeywordField="some-value"`;
 
-          for await (const schedule of client.schedule.list({ query: query })) {
+          for await (const schedule of client.schedule.list({ query })) {
             listedScheduleHandlesFromQuery.push(schedule);
           }
 
-          const listedScheduleIdsFromQuery = listedScheduleHandlesFromQuery
-            .map((x) => x.scheduleId)
-            .sort();
+          const listedScheduleIdsFromQuery = listedScheduleHandlesFromQuery.map((x) => x.scheduleId).sort();
 
           if (listedScheduleIdsFromQuery.length !== expectedIds.length) throw new Error('Entries are missing');
-          
+
           t.deepEqual(listedScheduleIdsFromQuery, expectedIds);
         },
         {

--- a/packages/test/src/test-schedules.ts
+++ b/packages/test/src/test-schedules.ts
@@ -567,7 +567,7 @@ if (RUN_INTEGRATION_TESTS) {
             workflowType: dummyWorkflow,
             taskQueue,
           },
-          searchAttributes: Object.keys(searchAttributes).length ? searchAttributes : undefined,
+          searchAttributes,
         })
       );
     }

--- a/packages/test/src/test-schedules.ts
+++ b/packages/test/src/test-schedules.ts
@@ -10,6 +10,7 @@ import {
   ScheduleHandle,
   ScheduleSummary,
   ScheduleUpdateOptions,
+  SearchAttributes,
 } from '@temporalio/client';
 import { msToNumber } from '@temporalio/common/lib/time';
 import { registerDefaultCustomSearchAttributes, RUN_INTEGRATION_TESTS } from './helpers';
@@ -550,40 +551,25 @@ if (RUN_INTEGRATION_TESTS) {
     const expectedIds: string[] = [];
     for(let i = 0; i < 4; i++) {
       const scheduleId = `test-query-${groupId}-${i + 1}`
+      const searchAttributes: SearchAttributes = {};
       if(i < 2) {
-        createdScheduleHandlesPromises.push(
-          client.schedule.create({
-            scheduleId,
-            spec: {
-              calendars: [{ hour: { start: 2, end: 7, step: 1 } }],
-            },
-            action: {
-              type: 'startWorkflow',
-              workflowType: dummyWorkflow,
-              taskQueue,
-            },
-            searchAttributes: {
-              "CustomKeywordField": ["some-value"],
-            }
-          })
-        )
+        searchAttributes["CustomKeywordField"] = ['some-value'];
         expectedIds.push(scheduleId);
       }
-      else {
-        createdScheduleHandlesPromises.push(
-          client.schedule.create({
-            scheduleId,
-            spec: {
-              calendars: [{ hour: { start: 2, end: 7, step: 1 } }],
-            },
-            action: {
-              type: 'startWorkflow',
-              workflowType: dummyWorkflow,
-              taskQueue,
-            },
-          })
-        )
-      }
+      createdScheduleHandlesPromises.push(
+        client.schedule.create({
+          scheduleId,
+          spec: {
+            calendars: [{ hour: { start: 2, end: 7, step: 1 } }],
+          },
+          action: {
+            type: 'startWorkflow',
+            workflowType: dummyWorkflow,
+            taskQueue,
+          },
+          searchAttributes: Object.keys(searchAttributes).length ? searchAttributes : undefined,
+        })
+      );
     }
 
     const createdScheduleHandles: { [k: string]: ScheduleHandle } = Object.fromEntries(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
 Added the support for query for listing schedules and added test coverage on the changes.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> [issue](https://github.com/temporalio/sdk-typescript/issues/1457)

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added a test to the above changes as discussed with @antlai-temporal .
Created four schedules with two schedules having a search attribute key and two of them not having search attribute keys and then listing with the key ensuring I got back two of them.
549 tests passed
2 tests skipped
9 tests todo

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
