### PR TITLE
feat(client): Add experimental support for Cloud Operations API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,12 @@ jobs:
           RUN_INTEGRATION_TESTS: true
           REUSE_V8_CONTEXT: ${{ matrix.reuse-v8-context }}
 
+          # Cloud Tests will be skipped if TEMPORAL_CLIENT_CLOUD_API_KEY is left empty
+          TEMPORAL_CLOUD_SAAS_ADDRESS: ${{ vars.TEMPORAL_CLOUD_SAAS_ADDRESS || 'saas-api.tmprl.cloud:443' }}
+          TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
+          TEMPORAL_CLIENT_CLOUD_API_VERSION: 2024-05-13-00
+          TEMPORAL_CLIENT_CLOUD_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
+
       - name: Upload NPM logs
         uses: actions/upload-artifact@v4
         if: failure() || cancelled()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "workspaces": [
         "packages/activity",
         "packages/client",
+        "packages/cloud",
         "packages/common",
         "packages/core-bridge",
         "packages/create-project",
@@ -22,6 +23,7 @@
       ],
       "dependencies": {
         "@temporalio/client": "file:packages/client",
+        "@temporalio/cloud": "file:packages/cloud",
         "@temporalio/common": "file:packages/common",
         "@temporalio/create": "file:packages/create-project",
         "@temporalio/interceptors-opentelemetry": "file:packages/interceptors-opentelemetry",
@@ -2819,6 +2821,10 @@
     },
     "node_modules/@temporalio/client": {
       "resolved": "packages/client",
+      "link": true
+    },
+    "node_modules/@temporalio/cloud": {
+      "resolved": "packages/cloud",
       "link": true
     },
     "node_modules/@temporalio/common": {
@@ -18822,6 +18828,22 @@
         "protobufjs": "^7.2.5"
       }
     },
+    "packages/cloud": {
+      "name": "@temporalio/cloud",
+      "version": "1.11.2",
+      "license": "MIT",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.7",
+        "@temporalio/common": "file:../common",
+        "@temporalio/proto": "file:../proto",
+        "abort-controller": "^3.0.0",
+        "long": "^5.2.3",
+        "uuid": "^9.0.1"
+      },
+      "devDependencies": {
+        "protobufjs": "^7.2.5"
+      }
+    },
     "packages/common": {
       "name": "@temporalio/common",
       "version": "1.11.2",
@@ -19026,6 +19048,7 @@
         "@opentelemetry/semantic-conventions": "^1.19.0",
         "@temporalio/activity": "file:../activity",
         "@temporalio/client": "file:../client",
+        "@temporalio/cloud": "file:../cloud",
         "@temporalio/common": "file:../common",
         "@temporalio/core-bridge": "file:../core-bridge",
         "@temporalio/interceptors-opentelemetry": "file:../interceptors-opentelemetry",
@@ -21136,6 +21159,18 @@
         "uuid": "^9.0.1"
       }
     },
+    "@temporalio/cloud": {
+      "version": "file:packages/cloud",
+      "requires": {
+        "@grpc/grpc-js": "^1.10.7",
+        "@temporalio/common": "file:../common",
+        "@temporalio/proto": "file:../proto",
+        "abort-controller": "^3.0.0",
+        "long": "^5.2.3",
+        "protobufjs": "^7.2.5",
+        "uuid": "^9.0.1"
+      }
+    },
     "@temporalio/common": {
       "version": "file:packages/common",
       "requires": {
@@ -21252,6 +21287,7 @@
         "@opentelemetry/semantic-conventions": "^1.19.0",
         "@temporalio/activity": "file:../activity",
         "@temporalio/client": "file:../client",
+        "@temporalio/cloud": "file:../cloud",
         "@temporalio/common": "file:../common",
         "@temporalio/core-bridge": "file:../core-bridge",
         "@temporalio/interceptors-opentelemetry": "file:../interceptors-opentelemetry",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18834,6 +18834,7 @@
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.7",
+        "@temporalio/client": "file:../client",
         "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
         "abort-controller": "^3.0.0"
@@ -21158,6 +21159,7 @@
       "version": "file:packages/cloud",
       "requires": {
         "@grpc/grpc-js": "^1.10.7",
+        "@temporalio/client": "file:../client",
         "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
         "abort-controller": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18836,12 +18836,7 @@
         "@grpc/grpc-js": "^1.10.7",
         "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
-        "abort-controller": "^3.0.0",
-        "long": "^5.2.3",
-        "uuid": "^9.0.1"
-      },
-      "devDependencies": {
-        "protobufjs": "^7.2.5"
+        "abort-controller": "^3.0.0"
       }
     },
     "packages/common": {
@@ -21165,10 +21160,7 @@
         "@grpc/grpc-js": "^1.10.7",
         "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
-        "abort-controller": "^3.0.0",
-        "long": "^5.2.3",
-        "protobufjs": "^7.2.5",
-        "uuid": "^9.0.1"
+        "abort-controller": "^3.0.0"
       }
     },
     "@temporalio/common": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "rebuild": "npm run clean && npm run build",
     "build": "lerna run --stream build",
-    "build.watch": "tsc --build --watch packages/create-project packages/test",
+    "build.watch": "npm run build:protos && tsc --build --watch packages/*",
     "build:protos": "node ./packages/proto/scripts/compile-proto.js",
     "test": "lerna run --stream test",
     "test.watch": "lerna run --stream test.watch",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "rebuild": "npm run clean && npm run build",
     "build": "lerna run --stream build",
-    "build.watch": "lerna run --stream build.watch",
+    "build.watch": "tsc --build --watch packages/create-project packages/test",
+    "build:protos": "node ./packages/proto/scripts/compile-proto.js",
     "test": "lerna run --stream test",
     "test.watch": "lerna run --stream test.watch",
     "ci-stress": "node ./packages/test/lib/load/run-all-stress-ci-scenarios.js",
@@ -38,6 +39,7 @@
   },
   "dependencies": {
     "@temporalio/client": "file:packages/client",
+    "@temporalio/cloud": "file:packages/cloud",
     "@temporalio/common": "file:packages/common",
     "@temporalio/create": "file:packages/create-project",
     "@temporalio/interceptors-opentelemetry": "file:packages/interceptors-opentelemetry",
@@ -79,6 +81,7 @@
   "workspaces": [
     "packages/activity",
     "packages/client",
+    "packages/cloud",
     "packages/common",
     "packages/core-bridge",
     "packages/create-project",

--- a/packages/client/src/base-client.ts
+++ b/packages/client/src/base-client.ts
@@ -51,7 +51,14 @@ export function defaultBaseClientOptions(): WithDefaults<BaseClientOptions> {
 }
 
 export class BaseClient {
+  /**
+   * The underlying {@link Connection | connection} used by this client.
+   *
+   * Clients are cheap to create, but connections are expensive. Where that make sense,
+   * a single connection may and should be reused by multiple `Client`.
+   */
   public readonly connection: ConnectionLike;
+
   private readonly loadedDataConverter: LoadedDataConverter;
 
   protected constructor(options?: BaseClientOptions) {

--- a/packages/client/src/base-client.ts
+++ b/packages/client/src/base-client.ts
@@ -1,4 +1,5 @@
 import os from 'node:os';
+import type * as _grpc from '@grpc/grpc-js'; // For JSDoc only
 import { DataConverter, LoadedDataConverter } from '@temporalio/common';
 import { isLoadedDataConverter, loadDataConverter } from '@temporalio/common/lib/internal-non-workflow';
 import { Connection } from './connection';
@@ -68,19 +69,37 @@ export class BaseClient {
   }
 
   /**
-   * Set the deadline for any service requests executed in `fn`'s scope.
+   * Set a deadline for any service requests executed in `fn`'s scope.
+   *
+   * The deadline is a point in time after which any pending gRPC request will be considered as failed;
+   * this will locally result in the request call throwing a {@link _grpc.ServiceError|ServiceError}
+   * with code {@link _grpc.status.DEADLINE_EXCEEDED|DEADLINE_EXCEEDED}.
+   *
+   * It is stronly recommended to explicitly set deadlines. If no deadline is set, then it is
+   * possible for the client to end up waiting forever for a response.
+   *
+   * This method is only a convenience wrapper around {@link Connection.withDeadline}.
+   *
+   * @param deadline a point in time after which the request will be considered as failed; either a
+   *                 Date object, or a number of milliseconds since the Unix epoch (UTC).
+   * @returns the value returned from `fn`
+   *
+   * @see https://grpc.io/docs/guides/deadlines/
    */
   public async withDeadline<R>(deadline: number | Date, fn: () => Promise<R>): Promise<R> {
     return await this.connection.withDeadline(deadline, fn);
   }
 
   /**
-   * Set an {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal | `AbortSignal`} that, when aborted,
-   * cancels any ongoing service requests executed in `fn`'s scope.
+   * Set an {@link AbortSignal} that, when aborted, cancels any ongoing service requests executed in
+   * `fn`'s scope. This will locally result in the request call throwing a {@link _grpc.ServiceError|ServiceError}
+   * with code {@link _grpc.status.CANCELLED|CANCELLED}.
+   *
+   * This method is only a convenience wrapper around {@link Connection.withAbortSignal}.
    *
    * @returns value returned from `fn`
    *
-   * @see {@link Connection.withAbortSignal}
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
    */
   async withAbortSignal<R>(abortSignal: AbortSignal, fn: () => Promise<R>): Promise<R> {
     return await this.connection.withAbortSignal(abortSignal, fn);
@@ -89,9 +108,9 @@ export class BaseClient {
   /**
    * Set metadata for any service requests executed in `fn`'s scope.
    *
-   * @returns returned value of `fn`
+   * This method is only a convenience wrapper around {@link Connection.withMetadata}.
    *
-   * @see {@link Connection.withMetadata}
+   * @returns returned value of `fn`
    */
   public async withMetadata<R>(metadata: Metadata, fn: () => Promise<R>): Promise<R> {
     return await this.connection.withMetadata(metadata, fn);

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -14,6 +14,11 @@ import pkg from './pkg';
 import { CallContext, HealthService, Metadata, OperatorService, WorkflowService } from './types';
 
 /**
+ * The default Temporal Server's TCP port for public gRPC connections.
+ */
+const DEFAULT_TEMPORAL_GRPC_PORT = 7233;
+
+/**
  * gRPC and Temporal Server connection options
  */
 export interface ConnectionOptions {
@@ -174,7 +179,7 @@ function normalizeGRPCConfig(options?: ConnectionOptions): ConnectionOptions {
     }
   }
   if (rest.address) {
-    rest.address = normalizeGrpcEndpointAddress(rest.address, 7233);
+    rest.address = normalizeGrpcEndpointAddress(rest.address, DEFAULT_TEMPORAL_GRPC_PORT);
   }
   const tls = normalizeTlsConfig(tlsFromConfig);
   if (tls) {

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -5,7 +5,7 @@ import {
   filterNullAndUndefined,
   normalizeTlsConfig,
   TLSConfig,
-  normalizeTemporalGrpcEndpointAddress,
+  normalizeGrpcEndpointAddress,
 } from '@temporalio/common/lib/internal-non-workflow';
 import { Duration, msOptionalToNumber } from '@temporalio/common/lib/time';
 import { isGrpcServiceError, ServiceError } from './errors';
@@ -174,7 +174,7 @@ function normalizeGRPCConfig(options?: ConnectionOptions): ConnectionOptions {
     }
   }
   if (rest.address) {
-    rest.address = normalizeTemporalGrpcEndpointAddress(rest.address);
+    rest.address = normalizeGrpcEndpointAddress(rest.address, 7233);
   }
   const tls = normalizeTlsConfig(tlsFromConfig);
   if (tls) {
@@ -572,5 +572,6 @@ export class Connection {
    */
   public async close(): Promise<void> {
     this.client.close();
+    this.callContextStorage.disable();
   }
 }

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -225,20 +225,24 @@ export interface RPCImplOptions {
 export interface ConnectionCtorOptions {
   readonly options: ConnectionOptionsWithDefaults;
   readonly client: grpc.Client;
+
   /**
    * Raw gRPC access to the Temporal service.
    *
    * **NOTE**: The namespace provided in {@link options} is **not** automatically set on requests made to the service.
    */
   readonly workflowService: WorkflowService;
+
   /**
    * Raw gRPC access to the Temporal {@link https://github.com/temporalio/api/blob/ddf07ab9933e8230309850e3c579e1ff34b03f53/temporal/api/operatorservice/v1/service.proto | operator service}.
    */
   readonly operatorService: OperatorService;
+
   /**
    * Raw gRPC access to the standard gRPC {@link https://github.com/grpc/grpc/blob/92f58c18a8da2728f571138c37760a721c8915a2/doc/health-checking.md | health service}.
    */
   readonly healthService: HealthService;
+
   readonly callContextStorage: AsyncLocalStorage<CallContext>;
   readonly apiKeyFnRef: { fn?: () => string };
 }
@@ -246,8 +250,8 @@ export interface ConnectionCtorOptions {
 /**
  * Client connection to the Temporal Server
  *
- * ⚠️ Connections are expensive to construct and should be reused. Make sure to {@link close} any unused connections to
- * avoid leaking resources.
+ * ⚠️ Connections are expensive to construct and should be reused.
+ * Make sure to {@link close} any unused connections to avoid leaking resources.
  */
 export class Connection {
   /**
@@ -280,7 +284,12 @@ export class Connection {
    * Cloud namespace will result in gRPC `unauthorized` error.
    */
   public readonly operatorService: OperatorService;
+
+  /**
+   * Raw gRPC access to the standard gRPC {@link https://github.com/grpc/grpc/blob/92f58c18a8da2728f571138c37760a721c8915a2/doc/health-checking.md | health service}.
+   */
   public readonly healthService: HealthService;
+
   readonly callContextStorage: AsyncLocalStorage<CallContext>;
   private readonly apiKeyFnRef: { fn?: () => string };
 
@@ -429,7 +438,8 @@ export class Connection {
       const metadataContainer = new grpc.Metadata();
       const { metadata, deadline, abortSignal } = callContextStorage.getStore() ?? {};
       if (apiKeyFnRef.fn) {
-        metadataContainer.set('Authorization', `Bearer ${apiKeyFnRef.fn()}`);
+        const apiKey = apiKeyFnRef.fn();
+        if (apiKey) metadataContainer.set('Authorization', `Bearer ${apiKey}`);
       }
       for (const [k, v] of Object.entries(staticMetadata)) {
         metadataContainer.set(k, v);
@@ -457,9 +467,20 @@ export class Connection {
   }
 
   /**
-   * Set the deadline for any service requests executed in `fn`'s scope.
+   * Set a deadline for any service requests executed in `fn`'s scope.
    *
-   * @returns value returned from `fn`
+   * The deadline is a point in time after which any pending gRPC request will be considered as failed;
+   * this will locally result in the request call throwing a {@link grpc.ServiceError|ServiceError}
+   * with code {@link grpc.status.DEADLINE_EXCEEDED|DEADLINE_EXCEEDED}.
+   *
+   * It is stronly recommended to explicitly set deadlines. If no deadline is set, then it is
+   * possible for the client to end up waiting forever for a response.
+   *
+   * @param deadline a point in time after which the request will be considered as failed; either a
+   *                 Date object, or a number of milliseconds since the Unix epoch (UTC).
+   * @returns the value returned from `fn`
+   *
+   * @see https://grpc.io/docs/guides/deadlines/
    */
   async withDeadline<ReturnType>(deadline: number | Date, fn: () => Promise<ReturnType>): Promise<ReturnType> {
     const cc = this.callContextStorage.getStore();
@@ -467,10 +488,11 @@ export class Connection {
   }
 
   /**
-   * Set an {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal | `AbortSignal`} that, when aborted,
-   * cancels any ongoing requests executed in `fn`'s scope.
+   * Set an {@link AbortSignal} that, when aborted, cancels any ongoing service requests executed in
+   * `fn`'s scope. This will locally result in the request call throwing a {@link _grpc.ServiceError|ServiceError}
+   * with code {@link _grpc.status.CANCELLED|CANCELLED}.
    *
-   * @returns value returned from `fn`
+   * This method is only a convenience wrapper around {@link Connection.withAbortSignal}.
    *
    * @example
    *
@@ -480,6 +502,10 @@ export class Connection {
    * // 👇 throws if incomplete by the timeout.
    * await conn.withAbortSignal(ctrl.signal, () => client.workflow.execute(myWorkflow, options));
    * ```
+   *
+   * @returns value returned from `fn`
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
    */
   async withAbortSignal<ReturnType>(abortSignal: AbortSignal, fn: () => Promise<ReturnType>): Promise<ReturnType> {
     const cc = this.callContextStorage.getStore();

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -489,8 +489,8 @@ export class Connection {
 
   /**
    * Set an {@link AbortSignal} that, when aborted, cancels any ongoing service requests executed in
-   * `fn`'s scope. This will locally result in the request call throwing a {@link _grpc.ServiceError|ServiceError}
-   * with code {@link _grpc.status.CANCELLED|CANCELLED}.
+   * `fn`'s scope. This will locally result in the request call throwing a {@link grpc.ServiceError|ServiceError}
+   * with code {@link grpc.status.CANCELLED|CANCELLED}.
    *
    * This method is only a convenience wrapper around {@link Connection.withAbortSignal}.
    *

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -96,8 +96,24 @@ export interface ConnectionLike {
   workflowService: WorkflowService;
   close(): Promise<void>;
   ensureConnected(): Promise<void>;
+
   /**
-   * Set the deadline for any service requests executed in `fn`'s scope.
+   * Set a deadline for any service requests executed in `fn`'s scope.
+   *
+   * The deadline is a point in time after which any pending gRPC request will be considered as failed;
+   * this will locally result in the request call throwing a {@link grpc.ServiceError|ServiceError}
+   * with code {@link grpc.status.DEADLINE_EXCEEDED|DEADLINE_EXCEEDED}.
+   *
+   * It is stronly recommended to explicitly set deadlines. If no deadline is set, then it is
+   * possible for the client to end up waiting forever for a response.
+   *
+   * This method is only a convenience wrapper around {@link Connection.withDeadline}.
+   *
+   * @param deadline a point in time after which the request will be considered as failed; either a
+   *                 Date object, or a number of milliseconds since the Unix epoch (UTC).
+   * @returns the value returned from `fn`
+   *
+   * @see https://grpc.io/docs/guides/deadlines/
    */
   withDeadline<R>(deadline: number | Date, fn: () => Promise<R>): Promise<R>;
 
@@ -109,10 +125,13 @@ export interface ConnectionLike {
   withMetadata<R>(metadata: Metadata, fn: () => Promise<R>): Promise<R>;
 
   /**
-   * Set an {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal | `AbortSignal`} that, when aborted,
-   * cancels any ongoing requests executed in `fn`'s scope.
+   * Set an {@link AbortSignal} that, when aborted, cancels any ongoing service requests executed in
+   * `fn`'s scope. This will locally result in the request call throwing a {@link grpc.ServiceError|ServiceError}
+   * with code {@link grpc.status.CANCELLED|CANCELLED}.
    *
    * @returns value returned from `fn`
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
    */
   withAbortSignal<R>(abortSignal: AbortSignal, fn: () => Promise<R>): Promise<R>;
 }

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -1,0 +1,8 @@
+# `@temporalio/cloud`
+
+[![NPM](https://img.shields.io/npm/v/@temporalio/cloud?style=for-the-badge)](https://www.npmjs.com/package/@temporalio/cloud)
+
+Part of [Temporal](https://temporal.io)'s [TypeScript SDK](https://docs.temporal.io/typescript/introduction/).
+
+- [API reference](https://typescript.temporal.io/api/namespaces/cloud)
+- [Sample projects](https://github.com/temporalio/samples-typescript)

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@temporalio/cloud",
+  "version": "1.11.2",
+  "description": "Temporal.io SDK — Temporal Cloud Client",
+  "main": "lib/index.js",
+  "types": "./lib/index.d.ts",
+  "scripts": {},
+  "keywords": [
+    "temporal",
+    "workflow",
+    "client",
+    "temporal cloud"
+  ],
+  "author": "Temporal Technologies Inc. <sdk@temporal.io>",
+  "license": "MIT",
+  "dependencies": {
+    "@grpc/grpc-js": "^1.10.7",
+    "@temporalio/common": "file:../common",
+    "@temporalio/proto": "file:../proto",
+    "abort-controller": "^3.0.0",
+    "long": "^5.2.3",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "protobufjs": "^7.2.5"
+  },
+  "bugs": {
+    "url": "https://github.com/temporalio/sdk-typescript/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/temporalio/sdk-typescript.git",
+    "directory": "packages/cloud"
+  },
+  "homepage": "https://github.com/temporalio/sdk-typescript/tree/main/packages/cloud",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "src",
+    "lib"
+  ]
+}

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@grpc/grpc-js": "^1.10.7",
+    "@temporalio/client": "file:../client",
     "@temporalio/common": "file:../common",
     "@temporalio/proto": "file:../proto",
     "abort-controller": "^3.0.0"

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -17,12 +17,7 @@
     "@grpc/grpc-js": "^1.10.7",
     "@temporalio/common": "file:../common",
     "@temporalio/proto": "file:../proto",
-    "abort-controller": "^3.0.0",
-    "long": "^5.2.3",
-    "uuid": "^9.0.1"
-  },
-  "devDependencies": {
-    "protobufjs": "^7.2.5"
+    "abort-controller": "^3.0.0"
   },
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"

--- a/packages/cloud/src/cloud-operations-client.ts
+++ b/packages/cloud/src/cloud-operations-client.ts
@@ -79,8 +79,8 @@ export class CloudOperationsClient {
 
   /**
    * Set an {@link AbortSignal} that, when aborted, cancels any ongoing service requests executed in
-   * `fn`'s scope. This will locally result in the request call throwing a {@link _grpc.ServiceError|ServiceError}
-   * with code {@link _grpc.status.CANCELLED|CANCELLED}.
+   * `fn`'s scope. This will locally result in the request call throwing a {@link grpc.ServiceError|ServiceError}
+   * with code {@link grpc.status.CANCELLED|CANCELLED}.
    *
    * This method is only a convenience wrapper around {@link CloudOperationsConnection.withAbortSignal}.
    *

--- a/packages/cloud/src/cloud-operations-client.ts
+++ b/packages/cloud/src/cloud-operations-client.ts
@@ -40,8 +40,14 @@ export interface CloudOperationsClientOptions {
  * @experimental
  */
 export class CloudOperationsClient {
+  /**
+   * The underlying {@link CloudOperationsConnection | connection} used by this client.
+   *
+   * Clients are cheap to create, but connections are expensive. Where that make sense,
+   * a single connection may and should be reused by multiple `CloudOperationsClient`.
+   */
   public readonly connection: CloudOperationsConnection;
-  public readonly options: CloudOperationsClientOptions;
+  public readonly options: Readonly<CloudOperationsClientOptions>;
 
   constructor(options: CloudOperationsClientOptions) {
     this.connection = options.connection;
@@ -49,17 +55,31 @@ export class CloudOperationsClient {
   }
 
   /**
-   * Set the deadline for any service requests executed in `fn`'s scope.
+   * Set a deadline for any service requests executed in `fn`'s scope.
+   *
+   * The deadline is a point in time after which any pending gRPC request will be considered as failed;
+   * this will locally result in the request call throwing a `ServiceError`, with code {@link DEADLINE_EXCEEDED|grpc.}.
+   *
+   *
+   * the deadline
+   * The deadline Date object or a number of millisecond )
+   * The gRPC
+   * @param deadline the deadline after which the request will be considered as failed; either a Date
+   *        object new
+   * @returns the value returned from `fn`
+   *
+   * @see https://grpc.io/docs/guides/deadlines/
    */
   public async withDeadline<R>(deadline: number | Date, fn: () => Promise<R>): Promise<R> {
+    Date.now;
     return await this.connection.withDeadline(deadline, fn);
   }
 
   /**
-   * Set an {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal | `AbortSignal`} that, when aborted,
-   * cancels any ongoing service requests executed in `fn`'s scope.
+   * Set an {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal | `AbortSignal`}
+   * that, when aborted, cancels any ongoing service requests executed in `fn`'s scope.
    *
-   * @returns value returned from `fn`
+   * @returns the value returned from `fn`
    *
    * @see {@link CloudOperationsConnection.withAbortSignal}
    */

--- a/packages/cloud/src/cloud-operations-client.ts
+++ b/packages/cloud/src/cloud-operations-client.ts
@@ -1,0 +1,555 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import * as grpc from '@grpc/grpc-js';
+import type { RPCImpl } from 'protobufjs';
+import {
+  filterNullAndUndefined,
+  normalizeTlsConfig,
+  TLSConfig,
+  normalizeTemporalGrpcEndpointAddress,
+} from '@temporalio/common/lib/internal-non-workflow';
+import { Duration, msOptionalToNumber } from '@temporalio/common/lib/time';
+import {
+  CallContext,
+  HealthService,
+  Metadata,
+  defaultGrpcRetryOptions,
+  makeGrpcRetryInterceptor,
+} from '@temporalio/client';
+import pkg from './pkg';
+import { CloudService } from './types';
+
+/**
+ * @experimental
+ */
+export interface CloudOperationsClientOptions {
+  /**
+   * Connection to use to communicate with the server.
+   *
+   * By default, connects to 'saas-api.tmprl.cloud:443'.
+   */
+  connection: CloudOperationsConnection;
+
+  /**
+   * Version header for safer mutations.
+   * May or may not be required depending on cloud settings.
+   */
+  apiVersion?: string;
+}
+
+/**
+ * High level SDK client.
+ *
+ * @experimental
+ */
+export class CloudOperationsClient {
+  public readonly connection: CloudOperationsConnection;
+  public readonly options: CloudOperationsClientOptions;
+
+  constructor(options: CloudOperationsClientOptions) {
+    this.connection = options.connection;
+    this.options = filterNullAndUndefined(options ?? {});
+  }
+
+  /**
+   * Set the deadline for any service requests executed in `fn`'s scope.
+   */
+  public async withDeadline<R>(deadline: number | Date, fn: () => Promise<R>): Promise<R> {
+    return await this.connection.withDeadline(deadline, fn);
+  }
+
+  /**
+   * Set an {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal | `AbortSignal`} that, when aborted,
+   * cancels any ongoing service requests executed in `fn`'s scope.
+   *
+   * @returns value returned from `fn`
+   *
+   * @see {@link Connection.withAbortSignal}
+   */
+  async withAbortSignal<R>(abortSignal: AbortSignal, fn: () => Promise<R>): Promise<R> {
+    return await this.connection.withAbortSignal(abortSignal, fn);
+  }
+
+  /**
+   * Set metadata for any service requests executed in `fn`'s scope.
+   *
+   * @returns returned value of `fn`
+   *
+   * @see {@link Connection.withMetadata}
+   */
+  public async withMetadata<R>(metadata: Metadata, fn: () => Promise<R>): Promise<R> {
+    return await this.connection.withMetadata(metadata, fn);
+  }
+
+  /**
+   * Raw gRPC access to the Temporal Cloud Operations service.
+   *
+   * **NOTE**: The API Version provided in {@link options} is **not** automatically set on requests made via this service
+   * object.
+   */
+  get cloudService(): CloudService {
+    return this.connection.cloudService;
+  }
+}
+
+/**
+ * gRPC and Temporal Server connection options
+ *
+ * @experimental
+ */
+export interface CloudOperationsConnectionOptions {
+  /**
+   * The address of the Temporal Cloud Operations API to connect to, in `hostname:port` format.
+   *
+   * @default saas-api.tmprl.cloud:443
+   */
+  address?: string;
+
+  /**
+   * TLS configuration. Pass `true` or `{}` to connect with TLS without any customization.
+   * TLS is required for connecting to the Temporal Cloud Operations API.
+   *
+   @default true
+   */
+  tls?: Pick<TLSConfig, 'serverNameOverride'> | true;
+
+  /**
+   * GRPC Channel arguments
+   *
+   * @see option descriptions {@link https://grpc.github.io/grpc/core/group__grpc__arg__keys.html | here}
+   *
+   * By default the SDK sets the following keepalive arguments:
+   *
+   * ```
+   * grpc.keepalive_permit_without_calls: 1
+   * grpc.keepalive_time_ms: 30_000
+   * grpc.keepalive_timeout_ms: 15_000
+   * ```
+   *
+   * To opt-out of keepalive, override these keys with `undefined`.
+   */
+  channelArgs?: grpc.ChannelOptions;
+
+  /**
+   * {@link https://grpc.github.io/grpc/node/module-src_client_interceptors.html | gRPC interceptors} which will be
+   * applied to every RPC call performed by this connection. By default, an interceptor will be included which
+   * automatically retries retryable errors. If you do not wish to perform automatic retries, set this to an empty list
+   * (or a list with your own interceptors). If you want to add your own interceptors while keeping the default retry
+   * behavior, add this to your list of interceptors: `makeGrpcRetryInterceptor(defaultGrpcRetryOptions())`. See:
+   *
+   * - {@link makeGrpcRetryInterceptor}
+   * - {@link defaultGrpcRetryOptions}
+   */
+  interceptors?: grpc.Interceptor[];
+
+  /**
+   * Optional mapping of gRPC metadata (HTTP headers) to send with each request to the server. An
+   * `Authorization` header set through `metadata` will be ignored and overriden by the value of the
+   * {@link apiKey} option.
+   *
+   * In order to dynamically set metadata, use {@link Connection.withMetadata}
+   */
+  metadata?: Metadata;
+
+  /**
+   * API key for Temporal. This becomes the "Authorization" HTTP header with "Bearer " prepended.
+   *
+   * You may provide a static string or a callback. Also see {@link Connection.withApiKey} or
+   * {@link Connection.setApiKey}
+   */
+  apiKey: string | (() => string);
+
+  /**
+   * Milliseconds to wait until establishing a connection with the server.
+   *
+   * Used either when connecting eagerly with {@link Connection.connect} or
+   * calling {@link Connection.ensureConnected}.
+   *
+   * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
+   * @default 10 seconds
+   */
+  connectTimeout?: Duration;
+}
+
+export type ResolvedCloudOperationsConnectionOptions = Required<
+  Omit<CloudOperationsConnectionOptions, 'tls' | 'connectTimeout'>
+> & {
+  connectTimeoutMs: number;
+  credentials: grpc.ChannelCredentials;
+};
+
+/**
+ * - Convert {@link ConnectionOptions.tls} to {@link grpc.ChannelCredentials}
+ * - Add the grpc.ssl_target_name_override GRPC {@link ConnectionOptions.channelArgs | channel arg}
+ * - Add default port to address if port not specified
+ * - Set `Authorization` header based on {@link ConnectionOptions.apiKey}
+ */
+function normalizeGRPCConfig(options: CloudOperationsConnectionOptions): ResolvedCloudOperationsConnectionOptions {
+  const {
+    address: addressFromConfig,
+    tls: tlsFromConfig,
+    channelArgs,
+    interceptors,
+    connectTimeout,
+    ...rest
+  } = options;
+
+  let address = 'saas-api.tmprl.cloud:443';
+  if (addressFromConfig) {
+    address = normalizeTemporalGrpcEndpointAddress(addressFromConfig);
+  }
+  const tls = normalizeTlsConfig(tlsFromConfig) ?? {};
+
+  return {
+    address,
+    credentials: grpc.credentials.combineChannelCredentials(grpc.credentials.createSsl()),
+    channelArgs: {
+      'grpc.keepalive_permit_without_calls': 1,
+      'grpc.keepalive_time_ms': 30_000,
+      'grpc.keepalive_timeout_ms': 15_000,
+      max_receive_message_length: 128 * 1024 * 1024, // 128 MB
+      ...channelArgs,
+      ...(tls.serverNameOverride
+        ? {
+            'grpc.ssl_target_name_override': tls.serverNameOverride,
+            'grpc.default_authority': tls.serverNameOverride,
+          }
+        : undefined),
+    },
+    interceptors: interceptors ?? [makeGrpcRetryInterceptor(defaultGrpcRetryOptions())],
+    metadata: {},
+    connectTimeoutMs: msOptionalToNumber(connectTimeout) ?? 10_000,
+    ...filterNullAndUndefined(rest),
+  };
+}
+
+interface RPCImplOptions {
+  serviceName: string;
+  client: grpc.Client;
+  callContextStorage: AsyncLocalStorage<CallContext>;
+  interceptors?: grpc.Interceptor[];
+  staticMetadata: Metadata;
+  apiKeyFnRef: { fn?: () => string };
+}
+
+interface CloudOperationsConnectionCtorOptions {
+  readonly options: ResolvedCloudOperationsConnectionOptions;
+  readonly client: grpc.Client;
+  /**
+   * Raw gRPC access to the
+   * {@link https://github.com/temporalio/api-cloud/blob/main/temporal/api/cloud/cloudservice/v1/service.proto | Temporal Cloud's Operator Service}.
+   */
+  readonly cloudService: CloudService;
+  /**
+   * Raw gRPC access to the standard gRPC {@link https://github.com/grpc/grpc/blob/92f58c18a8da2728f571138c37760a721c8915a2/doc/health-checking.md | health service}.
+   */
+  readonly healthService: HealthService;
+  readonly callContextStorage: AsyncLocalStorage<CallContext>;
+  readonly apiKeyFnRef: { fn?: () => string };
+}
+
+/**
+ * Client connection to the Temporal Server
+ *
+ * ⚠️ Connections are expensive to construct and should be reused. Make sure to {@link close} any unused connections to
+ * avoid leaking resources.
+ *
+ * @experimental
+ */
+export class CloudOperationsConnection {
+  /**
+   * @internal
+   */
+  public static readonly Client = grpc.makeGenericClientConstructor({}, 'CloudService', {});
+
+  public readonly options: ResolvedCloudOperationsConnectionOptions;
+  protected readonly client: grpc.Client;
+
+  /**
+   * Used to ensure `ensureConnected` is called once.
+   */
+  protected connectPromise?: Promise<void>;
+
+  /**
+   * Raw gRPC access to the
+   * {@link https://github.com/temporalio/api-cloud/blob/main/temporal/api/cloud/cloudservice/v1/service.proto | Temporal Cloud's Operator Service}.
+   *
+   * The Temporal Cloud Operator Service API defines how Temporal SDKs and other clients interact with the Temporal
+   * Cloud platform to perform administrative functions like registering a search attribute or a namespace.
+   *
+   * This Service API is NOT compatible with self-hosted Temporal deployments.
+   */
+  public readonly cloudService: CloudService;
+
+  public readonly healthService: HealthService;
+
+  readonly callContextStorage: AsyncLocalStorage<CallContext>;
+  private readonly apiKeyFnRef: { fn?: () => string };
+
+  protected static createCtorOptions(options: CloudOperationsConnectionOptions): CloudOperationsConnectionCtorOptions {
+    const normalizedOptions = normalizeGRPCConfig(options);
+    const apiKeyFnRef: { fn?: () => string } = {};
+    if (typeof normalizedOptions.apiKey === 'string') {
+      const apiKey = normalizedOptions.apiKey;
+      apiKeyFnRef.fn = () => apiKey;
+    } else {
+      apiKeyFnRef.fn = normalizedOptions.apiKey;
+    }
+    // Allow overriding this
+    normalizedOptions.metadata['client-name'] ??= 'temporal-typescript';
+    normalizedOptions.metadata['client-version'] ??= pkg.version;
+
+    const client = new this.Client(
+      normalizedOptions.address,
+      normalizedOptions.credentials,
+      normalizedOptions.channelArgs
+    );
+    const callContextStorage = new AsyncLocalStorage<CallContext>();
+
+    const cloudRpcImpl = this.generateRPCImplementation({
+      serviceName: 'temporal.api.cloud.cloudservice.v1.CloudService',
+      client,
+      callContextStorage,
+      interceptors: normalizedOptions?.interceptors,
+      staticMetadata: normalizedOptions.metadata,
+      apiKeyFnRef,
+    });
+    const cloudService = CloudService.create(cloudRpcImpl, false, false);
+
+    const healthRpcImpl = this.generateRPCImplementation({
+      serviceName: 'grpc.health.v1.Health',
+      client,
+      callContextStorage,
+      interceptors: normalizedOptions?.interceptors,
+      staticMetadata: normalizedOptions.metadata,
+      apiKeyFnRef,
+    });
+    const healthService = HealthService.create(healthRpcImpl, false, false);
+
+    return {
+      client,
+      callContextStorage,
+      cloudService,
+      healthService,
+      options: normalizedOptions,
+      apiKeyFnRef,
+    };
+  }
+
+  /**
+   * Ensure connection can be established.
+   *
+   * Does not need to be called if you use {@link connect}.
+   *
+   * This method's result is memoized to ensure it runs only once.
+   *
+   * Calls {@link proto.temporal.api.workflowservice.v1.WorkflowService.getSystemInfo} internally.
+   */
+  async ensureConnected(): Promise<void> {
+    if (this.connectPromise == null) {
+      const deadline = Date.now() + this.options.connectTimeoutMs;
+      this.connectPromise = (async () => {
+        await this.untilReady(deadline);
+      })();
+    }
+    return this.connectPromise;
+  }
+
+  /**
+   * Create a lazy `CloudOperationsConnection` instance.
+   *
+   * This method does not verify connectivity with the server. We recommend using {@link connect} instead.
+   */
+  static lazy(options: CloudOperationsConnectionOptions): CloudOperationsConnection {
+    return new this(this.createCtorOptions(options));
+  }
+
+  /**
+   * Establish a connection with the server and return a `CloudOperationsConnection` instance.
+   *
+   * This is the preferred method of creating connections as it verifies connectivity by calling
+   * {@link ensureConnected}.
+   */
+  static async connect(options: CloudOperationsConnectionOptions): Promise<CloudOperationsConnection> {
+    const conn = this.lazy(options);
+    await conn.ensureConnected();
+    return conn;
+  }
+
+  protected constructor({
+    options,
+    client,
+    cloudService,
+    healthService,
+    callContextStorage,
+    apiKeyFnRef,
+  }: CloudOperationsConnectionCtorOptions) {
+    this.options = options;
+    this.client = client;
+    this.cloudService = cloudService;
+    this.healthService = healthService;
+    this.callContextStorage = callContextStorage;
+    this.apiKeyFnRef = apiKeyFnRef;
+  }
+
+  protected static generateRPCImplementation({
+    serviceName,
+    client,
+    callContextStorage,
+    interceptors,
+    staticMetadata,
+    apiKeyFnRef,
+  }: RPCImplOptions): RPCImpl {
+    return (method: { name: string }, requestData: any, callback: grpc.requestCallback<any>) => {
+      const metadataContainer = new grpc.Metadata();
+      const { metadata, deadline, abortSignal } = callContextStorage.getStore() ?? {};
+      if (apiKeyFnRef.fn) {
+        metadataContainer.set('Authorization', `Bearer ${apiKeyFnRef.fn()}`);
+      }
+      for (const [k, v] of Object.entries(staticMetadata)) {
+        metadataContainer.set(k, v);
+      }
+      if (metadata != null) {
+        for (const [k, v] of Object.entries(metadata)) {
+          metadataContainer.set(k, v);
+        }
+      }
+      const call = client.makeUnaryRequest(
+        `/${serviceName}/${method.name}`,
+        (arg: any) => arg,
+        (arg: any) => arg,
+        requestData,
+        metadataContainer,
+        { interceptors, deadline },
+        callback
+      );
+      if (abortSignal != null) {
+        abortSignal.addEventListener('abort', () => call.cancel());
+      }
+
+      return call;
+    };
+  }
+
+  /**
+   * Set the deadline for any service requests executed in `fn`'s scope.
+   *
+   * @returns value returned from `fn`
+   */
+  async withDeadline<ReturnType>(deadline: number | Date, fn: () => Promise<ReturnType>): Promise<ReturnType> {
+    const cc = this.callContextStorage.getStore();
+    return await this.callContextStorage.run({ ...cc, deadline }, fn);
+  }
+
+  /**
+   * Set an {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal | `AbortSignal`} that, when aborted,
+   * cancels any ongoing requests executed in `fn`'s scope.
+   *
+   * @returns value returned from `fn`
+   *
+   * @example
+   *
+   * ```ts
+   * const ctrl = new AbortController();
+   * setTimeout(() => ctrl.abort(), 10_000);
+   * // 👇 throws if incomplete by the timeout.
+   * await conn.withAbortSignal(ctrl.signal, () => client.cloudService.someOperation(...));
+   * ```
+   */
+  async withAbortSignal<ReturnType>(abortSignal: AbortSignal, fn: () => Promise<ReturnType>): Promise<ReturnType> {
+    const cc = this.callContextStorage.getStore();
+    return await this.callContextStorage.run({ ...cc, abortSignal }, fn);
+  }
+
+  /**
+   * Set metadata for any service requests executed in `fn`'s scope.
+   *
+   * The provided metadata is merged on top of any existing metadata in current scope, including metadata provided in
+   * {@link ConnectionOptions.metadata}.
+   *
+   * @returns value returned from `fn`
+   *
+   * @example
+   *
+   * ```ts
+   * const result = await conn.withMetadata({ someMetadata: 'value' }, () =>
+   *   conn.withMetadata({ otherKey: 'set' }, () => client.cloudService.someOperation(...)))
+   * );
+   * ```
+   */
+  async withMetadata<ReturnType>(metadata: Metadata, fn: () => Promise<ReturnType>): Promise<ReturnType> {
+    const cc = this.callContextStorage.getStore();
+    return await this.callContextStorage.run(
+      {
+        ...cc,
+        metadata: { ...cc?.metadata, ...metadata },
+      },
+      fn
+    );
+  }
+
+  /**
+   * Set the apiKey for any service requests executed in `fn`'s scope (thus changing the `Authorization` header).
+   *
+   * @returns value returned from `fn`
+   *
+   * @example
+   *
+   * ```ts
+   * const workflowHandle = await conn.withApiKey('secret', () =>
+   *   conn.withMetadata({ otherKey: 'set' }, () => client.start(options)))
+   * );
+   * ```
+   */
+  async withApiKey<ReturnType>(apiKey: string, fn: () => Promise<ReturnType>): Promise<ReturnType> {
+    const cc = this.callContextStorage.getStore();
+    return await this.callContextStorage.run(
+      {
+        ...cc,
+        metadata: { ...cc?.metadata, Authorization: `Bearer ${apiKey}` },
+      },
+      fn
+    );
+  }
+
+  /**
+   * Set the {@link ConnectionOptions.apiKey} for all subsequent requests. A static string or a
+   * callback function may be provided.
+   */
+  setApiKey(apiKey: string | (() => string)): void {
+    if (typeof apiKey === 'string') {
+      if (apiKey === '') {
+        throw new TypeError('`apiKey` must not be an empty string');
+      }
+      this.apiKeyFnRef.fn = () => apiKey;
+    } else {
+      this.apiKeyFnRef.fn = apiKey;
+    }
+  }
+
+  /**
+   * Wait for successful connection to the server.
+   *
+   * @see https://grpc.github.io/grpc/node/grpc.Client.html#waitForReady__anchor
+   */
+  protected async untilReady(deadline: number): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.client.waitForReady(deadline, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  // This method is async for uniformity with Connection and NativeConnection
+  /**
+   * Close the underlying gRPC client.
+   *
+   * Make sure to call this method to ensure proper resource cleanup.
+   */
+  public async close(): Promise<void> {
+    this.client.close();
+  }
+}

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -1,0 +1,7 @@
+/** @experimental */
+export {
+  CloudOperationsClient,
+  CloudOperationsConnection,
+  CloudOperationsConnectionOptions,
+  CloudOperationsClientOptions,
+} from './cloud-operations-client';

--- a/packages/cloud/src/pkg.ts
+++ b/packages/cloud/src/pkg.ts
@@ -1,0 +1,7 @@
+// ../package.json is outside of the TS project rootDir which causes TS to complain about this import.
+// We do not want to change the rootDir because it messes up the output structure.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import pkg from '../package.json';
+
+export default pkg as { name: string; version: string };

--- a/packages/cloud/src/types.ts
+++ b/packages/cloud/src/types.ts
@@ -1,0 +1,4 @@
+import * as proto from '@temporalio/proto';
+
+export type CloudService = proto.temporal.api.cloud.cloudservice.v1.CloudService;
+export const { CloudService } = proto.temporal.api.cloud.cloudservice.v1;

--- a/packages/cloud/tsconfig.json
+++ b/packages/cloud/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDir": "./src"
+  },
+  "references": [{ "path": "../common" }],
+  "include": ["./src/**/*.ts"]
+}

--- a/packages/common/src/internal-non-workflow/parse-host-uri.ts
+++ b/packages/common/src/internal-non-workflow/parse-host-uri.ts
@@ -80,23 +80,24 @@ export function joinProtoHostPort(components: ProtoHostPort): string {
  * Parse the address for the gRPC endpoint of a Temporal server.
  *
  * - The URI may only contain a hostname and a port.
- * - Port is optional; it defaults to 7233.
+ * - Port is optional; if not specified, set it to `defaultPort`.
  *
- * Examples of valid URIs:
+ * Examples of valid URIs (assuming `defaultPort` is 7233):
  *
  * ```
- * 127.0.0.1:7233 => { host: '192.168.0.1', port: 7233 }
+ * 127.0.0.1 => { host: '127.0.0.1', port: 7233 }
+ * 192.168.0.1:7233 => { host: '192.168.0.1', port: 7233 }
  * my.temporal.service.com:7233 => { host: 'my.temporal.service.com', port: 7233 }
  * [::ffff:192.0.2.128]:8080 => { host: '[::ffff:192.0.2.128]', port: 8080 }
  * ```
  */
-export function normalizeTemporalGrpcEndpointAddress(uri: string): string {
+export function normalizeGrpcEndpointAddress(uri: string, defaultPort: number): string {
   const splitted = splitProtoHostPort(uri);
   if (!splitted || splitted.scheme !== undefined) {
     throw new TypeError(
       `Invalid address for Temporal gRPC endpoint: expected URI of the form 'hostname' or 'hostname:port'; got '${uri}'`
     );
   }
-  splitted.port ??= 7233;
+  splitted.port ??= defaultPort;
   return joinProtoHostPort(splitted);
 }

--- a/packages/common/src/internal-non-workflow/tls-config.ts
+++ b/packages/common/src/internal-non-workflow/tls-config.ts
@@ -27,11 +27,11 @@ export interface TLSConfig {
  * Pass a falsy value to use a non-encrypted connection or `true` or `{}` to
  * connect with TLS without any customization.
  */
-export type TLSConfigOption = TLSConfig | boolean | null;
+export type TLSConfigOption = TLSConfig | boolean | undefined | null;
 
 /**
  * Normalize {@link TLSConfigOption} by turning false and null to undefined and true to and empty object
  */
-export function normalizeTlsConfig(tls?: TLSConfigOption): TLSConfig | undefined {
+export function normalizeTlsConfig(tls: TLSConfigOption): TLSConfig | undefined {
   return typeof tls === 'object' ? (tls === null ? undefined : tls) : tls ? {} : undefined;
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -5,8 +5,8 @@
   "description": "Temporal.io SDK Tests",
   "scripts": {
     "build": "npm-run-all build:protos build:ts",
-    "build:protos": "node ./scripts/compile-proto.js",
     "build:ts": "tsc --build",
+    "build:protos": "node ./scripts/compile-proto.js",
     "test": "ava ./lib/test-*.js",
     "test.watch": "ava --watch ./lib/test-*.js"
   },

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -5,10 +5,8 @@
   "description": "Temporal.io SDK Tests",
   "scripts": {
     "build": "npm-run-all build:protos build:ts",
-    "build.watch": "npm-run-all build:protos build:ts-watch",
-    "build:ts": "tsc --build",
-    "build:ts-watch": "tsc --build --watch",
     "build:protos": "node ./scripts/compile-proto.js",
+    "build:ts": "tsc --build",
     "test": "ava ./lib/test-*.js",
     "test.watch": "ava --watch ./lib/test-*.js"
   },
@@ -35,6 +33,7 @@
     "@opentelemetry/semantic-conventions": "^1.19.0",
     "@temporalio/activity": "file:../activity",
     "@temporalio/client": "file:../client",
+    "@temporalio/cloud": "file:../cloud",
     "@temporalio/common": "file:../common",
     "@temporalio/core-bridge": "file:../core-bridge",
     "@temporalio/interceptors-opentelemetry": "file:../interceptors-opentelemetry",

--- a/packages/test/src/test-client-cloud-operations.ts
+++ b/packages/test/src/test-client-cloud-operations.ts
@@ -1,0 +1,31 @@
+import test from 'ava';
+import { Metadata } from '@temporalio/client';
+import { CloudOperationsClient, CloudOperationsConnection } from '@temporalio/cloud';
+
+test('Can create connection to Temporal Cloud Operation service', async (t) => {
+  const address = process.env.TEMPORAL_CLOUD_SAAS_ADDRESS ?? 'saas-api.tmprl.cloud:443';
+  const apiKey = process.env.TEMPORAL_CLIENT_CLOUD_API_KEY;
+  const apiVersion = process.env.TEMPORAL_CLIENT_CLOUD_API_VERSION;
+  const namespace = process.env.TEMPORAL_CLIENT_CLOUD_NAMESPACE;
+
+  if (!apiKey) {
+    t.pass('Skipping: No Cloud API key provided');
+    return;
+  }
+
+  const connection = await CloudOperationsConnection.connect({
+    address,
+    apiKey,
+  });
+  const client = new CloudOperationsClient({ connection, apiVersion });
+
+  const metadata: Metadata = {};
+  if (apiVersion) {
+    metadata['temporal-cloud-api-version'] = apiVersion;
+  }
+
+  const response = await client.withMetadata(metadata, async () => {
+    return client.cloudService.getNamespace({ namespace });
+  });
+  t.is(response?.namespace?.namespace, namespace);
+});

--- a/packages/test/src/test-client-connection.ts
+++ b/packages/test/src/test-client-connection.ts
@@ -26,6 +26,11 @@ const workflowServicePackageDefinition = protoLoader.loadSync(
 );
 const workflowServiceProtoDescriptor = grpc.loadPackageDefinition(workflowServicePackageDefinition) as any;
 
+const healthServicePackageDefinition = protoLoader.loadSync(
+  path.resolve(__dirname, '../../core-bridge/sdk-core/sdk-core-protos/protos/grpc/health/v1/health.proto')
+);
+const healthServicePackageDescriptor = grpc.loadPackageDefinition(healthServicePackageDefinition) as any;
+
 async function bindLocalhost(server: grpc.Server): Promise<number> {
   return await util.promisify(server.bindAsync.bind(server))('localhost:0', grpc.ServerCredentials.createInsecure());
 }
@@ -145,13 +150,8 @@ test('Connection can connect using "[ipv6]:port" address', async (t) => {
 });
 
 test('healthService works', async (t) => {
-  const packageDefinition = protoLoader.loadSync(
-    path.resolve(__dirname, '../../core-bridge/sdk-core/sdk-core-protos/protos/grpc/health/v1/health.proto')
-  );
-  const protoDescriptor = grpc.loadPackageDefinition(packageDefinition) as any;
-
   const server = new grpc.Server();
-  server.addService(protoDescriptor.grpc.health.v1.Health.service, {
+  server.addService(healthServicePackageDescriptor.grpc.health.v1.Health.service, {
     check(
       _call: grpc.ServerUnaryCall<grpcProto.health.v1.HealthCheckRequest, grpcProto.health.v1.HealthCheckResponse>,
       callback: grpc.sendUnaryData<grpcProto.health.v1.HealthCheckResponse>

--- a/packages/test/src/test-parse-uri.ts
+++ b/packages/test/src/test-parse-uri.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { splitProtoHostPort, normalizeTemporalGrpcEndpointAddress } from '@temporalio/common/lib/internal-non-workflow';
+import { splitProtoHostPort, normalizeGrpcEndpointAddress } from '@temporalio/common/lib/internal-non-workflow';
 
 test('splitProtoHostPort', (t) => {
   t.deepEqual(splitProtoHostPort('127.0.0.1'), { scheme: undefined, hostname: '127.0.0.1', port: undefined });
@@ -16,7 +16,7 @@ test('splitProtoHostPort', (t) => {
 });
 
 test('normalizeTemporalGrpcEndpointAddress', (t) => {
-  const normalize = (s: string) => normalizeTemporalGrpcEndpointAddress(s);
+  const normalize = (s: string) => normalizeGrpcEndpointAddress(s, 7233);
 
   t.is(normalize('127.0.0.1'), '127.0.0.1:7233');
   t.is(normalize('127.0.0.1:7890'), '127.0.0.1:7890');

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "../proto" },
     { "path": "../activity" },
     { "path": "../client" },
+    { "path": "../cloud" },
     { "path": "../common" },
     { "path": "../interceptors-opentelemetry" },
     { "path": "../testing" },

--- a/packages/worker/src/connection-options.ts
+++ b/packages/worker/src/connection-options.ts
@@ -1,6 +1,6 @@
 import * as native from '@temporalio/core-bridge';
 import {
-  normalizeTemporalGrpcEndpointAddress,
+  normalizeGrpcEndpointAddress,
   joinProtoHostPort,
   parseHttpConnectProxyAddress,
 } from '@temporalio/common/lib/internal-non-workflow';
@@ -82,7 +82,7 @@ export function compileConnectionOptions(options: RequiredNativeConnectionOption
   }
   return {
     ...rest,
-    address: normalizeTemporalGrpcEndpointAddress(address),
+    address: normalizeGrpcEndpointAddress(address, 7233),
     ...proxyOpts,
   };
 }

--- a/packages/worker/src/connection-options.ts
+++ b/packages/worker/src/connection-options.ts
@@ -11,6 +11,11 @@ type ProxyConfig = native.ProxyConfig;
 
 export { TLSConfig, ProxyConfig };
 
+/**
+ * The default Temporal Server's TCP port for public gRPC connections.
+ */
+const DEFAULT_TEMPORAL_GRPC_PORT = 7233;
+
 export interface NativeConnectionOptions {
   /**
    * The address of the Temporal server to connect to, in `hostname:port` format.
@@ -82,7 +87,7 @@ export function compileConnectionOptions(options: RequiredNativeConnectionOption
   }
   return {
     ...rest,
-    address: normalizeGrpcEndpointAddress(address, 7233),
+    address: normalizeGrpcEndpointAddress(address, DEFAULT_TEMPORAL_GRPC_PORT),
     ...proxyOpts,
   };
 }

--- a/tsconfig.prune.json
+++ b/tsconfig.prune.json
@@ -8,6 +8,7 @@
   "files": [
     "./packages/activity/src/index.ts",
     "./packages/client/src/index.ts",
+    "./packages/cloud/src/index.ts",
     "./packages/common/src/index.ts",
     "./packages/common/src/type-helpers.ts",
     "./packages/create-project/src/index.ts",


### PR DESCRIPTION
## What was changed

- Add experimental support for the Cloud Operations API. Resolves #1416.


## Details 

- Introduced a new NPM package: `@temporalio/cloud`

- Introduced a new "high level Client" class, `CloudOperationsClient`. That needs to be distinct from the `Client` class, as Cloud Operations API goes through a different endpoint and requires different metadata.

- For now, the client provides no "high level" API. Users may use the low level, raw gRPC interface. They are responsible for providing the "temporal-cloud-api-version" metadata when doing so.

- Example usage:

```
  const apiVersion = 2024-05-13-00;

  // Note that this `connection` can't be shared with a `Client` object, they are distinct things
  const connection = await CloudOperationsConnection.connect({
    address: 'saas-api.tmprl.cloud:443',
    apiKey,
    tls: true,
  });
  const client = new CloudOperationsClient({ connection, apiVersion });

  // This part will get simplified when we add high level operations to the client
  const metadata: Metadata = { ['temporal-cloud-api-version']: apiVersion }
  const response = await client.withMetadata(metadata, async () => {
    return client.cloudService.getNamespace({ namespace });
  });
```