### PR TITLE
Add vitest support to `@temporalio/nyc-test-coverage`

### DIFF
--- a/packages/nyc-test-coverage/README.md
+++ b/packages/nyc-test-coverage/README.md
@@ -88,3 +88,8 @@ afterAll(() => {
   workflowCoverage.mergeIntoGlobalCoverage();
 });
 ```
+
+## Usage with vitest
+
+This package works with [vitest](https://vitest.dev/) code coverage. Make sure you have configured vitest to use the 
+`instanbul` provider https://vitest.dev/guide/coverage.html#coverage-providers.

--- a/packages/nyc-test-coverage/src/globalCoverage.ts
+++ b/packages/nyc-test-coverage/src/globalCoverage.ts
@@ -3,6 +3,8 @@ import { CoverageMapData } from 'istanbul-lib-coverage';
 declare global {
   // eslint-disable-next-line no-var
   var __coverage__: CoverageMapData;
+  // eslint-disable-next-line no-var
+  var __VITEST_COVERAGE__: CoverageMapData;
 }
 
 export {};

--- a/packages/nyc-test-coverage/src/index.ts
+++ b/packages/nyc-test-coverage/src/index.ts
@@ -12,7 +12,7 @@ export class WorkflowCoverage {
   // Check if running through nyc or some other Istanbul-based tool.
   // If not, any `workflowCoverage()` tools are a no-op.
   private hasCoverageGlobal() {
-    return '__coverage__' in global;
+    return coverage() !== undefined;
   }
 
   /**
@@ -204,4 +204,8 @@ export class WorkflowCoverage {
 
     global.__coverage__ = coverageMap.data;
   }
+}
+
+function coverage() {
+  return global.__coverage__ ?? global.__VITEST_COVERAGE__;
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Add support for `vitest` coverage reports using istanbul

## Why?
<!-- Tell your future self why have you made these changes -->
More test frameworks supported = better!

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

I did not create an issue since it was reasonably easy to add and I figure discussions on whether or not to support can be done in the PR

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Locally with my setup that uses vitest

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

packages/nyc-test-coverage/README.md