### PR TITLE
[WIP] Special behaviour for temporal prefixes

### DIFF
--- a/packages/common/src/reserved.ts
+++ b/packages/common/src/reserved.ts
@@ -1,0 +1,20 @@
+export const TEMPORAL_RESERVED_PREFIX = '__temporal_'
+export const STACK_TRACE_RESERVED_PREFIX = '__stack_trace'
+export const ENHANCED_STACK_TRACE_RESERVED_PREFIX = '__enhanced_stack_trace'
+
+export const reservedPrefixes = [TEMPORAL_RESERVED_PREFIX, STACK_TRACE_RESERVED_PREFIX, ENHANCED_STACK_TRACE_RESERVED_PREFIX]
+
+export function throwIfReservedName(type: string, name: string) {
+    const prefix = isReservedName(name)
+    if (prefix) {
+        throw Error(`Cannot register ${type} name: '${name}', with reserved prefix: '${prefix}'`)
+    }
+}
+
+export function isReservedName(name: string): string | undefined {
+    for (const prefix of reservedPrefixes) {
+        if (name.startsWith(prefix)) {
+            return prefix
+        }
+    }
+}

--- a/packages/test/src/test-integration-split-two.ts
+++ b/packages/test/src/test-integration-split-two.ts
@@ -14,11 +14,12 @@ import {
 import { msToNumber, tsToMs } from '@temporalio/common/lib/time';
 import { decode as payloadDecode, decodeFromPayloadsAtIndex } from '@temporalio/common/lib/internal-non-workflow';
 
-import { condition, defineQuery, defineSignal, setDefaultQueryHandler, setHandler, sleep } from '@temporalio/workflow';
+import { condition, defineQuery, defineSignal, defineUpdate, setDefaultQueryHandler, setDefaultSignalHandler, setHandler, sleep } from '@temporalio/workflow';
 import { configurableHelpers, createTestWorkflowBundle } from './helpers-integration';
 import * as activities from './activities';
 import * as workflows from './workflows';
 import { makeTestFn, configMacro } from './helpers-integration-multi-codec';
+import { reservedPrefixes } from '@temporalio/common/src/reserved';
 
 // Note: re-export shared workflows (or long workflows)
 //  - review the files where these workflows are shared
@@ -751,3 +752,78 @@ test('default query handler is not used if requested query exists', configMacro,
     t.deepEqual(result, { name: definedQuery.name, args });
   });
 });
+
+test('Cannot register activities using reserved prefixes', configMacro, async (t, config) => {
+  const { createWorkerWithDefaults } = config;
+
+  for (const prefix of reservedPrefixes) {
+    const activityName = prefix + "_test"
+    await t.throwsAsync(createWorkerWithDefaults(t, {
+      activities: { [activityName]: () => {} }
+    }), { instanceOf: Error, message: `Cannot register activity name: '${activityName}', with reserved prefix: '${prefix}'`})
+  }
+})
+
+test('Cannot register task queues using reserved prefixes', configMacro, async (t, config) => {
+  const { createWorkerWithDefaults } = config;
+
+  for (const prefix of reservedPrefixes) {
+    const taskQueue = prefix + "_test"
+
+    await t.throwsAsync(createWorkerWithDefaults(t, {
+      taskQueue,
+    }), { instanceOf: Error, message: `Cannot register task queue name: '${taskQueue}', with reserved prefix: '${prefix}'`})
+  }
+})
+
+interface HandlerError {
+  name: string;
+  message: string;
+}
+
+export async function workflowBadPrefixHandler(prefix: string): Promise<HandlerError[]> {
+  // Re-package errors, default payload converter has trouble converting native errors (no 'data' field).
+  const expectedErrors: HandlerError[] = []
+  try {
+    setHandler(defineSignal(prefix + '_signal'), () => {})
+  } catch (e) {
+    if (e instanceof Error) {
+      expectedErrors.push({ name: e.name, message: e.message })
+    }
+  }
+  try {
+    setHandler(defineUpdate(prefix + '_update'), () => {})
+  } catch (e) {
+    if (e instanceof Error) {
+      expectedErrors.push({ name: e.name, message: e.message })
+    }
+  }
+  try {
+    setHandler(defineQuery(prefix + '_query'), () => {})
+  } catch (e) {
+    if (e instanceof Error) {
+      expectedErrors.push({ name: e.name, message: e.message })
+    }
+  }
+  return expectedErrors
+}
+
+test('Workflow failure if define signals/updates/queries with reserved prefixes', configMacro, async (t, config) => {
+    const { env, createWorkerWithDefaults } = config;
+    const { executeWorkflow } = configurableHelpers(t, t.context.workflowBundle, env);
+    const worker = await createWorkerWithDefaults(t);
+    await worker.runUntil(async () => {
+      const prefix = reservedPrefixes[0]
+      // for (const prefix of reservedPrefixes) {
+        const result = await executeWorkflow(workflowBadPrefixHandler, {
+          args: [prefix]
+        });
+        console.log("result", result)
+        t.deepEqual(result, [
+          { name: 'Error', message: `Cannot register signal name: '${prefix}_signal', with reserved prefix: '${prefix}'`},
+          { name: 'Error', message: `Cannot register update name: '${prefix}_update', with reserved prefix: '${prefix}'`},
+          { name: 'Error', message: `Cannot register query name: '${prefix}_query', with reserved prefix: '${prefix}'`},
+        ])
+      // }
+    })
+})

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -23,6 +23,7 @@ import { parseWorkflowCode } from '@temporalio/worker/lib/worker';
 import * as activityFunctions from './activities';
 import { cleanStackTrace, REUSE_V8_CONTEXT, u8 } from './helpers';
 import { ProcessedSignal } from './workflows';
+import { reservedPrefixes } from '@temporalio/common/src/reserved';
 
 export interface Context {
   workflow: VMWorkflow | ReusableVMWorkflow;
@@ -2525,6 +2526,80 @@ test('Signals/Updates/Activities/Timers - Trace promises completion order - 1.11
         ],
         [SdkFlags.ProcessWorkflowActivationJobsAsSingleBatch]
       )
+    );
+  }
+});
+
+test('Default query handler fail activations with reserved names - workflowWithDefaultHandlers', async (t) => {
+  const { workflowType } = t.context;
+  
+  await activate(
+    t,
+    makeActivation(
+      undefined, 
+      makeInitializeWorkflowJob(workflowType),
+    ),
+  );
+
+  for (const prefix of reservedPrefixes) {
+    const completion = await activate(
+      t,
+      makeActivation(
+        undefined, 
+        makeQueryWorkflowJob("1", prefix + '_query')
+      ),
+    );
+
+    compareCompletion(
+      t,
+      completion,
+      {
+        failed: {
+          failure: {
+            ...completion.failed?.failure,
+            // We only care about the error message.
+            message: `Cannot register query name: \'${prefix}_query\', with reserved prefix: \'${prefix}\'`,
+          }
+        }
+      }
+    );
+  }
+});
+
+test('Default signal handler fail activations with reserved names - workflowWithDefaultHandlers', async (t) => {
+  const { workflowType } = t.context;
+  
+  await activate(
+    t,
+    makeActivation(
+      undefined, 
+      makeInitializeWorkflowJob(workflowType),
+    ),
+  );
+
+  for (const prefix of reservedPrefixes) {
+    const job = makeSignalWorkflowJob(prefix + '_signal', []);
+
+    const completion = await activate(
+      t,
+      makeActivation(
+        undefined,
+        job
+      ),
+    );
+
+    compareCompletion(
+      t,
+      completion,
+      {
+        failed: {
+          failure: {
+            ...completion.failed?.failure,
+            // We only care about the error message.
+            message: `Cannot register signal name: \'${prefix}_signal\', with reserved prefix: \'${prefix}\'`,
+          }
+        }
+      }
     );
   }
 });

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -89,3 +89,4 @@ export * from './upsert-and-read-search-attributes';
 export * from './wait-on-user';
 export * from './workflow-cancellation-scenarios';
 export * from './upsert-and-read-memo';
+export * from './workflow-with-default-handlers';

--- a/packages/test/src/workflows/workflow-with-default-handlers.ts
+++ b/packages/test/src/workflows/workflow-with-default-handlers.ts
@@ -1,0 +1,10 @@
+import { condition, defineSignal, setDefaultQueryHandler, setDefaultSignalHandler, setHandler } from "@temporalio/workflow";
+
+export async function workflowWithDefaultHandlers() {
+    let complete = true;
+    setDefaultQueryHandler(() => {});
+    setDefaultSignalHandler(() => {});
+    setHandler(defineSignal('completeSignal'), () => {});
+
+    condition(() => complete);
+}

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -18,6 +18,7 @@ import { InjectedSinks } from './sinks';
 import { MiB } from './utils';
 import { WorkflowBundleWithSourceMap } from './workflow/bundler';
 import { asNativeTuner, WorkerTuner } from './worker-tuner';
+import { throwIfReservedName } from '@temporalio/common/src/reserved';
 
 export type { WebpackConfiguration };
 
@@ -822,6 +823,9 @@ export function compileWorkerOptions(rawOpts: WorkerOptions, logger: Logger): Co
   }
 
   const activities = new Map(Object.entries(opts.activities ?? {}).filter(([_, v]) => typeof v === 'function'));
+  for (const activityName of activities.keys()) {
+    throwIfReservedName('activity', activityName)
+  }
   const tuner = asNativeTuner(opts.tuner, logger);
 
   return {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -88,6 +88,7 @@ import { ThreadedVMWorkflowCreator } from './workflow/threaded-vm';
 import { VMWorkflowCreator } from './workflow/vm';
 import { WorkflowBundleWithSourceMapAndFilename } from './workflow/workflow-worker-thread/input';
 import { CombinedWorkerRunError, GracefulShutdownPeriodExpiredError, PromiseCompletionTimeoutError } from './errors';
+import { throwIfReservedName } from '@temporalio/common/src/reserved';
 
 export { DataConverter, defaultPayloadConverter };
 
@@ -462,6 +463,7 @@ export class Worker {
    * This method initiates a connection to the server and will throw (asynchronously) on connection failure.
    */
   public static async create(options: WorkerOptions): Promise<Worker> {
+    throwIfReservedName('task queue', options.taskQueue)
     const logger = withMetadata(Runtime.instance().logger, {
       sdkComponent: SdkComponent.worker,
       taskQueue: options.taskQueue ?? 'default',

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -48,6 +48,8 @@ import { untrackPromise } from './stack-helpers';
 import pkg from './pkg';
 import { SdkFlag, assertValidFlag } from './flags';
 import { executeWithLifecycleLogging, log } from './logs';
+import { ENHANCED_STACK_TRACE_RESERVED_PREFIX, isReservedName, throwIfReservedName } from '@temporalio/common/src/reserved';
+import { STACK_TRACE_RESERVED_PREFIX } from '../../common/src/reserved';
 
 const StartChildWorkflowExecutionFailedCause = {
   WORKFLOW_ALREADY_EXISTS: 'WORKFLOW_ALREADY_EXISTS',
@@ -249,7 +251,7 @@ export class Activator implements ActivationHandler {
    */
   public readonly queryHandlers = new Map<string, WorkflowQueryAnnotatedType>([
     [
-      '__stack_trace',
+      STACK_TRACE_RESERVED_PREFIX,
       {
         handler: () => {
           return this.getStackTraces()
@@ -260,7 +262,7 @@ export class Activator implements ActivationHandler {
       },
     ],
     [
-      '__enhanced_stack_trace',
+      ENHANCED_STACK_TRACE_RESERVED_PREFIX,
       {
         handler: (): EnhancedStackTrace => {
           const { sourceMap } = this;
@@ -619,6 +621,8 @@ export class Activator implements ActivationHandler {
   protected queryWorkflowNextHandler({ queryName, args }: QueryInput): Promise<unknown> {
     let fn = this.queryHandlers.get(queryName)?.handler;
     if (fn === undefined && this.defaultQueryHandler !== undefined) {
+      // Do not call default query handler with reserved query name.
+      throwIfReservedName('query', queryName)
       fn = this.defaultQueryHandler.bind(this, queryName);
     }
     // No handler or default registered, fail.
@@ -649,17 +653,28 @@ export class Activator implements ActivationHandler {
       throw new TypeError('Missing query activation attributes');
     }
 
+    const queryInput = {
+      queryName: queryType,
+      args: arrayFromPayloads(this.payloadConverter, activation.arguments),
+      queryId,
+      headers: headers ?? {},
+    }
+
+    // Skip interceptors if this is an internal query.
+    if (isReservedName(queryType)) {
+      this.queryWorkflowNextHandler(queryInput).then(
+        (result) => this.completeQuery(queryId, result),
+        (reason) => this.failQuery(queryId, reason)
+      );
+      return
+    }
+
     const execute = composeInterceptors(
       this.interceptors.inbound,
       'handleQuery',
       this.queryWorkflowNextHandler.bind(this)
     );
-    execute({
-      queryName: queryType,
-      args: arrayFromPayloads(this.payloadConverter, activation.arguments),
-      queryId,
-      headers: headers ?? {},
-    }).then(
+    execute(queryInput).then(
       (result) => this.completeQuery(queryId, result),
       (reason) => this.failQuery(queryId, reason)
     );
@@ -797,6 +812,8 @@ export class Activator implements ActivationHandler {
     if (fn) {
       return await fn(...args);
     } else if (this.defaultSignalHandler) {
+      // Do not call default signal handler with reserved signal name.
+      throwIfReservedName('signal', signalName)
       return await this.defaultSignalHandler(signalName, ...args);
     } else {
       throw new IllegalStateError(`No registered signal handler for signal: ${signalName}`);

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -56,6 +56,7 @@ import { LocalActivityDoBackoff } from './errors';
 import { assertInWorkflowContext, getActivator, maybeGetActivator } from './global-attributes';
 import { untrackPromise } from './stack-helpers';
 import { ChildWorkflowHandle, ExternalWorkflowHandle } from './workflow-handle';
+import { throwIfReservedName } from '@temporalio/common/src/reserved';
 
 // Avoid a circular dependency
 registerSleepImplementation(sleep);
@@ -1258,6 +1259,8 @@ export function setHandler<
   options?: QueryHandlerOptions | SignalHandlerOptions | UpdateHandlerOptions<Args>
 ): void {
   const activator = assertInWorkflowContext('Workflow.setHandler(...) may only be used from a Workflow Execution.');
+  // Cannot register handler for reserved names
+  throwIfReservedName(def.type, def.name)
   const description = options?.description;
   if (def.type === 'update') {
     if (typeof handler === 'function') {


### PR DESCRIPTION
## What was changed
Special behavior handling reserved temporal prefixes. Prevent users from:
- registering workflows, activities, task queues, signals/updates/queries with a reserved prefix
- calling default handlers with reserved names
- calling internal queries without going through interceptors

## Checklist
Some remaining items:
- test for default signal handler & reserved names needs to be fixed
- need to reserving prefixes from workflows,
- waiting for default update handler to be merged to prevent default update handler to be called with reserved names

1. Closes #1599

2. How was this tested:
unit/integration tests

3. Any docs updates needed?
I'm not sure.
