### PR TITLE
Add search attributes to dev server

### DIFF
--- a/packages/core-bridge/ts/index.ts
+++ b/packages/core-bridge/ts/index.ts
@@ -459,10 +459,6 @@ export interface TimeSkippingServerConfig {
    * be supported in the future.
    */
   extraArgs?: string[];
-  /**
-   * Search attributes to be registered with the dev server.
-   */
-  searchAttributes?: SearchAttributeKey<SearchAttributeType>[];
 }
 
 /**

--- a/packages/core-bridge/ts/index.ts
+++ b/packages/core-bridge/ts/index.ts
@@ -1,6 +1,7 @@
-import { LogLevel, Duration } from '@temporalio/common';
+import { LogLevel, Duration, SearchAttributeType } from '@temporalio/common';
 import type { TLSConfig, ProxyConfig, HttpConnectProxyConfig } from '@temporalio/common/lib/internal-non-workflow';
 import { WorkerTuner } from './worker-tuner';
+import { SearchAttributeKey } from '@temporalio/common/src/search-attributes';
 
 export {
   WorkerTuner,
@@ -458,6 +459,10 @@ export interface TimeSkippingServerConfig {
    * be supported in the future.
    */
   extraArgs?: string[];
+  /**
+   * Search attributes to be registered with the dev server.
+   */
+  searchAttributes?: SearchAttributeKey<SearchAttributeType>[];
 }
 
 /**
@@ -509,6 +514,10 @@ export interface DevServerConfig {
    * be supported in the future.
    */
   extraArgs?: string[];
+  /**
+   * Search attributes to be registered with the dev server.
+   */
+  searchAttributes?: SearchAttributeKey<SearchAttributeType>[];
 }
 
 /**

--- a/packages/test/src/helpers-integration-multi-codec.ts
+++ b/packages/test/src/helpers-integration-multi-codec.ts
@@ -10,7 +10,7 @@ import {
   createLocalTestEnvironment,
   makeConfigurableEnvironmentTestFn,
 } from './helpers-integration';
-import { ByteSkewerPayloadCodec, registerDefaultCustomSearchAttributes, Worker } from './helpers';
+import { ByteSkewerPayloadCodec, Worker } from './helpers';
 
 // Note: re-export shared workflows (or long workflows)
 export * from './workflows';
@@ -43,7 +43,6 @@ export function makeTestFn(makeBundle: () => Promise<WorkflowBundle>): TestFn<Te
           const env = await createLocalTestEnvironment({
             client: { dataConverter },
           });
-          await registerDefaultCustomSearchAttributes(env.connection);
 
           configs.push({
             loadedDataConverter,

--- a/packages/test/src/helpers-integration.ts
+++ b/packages/test/src/helpers-integration.ts
@@ -84,14 +84,14 @@ export async function createTestWorkflowBundle({
   });
 }
 
-export const defaultSearchAttributes = [
-  defineSearchAttributeKey('CustomIntField', SearchAttributeType.INT),
-  defineSearchAttributeKey('CustomBoolField', SearchAttributeType.BOOL),
-  defineSearchAttributeKey('CustomKeywordField', SearchAttributeType.KEYWORD),
-  defineSearchAttributeKey('CustomTextField', SearchAttributeType.TEXT),
-  defineSearchAttributeKey('CustomDatetimeField', SearchAttributeType.DATETIME),
-  defineSearchAttributeKey('CustomDoubleField', SearchAttributeType.DOUBLE),
-];
+export const defaultSAKeys = {
+  CustomIntField: defineSearchAttributeKey('CustomIntField', SearchAttributeType.INT),
+  CustomBoolField: defineSearchAttributeKey('CustomBoolField', SearchAttributeType.BOOL),
+  CustomKeywordField: defineSearchAttributeKey('CustomKeywordField', SearchAttributeType.KEYWORD),
+  CustomTextField: defineSearchAttributeKey('CustomTextField', SearchAttributeType.TEXT),
+  CustomDatetimeField: defineSearchAttributeKey('CustomDatetimeField', SearchAttributeType.DATETIME),
+  CustomDoubleField: defineSearchAttributeKey('CustomDoubleField', SearchAttributeType.DOUBLE),
+};
 
 export async function createLocalTestEnvironment(
   opts?: LocalTestWorkflowEnvironmentOptions
@@ -99,7 +99,7 @@ export async function createLocalTestEnvironment(
   return await TestWorkflowEnvironment.createLocal({
     ...(opts || {}), // Use provided options or default to an empty object
     server: {
-      searchAttributes: defaultSearchAttributes,
+      searchAttributes: Object.values(defaultSAKeys),
       ...(opts?.server || {}), // Use provided server options or default to an empty object
       extraArgs: [
         ...defaultDynamicConfigOptions.flatMap((opt) => ['--dynamic-config-value', opt]),

--- a/packages/test/src/helpers.ts
+++ b/packages/test/src/helpers.ts
@@ -217,6 +217,7 @@ export class TestWorkflowEnvironment extends RealTestWorkflowEnvironment {
 // Some of our tests expect "default custom search attributes" to exists, which used to be the case
 // in all deployment with support for advanced visibility. However, this might no longer be true in
 // some environement (e.g. Temporal CLI). Use the operator service to create them if they're missing.
+// TODO: register search attributes when creating test environment (#1624)
 export async function registerDefaultCustomSearchAttributes(connection: Connection): Promise<void> {
   const client = new Client({ connection }).workflow;
   console.log(`Registering custom search attributes...`);

--- a/packages/test/src/helpers.ts
+++ b/packages/test/src/helpers.ts
@@ -217,7 +217,6 @@ export class TestWorkflowEnvironment extends RealTestWorkflowEnvironment {
 // Some of our tests expect "default custom search attributes" to exists, which used to be the case
 // in all deployment with support for advanced visibility. However, this might no longer be true in
 // some environement (e.g. Temporal CLI). Use the operator service to create them if they're missing.
-// TODO: register search attributes when creating test environment (#1624)
 export async function registerDefaultCustomSearchAttributes(connection: Connection): Promise<void> {
   const client = new Client({ connection }).workflow;
   console.log(`Registering custom search attributes...`);

--- a/packages/test/src/test-integration-workflows.ts
+++ b/packages/test/src/test-integration-workflows.ts
@@ -2,7 +2,7 @@ import { setTimeout as setTimeoutPromise } from 'timers/promises';
 import { randomUUID } from 'crypto';
 import { ExecutionContext } from 'ava';
 import { firstValueFrom, Subject } from 'rxjs';
-import { isGrpcServiceError, ServiceError, WorkflowFailedError } from '@temporalio/client';
+import { WorkflowFailedError } from '@temporalio/client';
 import * as activity from '@temporalio/activity';
 import { msToNumber, tsToMs } from '@temporalio/common/lib/time';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
@@ -1313,24 +1313,8 @@ test('Count workflow executions', async (t) => {
 });
 
 test('can register search attributes to dev server', async (t) => {
-  const { startWorkflow } = helpers(t);
   const key = defineSearchAttributeKey('new-search-attr', SearchAttributeType.INT);
   const newSearchAttribute: SearchAttributePair = { key, value: 12 };
-
-  // Ensure that search attribute is not registered on current env.
-  try {
-    await startWorkflow(completableWorkflow, { typedSearchAttributes: [newSearchAttribute] });
-  } catch (err) {
-    if (
-      err instanceof ServiceError &&
-      isGrpcServiceError(err.cause) &&
-      err.cause.details.includes('Namespace default has no mapping defined for search attribute new-search-attr')
-    ) {
-      // Expected error
-    } else {
-      throw err;
-    }
-  }
 
   // Create new test environment with search attribute registered.
   const env = await createLocalTestEnvironment({

--- a/packages/test/src/test-schedules.ts
+++ b/packages/test/src/test-schedules.ts
@@ -12,8 +12,9 @@ import {
   ScheduleUpdateOptions,
 } from '@temporalio/client';
 import { msToNumber } from '@temporalio/common/lib/time';
-import { SearchAttributes, SearchAttributeType, TypedSearchAttributes } from '@temporalio/common';
+import { SearchAttributes, TypedSearchAttributes } from '@temporalio/common';
 import { registerDefaultCustomSearchAttributes, RUN_INTEGRATION_TESTS } from './helpers';
+import { defaultSAKeys } from './helpers-integration';
 
 export interface Context {
   client: Client;
@@ -168,9 +169,7 @@ if (RUN_INTEGRATION_TESTS) {
         searchAttributes: {
           CustomKeywordField: ['test-value2'],
         },
-        typedSearchAttributes: new TypedSearchAttributes([
-          { key: { name: 'CustomIntField', type: SearchAttributeType.INT }, value: 42 },
-        ]),
+        typedSearchAttributes: new TypedSearchAttributes([{ key: defaultSAKeys.CustomIntField, value: 42 }]),
       },
     });
 
@@ -188,8 +187,8 @@ if (RUN_INTEGRATION_TESTS) {
       t.deepEqual(
         describedSchedule.action.typedSearchAttributes,
         new TypedSearchAttributes([
-          { key: { name: 'CustomIntField', type: SearchAttributeType.INT }, value: 42 },
-          { key: { name: 'CustomKeywordField', type: SearchAttributeType.KEYWORD }, value: 'test-value2' },
+          { key: defaultSAKeys.CustomIntField, value: 42 },
+          { key: defaultSAKeys.CustomKeywordField, value: 'test-value2' },
         ])
       );
     } finally {
@@ -216,9 +215,7 @@ if (RUN_INTEGRATION_TESTS) {
         searchAttributes: {
           CustomKeywordField: ['test-value2'],
         },
-        typedSearchAttributes: new TypedSearchAttributes([
-          { key: { name: 'CustomIntField', type: SearchAttributeType.INT }, value: 42 },
-        ]),
+        typedSearchAttributes: new TypedSearchAttributes([{ key: defaultSAKeys.CustomIntField, value: 42 }]),
       },
     });
 
@@ -237,8 +234,8 @@ if (RUN_INTEGRATION_TESTS) {
       t.deepEqual(
         describedSchedule.action.typedSearchAttributes,
         new TypedSearchAttributes([
-          { key: { name: 'CustomIntField', type: SearchAttributeType.INT }, value: 42 },
-          { key: { name: 'CustomKeywordField', type: SearchAttributeType.KEYWORD }, value: 'test-value2' },
+          { key: defaultSAKeys.CustomIntField, value: 42 },
+          { key: defaultSAKeys.CustomKeywordField, value: 'test-value2' },
         ])
       );
     } finally {
@@ -351,9 +348,7 @@ if (RUN_INTEGRATION_TESTS) {
         searchAttributes: {
           CustomKeywordField: ['test-value2'],
         },
-        typedSearchAttributes: new TypedSearchAttributes([
-          { key: { name: 'CustomIntField', type: SearchAttributeType.INT }, value: 42 },
-        ]),
+        typedSearchAttributes: new TypedSearchAttributes([{ key: defaultSAKeys.CustomIntField, value: 42 }]),
       },
     });
 
@@ -598,9 +593,7 @@ if (RUN_INTEGRATION_TESTS) {
             taskQueue,
           },
           searchAttributes,
-          typedSearchAttributes: new TypedSearchAttributes([
-            { key: { name: 'CustomIntField', type: SearchAttributeType.INT }, value: 42 },
-          ]),
+          typedSearchAttributes: new TypedSearchAttributes([{ key: defaultSAKeys.CustomIntField, value: 42 }]),
         })
       );
     }

--- a/packages/test/src/test-typed-search-attributes.ts
+++ b/packages/test/src/test-typed-search-attributes.ts
@@ -28,6 +28,7 @@ const test = makeTestFunction({
   workflowEnvironmentOpts: {
     server: {
       namespace: 'test-typed-search-attributes',
+      searchAttributes: [],
     },
   },
 });

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -27,6 +27,7 @@ import {
   Logger,
   defaultFailureConverter,
   defaultPayloadConverter,
+  TypedSearchAttributes,
 } from '@temporalio/common';
 import { msToNumber, msToTs, tsToMs } from '@temporalio/common/lib/time';
 import { ActivityInterceptorsFactory, DefaultLogger, NativeConnection, Runtime } from '@temporalio/worker';
@@ -302,6 +303,18 @@ export class TestWorkflowEnvironment {
   ): Promise<TestWorkflowEnvironment> {
     const { supportsTimeSkipping, namespace, ...rest } = opts;
     const optsWithDefaults = addDefaults(filterNullAndUndefined(rest));
+
+    // Add search attributes to CLI server arguments
+    if (optsWithDefaults.server.searchAttributes) {
+      let newArgs: string[] = [];
+      for (const { name, type } of optsWithDefaults.server.searchAttributes) {
+        newArgs.push('--search-attribute');
+        newArgs.push(`${name}=${TypedSearchAttributes.toMetadataType(type)}`);
+      }
+      newArgs = newArgs.concat(optsWithDefaults.server.extraArgs ?? []);
+      optsWithDefaults.server.extraArgs = newArgs;
+    }
+
     const server = await Runtime.instance().createEphemeralServer(optsWithDefaults.server);
     const address = getEphemeralServerTarget(server);
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -305,7 +305,7 @@ export class TestWorkflowEnvironment {
     const optsWithDefaults = addDefaults(filterNullAndUndefined(rest));
 
     // Add search attributes to CLI server arguments
-    if (optsWithDefaults.server.searchAttributes) {
+    if ('searchAttributes' in optsWithDefaults.server && optsWithDefaults.server.searchAttributes) {
       let newArgs: string[] = [];
       for (const { name, type } of optsWithDefaults.server.searchAttributes) {
         newArgs.push('--search-attribute');


### PR DESCRIPTION
## What was changed
Can pass `searchAttributes` as a workflow options when creating test dev server (with or without time-skipping)

1. Closes #1447

2. How was this tested:
Added integration test

3. Any docs updates needed?
No
