### PR TITLE
feat(client): added keepOriginalWorkflowId in SchedulePolicies

### DIFF
--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -431,6 +431,7 @@ export class ScheduleClient extends BaseClient {
             overlap: decodeScheduleOverlapPolicy(raw.schedule.policies?.overlapPolicy) ?? ScheduleOverlapPolicy.SKIP,
             catchupWindow: optionalTsToMs(raw.schedule.policies?.catchupWindow) ?? 60_000,
             pauseOnFailure: raw.schedule.policies?.pauseOnFailure === true,
+            keepOriginalWorkflowId: raw.schedule.policies?.keepOriginalWorkflowId === true,
           },
           state: {
             paused: raw.schedule.state?.paused === true,

--- a/packages/client/src/schedule-helpers.ts
+++ b/packages/client/src/schedule-helpers.ts
@@ -277,6 +277,7 @@ export function encodeSchedulePolicies(
     catchupWindow: msOptionalToTs(policies?.catchupWindow),
     overlapPolicy: policies?.overlap ? encodeScheduleOverlapPolicy(policies.overlap) : undefined,
     pauseOnFailure: policies?.pauseOnFailure,
+    keepOriginalWorkflowId: policies?.keepOriginalWorkflowId,
   };
 }
 

--- a/packages/client/src/schedule-types.ts
+++ b/packages/client/src/schedule-types.ts
@@ -57,6 +57,13 @@ export interface ScheduleOptions<A extends ScheduleOptionsAction = ScheduleOptio
      * @default false
      */
     pauseOnFailure?: boolean;
+
+    /**
+     * If true, and the action would start a workflow, a timestamp will not be appended to the scheduled workflow id.
+     *
+     * @default false
+     */
+    keepOriginalWorkflowId?: boolean;
   };
 
   /**
@@ -275,6 +282,13 @@ export type ScheduleDescription = {
      * to start after the failed one finishes.
      */
     pauseOnFailure: boolean;
+
+    /**
+     * If true, and the action would start a workflow, a timestamp will not be appended to the scheduled workflow id.
+     *
+     * @default false
+     */
+    keepOriginalWorkflowId: boolean;
   };
 
   /**


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Implemented keepOriginalWorkflowId in the client scheduling policies in client package. This updates the schedule policies to match [documentation](https://typescript.temporal.io/api/interfaces/proto.temporal.api.schedule.v1.ISchedulePolicies#keeporiginalworkflowid).

## Why?
<!-- Tell your future self why have you made these changes -->
Change was made to update the SDK to reflect documentation. Code is analogous to ISchedulePolicies.pauseOnFailure in the client package. 