### PR TITLE
feat(client): Add utility functions isGrpcDeadlineError and isGrpcCancelledError

### DIFF
--- a/packages/client/src/base-client.ts
+++ b/packages/client/src/base-client.ts
@@ -73,7 +73,7 @@ export class BaseClient {
    *
    * The deadline is a point in time after which any pending gRPC request will be considered as failed;
    * this will locally result in the request call throwing a {@link _grpc.ServiceError|ServiceError}
-   * with code {@link _grpc.status.DEADLINE_EXCEEDED|DEADLINE_EXCEEDED}.
+   * with code {@link _grpc.status.DEADLINE_EXCEEDED|DEADLINE_EXCEEDED}; see {@link isGrpcDeadlineError}.
    *
    * It is stronly recommended to explicitly set deadlines. If no deadline is set, then it is
    * possible for the client to end up waiting forever for a response.
@@ -93,7 +93,7 @@ export class BaseClient {
   /**
    * Set an {@link AbortSignal} that, when aborted, cancels any ongoing service requests executed in
    * `fn`'s scope. This will locally result in the request call throwing a {@link _grpc.ServiceError|ServiceError}
-   * with code {@link _grpc.status.CANCELLED|CANCELLED}.
+   * with code {@link _grpc.status.CANCELLED|CANCELLED}; see {@link isGrpcCancelledError}.
    *
    * This method is only a convenience wrapper around {@link Connection.withAbortSignal}.
    *

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -471,7 +471,7 @@ export class Connection {
    *
    * The deadline is a point in time after which any pending gRPC request will be considered as failed;
    * this will locally result in the request call throwing a {@link grpc.ServiceError|ServiceError}
-   * with code {@link grpc.status.DEADLINE_EXCEEDED|DEADLINE_EXCEEDED}.
+   * with code {@link grpc.status.DEADLINE_EXCEEDED|DEADLINE_EXCEEDED}; see {@link isGrpcDeadlineError}.
    *
    * It is stronly recommended to explicitly set deadlines. If no deadline is set, then it is
    * possible for the client to end up waiting forever for a response.
@@ -490,7 +490,7 @@ export class Connection {
   /**
    * Set an {@link AbortSignal} that, when aborted, cancels any ongoing service requests executed in
    * `fn`'s scope. This will locally result in the request call throwing a {@link grpc.ServiceError|ServiceError}
-   * with code {@link grpc.status.CANCELLED|CANCELLED}.
+   * with code {@link grpc.status.CANCELLED|CANCELLED}; see {@link isGrpcCancelledError}.
    *
    * This method is only a convenience wrapper around {@link Connection.withAbortSignal}.
    *

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,4 +1,4 @@
-import { ServiceError as GrpcServiceError } from '@grpc/grpc-js';
+import { ServiceError as GrpcServiceError, status } from '@grpc/grpc-js';
 import { RetryState, TemporalFailure } from '@temporalio/common';
 import { isError, isRecord, SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 
@@ -79,12 +79,29 @@ export class WorkflowContinuedAsNewError extends Error {
   }
 }
 
+/**
+ * Returns true if the provided error is a {@link GrpcServiceError}.
+ */
 export function isGrpcServiceError(err: unknown): err is GrpcServiceError {
   return (
     isError(err) &&
     typeof (err as GrpcServiceError)?.details === 'string' &&
     isRecord((err as GrpcServiceError).metadata)
   );
+}
+
+/**
+ * Returns true if the provided error is a {@link GrpcServiceError} with code DEADLINE_EXCEEDED.
+ */
+export function isGrpcDeadlineError(err: unknown): err is GrpcServiceError & { code: status.DEADLINE_EXCEEDED } {
+  return isGrpcServiceError(err) && (err as GrpcServiceError).code === status.DEADLINE_EXCEEDED;
+}
+
+/**
+ * Returns true if the provided error is a {@link GrpcServiceError} with code CANCELLED.
+ */
+export function isGrpcCancelledError(err: unknown): err is GrpcServiceError & { code: status.CANCELLED } {
+  return isGrpcServiceError(err) && (err as GrpcServiceError).code === status.CANCELLED;
 }
 
 /**

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -91,17 +91,33 @@ export function isGrpcServiceError(err: unknown): err is GrpcServiceError {
 }
 
 /**
- * Returns true if the provided error is a {@link GrpcServiceError} with code DEADLINE_EXCEEDED.
+ * Returns true if the provided error or its cause is a {@link GrpcServiceError} with code DEADLINE_EXCEEDED.
+ *
+ * @see {@link Connection.withDeadline}
  */
-export function isGrpcDeadlineError(err: unknown): err is GrpcServiceError & { code: status.DEADLINE_EXCEEDED } {
-  return isGrpcServiceError(err) && (err as GrpcServiceError).code === status.DEADLINE_EXCEEDED;
+export function isGrpcDeadlineError(err: unknown): err is Error {
+  while (isError(err)) {
+    if (isGrpcServiceError(err) && (err as GrpcServiceError).code === status.DEADLINE_EXCEEDED) {
+      return true;
+    }
+    err = (err as any).cause;
+  }
+  return false;
 }
 
 /**
- * Returns true if the provided error is a {@link GrpcServiceError} with code CANCELLED.
+ * Returns true if the provided error or its cause is a {@link GrpcServiceError} with code CANCELLED.
+ *
+ * @see {@link Connection.withAbortSignal}
  */
-export function isGrpcCancelledError(err: unknown): err is GrpcServiceError & { code: status.CANCELLED } {
-  return isGrpcServiceError(err) && (err as GrpcServiceError).code === status.CANCELLED;
+export function isGrpcCancelledError(err: unknown): err is Error {
+  while (isError(err)) {
+    if (isGrpcServiceError(err) && (err as GrpcServiceError).code === status.CANCELLED) {
+      return true;
+    }
+    err = (err as any).cause;
+  }
+  return false;
 }
 
 /**

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -102,7 +102,7 @@ export interface ConnectionLike {
    *
    * The deadline is a point in time after which any pending gRPC request will be considered as failed;
    * this will locally result in the request call throwing a {@link grpc.ServiceError|ServiceError}
-   * with code {@link grpc.status.DEADLINE_EXCEEDED|DEADLINE_EXCEEDED}.
+   * with code {@link grpc.status.DEADLINE_EXCEEDED|DEADLINE_EXCEEDED}; see {@link isGrpcDeadlineError}.
    *
    * It is stronly recommended to explicitly set deadlines. If no deadline is set, then it is
    * possible for the client to end up waiting forever for a response.
@@ -127,7 +127,7 @@ export interface ConnectionLike {
   /**
    * Set an {@link AbortSignal} that, when aborted, cancels any ongoing service requests executed in
    * `fn`'s scope. This will locally result in the request call throwing a {@link grpc.ServiceError|ServiceError}
-   * with code {@link grpc.status.CANCELLED|CANCELLED}.
+   * with code {@link grpc.status.CANCELLED|CANCELLED}; see {@link isGrpcCancelledError}.
    *
    * @returns value returned from `fn`
    *

--- a/packages/cloud/src/cloud-operations-client.ts
+++ b/packages/cloud/src/cloud-operations-client.ts
@@ -59,7 +59,7 @@ export class CloudOperationsClient {
    *
    * The deadline is a point in time after which any pending gRPC request will be considered as failed;
    * this will locally result in the request call throwing a {@link grpc.ServiceError|ServiceError}
-   * with code {@link grpc.status.DEADLINE_EXCEEDED|DEADLINE_EXCEEDED}.
+   * with code {@link grpc.status.DEADLINE_EXCEEDED|DEADLINE_EXCEEDED}; see {@link isGrpcDeadlineError}.
    *
    * It is stronly recommended to explicitly set deadlines. If no deadline is set, then it is
    * possible for the client to end up waiting forever for a response.
@@ -80,7 +80,7 @@ export class CloudOperationsClient {
   /**
    * Set an {@link AbortSignal} that, when aborted, cancels any ongoing service requests executed in
    * `fn`'s scope. This will locally result in the request call throwing a {@link grpc.ServiceError|ServiceError}
-   * with code {@link grpc.status.CANCELLED|CANCELLED}.
+   * with code {@link grpc.status.CANCELLED|CANCELLED}; see {@link isGrpcCancelledError}.
    *
    * This method is only a convenience wrapper around {@link CloudOperationsConnection.withAbortSignal}.
    *
@@ -468,7 +468,7 @@ export class CloudOperationsConnection {
    *
    * The deadline is a point in time after which any pending gRPC request will be considered as failed;
    * this will locally result in the request call throwing a {@link grpc.ServiceError|ServiceError}
-   * with code {@link grpc.status.DEADLINE_EXCEEDED|DEADLINE_EXCEEDED}.
+   * with code {@link grpc.status.DEADLINE_EXCEEDED|DEADLINE_EXCEEDED}; see {@link isGrpcDeadlineError}.
    *
    * It is stronly recommended to explicitly set deadlines. If no deadline is set, then it is
    * possible for the client to end up waiting forever for a response.

--- a/packages/test/src/test-client-connection.ts
+++ b/packages/test/src/test-client-connection.ts
@@ -10,6 +10,7 @@ import {
   Client,
   Connection,
   defaultGrpcRetryOptions,
+  isGrpcCancelledError,
   isGrpcServiceError,
   isRetryableError,
   makeGrpcRetryInterceptor,
@@ -123,7 +124,7 @@ test('withMetadata / withDeadline / withAbortSignal set the CallContext for RPC 
   const ctrl = new AbortController();
   setTimeout(() => ctrl.abort(), 10);
   const err = await t.throwsAsync(conn.withAbortSignal(ctrl.signal, () => conn.workflowService.updateNamespace({})));
-  t.true(isGrpcServiceError(err) && err.code === grpc.status.CANCELLED);
+  t.true(isGrpcCancelledError(err));
 });
 
 test('Connection can connect using "[ipv6]:port" address', async (t) => {


### PR DESCRIPTION
## What was changed

- Added utility functions `isGrpcDeadlineError` and `isGrpcCancelledError` .

## Why?

- Setting a deadline on gRPC calls (including all "high level" client calls made using our WorkflowClient) is a best practice, as not doing so may possibly result in waiting forever for a response that will never come. Yet, doing so implies that the user will need to check thrown errors, which turns this into a non-trivial exercise.

See for example the following snippet provided by a user. Note that they needed to add an explicit dependency on `@grpc/grpc-js` only for this purpose, as they need access to the `status` enum.

```
import { status as grpcStatus } from "@grpc/grpc-js";
import { isGrpcServiceError, ServiceError, WorkflowClient } from "@temporalio/client";

async function isWorkflowCompleted(workflowClient: WorkflowClient, workflowId: string, ms: number): Promise<boolean> {
    const handle = workflowClient.getHandle(workflowId);
    try {
      await workflowClient.withDeadline(Date.now() + ms, () => handle.result());
      return true;
    } catch (e) {
      if (
        e instanceof ServiceError &&
        isGrpcServiceError(e.cause) &&
        e.cause.code === grpcStatus.DEADLINE_EXCEEDED
      ) {
        return false;
      }
      throw e;
    }
}
```

After this PR, this snippet can be reduced to:

```
import { isGrpcDeadlineError, WorkflowClient } from "@temporalio/client";

async function isWorkflowCompleted(workflowClient: WorkflowClient, workflowId: string, ms: number): Promise<boolean> {
    const handle = workflowClient.getHandle(workflowId);
    try {
      await workflowClient.withDeadline(Date.now() + ms, () => handle.result());
      return true;
    } catch (e) {
      if (isGrpcDeadlineError(e)) return false;
      throw e;
    }
}
```

… and the user probably no longer needs an explicit dependency on `@grpc/grpc-js`.