### PR TITLE
chore: Review all @experimental annotations

### DIFF
--- a/packages/client/src/build-id-types.ts
+++ b/packages/client/src/build-id-types.ts
@@ -3,7 +3,7 @@ import { temporal } from '@temporalio/proto';
 /**
  * Operations that can be passed to {@link TaskQueueClient.updateBuildIdCompatibility}.
  *
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export type BuildIdOperation =
   | AddNewIdInNewDefaultSet
@@ -16,7 +16,7 @@ export type BuildIdOperation =
  * Adds a new Build Id into a new set, which will be used as the default set for
  * the queue. This means all new workflows will start on this Build Id.
  *
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export interface AddNewIdInNewDefaultSet {
   operation: 'addNewIdInNewDefaultSet';
@@ -28,7 +28,7 @@ export interface AddNewIdInNewDefaultSet {
  * the default for that compatible set, and thus new workflow tasks for workflows which have been
  * executing on workers in that set will now start on this new Build Id.
  *
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export interface AddNewCompatibleVersion {
   operation: 'addNewCompatibleVersion';
@@ -47,7 +47,7 @@ export interface AddNewCompatibleVersion {
  * default set for the task queue. Any Build Id in the set may be used to
  * target it.
  *
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export interface PromoteSetByBuildId {
   operation: 'promoteSetByBuildId';
@@ -58,7 +58,7 @@ export interface PromoteSetByBuildId {
  * Promotes a Build Id within an existing set to become the default ID for that
  * set.
  *
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export interface PromoteBuildIdWithinSet {
   operation: 'promoteBuildIdWithinSet';
@@ -70,7 +70,7 @@ export interface PromoteBuildIdWithinSet {
  * compatible with one another. The default of the primary set is maintained as
  * the merged set's overall default.
  *
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export interface MergeSets {
   operation: 'mergeSets';
@@ -84,7 +84,7 @@ export interface MergeSets {
  * Represents the sets of compatible Build Id versions associated with some
  * Task Queue, as fetched by {@link TaskQueueClient.getBuildIdCompatability}.
  *
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export interface WorkerBuildIdVersionSets {
   /**
@@ -108,7 +108,7 @@ export interface WorkerBuildIdVersionSets {
 /**
  * Represents one set of compatible Build Ids.
  *
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export interface BuildIdVersionSet {
   // All build IDs contained in the set.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -47,7 +47,7 @@ export class Client extends BaseClient {
   /**
    * Task Queue sub-client - use to perform operations on Task Queues
    *
-   * @experimental
+   * @experimental The Worker Versioning API is still being designed. Major changes are expected.
    */
   public readonly taskQueue: TaskQueueClient;
 

--- a/packages/client/src/grpc-retry.ts
+++ b/packages/client/src/grpc-retry.ts
@@ -1,9 +1,6 @@
 import { InterceptingCall, Interceptor, ListenerBuilder, RequesterBuilder, StatusObject } from '@grpc/grpc-js';
 import * as grpc from '@grpc/grpc-js';
 
-/**
- * @experimental
- */
 export interface GrpcRetryOptions {
   /**
    * A function which accepts the current retry attempt (starts at 1) and returns the millisecond
@@ -19,8 +16,6 @@ export interface GrpcRetryOptions {
 
 /**
  * Options for the backoff formula: `factor ^ attempt * initialIntervalMs(status) * jitter(maxJitter)`
- *
- * @experimental
  */
 export interface BackoffOptions {
   /**
@@ -79,8 +74,6 @@ function withDefaultBackoffOptions({
 
 /**
  * Generates the default retry behavior based on given backoff options
- *
- * @experimental
  */
 export function defaultGrpcRetryOptions(options: Partial<BackoffOptions> = {}): GrpcRetryOptions {
   const { maxAttempts, factor, maxJitter, initialIntervalMs, maxIntervalMs } = withDefaultBackoffOptions(options);
@@ -165,8 +158,6 @@ function defaultInitialIntervalMs({ code }: StatusObject) {
  * Returns a GRPC interceptor that will perform automatic retries for some types of failed calls
  *
  * @param retryOptions Options for the retry interceptor
- *
- * @experimental
  */
 export function makeGrpcRetryInterceptor(retryOptions: GrpcRetryOptions): Interceptor {
   return (options, nextCall) => {

--- a/packages/client/src/task-queue-client.ts
+++ b/packages/client/src/task-queue-client.ts
@@ -14,18 +14,18 @@ type IUpdateWorkerBuildIdCompatibilityRequest =
 type GetWorkerTaskReachabilityResponse = temporal.api.workflowservice.v1.GetWorkerTaskReachabilityResponse;
 
 /**
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export type TaskQueueClientOptions = BaseClientOptions;
 
 /**
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export type LoadedTaskQueueClientOptions = LoadedWithDefaults<TaskQueueClientOptions>;
 
 /**
  * A stand-in for a Build Id for unversioned Workers
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export const UnversionedBuildId = Symbol.for('__temporal_unversionedBuildId');
 export type UnversionedBuildIdType = typeof UnversionedBuildId;
@@ -33,7 +33,7 @@ export type UnversionedBuildIdType = typeof UnversionedBuildId;
 /**
  * Client for starting Workflow executions and creating Workflow handles
  *
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export class TaskQueueClient extends BaseClient {
   public readonly options: LoadedTaskQueueClientOptions;
@@ -285,7 +285,7 @@ export function reachabilityResponseFromProto(resp: GetWorkerTaskReachabilityRes
  * - Id passed is incorrect
  * - Build Id has been scavenged by the server.
  *
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 @SymbolBasedInstanceOfError('BuildIdNotFoundError')
 export class BuildIdNotFoundError extends Error {}

--- a/packages/cloud/src/cloud-operations-client.ts
+++ b/packages/cloud/src/cloud-operations-client.ts
@@ -19,7 +19,7 @@ import pkg from './pkg';
 import { CloudService } from './types';
 
 /**
- * @experimental
+ * @experimental The Temporal Cloud Operations Client API is an experimental feature and may be subject to change.
  */
 export interface CloudOperationsClientOptions {
   /**
@@ -37,7 +37,7 @@ export interface CloudOperationsClientOptions {
 /**
  * High level client for the Temporal Cloud API.
  *
- * @experimental
+ * @experimental The Temporal Cloud Operations Client API is an experimental feature and may be subject to change.
  */
 export class CloudOperationsClient {
   /**
@@ -131,7 +131,7 @@ export class CloudOperationsClient {
 }
 
 /**
- * @experimental
+ * @experimental The Temporal Cloud Operations Client API is an experimental feature and may be subject to change.
  */
 export interface CloudOperationsConnectionOptions {
   /**
@@ -288,7 +288,7 @@ interface CloudOperationsConnectionCtorOptions {
  * ⚠️ Connections are expensive to construct and should be reused.
  * Make sure to {@link close} any unused connections to avoid leaking resources.
  *
- * @experimental
+ * @experimental The Temporal Cloud Operations Client API is an experimental feature and may be subject to change.
  */
 export class CloudOperationsConnection {
   private static readonly Client = grpc.makeGenericClientConstructor({}, 'CloudService', {});

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -1,4 +1,6 @@
-/** @experimental */
+/**
+ * @experimental The Temporal Cloud Operations Client API is an experimental feature and may be subject to change.
+ */
 export {
   CloudOperationsClient,
   CloudOperationsConnection,

--- a/packages/common/src/activity-options.ts
+++ b/packages/common/src/activity-options.ts
@@ -119,7 +119,7 @@ export interface ActivityOptions {
    *
    * @default 'COMPATIBLE'
    *
-   * @experimental
+   * @experimental The Worker Versioning API is still being designed. Major changes are expected.
    */
   versioningIntent?: VersioningIntent;
 }

--- a/packages/common/src/versioning-intent-enum.ts
+++ b/packages/common/src/versioning-intent-enum.ts
@@ -7,7 +7,7 @@ import { assertNever, checkExtends } from './type-helpers';
 /**
  * Protobuf enum representation of {@link VersioningIntentString}.
  *
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export enum VersioningIntent {
   UNSPECIFIED = 0,

--- a/packages/common/src/versioning-intent.ts
+++ b/packages/common/src/versioning-intent.ts
@@ -11,6 +11,6 @@
  * current worker. The default behavior for starting Workflows is `DEFAULT`. The default behavior for Workflows starting
  * Activities, starting Child Workflows, or Continuing As New is `COMPATIBLE`.
  *
- * @experimental
+ * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export type VersioningIntent = 'COMPATIBLE' | 'DEFAULT';

--- a/packages/core-bridge/ts/index.ts
+++ b/packages/core-bridge/ts/index.ts
@@ -221,7 +221,7 @@ export interface TelemetryOptions {
   /**
    * If set true, do not prefix metrics with `temporal_`.
    *
-   * @deprecated Use `metrics.metricPrefix` instead
+   * @default `false`
    */
   noTemporalPrefixForMetrics?: boolean;
 
@@ -262,6 +262,7 @@ export interface TelemetryOptions {
 }
 
 export type CompiledTelemetryOptions = {
+  noTemporalPrefixForMetrics?: boolean;
   logging: {
     filter: string;
   } & (

--- a/packages/core-bridge/ts/index.ts
+++ b/packages/core-bridge/ts/index.ts
@@ -75,8 +75,6 @@ export interface ClientOptions {
 
   /**
    * Proxying configuration.
-   *
-   * @experimental
    */
   proxy?: ProxyConfig;
 
@@ -103,8 +101,6 @@ export interface ClientOptions {
 
 /**
  * Log directly to console
- *
- * @experimental
  */
 export interface ConsoleLogger {
   console: {}; // eslint-disable-line @typescript-eslint/no-empty-object-type
@@ -112,8 +108,6 @@ export interface ConsoleLogger {
 
 /**
  * Forward logs to {@link Runtime} logger
- *
- * @experimental
  */
 export interface ForwardLogger {
   forward: {
@@ -128,15 +122,11 @@ export interface ForwardLogger {
 
 /**
  * Logger types supported by Core
- *
- * @experimental
  */
 export type Logger = ConsoleLogger | ForwardLogger;
 
 /**
  * OpenTelemetry Collector options for exporting metrics or traces
- *
- * @experimental
  */
 export interface OtelCollectorExporter {
   otel: {
@@ -171,7 +161,6 @@ export interface OtelCollectorExporter {
   };
 }
 
-/** @experimental */
 export type CompiledOtelMetricsExporter = Shadow<
   OtelCollectorExporter,
   {
@@ -181,8 +170,6 @@ export type CompiledOtelMetricsExporter = Shadow<
 
 /**
  * Prometheus metrics exporter options
- *
- * @experimental
  */
 export interface PrometheusMetricsExporter {
   prometheus: {
@@ -215,14 +202,11 @@ export interface PrometheusMetricsExporter {
  * `temporality` is the type of aggregation temporality for metric export. Applies to both Prometheus and OpenTelemetry exporters.
  *
  * See the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/ce50e4634efcba8da445cc23523243cb893905cb/specification/metrics/datamodel.md#temporality) for more information.
- *
- * @experimental
  */
 export type MetricsExporter = {
   temporality?: 'cumulative' | 'delta';
 } & (PrometheusMetricsExporter | OtelCollectorExporter);
 
-/** @experimental */
 export interface TelemetryOptions {
   /**
    * A string in the env filter format specified here:
@@ -235,10 +219,9 @@ export interface TelemetryOptions {
   tracingFilter?: string;
 
   /**
-   * If set true, do not prefix metrics with `temporal_`. Will be removed eventually as
-   * the prefix is consistent with other SDKs.
+   * If set true, do not prefix metrics with `temporal_`.
    *
-   * @default `false`
+   * @deprecated Use `metrics.metricPrefix` instead
    */
   noTemporalPrefixForMetrics?: boolean;
 
@@ -278,9 +261,7 @@ export interface TelemetryOptions {
   tracing?: unknown;
 }
 
-/** @experimental */
 export type CompiledTelemetryOptions = {
-  noTemporalPrefixForMetrics?: boolean;
   logging: {
     filter: string;
   } & (

--- a/packages/core-bridge/ts/worker-tuner.ts
+++ b/packages/core-bridge/ts/worker-tuner.ts
@@ -3,7 +3,7 @@
  * controlling how "slots" are handed out for different task types. In order to poll for and then
  * run tasks, a slot must first be reserved by the {@link SlotSupplier} returned by the tuner.
  *
- * @experimental
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
  */
 export interface WorkerTuner {
   workflowTaskSlotSupplier: SlotSupplier;
@@ -35,14 +35,14 @@ export interface LocalActivitySlotInfo {
  * For now, only {@link ResourceBasedSlotOptions} and {@link FixedSizeSlotSupplier} are supported,
  * but we may add support for custom tuners in the future.
  *
- * @experimental
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
  */
 export type SlotSupplier = ResourceBasedSlotsForType | FixedSizeSlotSupplier | CustomSlotSupplier<any>;
 
 /**
  * Options for a specific slot type within a {@link ResourceBasedSlotsForType}
  *
- * @experimental
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
  */
 export interface ResourceBasedSlotOptions {
   // Amount of slots that will be issued regardless of any other checks
@@ -55,7 +55,7 @@ export interface ResourceBasedSlotOptions {
 }
 
 /**
- * @experimental
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
  */
 type ResourceBasedSlotsForType = ResourceBasedSlotOptions & {
   type: 'resource-based';
@@ -65,7 +65,7 @@ type ResourceBasedSlotsForType = ResourceBasedSlotOptions & {
 /**
  * Options for a {@link ResourceBasedTuner} to control target resource usage
  *
- * @experimental
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
  */
 export interface ResourceBasedTunerOptions {
   // A value between 0 and 1 that represents the target (system) memory usage. It's not recommended
@@ -80,7 +80,7 @@ export interface ResourceBasedTunerOptions {
 /**
  * A fixed-size slot supplier that will never issue more than a fixed number of slots.
  *
- * @experimental
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
  */
 export interface FixedSizeSlotSupplier {
   type: 'fixed-size';
@@ -90,6 +90,8 @@ export interface FixedSizeSlotSupplier {
 
 /**
  * The interface can be implemented to provide custom slot supplier behavior.
+ *
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
  */
 export interface CustomSlotSupplier<SI extends SlotInfo> {
   type: 'custom';
@@ -144,6 +146,12 @@ export interface CustomSlotSupplier<SI extends SlotInfo> {
   releaseSlot(slot: SlotReleaseContext<SI>): void;
 }
 
+/**
+ * A permit to use a slot.
+ *
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface SlotPermit {}
 
 export interface SlotReserveContext {
@@ -169,6 +177,11 @@ export interface SlotReserveContext {
   isSticky: boolean;
 }
 
+/**
+ * Context for marking a slot as used.
+ *
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
+ */
 export interface SlotMarkUsedContext<SI extends SlotInfo> {
   /**
    * Info about the task that will be using the slot
@@ -180,6 +193,11 @@ export interface SlotMarkUsedContext<SI extends SlotInfo> {
   permit: SlotPermit;
 }
 
+/**
+ * Context for releasing a slot.
+ *
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
+ */
 export interface SlotReleaseContext<SI extends SlotInfo> {
   /**
    * Info about the task that used this slot, if any. A slot may be released without being used in

--- a/packages/worker/src/connection-options.ts
+++ b/packages/worker/src/connection-options.ts
@@ -36,8 +36,6 @@ export interface NativeConnectionOptions {
 
   /**
    * Proxying configuration.
-   *
-   * @experimental
    */
   proxy?: ProxyConfig;
 

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -97,7 +97,7 @@ export interface WorkerOptions {
    *
    * @default `@temporalio/worker` package name and version + checksum of workflow bundle's code
    *
-   * @experimental
+   * @experimental The Worker Versioning API is still being designed. Major changes are expected.
    */
   buildId?: string;
 
@@ -108,7 +108,7 @@ export interface WorkerOptions {
    *
    * For more information, see https://docs.temporal.io/workers#worker-versioning
    *
-   * @experimental
+   * @experimental The Worker Versioning API is still being designed. Major changes are expected.
    */
   useVersioning?: boolean;
 
@@ -193,7 +193,7 @@ export interface WorkerOptions {
    * Mutually exclusive with the {@link maxConcurrentWorkflowTaskExecutions}, {@link
    * maxConcurrentActivityTaskExecutions}, and {@link maxConcurrentLocalActivityExecutions} options.
    *
-   * @experimental
+   * @experimental Worker Tuner is an experimental feature and may be subject to change.
    */
   tuner?: WorkerTuner;
 
@@ -290,9 +290,6 @@ export interface WorkerOptions {
    * minimum for either poller is 1, so if `maxConcurrentWorkflowTaskPolls` is 1 and sticky queues are
    * enabled, there will be 2 concurrent polls.
    *
-   * ⚠️ This API is experimental and may be removed in the future if the poll scaling algorithm changes.
-   *
-   * @experimental This API is experimental and may be removed in the future if the poll scaling algorithm changes.
    * @default 0.2
    */
   nonStickyToStickyPollRatio?: number;

--- a/packages/worker/src/worker-tuner.ts
+++ b/packages/worker/src/worker-tuner.ts
@@ -21,14 +21,14 @@ export { FixedSizeSlotSupplier, ResourceBasedTunerOptions };
 /**
  * Controls how slots for different task types will be handed out.
  *
- * @experimental
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
  */
 export type WorkerTuner = ResourceBasedTuner | TunerHolder;
 
 /**
  * This tuner allows for different slot suppliers for different slot types.
  *
- * @experimental
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
  */
 export interface TunerHolder {
   workflowTaskSlotSupplier: SlotSupplier<WorkflowSlotInfo>;
@@ -42,7 +42,7 @@ export interface TunerHolder {
  * For now, only {@link ResourceBasedSlotOptions} and {@link FixedSizeSlotSupplier} are supported,
  * but we may add support for custom tuners in the future.
  *
- * @experimental
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
  */
 export type SlotSupplier<SI extends SlotInfo> =
   | ResourceBasedSlotsForType
@@ -52,7 +52,7 @@ export type SlotSupplier<SI extends SlotInfo> =
 /**
  * Resource based slot supplier options for a specific kind of slot.
  *
- * @experimental
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
  */
 type ResourceBasedSlotsForType = ResourceBasedSlotOptions & {
   type: 'resource-based';
@@ -62,7 +62,7 @@ type ResourceBasedSlotsForType = ResourceBasedSlotOptions & {
 /**
  * Options for a specific slot type within a {@link ResourceBasedSlotsForType}
  *
- * @experimental
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
  */
 export interface ResourceBasedSlotOptions {
   /**
@@ -86,7 +86,7 @@ export interface ResourceBasedSlotOptions {
  * This tuner attempts to maintain certain levels of resource usage when under load. You do not
  * need more than one instance of this when using it for multiple slot types.
  *
- * @experimental
+ * @experimental Worker Tuner is an experimental feature and may be subject to change.
  */
 export interface ResourceBasedTuner {
   /**

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -259,7 +259,7 @@ export interface ContinueAsNewOptions {
    *
    * @default 'COMPATIBLE'
    *
-   * @experimental
+   * @experimental The Worker Versioning API is still being designed. Major changes are expected.
    */
   versioningIntent?: VersioningIntent;
 }
@@ -429,7 +429,7 @@ export interface ChildWorkflowOptions extends CommonWorkflowOptions {
    *
    * @default 'COMPATIBLE'
    *
-   * @experimental
+   * @experimental The Worker Versioning API is still being designed. Major changes are expected.
    */
   versioningIntent?: VersioningIntent;
 }


### PR DESCRIPTION
## What was changed

Reviewed and updated all `@experimental` annotations.

The following APIs are no longer tagged as experimental:

- Client gRPC Retry interceptor
- HTTP Proxy support
- Forwarding and filtering of Core's logs
- Configuration of Core's metrics
- `WorkerOptions.nonStickyToStickyPollRatio`

Text on remaining `@experimental` annotations have been updated to clearly and correctly reflect the expected future of each feature.
