### PR TITLE
feat(client): add `client.workflow.count` high level API

### DIFF
--- a/packages/client/src/helpers.ts
+++ b/packages/client/src/helpers.ts
@@ -12,9 +12,6 @@ import { decodeMapFromPayloads } from '@temporalio/common/lib/internal-non-workf
 import { temporal, google } from '@temporalio/proto';
 import {
   CountWorkflowExecution,
-  CountWorkflowExecutionsAggregationGroup,
-  RawCountWorkflowExecutions,
-  RawCountWorkflowExecutionsAggregationGroup,
   RawWorkflowExecutionInfo,
   WorkflowExecutionInfo,
   WorkflowExecutionStatusName,
@@ -89,21 +86,19 @@ export async function executionInfoFromRaw<T>(
   };
 }
 
-export function decodeCountWorkflowExecutionsResponse(raw: RawCountWorkflowExecutions): CountWorkflowExecution {
+export function decodeCountWorkflowExecutionsResponse(
+  raw: temporal.api.workflowservice.v1.ICountWorkflowExecutionsResponse
+): CountWorkflowExecution {
   return {
     // Note: lossy conversion of Long to number
     count: raw.count!.toNumber(),
-    groups: raw.groups!.map((group) => executionCountAggregationGroupFromRaw(group)),
-  };
-}
-
-export function executionCountAggregationGroupFromRaw(
-  raw: RawCountWorkflowExecutionsAggregationGroup
-): CountWorkflowExecutionsAggregationGroup {
-  return {
-    // Note: lossy conversion of Long to number
-    count: raw.count!.toNumber(),
-    groupValues: raw.groupValues!.map((group_value) => searchAttributePayloadConverter.fromPayload(group_value)),
+    groups: raw.groups!.map((group) => {
+      return {
+        // Note: lossy conversion of Long to number
+        count: group.count!.toNumber(),
+        groupValues: group.groupValues!.map((value) => searchAttributePayloadConverter.fromPayload(value)),
+      };
+    }),
   };
 }
 

--- a/packages/client/src/helpers.ts
+++ b/packages/client/src/helpers.ts
@@ -10,7 +10,15 @@ import { Replace } from '@temporalio/common/lib/type-helpers';
 import { optionalTsToDate, requiredTsToDate } from '@temporalio/common/lib/time';
 import { decodeMapFromPayloads } from '@temporalio/common/lib/internal-non-workflow/codec-helpers';
 import { temporal, google } from '@temporalio/proto';
-import { RawWorkflowExecutionInfo, WorkflowExecutionInfo, WorkflowExecutionStatusName } from './types';
+import {
+  CountWorkflowExecution,
+  CountWorkflowExecutionsAggregationGroup,
+  RawCountWorkflowExecutions,
+  RawCountWorkflowExecutionsAggregationGroup,
+  RawWorkflowExecutionInfo,
+  WorkflowExecutionInfo,
+  WorkflowExecutionStatusName,
+} from './types';
 
 function workflowStatusCodeToName(code: temporal.api.enums.v1.WorkflowExecutionStatus): WorkflowExecutionStatusName {
   return workflowStatusCodeToNameInternal(code) ?? 'UNKNOWN';
@@ -78,6 +86,24 @@ export async function executionInfoFromRaw<T>(
         }
       : undefined,
     raw: rawDataToEmbed,
+  };
+}
+
+export function countWorkflowExecutionFromRaw(raw: RawCountWorkflowExecutions): CountWorkflowExecution {
+  return {
+    // Note: lossy conversion of Long to number
+    count: raw.count!.toNumber(),
+    groups: raw.groups!.map((group) => executionCountAggregationGroupFromRaw(group)),
+  };
+}
+
+export function executionCountAggregationGroupFromRaw(
+  raw: RawCountWorkflowExecutionsAggregationGroup
+): CountWorkflowExecutionsAggregationGroup {
+  return {
+    // Note: lossy conversion of Long to number
+    count: raw.count!.toNumber(),
+    group_values: raw.groupValues!.map((group_value) => searchAttributePayloadConverter.fromPayload(group_value)),
   };
 }
 

--- a/packages/client/src/helpers.ts
+++ b/packages/client/src/helpers.ts
@@ -89,7 +89,7 @@ export async function executionInfoFromRaw<T>(
   };
 }
 
-export function countWorkflowExecutionFromRaw(raw: RawCountWorkflowExecutions): CountWorkflowExecution {
+export function decodeCountWorkflowExecutionsResponse(raw: RawCountWorkflowExecutions): CountWorkflowExecution {
   return {
     // Note: lossy conversion of Long to number
     count: raw.count!.toNumber(),
@@ -103,7 +103,7 @@ export function executionCountAggregationGroupFromRaw(
   return {
     // Note: lossy conversion of Long to number
     count: raw.count!.toNumber(),
-    group_values: raw.groupValues!.map((group_value) => searchAttributePayloadConverter.fromPayload(group_value)),
+    groupValues: raw.groupValues!.map((group_value) => searchAttributePayloadConverter.fromPayload(group_value)),
   };
 }
 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -62,7 +62,7 @@ export interface CountWorkflowExecution {
 
 export interface CountWorkflowExecutionsAggregationGroup {
   count: number;
-  group_values: SearchAttributeValue[];
+  groupValues: SearchAttributeValue[];
 }
 
 export type WorkflowExecutionDescription = Replace<

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,5 +1,5 @@
 import type * as grpc from '@grpc/grpc-js';
-import type { SearchAttributes } from '@temporalio/common';
+import type { SearchAttributes, SearchAttributeValue } from '@temporalio/common';
 import { makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow';
 import * as proto from '@temporalio/proto';
 import { Replace } from '@temporalio/common/lib/type-helpers';
@@ -14,6 +14,9 @@ export type GetWorkflowExecutionHistoryRequest =
 export type DescribeWorkflowExecutionResponse =
   proto.temporal.api.workflowservice.v1.IDescribeWorkflowExecutionResponse;
 export type RawWorkflowExecutionInfo = proto.temporal.api.workflow.v1.IWorkflowExecutionInfo;
+export type RawCountWorkflowExecutions = proto.temporal.api.workflowservice.v1.ICountWorkflowExecutionsResponse;
+export type RawCountWorkflowExecutionsAggregationGroup =
+  proto.temporal.api.workflowservice.v1.CountWorkflowExecutionsResponse.IAggregationGroup;
 export type TerminateWorkflowExecutionResponse =
   proto.temporal.api.workflowservice.v1.ITerminateWorkflowExecutionResponse;
 export type RequestCancelWorkflowExecutionResponse =
@@ -50,6 +53,16 @@ export interface WorkflowExecutionInfo {
   searchAttributes: SearchAttributes;
   parentExecution?: Required<proto.temporal.api.common.v1.IWorkflowExecution>;
   raw: RawWorkflowExecutionInfo;
+}
+
+export interface CountWorkflowExecution {
+  count: number;
+  groups: CountWorkflowExecutionsAggregationGroup[];
+}
+
+export interface CountWorkflowExecutionsAggregationGroup {
+  count: number;
+  group_values: SearchAttributeValue[];
 }
 
 export type WorkflowExecutionDescription = Replace<

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -14,9 +14,6 @@ export type GetWorkflowExecutionHistoryRequest =
 export type DescribeWorkflowExecutionResponse =
   proto.temporal.api.workflowservice.v1.IDescribeWorkflowExecutionResponse;
 export type RawWorkflowExecutionInfo = proto.temporal.api.workflow.v1.IWorkflowExecutionInfo;
-export type RawCountWorkflowExecutions = proto.temporal.api.workflowservice.v1.ICountWorkflowExecutionsResponse;
-export type RawCountWorkflowExecutionsAggregationGroup =
-  proto.temporal.api.workflowservice.v1.CountWorkflowExecutionsResponse.IAggregationGroup;
 export type TerminateWorkflowExecutionResponse =
   proto.temporal.api.workflowservice.v1.ITerminateWorkflowExecutionResponse;
 export type RequestCancelWorkflowExecutionResponse =
@@ -57,12 +54,10 @@ export interface WorkflowExecutionInfo {
 
 export interface CountWorkflowExecution {
   count: number;
-  groups: CountWorkflowExecutionsAggregationGroup[];
-}
-
-export interface CountWorkflowExecutionsAggregationGroup {
-  count: number;
-  groupValues: SearchAttributeValue[];
+  groups: {
+    count: number;
+    groupValues: SearchAttributeValue[];
+  }[];
 }
 
 export type WorkflowExecutionDescription = Replace<

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -78,7 +78,7 @@ import {
   WorkflowStartOptions,
   WorkflowUpdateOptions,
 } from './workflow-options';
-import { countWorkflowExecutionFromRaw, executionInfoFromRaw, rethrowKnownErrorTypes } from './helpers';
+import { decodeCountWorkflowExecutionsResponse, executionInfoFromRaw, rethrowKnownErrorTypes } from './helpers';
 import {
   BaseClient,
   BaseClientOptions,
@@ -1325,10 +1325,10 @@ export class WorkflowClient extends BaseClient {
         query,
       });
     } catch (e) {
-      this.rethrowGrpcError(e, 'Failed to count workflows', undefined);
+      this.rethrowGrpcError(e, 'Failed to count workflows');
     }
 
-    return countWorkflowExecutionFromRaw(response);
+    return decodeCountWorkflowExecutionsResponse(response);
   }
 
   protected getOrMakeInterceptors(workflowId: string, runId?: string): WorkflowClientInterceptor[] {

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -1286,8 +1286,7 @@ export class WorkflowClient extends BaseClient {
   }
 
   /**
-   * Return a list of Workflow Executions matching the given `query`. If no `query` is provided, returns the 10 most
-   * recently closed Workflow Executions.
+   * Return a list of Workflow Executions matching the given `query`.
    *
    * Note that the list of Workflow Executions returned is approximate and eventually consistent.
    *

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -1288,9 +1288,9 @@ export class WorkflowClient extends BaseClient {
   /**
    * Return a list of Workflow Executions matching the given `query`. If no `query` is provided, returns the 10 most
    * recently closed Workflow Executions.
-   * 
+   *
    * Note that the list of Workflow Executions returned is approximate and eventually consistent.
-   * 
+   *
    * More info on the concept of "visibility" and the query syntax on the Temporal documentation site:
    * https://docs.temporal.io/visibility
    */
@@ -1311,11 +1311,11 @@ export class WorkflowClient extends BaseClient {
   }
 
   /**
-   * Return the number of Workflow Executions matching the given `query`. If no `query` is provided, then return the 
+   * Return the number of Workflow Executions matching the given `query`. If no `query` is provided, then return the
    * total number of Workflow Executions for this namespace.
    *
    * Note that the number of Workflow Executions returned is approximate and eventually consistent.
-   * 
+   *
    * More info on the concept of "visibility" and the query syntax on the Temporal documentation site:
    * https://docs.temporal.io/visibility
    */

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -1286,10 +1286,11 @@ export class WorkflowClient extends BaseClient {
   }
 
   /**
-   * List workflows by given `query`.
-   *
-   * ⚠️ To use advanced query functionality, as of the 1.18 server release, you must use Elasticsearch based visibility.
-   *
+   * Return a list of Workflow Executions matching the given `query`. If no `query` is provided, returns the 10 most
+   * recently closed Workflow Executions.
+   * 
+   * Note that the list of Workflow Executions returned is approximate and eventually consistent.
+   * 
    * More info on the concept of "visibility" and the query syntax on the Temporal documentation site:
    * https://docs.temporal.io/visibility
    */
@@ -1310,10 +1311,11 @@ export class WorkflowClient extends BaseClient {
   }
 
   /**
-   * Return workflow execution count by given `query`.
+   * Return the number of Workflow Executions matching the given `query`. If no `query` is provided, then return the 
+   * total number of Workflow Executions for this namespace.
    *
-   * ⚠️ To use advanced query functionality, as of the 1.18 server release, you must use Elasticsearch based visibility.
-   *
+   * Note that the number of Workflow Executions returned is approximate and eventually consistent.
+   * 
    * More info on the concept of "visibility" and the query syntax on the Temporal documentation site:
    * https://docs.temporal.io/visibility
    */

--- a/packages/test/src/test-integration-workflows.ts
+++ b/packages/test/src/test-integration-workflows.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { ExecutionContext } from 'ava';
 import { firstValueFrom, Subject } from 'rxjs';
+import asyncRetry from 'async-retry';
 import { CountWorkflowExecution, WorkflowFailedError } from '@temporalio/client';
 import * as activity from '@temporalio/activity';
 import { msToNumber, tsToMs } from '@temporalio/common/lib/time';
@@ -16,7 +17,6 @@ import * as workflows from './workflows';
 import { Context, helpers, makeTestFunction } from './helpers-integration';
 import { overrideSdkInternalFlag } from './mock-internal-flags';
 import { asSdkLoggerSink, loadHistory, RUN_TIME_SKIPPING_TESTS, waitUntil } from './helpers';
-import asyncRetry from 'async-retry';
 
 const test = makeTestFunction({
   workflowsPath: __filename,
@@ -1287,11 +1287,11 @@ test('Count workflow executions', async (t) => {
       await Promise.all([
         executeWorkflow(completableWorkflow, { args: [true] }),
         executeWorkflow(completableWorkflow, { args: [true] }),
-        executeWorkflow(completableWorkflow, { args: [true] })
-      ])
+        executeWorkflow(completableWorkflow, { args: [true] }),
+      ]);
     } catch (err) {
-      throw new Error('executing workflow unexpectedly failed')
-    };
+      throw new Error('executing workflow unexpectedly failed');
+    }
   });
 
   const actualTotal = await client.workflow.count(`TaskQueue = '${taskQueue}'`);
@@ -1304,7 +1304,7 @@ test('Count workflow executions', async (t) => {
       { count: 3, groupValues: [['Completed']] },
     ],
   };
-  
+
   const actualByExecutionStatus = await client.workflow.count(`TaskQueue = '${taskQueue}' GROUP BY ExecutionStatus`);
   t.deepEqual(actualByExecutionStatus, expectedByExecutionStatus);
 });

--- a/packages/test/src/test-integration-workflows.ts
+++ b/packages/test/src/test-integration-workflows.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'crypto';
 import { ExecutionContext } from 'ava';
 import { firstValueFrom, Subject } from 'rxjs';
-import asyncRetry from 'async-retry';
 import { CountWorkflowExecution, WorkflowFailedError } from '@temporalio/client';
 import * as activity from '@temporalio/activity';
 import { msToNumber, tsToMs } from '@temporalio/common/lib/time';
@@ -16,7 +15,7 @@ import { activityStartedSignal } from './workflows/definitions';
 import * as workflows from './workflows';
 import { Context, helpers, makeTestFunction } from './helpers-integration';
 import { overrideSdkInternalFlag } from './mock-internal-flags';
-import { asSdkLoggerSink, loadHistory, RUN_TIME_SKIPPING_TESTS, waitUntil } from './helpers';
+import { asSdkLoggerSink, loadHistory, RUN_TIME_SKIPPING_TESTS } from './helpers';
 
 const test = makeTestFunction({
   workflowsPath: __filename,
@@ -1282,16 +1281,12 @@ test('Count workflow executions', async (t) => {
   }
 
   await worker.runUntil(async () => {
-    try {
-      // Run 3 workflows that complete.
-      await Promise.all([
-        executeWorkflow(completableWorkflow, { args: [true] }),
-        executeWorkflow(completableWorkflow, { args: [true] }),
-        executeWorkflow(completableWorkflow, { args: [true] }),
-      ]);
-    } catch (err) {
-      throw new Error('executing workflow unexpectedly failed');
-    }
+    // Run 3 workflows that complete.
+    await Promise.all([
+      executeWorkflow(completableWorkflow, { args: [true] }),
+      executeWorkflow(completableWorkflow, { args: [true] }),
+      executeWorkflow(completableWorkflow, { args: [true] }),
+    ]);
   });
 
   const actualTotal = await client.workflow.count(`TaskQueue = '${taskQueue}'`);


### PR DESCRIPTION
## What was changed
Added a `count` method to the workflow client, a higher-level, user-friendlier option to using the corresponding GRPC method directly.

1. Closes #1069

2. How was this tested:
Added an integration test.

3. Any docs updates needed?
Not sure
