### PR TITLE
fix!: Use plain Error in FailureConverter, WorkflowFailedError, and WorkflowUpdateFailedError

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
       typescript-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
       version-is-repo-ref: true
-      features-repo-ref: sdk-1403-ts-startUpdate-require-wait-stage
+      features-repo-ref: main
 
   stress-tests-no-reuse-context:
     name: Stress Tests (No Reuse V8 Context)

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,5 +1,5 @@
 import { ServiceError as GrpcServiceError, status } from '@grpc/grpc-js';
-import { RetryState, TemporalFailure } from '@temporalio/common';
+import { RetryState } from '@temporalio/common';
 import { isError, isRecord, SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 
 /**
@@ -28,7 +28,7 @@ export class ServiceError extends Error {
 export class WorkflowFailedError extends Error {
   public constructor(
     message: string,
-    public readonly cause: TemporalFailure | undefined,
+    public readonly cause: Error | undefined,
     public readonly retryState: RetryState
   ) {
     super(message);
@@ -43,7 +43,7 @@ export class WorkflowFailedError extends Error {
 export class WorkflowUpdateFailedError extends Error {
   public constructor(
     message: string,
-    public readonly cause: TemporalFailure | undefined
+    public readonly cause: Error | undefined
   ) {
     super(message);
   }

--- a/packages/common/src/converter/failure-converter.ts
+++ b/packages/common/src/converter/failure-converter.ts
@@ -75,7 +75,7 @@ export interface FailureConverter {
    *
    * The returned error must be an instance of `TemporalFailure`.
    */
-  failureToError(err: ProtoFailure, payloadConverter: PayloadConverter): TemporalFailure;
+  failureToError(err: ProtoFailure, payloadConverter: PayloadConverter): Error;
 }
 
 /**
@@ -198,7 +198,7 @@ export class DefaultFailureConverter implements FailureConverter {
     );
   }
 
-  failureToError(failure: ProtoFailure, payloadConverter: PayloadConverter): TemporalFailure {
+  failureToError(failure: ProtoFailure, payloadConverter: PayloadConverter): Error {
     if (failure.encodedAttributes) {
       const attrs = payloadConverter.fromPayload<DefaultEncodedFailureAttributes>(failure.encodedAttributes);
       // Don't apply encodedAttributes unless they conform to an expected schema
@@ -351,7 +351,7 @@ export class DefaultFailureConverter implements FailureConverter {
   optionalFailureToOptionalError(
     failure: ProtoFailure | undefined | null,
     payloadConverter: PayloadConverter
-  ): TemporalFailure | undefined {
+  ): Error | undefined {
     return failure ? this.failureToError(failure, payloadConverter) : undefined;
   }
 

--- a/packages/common/src/internal-non-workflow/codec-helpers.ts
+++ b/packages/common/src/internal-non-workflow/codec-helpers.ts
@@ -2,7 +2,7 @@ import { Payload } from '../interfaces';
 import { arrayFromPayloads, fromPayloadsAtIndex, toPayloads } from '../converter/payload-converter';
 import { PayloadConverterError } from '../errors';
 import { PayloadCodec } from '../converter/payload-codec';
-import { ProtoFailure, TemporalFailure } from '../failure';
+import { ProtoFailure } from '../failure';
 import { LoadedDataConverter } from '../converter/data-converter';
 import { DecodedPayload, DecodedProtoFailure, EncodedPayload, EncodedProtoFailure } from './codec-types';
 
@@ -109,7 +109,7 @@ export async function decodeFromPayloadsAtIndex<T>(
 export async function decodeOptionalFailureToOptionalError(
   converter: LoadedDataConverter,
   failure: ProtoFailure | undefined | null
-): Promise<TemporalFailure | undefined> {
+): Promise<Error | undefined> {
   const { failureConverter, payloadConverter, payloadCodecs } = converter;
   return failure
     ? failureConverter.failureToError(await decodeFailure(payloadCodecs, failure), payloadConverter)

--- a/packages/test/src/test-failure-converter.ts
+++ b/packages/test/src/test-failure-converter.ts
@@ -4,6 +4,7 @@ import {
   ApplicationFailure,
   DataConverter,
   DefaultEncodedFailureAttributes,
+  TemporalFailure,
 } from '@temporalio/common';
 import { proxyActivities } from '@temporalio/workflow';
 import { WorkflowFailedError } from '@temporalio/client';
@@ -45,6 +46,10 @@ test('Client and Worker use provided failureConverter', async (t) => {
     const handle = await env.client.workflow.start(workflow, { taskQueue, workflowId: randomUUID() });
     const err = (await worker.runUntil(t.throwsAsync(handle.result()))) as WorkflowFailedError;
     t.is(err.cause?.message, 'Activity task failed');
+    if (!(err.cause instanceof TemporalFailure)) {
+      t.fail('expected error cause to be a TemporalFailure');
+      return;
+    }
     t.is(err.cause?.cause?.message, 'error message');
     t.true(err.cause?.cause?.stack?.includes('ApplicationFailure: error message\n'));
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1,7 +1,6 @@
 import type { RawSourceMap } from 'source-map';
 import {
   RetryPolicy,
-  TemporalFailure,
   CommonWorkflowOptions,
   HandlerUnfinishedPolicy,
   SearchAttributes,
@@ -73,7 +72,7 @@ export interface WorkflowInfo {
   /**
    * Failure from the previous Run (present when this Run is a retry, or the last Run of a Cron Workflow failed)
    */
-  readonly lastFailure?: TemporalFailure;
+  readonly lastFailure?: Error;
 
   /**
    * Length of Workflow history up until the current Workflow Task.


### PR DESCRIPTION
💥 BREAKING CHANGE 💥 

Instead of expecting that the FailureConverter will always return a TemporalFailure.
This change is required for the FailureConverter to support Nexus HandlerError.

NOTE: a similar breaking change has been made in the Java SDK a little while ago: https://github.com/temporalio/sdk-java/pull/2365