### PR TITLE
Added limit to number of 'available activities' list when calling an unregistered activity

### DIFF
--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -917,11 +917,12 @@ export class Worker {
                     const { activityType } = info;
                     const fn = this.options.activities.get(activityType);
                     if (typeof fn !== 'function') {
+                      const keys = [...this.options.activities.keys()];
                       throw ApplicationFailure.create({
                         type: 'NotFoundError',
-                        message: `Activity function ${activityType} is not registered on this Worker, available activities: ${JSON.stringify(
-                          [...this.options.activities.keys()]
-                        )}`,
+                        message: `Activity function ${activityType} is not registered on this Worker, available activities are: ${JSON.stringify(
+                          keys.slice(0, 10)
+                        )}` + keys.length > 10 ? `, and ${keys.length - 10} others` : '',
                         nonRetryable: false,
                       });
                     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
When emitting an 'Activity function xyz is not registered on this Worker' error, the number of activities listed in 'available activities are:' has been capped to a maximum of 10. It will be of the format 'Activity function xyz is not registered on this Worker, available activities: activity1, activity2 ... activity10 and 37 others.'

## Why?
<!-- Tell your future self why have you made these changes -->
'Available activities are:' can be a useful hint as to which worker picked up the activity, and can immediately highlight problems if there are, in fact, _no_ registered activities! But for workers with hundreds or thousands of activities registered, these logs quickly become huge, taking up too much storage and memory.