### PR TITLE
feat: Add OTel correlation metadata on emitted logs from Workflow and Activity context loggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             container: quay.io/pypa/manylinux_2_24_aarch64
             out-file: libtemporal_sdk_typescript_bridge.so
           - platform: macos-x64
-            runner: macos-12
+            runner: macos-13
             target: x86_64-apple-darwin
             out-file: libtemporal_sdk_typescript_bridge.dylib
           - platform: macos-arm
@@ -221,7 +221,7 @@ jobs:
           - platform: linux-arm
             runner: buildjet-4vcpu-ubuntu-2204-arm
           - platform: macos-x64
-            runner: macos-12
+            runner: macos-13
           - platform: macos-arm
             runner: macos-14
           - platform: windows-x64
@@ -336,7 +336,7 @@ jobs:
           - platform: linux-arm
             runner: buildjet-4vcpu-ubuntu-2204-arm
           - platform: macos-x64
-            runner: macos-12
+            runner: macos-13
           - platform: macos-arm
             runner: macos-14
           - platform: windows-x64

--- a/packages/core-bridge/ts/index.ts
+++ b/packages/core-bridge/ts/index.ts
@@ -107,7 +107,7 @@ export interface ClientOptions {
  * @experimental
  */
 export interface ConsoleLogger {
-  console: {}; // eslint-disable-line @typescript-eslint/ban-types
+  console: {}; // eslint-disable-line @typescript-eslint/no-empty-object-type
 }
 
 /**
@@ -143,7 +143,13 @@ export interface OtelCollectorExporter {
     /**
      * URL of a gRPC OpenTelemetry collector.
      *
-     * @format Starts with "grpc://" or "http://" for an unsecured connection (typical), or "grpcs://" or "https://" for a TLS connection.
+     * Syntax should generally look like `http://server:4317` (the `grpc://` is also fine). Core's OTLP
+     * metric exporter does not support the 'OTLP/HTTP' protocol (e.g. `http://server:4318/v1/metrics`).
+     * For grater flexibility, you may setup an OTel collector running as a sidecar (e.g. to proxy
+     * OTLP/gRPC requests to a remote OTLP/HTTP endpoint).
+     *
+     * @format Starts with "grpc://" or "http://" for an unsecured connection (typical),
+     *         or "grpcs://" or "https://" for a TLS connection.
      * @note The `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable, if set, will override this property.
      */
     url: string;
@@ -278,8 +284,8 @@ export type CompiledTelemetryOptions = {
   logging: {
     filter: string;
   } & (
-    | { console: {} /* eslint-disable-line @typescript-eslint/ban-types */ }
-    | { forward: {} /* eslint-disable-line @typescript-eslint/ban-types */ }
+    | { console: {} /* eslint-disable-line @typescript-eslint/no-empty-object-type */ }
+    | { forward: {} /* eslint-disable-line @typescript-eslint/no-empty-object-type */ }
   );
   metrics?: {
     temporality?: 'cumulative' | 'delta';

--- a/packages/core-bridge/ts/index.ts
+++ b/packages/core-bridge/ts/index.ts
@@ -145,7 +145,7 @@ export interface OtelCollectorExporter {
      *
      * Syntax should generally look like `http://server:4317` (the `grpc://` is also fine). Core's OTLP
      * metric exporter does not support the 'OTLP/HTTP' protocol (e.g. `http://server:4318/v1/metrics`).
-     * For grater flexibility, you may setup an OTel collector running as a sidecar (e.g. to proxy
+     * For greater flexibility, you may setup an OTel collector running as a sidecar (e.g. to proxy
      * OTLP/gRPC requests to a remote OTLP/HTTP endpoint).
      *
      * @format Starts with "grpc://" or "http://" for an unsecured connection (typical),

--- a/packages/test/src/test-otel.ts
+++ b/packages/test/src/test-otel.ts
@@ -15,6 +15,7 @@ import { OpenTelemetryWorkflowClientInterceptor } from '@temporalio/interceptors
 import {
   makeWorkflowExporter,
   OpenTelemetryActivityInboundInterceptor,
+  OpenTelemetryActivityOutboundInterceptor,
 } from '@temporalio/interceptors-opentelemetry/lib/worker';
 import { OpenTelemetrySinks, SpanName, SPAN_DELIMITER } from '@temporalio/interceptors-opentelemetry/lib/workflow';
 import { DefaultLogger, InjectedSinks, Runtime } from '@temporalio/worker';
@@ -36,6 +37,20 @@ async function withHttp2Server(
       }
       srv.on('request', async (req, res) => {
         if (requestListener) await requestListener(req, res);
+        res.statusCode = 200;
+        res.addTrailers({
+          'grpc-status': '0',
+          'grpc-message': 'OK',
+        });
+        res.write(
+          // This is a raw gRPC response, of length 0
+          Buffer.from([
+            // Frame Type: Data; Not Compressed
+            0,
+            // Message Length: 0
+            0, 0, 0, 0,
+          ])
+        );
         res.end();
       });
       fn(addr.port)
@@ -62,233 +77,245 @@ test.serial('Runtime.install() accepts metrics.otel.url without headers', async 
   }
 });
 
-// FIXME: Core's OTLP exporter has become extremely noisy when exporting metrics but not getting a
-// proper grpc response from the collector. I'm skipping this test until we can reimplement this using
-// a more a more convincing mock collector. This has also coincided with one case where of CI integration
-// tests hanged, though I don't know at this point etither that's related or just a coincidence.
-// https://github.com/temporalio/sdk-typescript/issues/1495
-test.serial.skip('Exporting OTEL metrics from Core works', async (t) => {
+test.serial('Exporting OTEL metrics from Core works', async (t) => {
   let resolveCapturedRequest = (_req: http2.Http2ServerRequest) => undefined as void;
   const capturedRequest = new Promise<http2.Http2ServerRequest>((r) => (resolveCapturedRequest = r));
-  await withHttp2Server(async (port: number) => {
-    Runtime.install({
-      telemetryOptions: {
-        metrics: {
-          otel: {
-            url: `http://127.0.0.1:${port}`,
-            headers: {
-              'x-test-header': 'test-value',
+  try {
+    await withHttp2Server(async (port: number) => {
+      Runtime.install({
+        telemetryOptions: {
+          metrics: {
+            otel: {
+              url: `http://127.0.0.1:${port}`,
+              headers: {
+                'x-test-header': 'test-value',
+              },
+              metricsExportInterval: 10,
             },
-            metricsExportInterval: 10,
           },
         },
-      },
-    });
+      });
 
-    const localEnv = await TestWorkflowEnvironment.createLocal();
-    try {
-      const worker = await Worker.create({
-        connection: localEnv.nativeConnection,
-        workflowsPath: require.resolve('./workflows'),
-        taskQueue: 'test-otel',
-      });
-      const client = new WorkflowClient({
-        connection: localEnv.connection,
-      });
-      await worker.runUntil(async () => {
-        await client.execute(workflows.successString, {
+      const localEnv = await TestWorkflowEnvironment.createLocal();
+      try {
+        const worker = await Worker.create({
+          connection: localEnv.nativeConnection,
+          workflowsPath: require.resolve('./workflows'),
           taskQueue: 'test-otel',
-          workflowId: uuid4(),
         });
-        const req = await Promise.race([
-          capturedRequest,
-          await new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 2000)),
-        ]);
-        t.truthy(req);
-        t.is(req?.url, '/opentelemetry.proto.collector.metrics.v1.MetricsService/Export');
-        t.is(req?.headers['x-test-header'], 'test-value');
-      });
-    } finally {
-      await localEnv.teardown();
-    }
-  }, resolveCapturedRequest);
+        const client = new WorkflowClient({
+          connection: localEnv.connection,
+        });
+        await worker.runUntil(async () => {
+          await client.execute(workflows.successString, {
+            taskQueue: 'test-otel',
+            workflowId: uuid4(),
+          });
+          const req = await Promise.race([
+            capturedRequest,
+            await new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 2000)),
+          ]);
+          t.truthy(req);
+          t.is(req?.url, '/opentelemetry.proto.collector.metrics.v1.MetricsService/Export');
+          t.is(req?.headers['x-test-header'], 'test-value');
+        });
+      } finally {
+        await localEnv.teardown();
+      }
+    }, resolveCapturedRequest);
+  } finally {
+    // Cleanup the runtime so that it doesn't interfere with other tests
+    await Runtime._instance?.shutdown();
+  }
 });
 
 if (RUN_INTEGRATION_TESTS) {
-  // FIXME: See comment above.
-  // https://github.com/temporalio/sdk-typescript/issues/1495
-  test.serial.skip('Otel interceptor spans are connected and complete', async (t) => {
-    const spans = Array<opentelemetry.tracing.ReadableSpan>();
+  test.serial('Otel interceptor spans are connected and complete', async (t) => {
+    Runtime.install({});
+    try {
+      const spans = Array<opentelemetry.tracing.ReadableSpan>();
 
-    const staticResource = new opentelemetry.resources.Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: 'ts-test-otel-worker',
-    });
-    const traceExporter: opentelemetry.tracing.SpanExporter = {
-      export(spans_, resultCallback) {
-        spans.push(...spans_);
-        resultCallback({ code: ExportResultCode.SUCCESS });
-      },
-      async shutdown() {
-        // Nothing to shutdown
-      },
-    };
-    const otel = new opentelemetry.NodeSDK({
-      resource: staticResource,
-      traceExporter,
-    });
-    await otel.start();
+      const staticResource = new opentelemetry.resources.Resource({
+        [SemanticResourceAttributes.SERVICE_NAME]: 'ts-test-otel-worker',
+      });
+      const traceExporter: opentelemetry.tracing.SpanExporter = {
+        export(spans_, resultCallback) {
+          spans.push(...spans_);
+          resultCallback({ code: ExportResultCode.SUCCESS });
+        },
+        async shutdown() {
+          // Nothing to shutdown
+        },
+      };
+      const otel = new opentelemetry.NodeSDK({
+        resource: staticResource,
+        traceExporter,
+      });
+      await otel.start();
 
-    const sinks: InjectedSinks<OpenTelemetrySinks> = {
-      exporter: makeWorkflowExporter(traceExporter, staticResource),
-    };
+      const sinks: InjectedSinks<OpenTelemetrySinks> = {
+        exporter: makeWorkflowExporter(traceExporter, staticResource),
+      };
 
-    const connection = await Connection.connect();
+      const connection = await Connection.connect();
 
-    const worker = await Worker.create({
-      workflowsPath: require.resolve('./workflows'),
-      activities,
-      taskQueue: 'test-otel',
-      interceptors: {
-        workflowModules: [require.resolve('./workflows/otel-interceptors')],
-        activity: [
-          (ctx) => ({ inbound: new OpenTelemetryActivityInboundInterceptor(ctx) }),
-          () => ({ inbound: new ConnectionInjectorInterceptor(connection) }),
-        ],
-      },
-      sinks,
-    });
+      const worker = await Worker.create({
+        workflowsPath: require.resolve('./workflows'),
+        activities,
+        taskQueue: 'test-otel',
+        interceptors: {
+          workflowModules: [require.resolve('./workflows/otel-interceptors')],
+          activity: [
+            (ctx) => ({
+              inbound: new OpenTelemetryActivityInboundInterceptor(ctx),
+              outbound: new OpenTelemetryActivityOutboundInterceptor(ctx),
+            }),
+            () => ({ inbound: new ConnectionInjectorInterceptor(connection) }),
+          ],
+        },
+        sinks,
+      });
 
-    const client = new WorkflowClient({
-      interceptors: [new OpenTelemetryWorkflowClientInterceptor()],
-    });
-    await worker.runUntil(client.execute(workflows.smorgasbord, { taskQueue: 'test-otel', workflowId: uuid4() }));
-    await otel.shutdown();
-    const originalSpan = spans.find(({ name }) => name === `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}smorgasbord`);
-    t.true(originalSpan !== undefined);
-    t.log(
-      spans.map((span) => ({ name: span.name, parentSpanId: span.parentSpanId, spanId: span.spanContext().spanId }))
-    );
+      const client = new WorkflowClient({
+        interceptors: [new OpenTelemetryWorkflowClientInterceptor()],
+      });
+      await worker.runUntil(client.execute(workflows.smorgasbord, { taskQueue: 'test-otel', workflowId: uuid4() }));
+      await otel.shutdown();
+      const originalSpan = spans.find(({ name }) => name === `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}smorgasbord`);
+      t.true(originalSpan !== undefined);
+      t.log(
+        spans.map((span) => ({ name: span.name, parentSpanId: span.parentSpanId, spanId: span.spanContext().spanId }))
+      );
 
-    const firstExecuteSpan = spans.find(
-      ({ name, parentSpanId }) =>
-        name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}smorgasbord` &&
-        parentSpanId === originalSpan?.spanContext().spanId
-    );
-    t.true(firstExecuteSpan !== undefined);
-    t.true(firstExecuteSpan!.status.code === SpanStatusCode.OK);
+      const firstExecuteSpan = spans.find(
+        ({ name, parentSpanId }) =>
+          name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}smorgasbord` &&
+          parentSpanId === originalSpan?.spanContext().spanId
+      );
+      t.true(firstExecuteSpan !== undefined);
+      t.true(firstExecuteSpan!.status.code === SpanStatusCode.OK);
 
-    const continueAsNewSpan = spans.find(
-      ({ name, parentSpanId }) =>
-        name === `${SpanName.CONTINUE_AS_NEW}${SPAN_DELIMITER}smorgasbord` &&
-        parentSpanId === firstExecuteSpan?.spanContext().spanId
-    );
-    t.true(continueAsNewSpan !== undefined);
-    t.true(continueAsNewSpan!.status.code === SpanStatusCode.OK);
+      const continueAsNewSpan = spans.find(
+        ({ name, parentSpanId }) =>
+          name === `${SpanName.CONTINUE_AS_NEW}${SPAN_DELIMITER}smorgasbord` &&
+          parentSpanId === firstExecuteSpan?.spanContext().spanId
+      );
+      t.true(continueAsNewSpan !== undefined);
+      t.true(continueAsNewSpan!.status.code === SpanStatusCode.OK);
 
-    const parentExecuteSpan = spans.find(
-      ({ name, parentSpanId }) =>
-        name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}smorgasbord` &&
-        parentSpanId === continueAsNewSpan?.spanContext().spanId
-    );
-    t.true(parentExecuteSpan !== undefined);
-    const firstActivityStartSpan = spans.find(
-      ({ name, parentSpanId }) =>
-        name === `${SpanName.ACTIVITY_START}${SPAN_DELIMITER}fakeProgress` &&
-        parentSpanId === parentExecuteSpan?.spanContext().spanId
-    );
-    t.true(firstActivityStartSpan !== undefined);
+      const parentExecuteSpan = spans.find(
+        ({ name, parentSpanId }) =>
+          name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}smorgasbord` &&
+          parentSpanId === continueAsNewSpan?.spanContext().spanId
+      );
+      t.true(parentExecuteSpan !== undefined);
+      const firstActivityStartSpan = spans.find(
+        ({ name, parentSpanId }) =>
+          name === `${SpanName.ACTIVITY_START}${SPAN_DELIMITER}fakeProgress` &&
+          parentSpanId === parentExecuteSpan?.spanContext().spanId
+      );
+      t.true(firstActivityStartSpan !== undefined);
 
-    const firstActivityExecuteSpan = spans.find(
-      ({ name, parentSpanId }) =>
-        name === `${SpanName.ACTIVITY_EXECUTE}${SPAN_DELIMITER}fakeProgress` &&
-        parentSpanId === firstActivityStartSpan?.spanContext().spanId
-    );
-    t.true(firstActivityExecuteSpan !== undefined);
+      const firstActivityExecuteSpan = spans.find(
+        ({ name, parentSpanId }) =>
+          name === `${SpanName.ACTIVITY_EXECUTE}${SPAN_DELIMITER}fakeProgress` &&
+          parentSpanId === firstActivityStartSpan?.spanContext().spanId
+      );
+      t.true(firstActivityExecuteSpan !== undefined);
 
-    const secondActivityStartSpan = spans.find(
-      ({ name, parentSpanId }) =>
-        name === `${SpanName.ACTIVITY_START}${SPAN_DELIMITER}queryOwnWf` &&
-        parentSpanId === parentExecuteSpan?.spanContext().spanId
-    );
-    t.true(secondActivityStartSpan !== undefined);
+      const secondActivityStartSpan = spans.find(
+        ({ name, parentSpanId }) =>
+          name === `${SpanName.ACTIVITY_START}${SPAN_DELIMITER}queryOwnWf` &&
+          parentSpanId === parentExecuteSpan?.spanContext().spanId
+      );
+      t.true(secondActivityStartSpan !== undefined);
 
-    const secondActivityExecuteSpan = spans.find(
-      ({ name, parentSpanId }) =>
-        name === `${SpanName.ACTIVITY_EXECUTE}${SPAN_DELIMITER}queryOwnWf` &&
-        parentSpanId === secondActivityStartSpan?.spanContext().spanId
-    );
-    t.true(secondActivityExecuteSpan !== undefined);
+      const secondActivityExecuteSpan = spans.find(
+        ({ name, parentSpanId }) =>
+          name === `${SpanName.ACTIVITY_EXECUTE}${SPAN_DELIMITER}queryOwnWf` &&
+          parentSpanId === secondActivityStartSpan?.spanContext().spanId
+      );
+      t.true(secondActivityExecuteSpan !== undefined);
 
-    const childWorkflowStartSpan = spans.find(
-      ({ name, parentSpanId }) =>
-        name === `${SpanName.CHILD_WORKFLOW_START}${SPAN_DELIMITER}signalTarget` &&
-        parentSpanId === parentExecuteSpan?.spanContext().spanId
-    );
-    t.true(childWorkflowStartSpan !== undefined);
+      const childWorkflowStartSpan = spans.find(
+        ({ name, parentSpanId }) =>
+          name === `${SpanName.CHILD_WORKFLOW_START}${SPAN_DELIMITER}signalTarget` &&
+          parentSpanId === parentExecuteSpan?.spanContext().spanId
+      );
+      t.true(childWorkflowStartSpan !== undefined);
 
-    const childWorkflowExecuteSpan = spans.find(
-      ({ name, parentSpanId }) =>
-        name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}signalTarget` &&
-        parentSpanId === childWorkflowStartSpan?.spanContext().spanId
-    );
-    t.true(childWorkflowExecuteSpan !== undefined);
+      const childWorkflowExecuteSpan = spans.find(
+        ({ name, parentSpanId }) =>
+          name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}signalTarget` &&
+          parentSpanId === childWorkflowStartSpan?.spanContext().spanId
+      );
+      t.true(childWorkflowExecuteSpan !== undefined);
 
-    const signalChildWithUnblockSpan = spans.find(
-      ({ name, parentSpanId }) =>
-        name === `${SpanName.WORKFLOW_SIGNAL}${SPAN_DELIMITER}unblock` &&
-        parentSpanId === parentExecuteSpan?.spanContext().spanId
-    );
-    t.true(signalChildWithUnblockSpan !== undefined);
+      const signalChildWithUnblockSpan = spans.find(
+        ({ name, parentSpanId }) =>
+          name === `${SpanName.WORKFLOW_SIGNAL}${SPAN_DELIMITER}unblock` &&
+          parentSpanId === parentExecuteSpan?.spanContext().spanId
+      );
+      t.true(signalChildWithUnblockSpan !== undefined);
 
-    const activityStartedSignalSpan = spans.find(
-      ({ name, parentSpanId }) =>
-        name === `${SpanName.WORKFLOW_SIGNAL}${SPAN_DELIMITER}activityStarted` &&
-        parentSpanId === firstActivityExecuteSpan?.spanContext().spanId
-    );
-    t.true(activityStartedSignalSpan !== undefined);
+      const activityStartedSignalSpan = spans.find(
+        ({ name, parentSpanId }) =>
+          name === `${SpanName.WORKFLOW_SIGNAL}${SPAN_DELIMITER}activityStarted` &&
+          parentSpanId === firstActivityExecuteSpan?.spanContext().spanId
+      );
+      t.true(activityStartedSignalSpan !== undefined);
 
-    t.deepEqual(new Set(spans.map((span) => span.spanContext().traceId)).size, 1);
+      t.deepEqual(new Set(spans.map((span) => span.spanContext().traceId)).size, 1);
+    } finally {
+      // Cleanup the runtime so that it doesn't interfere with other tests
+      await Runtime._instance?.shutdown();
+    }
   });
 
   // Un-skip this test and run it by hand to inspect outputted traces
   test.serial('Otel spans connected', async (t) => {
-    const oTelUrl = 'http://127.0.0.1:4317';
-    const exporter = new OTLPTraceExporter({ url: oTelUrl });
-    const staticResource = new opentelemetry.resources.Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: 'ts-test-otel-worker',
-    });
-    const otel = new opentelemetry.NodeSDK({
-      resource: staticResource,
-      traceExporter: exporter,
-    });
-    await otel.start();
-
     const logger = new DefaultLogger('DEBUG');
     Runtime.install({
       logger,
     });
-    const sinks: InjectedSinks<OpenTelemetrySinks> = {
-      exporter: makeWorkflowExporter(exporter, staticResource),
-    };
-    const worker = await Worker.create({
-      workflowsPath: require.resolve('./workflows'),
-      activities,
-      enableSDKTracing: true,
-      taskQueue: 'test-otel',
-      interceptors: {
-        workflowModules: [require.resolve('./workflows/otel-interceptors')],
-        activity: [(ctx) => ({ inbound: new OpenTelemetryActivityInboundInterceptor(ctx) })],
-      },
-      sinks,
-    });
+    try {
+      const oTelUrl = 'http://127.0.0.1:4317';
+      const exporter = new OTLPTraceExporter({ url: oTelUrl });
+      const staticResource = new opentelemetry.resources.Resource({
+        [SemanticResourceAttributes.SERVICE_NAME]: 'ts-test-otel-worker',
+      });
+      const otel = new opentelemetry.NodeSDK({
+        resource: staticResource,
+        traceExporter: exporter,
+      });
+      await otel.start();
 
-    const client = new WorkflowClient({
-      interceptors: [new OpenTelemetryWorkflowClientInterceptor()],
-    });
-    await worker.runUntil(client.execute(workflows.smorgasbord, { taskQueue: 'test-otel', workflowId: uuid4() }));
-    // Allow some time to ensure spans are flushed out to collector
-    await new Promise<void>((resolve) => setTimeout(resolve, 5000));
-    t.pass();
+      const sinks: InjectedSinks<OpenTelemetrySinks> = {
+        exporter: makeWorkflowExporter(exporter, staticResource),
+      };
+      const worker = await Worker.create({
+        workflowsPath: require.resolve('./workflows'),
+        activities,
+        enableSDKTracing: true,
+        taskQueue: 'test-otel',
+        interceptors: {
+          workflowModules: [require.resolve('./workflows/otel-interceptors')],
+          activity: [(ctx) => ({ inbound: new OpenTelemetryActivityInboundInterceptor(ctx) })],
+        },
+        sinks,
+      });
+
+      const client = new WorkflowClient({
+        interceptors: [new OpenTelemetryWorkflowClientInterceptor()],
+      });
+      await worker.runUntil(client.execute(workflows.smorgasbord, { taskQueue: 'test-otel', workflowId: uuid4() }));
+      // Allow some time to ensure spans are flushed out to collector
+      await new Promise<void>((resolve) => setTimeout(resolve, 5000));
+      t.pass();
+    } finally {
+      // Cleanup the runtime so that it doesn't interfere with other tests
+      await Runtime._instance?.shutdown();
+    }
   });
 
   test('Otel workflow module does not patch node window object', (t) => {


### PR DESCRIPTION
## What was changed

- Add OpenTelemetry's Trace and Span IDs on log entries emitted using the Workflow and Activity context loggers, if appropriate. This allows log correlation on OpenTelemetry aggregators that supports that feature. Resolves #1425.

- Fix some misbehaving OTel-related tests.

- Add some clarifications regarding Runtime's OpenTelemetry metrics exporter configuration.