### PR TITLE
docs: Replace broken otel doc link with sample link

### DIFF
--- a/packages/interceptors-opentelemetry/README.md
+++ b/packages/interceptors-opentelemetry/README.md
@@ -5,4 +5,4 @@
 [Temporal](https://temporal.io)'s [TypeScript SDK](https://docs.temporal.io/typescript/introduction) interceptors for tracing Workflow and Activity executions with [OpenTelemetry](https://opentelemetry.io/).
 
 - [Interceptors docs](https://docs.temporal.io/typescript/interceptors)
-- [OpenTelemetry interceptors docs](https://docs.temporal.io/typescript/logging/#opentelemetry-tracing)
+- [OpenTelemetry Interceptor example setup](https://github.com/temporalio/samples-typescript/tree/main/interceptors-opentelemetry)


### PR DESCRIPTION
## What was changed

On the OpenTelemetry interceptor README, I replaced a link to an anchor that no longer exists on the Temporal TypeScript SDK documentation page with a new link to an implementation sample of the OpenTelemetry interceptor in the samples-typescript repository.

## Why?

To help people like myself looking for how to implement the interceptor.