### PR TITLE
Fix code comment docs

### DIFF
--- a/packages/worker/src/worker-tuner.ts
+++ b/packages/worker/src/worker-tuner.ts
@@ -95,7 +95,7 @@ export interface ResourceBasedTuner {
   tunerOptions: ResourceBasedTunerOptions;
   /**
    * Options for workflow task slots. Defaults to a minimum of 2 slots and a maximum of 1000 slots
-   * with no ramp throttle
+   * with 10ms ramp throttle
    */
   workflowTaskSlotOptions?: ResourceBasedSlotOptions;
   /**


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
I made sure that the comments documenting the code were right.

Here it says defaults are (10ms wf task, 50ms activity task)
```
/**
     * Minimum time we will wait (after passing the minimum slots number) between handing out new
     * slots. Defaults to 10ms for workflow tasks and 50ms for activity tasks.
     */
    rampThrottle?: Duration;
```
But on the workflowTaskSlotOptions is says there is no rampThrottle
```
/**
     * Options for workflow task slots. Defaults to a minimum of 2 slots and a maximum of 1000 slots
     * with no ramp throttle
     */
    workflowTaskSlotOptions?: ResourceBasedSlotOptions;
```
which looking at the implementation, the right one is the one that says there is a 10ms throttle:
```
if (kind === 'workflow') {
        return {
            minimumSlots: slotOptions.minimumSlots ?? 2,
            maximumSlots: slotOptions.maximumSlots ?? 1000,
            rampThrottle: slotOptions.rampThrottle ?? 10,
        };
    }
```
## Why?
Looking at how to improve tuner configs, I saw that comments were wrong:
https://temporalio.slack.com/archives/C046BRWDV2R/p1745395666974519?thread_ts=1745334134.022959&cid=C046BRWDV2R

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
No tests needed

3. Any docs updates needed?
Not sure, don't think so.
