### PR TITLE
fix(ci): do not use next branch for samples-typescript tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,7 @@ jobs:
 
       # Note: here, `npx create` fails on windows if shell is bash.
       - name: Instantiate sample project using verdaccio artifacts
-        run: node scripts/init-from-verdaccio.js --registry-dir ./tmp/registry --sample https://github.com/temporalio/samples-typescript/tree/next/${{ matrix.sample }} --target-dir ${{ runner.temp }}/example
+        run: node scripts/init-from-verdaccio.js --registry-dir ./tmp/registry --sample ${{ matrix.sample }} --target-dir ${{ runner.temp }}/example
 
       - name: Install Temporal CLI
         if: matrix.server == 'cli'


### PR DESCRIPTION
## What was changed

- One of our CI test script was incorrectly pointing to the "next" branch of the sample-typescript repo, which is, ironically, very old and still depends on TS 4.x. This was causing build errors when running the SDK's sample tests.