### PR TITLE
fix(worker): abort reason should be CancellationFailure

### DIFF
--- a/packages/test/src/activities/index.ts
+++ b/packages/test/src/activities/index.ts
@@ -55,8 +55,16 @@ export async function throwAnError(useApplicationFailure: boolean, message: stri
   }
 }
 
-export async function waitForCancellation(): Promise<void> {
-  await Context.current().cancelled;
+export async function waitForCancellation(throwIfAborted?: boolean): Promise<void> {
+  try {
+    await Context.current().cancelled;
+  } catch (e) {
+    if (throwIfAborted) {
+      Context.current().cancellationSignal.throwIfAborted();
+    } else {
+      throw e;
+    }
+  }
 }
 
 export async function fakeProgress(sleepIntervalMs = 1000, numIters = 1000): Promise<void> {

--- a/packages/test/src/test-worker-activities.ts
+++ b/packages/test/src/test-worker-activities.ts
@@ -99,7 +99,7 @@ test('Worker runs an activity and reports failure', async (t) => {
   });
 });
 
-test('Worker cancels activity and reports cancellation', async (t) => {
+const workerCancelsActivityMacro = test.macro(async (t, throwIfAborted?: boolean) => {
   const { worker } = t.context;
   await runWorker(t, async () => {
     const taskToken = Buffer.from(uuid4());
@@ -109,7 +109,7 @@ test('Worker cancels activity and reports cancellation', async (t) => {
         start: {
           activityType: 'waitForCancellation',
           workflowExecution: { workflowId: 'wfid', runId: 'runId' },
-          input: toPayloads(defaultPayloadConverter),
+          input: toPayloads(defaultPayloadConverter, throwIfAborted),
         },
       },
     });
@@ -130,6 +130,10 @@ test('Worker cancels activity and reports cancellation', async (t) => {
     });
   });
 });
+
+test('Worker cancels activity and reports cancellation', workerCancelsActivityMacro);
+
+test('Worker cancels activity and reports cancellation when using throwIfAborted', workerCancelsActivityMacro, true);
 
 test('Activity Context AbortSignal cancels a fetch request', async (t) => {
   const { worker } = t.context;

--- a/packages/worker/src/activity.ts
+++ b/packages/worker/src/activity.ts
@@ -58,8 +58,9 @@ export class Activity {
     const promise = new Promise<never>((_, reject) => {
       this.cancel = (reason: CancelReason) => {
         this.cancelReason = reason;
-        this.abortController.abort();
-        reject(new CancelledFailure(reason));
+        const err = new CancelledFailure(reason);
+        this.abortController.abort(err);
+        reject(err);
       };
     });
     this.context = new Context(


### PR DESCRIPTION
## What was changed

- The activity cancellation's abort signal now has a `CancellationFailure` object as its `reason` property. This is useful when checking the `reason` as well as being what's thrown when `throwIfAborted()` is called (currently it's a `DOMException` as per [the default behavior](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/reason)).
- Unit test was added.

## Why?

- Useful to know the Temporal reason (e.g. "TIMED_OUT").
- Easier to identify the abort as coming from Temporal.
- Same behavior whether you call `throwIfAborted()` or `await cancelled`.