### PR TITLE
NativeConnection powered Client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19561,6 +19561,7 @@
       "version": "1.11.5",
       "license": "MIT",
       "dependencies": {
+        "@grpc/grpc-js": "^1.12.4",
         "@swc/core": "^1.3.102",
         "@temporalio/activity": "file:../activity",
         "@temporalio/client": "file:../client",
@@ -19571,6 +19572,7 @@
         "abort-controller": "^3.0.0",
         "heap-js": "^2.3.0",
         "memfs": "^4.6.0",
+        "protobufjs": "^7.2.5",
         "rxjs": "^7.8.1",
         "source-map": "^0.7.4",
         "source-map-loader": "^4.0.2",
@@ -21788,6 +21790,7 @@
     "@temporalio/worker": {
       "version": "file:packages/worker",
       "requires": {
+        "@grpc/grpc-js": "^1.12.4",
         "@swc/core": "^1.3.102",
         "@temporalio/activity": "file:../activity",
         "@temporalio/client": "file:../client",
@@ -21799,6 +21802,7 @@
         "abort-controller": "^3.0.0",
         "heap-js": "^2.3.0",
         "memfs": "^4.6.0",
+        "protobufjs": "^7.2.5",
         "rxjs": "^7.8.1",
         "source-map": "^0.7.4",
         "source-map-loader": "^4.0.2",

--- a/packages/core-bridge/Cargo.lock
+++ b/packages/core-bridge/Cargo.lock
@@ -2697,6 +2697,7 @@ dependencies = [
  "temporal-sdk-core",
  "tokio",
  "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/packages/core-bridge/Cargo.toml
+++ b/packages/core-bridge/Cargo.toml
@@ -31,3 +31,4 @@ once_cell = "1.19"
 temporal-sdk-core = { version = "*", path = "./sdk-core/core", features = ["ephemeral-server"] }
 temporal-client = { version = "*", path = "./sdk-core/client" }
 tokio-stream = "0.1"
+tonic = "0.12"

--- a/packages/core-bridge/src/client.rs
+++ b/packages/core-bridge/src/client.rs
@@ -1,0 +1,387 @@
+use crate::{conversions::ObjectHandleConversionsExt, helpers::*, runtime::*};
+use neon::prelude::*;
+use prost::DecodeError;
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::time::Duration;
+use std::{cell::RefCell, sync::Arc};
+use temporal_client::{
+    ConfiguredClient, RetryClient, TemporalServiceClientWithMetrics, WorkflowService,
+};
+use tonic::metadata::MetadataKey;
+
+#[derive(Clone)]
+pub struct Client {
+    pub(crate) runtime: Arc<RuntimeHandle>,
+    pub(crate) core_client: Arc<CoreClient>,
+}
+
+pub type CoreClient = RetryClient<ConfiguredClient<TemporalServiceClientWithMetrics>>;
+
+pub(crate) type BoxedClient = JsBox<RefCell<Option<Client>>>;
+impl Finalize for Client {}
+
+#[derive(Debug)]
+pub struct RpcCall {
+    pub rpc: String,
+    pub req: Vec<u8>,
+    pub retry: bool,
+    pub metadata: HashMap<String, String>,
+    pub timeout_millis: Option<u64>,
+}
+
+macro_rules! rpc_call {
+    ($retry_client:ident, $call:ident, $call_name:ident) => {
+        if $call.retry {
+            rpc_resp($retry_client.$call_name(rpc_req($call)?).await)
+        } else {
+            rpc_resp($retry_client.into_inner().$call_name(rpc_req($call)?).await)
+        }
+    };
+}
+
+#[derive(Debug)]
+pub enum RpcError {
+    Decode(DecodeError),
+    Tonic(tonic::Status),
+    Type(String),
+}
+
+fn rpc_req<P: prost::Message + Default>(call: RpcCall) -> Result<tonic::Request<P>, RpcError> {
+    let proto = P::decode(&*call.req).map_err(RpcError::Decode)?;
+    let mut req = tonic::Request::new(proto);
+    for (k, v) in call.metadata {
+        req.metadata_mut().insert(
+            MetadataKey::from_str(k.as_str())
+                .map_err(|err| RpcError::Type(format!("Invalid metadata key: {}", err)))?,
+            v.parse()
+                .map_err(|err| RpcError::Type(format!("Invalid metadata value: {}", err)))?,
+        );
+    }
+    if let Some(timeout_millis) = call.timeout_millis {
+        req.set_timeout(Duration::from_millis(timeout_millis));
+    }
+    Ok(req)
+}
+
+fn rpc_resp<P>(res: Result<tonic::Response<P>, tonic::Status>) -> Result<Vec<u8>, RpcError>
+where
+    P: prost::Message,
+    P: Default,
+{
+    match res {
+        Ok(resp) => Ok(resp.get_ref().encode_to_vec()),
+        Err(err) => Err(RpcError::Tonic(err)),
+    }
+}
+
+/// Update a Client's HTTP request headers
+pub fn client_update_headers(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let client = cx.argument::<BoxedClient>(0)?;
+    let headers = cx
+        .argument::<JsObject>(1)?
+        .as_hash_map_of_string_to_string(&mut cx)?;
+    let callback = cx.argument::<JsFunction>(2)?;
+
+    match client.borrow().as_ref() {
+        None => {
+            callback_with_unexpected_error(&mut cx, callback, "Tried to use closed Client")?;
+        }
+        Some(client) => {
+            let request = RuntimeRequest::UpdateClientHeaders {
+                client: client.core_client.clone(),
+                headers,
+                callback: callback.root(&mut cx),
+            };
+            if let Err(err) = client.runtime.sender.send(request) {
+                callback_with_unexpected_error(&mut cx, callback, err)?;
+            };
+        }
+    }
+
+    Ok(cx.undefined())
+}
+
+/// Update a Client's API key
+pub fn client_update_api_key(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let client = cx.argument::<BoxedClient>(0)?;
+    let key = cx.argument::<JsString>(1)?.value(&mut cx);
+    let callback = cx.argument::<JsFunction>(2)?;
+
+    match client.borrow().as_ref() {
+        None => {
+            callback_with_unexpected_error(&mut cx, callback, "Tried to use closed Client")?;
+        }
+        Some(client) => {
+            let request = RuntimeRequest::UpdateClientApiKey {
+                client: client.core_client.clone(),
+                key,
+                callback: callback.root(&mut cx),
+            };
+            if let Err(err) = client.runtime.sender.send(request) {
+                callback_with_unexpected_error(&mut cx, callback, err)?;
+            };
+        }
+    }
+
+    Ok(cx.undefined())
+}
+
+/// Send a request using the provided Client
+pub fn client_send_request(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let client = cx.argument::<BoxedClient>(0)?;
+    let call = cx.argument::<JsObject>(1)?;
+    let callback = cx.argument::<JsFunction>(2)?;
+
+    match client.borrow().as_ref() {
+        None => {
+            callback_with_unexpected_error(&mut cx, callback, "Tried to use closed Client")?;
+        }
+        Some(client) => {
+            let call = call.as_rpc_call(&mut cx)?;
+            let request = RuntimeRequest::SendClientRequest {
+                client: client.core_client.clone(),
+                call,
+                callback: callback.root(&mut cx),
+            };
+            if let Err(err) = client.runtime.sender.send(request) {
+                callback_with_unexpected_error(&mut cx, callback, err)?;
+            };
+        }
+    }
+
+    Ok(cx.undefined())
+}
+
+pub async fn client_invoke(
+    mut retry_client: CoreClient,
+    call: RpcCall,
+) -> Result<Vec<u8>, RpcError> {
+    match call.rpc.as_str() {
+        "CountWorkflowExecutions" => {
+            rpc_call!(retry_client, call, count_workflow_executions)
+        }
+        "CreateSchedule" => {
+            rpc_call!(retry_client, call, create_schedule)
+        }
+        "DeleteSchedule" => {
+            rpc_call!(retry_client, call, delete_schedule)
+        }
+        "DeleteWorkerDeployment" => {
+            rpc_call!(retry_client, call, delete_worker_deployment)
+        }
+        "DeleteWorkerDeploymentVersion" => {
+            rpc_call!(retry_client, call, delete_worker_deployment_version)
+        }
+        "DeleteWorkflowExecution" => {
+            rpc_call!(retry_client, call, delete_workflow_execution)
+        }
+        "DescribeBatchOperation" => {
+            rpc_call!(retry_client, call, describe_batch_operation)
+        }
+        "DescribeDeployment" => {
+            rpc_call!(retry_client, call, describe_deployment)
+        }
+        "DeprecateNamespace" => rpc_call!(retry_client, call, deprecate_namespace),
+        "DescribeNamespace" => rpc_call!(retry_client, call, describe_namespace),
+        "DescribeSchedule" => rpc_call!(retry_client, call, describe_schedule),
+        "DescribeTaskQueue" => rpc_call!(retry_client, call, describe_task_queue),
+        "DescribeWorkerDeployment" => {
+            rpc_call!(retry_client, call, describe_worker_deployment)
+        }
+        "DescribeWorkerDeploymentVersion" => {
+            rpc_call!(retry_client, call, describe_worker_deployment_version)
+        }
+        "DescribeWorkflowExecution" => {
+            rpc_call!(retry_client, call, describe_workflow_execution)
+        }
+        "ExecuteMultiOperation" => rpc_call!(retry_client, call, execute_multi_operation),
+        "GetClusterInfo" => rpc_call!(retry_client, call, get_cluster_info),
+        "GetCurrentDeployment" => rpc_call!(retry_client, call, get_current_deployment),
+        "GetDeploymentReachability" => {
+            rpc_call!(retry_client, call, get_deployment_reachability)
+        }
+        "GetSearchAttributes" => {
+            rpc_call!(retry_client, call, get_search_attributes)
+        }
+        "GetSystemInfo" => rpc_call!(retry_client, call, get_system_info),
+        "GetWorkerBuildIdCompatibility" => {
+            rpc_call!(retry_client, call, get_worker_build_id_compatibility)
+        }
+        "GetWorkerTaskReachability" => {
+            rpc_call!(retry_client, call, get_worker_task_reachability)
+        }
+        "GetWorkerVersioningRules" => {
+            rpc_call!(retry_client, call, get_worker_versioning_rules)
+        }
+        "GetWorkflowExecutionHistory" => {
+            rpc_call!(retry_client, call, get_workflow_execution_history)
+        }
+        "GetWorkflowExecutionHistoryReverse" => {
+            rpc_call!(retry_client, call, get_workflow_execution_history_reverse)
+        }
+        "ListArchivedWorkflowExecutions" => {
+            rpc_call!(retry_client, call, list_archived_workflow_executions)
+        }
+        "ListBatchOperations" => {
+            rpc_call!(retry_client, call, list_batch_operations)
+        }
+        "ListClosedWorkflowExecutions" => {
+            rpc_call!(retry_client, call, list_closed_workflow_executions)
+        }
+        "ListDeployments" => {
+            rpc_call!(retry_client, call, list_deployments)
+        }
+        "ListNamespaces" => rpc_call!(retry_client, call, list_namespaces),
+        "ListOpenWorkflowExecutions" => {
+            rpc_call!(retry_client, call, list_open_workflow_executions)
+        }
+        "ListScheduleMatchingTimes" => {
+            rpc_call!(retry_client, call, list_schedule_matching_times)
+        }
+        "ListSchedules" => {
+            rpc_call!(retry_client, call, list_schedules)
+        }
+        "ListTaskQueuePartitions" => {
+            rpc_call!(retry_client, call, list_task_queue_partitions)
+        }
+        "ListWorkerDeployments" => {
+            rpc_call!(retry_client, call, list_worker_deployments)
+        }
+        "ListWorkflowExecutions" => {
+            rpc_call!(retry_client, call, list_workflow_executions)
+        }
+        "PatchSchedule" => {
+            rpc_call!(retry_client, call, patch_schedule)
+        }
+        "PauseActivity" => {
+            rpc_call!(retry_client, call, pause_activity)
+        }
+        "PollActivityTaskQueue" => {
+            rpc_call!(retry_client, call, poll_activity_task_queue)
+        }
+        "PollNexusTaskQueue" => rpc_call!(retry_client, call, poll_nexus_task_queue),
+        "PollWorkflowExecutionUpdate" => {
+            rpc_call!(retry_client, call, poll_workflow_execution_update)
+        }
+        "PollWorkflowTaskQueue" => {
+            rpc_call!(retry_client, call, poll_workflow_task_queue)
+        }
+        "QueryWorkflow" => rpc_call!(retry_client, call, query_workflow),
+        "RecordActivityTaskHeartbeat" => {
+            rpc_call!(retry_client, call, record_activity_task_heartbeat)
+        }
+        "RecordActivityTaskHeartbeatById" => {
+            rpc_call!(retry_client, call, record_activity_task_heartbeat_by_id)
+        }
+        "RegisterNamespace" => rpc_call!(retry_client, call, register_namespace),
+        "RequestCancelWorkflowExecution" => {
+            rpc_call!(retry_client, call, request_cancel_workflow_execution)
+        }
+        "ResetActivity" => {
+            rpc_call!(retry_client, call, reset_activity)
+        }
+        "ResetStickyTaskQueue" => {
+            rpc_call!(retry_client, call, reset_sticky_task_queue)
+        }
+        "ResetWorkflowExecution" => {
+            rpc_call!(retry_client, call, reset_workflow_execution)
+        }
+        "RespondActivityTaskCanceled" => {
+            rpc_call!(retry_client, call, respond_activity_task_canceled)
+        }
+        "RespondActivityTaskCanceledById" => {
+            rpc_call!(retry_client, call, respond_activity_task_canceled_by_id)
+        }
+        "RespondActivityTaskCompleted" => {
+            rpc_call!(retry_client, call, respond_activity_task_completed)
+        }
+        "RespondActivityTaskCompletedById" => {
+            rpc_call!(retry_client, call, respond_activity_task_completed_by_id)
+        }
+        "RespondActivityTaskFailed" => {
+            rpc_call!(retry_client, call, respond_activity_task_failed)
+        }
+        "RespondActivityTaskFailedById" => {
+            rpc_call!(retry_client, call, respond_activity_task_failed_by_id)
+        }
+        "RespondNexusTaskCompleted" => {
+            rpc_call!(retry_client, call, respond_nexus_task_completed)
+        }
+        "RespondNexusTaskFailed" => {
+            rpc_call!(retry_client, call, respond_nexus_task_failed)
+        }
+        "RespondQueryTaskCompleted" => {
+            rpc_call!(retry_client, call, respond_query_task_completed)
+        }
+        "RespondWorkflowTaskCompleted" => {
+            rpc_call!(retry_client, call, respond_workflow_task_completed)
+        }
+        "RespondWorkflowTaskFailed" => {
+            rpc_call!(retry_client, call, respond_workflow_task_failed)
+        }
+        "ScanWorkflowExecutions" => {
+            rpc_call!(retry_client, call, scan_workflow_executions)
+        }
+        "SetCurrentDeployment" => {
+            rpc_call!(retry_client, call, set_current_deployment)
+        }
+        "SetWorkerDeploymentCurrentVersion" => {
+            rpc_call!(retry_client, call, set_worker_deployment_current_version)
+        }
+        "SetWorkerDeploymentRampingVersion" => {
+            rpc_call!(retry_client, call, set_worker_deployment_ramping_version)
+        }
+        "ShutdownWorker" => {
+            rpc_call!(retry_client, call, shutdown_worker)
+        }
+        "SignalWithStartWorkflowExecution" => {
+            rpc_call!(retry_client, call, signal_with_start_workflow_execution)
+        }
+        "SignalWorkflowExecution" => {
+            rpc_call!(retry_client, call, signal_workflow_execution)
+        }
+        "StartWorkflowExecution" => {
+            rpc_call!(retry_client, call, start_workflow_execution)
+        }
+        "StartBatchOperation" => {
+            rpc_call!(retry_client, call, start_batch_operation)
+        }
+        "StopBatchOperation" => {
+            rpc_call!(retry_client, call, stop_batch_operation)
+        }
+        "TerminateWorkflowExecution" => {
+            rpc_call!(retry_client, call, terminate_workflow_execution)
+        }
+        "UnpauseActivity" => {
+            rpc_call!(retry_client, call, unpause_activity)
+        }
+        "UpdateActivityOptions" => {
+            rpc_call!(retry_client, call, update_activity_options)
+        }
+        "UpdateNamespace" => {
+            rpc_call!(retry_client, call, update_namespace)
+        }
+        "UpdateSchedule" => rpc_call!(retry_client, call, update_schedule),
+        "UpdateWorkerDeploymentVersionMetadata" => {
+            rpc_call!(
+                retry_client,
+                call,
+                update_worker_deployment_version_metadata
+            )
+        }
+        "UpdateWorkflowExecution" => {
+            rpc_call!(retry_client, call, update_workflow_execution)
+        }
+        "UpdateWorkflowExecutionOptions" => {
+            rpc_call!(retry_client, call, update_workflow_execution_options)
+        }
+        "UpdateWorkerBuildIdCompatibility" => {
+            rpc_call!(retry_client, call, update_worker_build_id_compatibility)
+        }
+        "UpdateWorkerVersioningRules" => {
+            rpc_call!(retry_client, call, update_worker_versioning_rules)
+        }
+        _ => Err(RpcError::Type(format!("Unknown RPC call {}", call.rpc))),
+    }
+}

--- a/packages/core-bridge/src/lib.rs
+++ b/packages/core-bridge/src/lib.rs
@@ -1,3 +1,4 @@
+mod client;
 mod conversions;
 mod errors;
 mod helpers;
@@ -5,6 +6,7 @@ mod runtime;
 mod testing;
 mod worker;
 
+use crate::client::*;
 use crate::runtime::*;
 use crate::worker::*;
 use neon::prelude::*;
@@ -17,6 +19,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("newClient", client_new)?;
     cx.export_function("clientUpdateHeaders", client_update_headers)?;
     cx.export_function("clientUpdateApiKey", client_update_api_key)?;
+    cx.export_function("clientSendRequest", client_send_request)?;
     cx.export_function("newWorker", worker_new)?;
     cx.export_function("newReplayWorker", replay_worker_new)?;
     cx.export_function("pushHistory", push_history)?;

--- a/packages/core-bridge/src/runtime.rs
+++ b/packages/core-bridge/src/runtime.rs
@@ -1,4 +1,10 @@
-use crate::{conversions::*, errors::*, helpers::*, worker::*};
+use crate::{
+    client::{BoxedClient, Client, CoreClient, RpcCall, RpcError, client_invoke},
+    conversions::*,
+    errors::*,
+    helpers::*,
+    worker::*,
+};
 use neon::{context::Context, prelude::*};
 use std::{
     cell::{Cell, RefCell},
@@ -8,9 +14,9 @@ use std::{
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use temporal_client::{ClientInitError, ConfiguredClient, TemporalServiceClientWithMetrics};
+use temporal_client::ClientInitError;
 use temporal_sdk_core::{
-    ClientOptions, CoreRuntime, RetryClient, TokioRuntimeBuilder, WorkerConfig,
+    ClientOptions, CoreRuntime, TokioRuntimeBuilder, WorkerConfig,
     api::telemetry::CoreTelemetry,
     ephemeral_server::EphemeralServer as CoreEphemeralServer,
     init_replay_worker, init_worker,
@@ -22,8 +28,6 @@ use tokio::sync::{
     oneshot,
 };
 use tokio_stream::wrappers::ReceiverStream;
-
-pub type CoreClient = RetryClient<ConfiguredClient<TemporalServiceClientWithMetrics>>;
 
 #[derive(Clone)]
 pub struct EphemeralServer {
@@ -40,15 +44,6 @@ pub struct RuntimeHandle {
 /// Box it so we can use the runtime from JS
 pub type BoxedRuntime = JsBox<Arc<RuntimeHandle>>;
 impl Finalize for RuntimeHandle {}
-
-#[derive(Clone)]
-pub struct Client {
-    pub(crate) runtime: Arc<RuntimeHandle>,
-    pub(crate) core_client: Arc<CoreClient>,
-}
-
-pub type BoxedClient = JsBox<RefCell<Option<Client>>>;
-impl Finalize for Client {}
 
 /// A request from JS to bridge to core
 pub enum RuntimeRequest {
@@ -110,6 +105,11 @@ pub enum RuntimeRequest {
     UpdateClientApiKey {
         client: Arc<CoreClient>,
         key: String,
+        callback: Root<JsFunction>,
+    },
+    SendClientRequest {
+        client: Arc<CoreClient>,
+        call: RpcCall,
         callback: Root<JsFunction>,
     },
 }
@@ -219,6 +219,46 @@ pub fn start_bridge_loop(
                     client.get_client().set_api_key(Some(key));
                     send_result(channel.clone(), callback, |cx| Ok(cx.undefined()));
                 }
+                RuntimeRequest::SendClientRequest { client, call, callback } => {
+                    core_runtime.tokio_handle().spawn(async move {
+                        match client_invoke((*client).clone(), call).await {
+                            Ok(bytes) => send_result(channel.clone(), callback, move |cx| {
+                                JsArrayBuffer::from_slice(cx, &bytes)
+                            }),
+                            Err(err) => send_error(channel.clone(), callback, |cx| {
+                                match err {
+                                    RpcError::Tonic(err) => {
+                                        let code = cx.number(err.code() as u32);
+                                        let metadata = JsObject::new(cx);
+                                        let details = err.details();
+                                        if !details.is_empty() {
+                                            let k = cx.string("grpc-status-details-bin");
+                                            let v = JsArrayBuffer::from_slice(cx, details)?;
+                                            metadata.set(cx, k, v)?;
+                                        }
+                                        let jserr = make_named_error_from_string(cx, TRANSPORT_ERROR, err.message())?;
+                                        for (k, v) in err.metadata().clone().into_headers().iter() {
+                                            let is_bin = k.to_string().ends_with("-bin");
+                                            let js_k = cx.string(k);
+                                            if is_bin {
+                                                let js_v = JsArrayBuffer::from_slice(cx, v.as_bytes())?;
+                                                metadata.set(cx, js_k, js_v)?;
+                                            } else {
+                                                let js_v = cx.string(v.to_str().unwrap());
+                                                metadata.set(cx, js_k, js_v)?;
+                                            };
+                                        }
+                                        jserr.set(cx, "code", code)?;
+                                        jserr.set(cx, "metadata", metadata)?;
+                                        Ok(jserr)
+                                    }
+                                    RpcError::Decode(err) => make_named_error_from_string(cx, UNEXPECTED_ERROR, format!("Invalid proto: {}", err)),
+                                    RpcError::Type(err) => JsError::type_error(cx, err),
+                                }
+                            }),
+                        }
+                    });
+                },
                 RuntimeRequest::PollLogs { callback } => {
                     let logs = core_runtime.telemetry().fetch_buffered_logs();
                     send_result(channel.clone(), callback, |cx| {
@@ -471,58 +511,6 @@ pub fn client_close(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         make_named_error_from_string(&mut cx, ILLEGAL_STATE_ERROR, "Client already closed")
             .and_then(|err| cx.throw(err))?;
     };
-    Ok(cx.undefined())
-}
-
-/// Update a Client's HTTP request headers
-pub fn client_update_headers(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-    let client = cx.argument::<BoxedClient>(0)?;
-    let headers = cx
-        .argument::<JsObject>(1)?
-        .as_hash_map_of_string_to_string(&mut cx)?;
-    let callback = cx.argument::<JsFunction>(2)?;
-
-    match client.borrow().as_ref() {
-        None => {
-            callback_with_unexpected_error(&mut cx, callback, "Tried to use closed Client")?;
-        }
-        Some(client) => {
-            let request = RuntimeRequest::UpdateClientHeaders {
-                client: client.core_client.clone(),
-                headers,
-                callback: callback.root(&mut cx),
-            };
-            if let Err(err) = client.runtime.sender.send(request) {
-                callback_with_unexpected_error(&mut cx, callback, err)?;
-            };
-        }
-    }
-
-    Ok(cx.undefined())
-}
-
-/// Update a Client's API key
-pub fn client_update_api_key(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-    let client = cx.argument::<BoxedClient>(0)?;
-    let key = cx.argument::<JsString>(1)?.value(&mut cx);
-    let callback = cx.argument::<JsFunction>(2)?;
-
-    match client.borrow().as_ref() {
-        None => {
-            callback_with_unexpected_error(&mut cx, callback, "Tried to use closed Client")?;
-        }
-        Some(client) => {
-            let request = RuntimeRequest::UpdateClientApiKey {
-                client: client.core_client.clone(),
-                key,
-                callback: callback.root(&mut cx),
-            };
-            if let Err(err) = client.runtime.sender.send(request) {
-                callback_with_unexpected_error(&mut cx, callback, err)?;
-            };
-        }
-    }
-
     Ok(cx.undefined())
 }
 

--- a/packages/core-bridge/src/worker.rs
+++ b/packages/core-bridge/src/worker.rs
@@ -1,4 +1,6 @@
-use crate::{conversions::ObjectHandleConversionsExt, errors::*, helpers::*, runtime::*};
+use crate::{
+    client::BoxedClient, conversions::ObjectHandleConversionsExt, errors::*, helpers::*, runtime::*,
+};
 use futures::stream::StreamExt;
 use neon::{prelude::*, types::buffer::TypedArray};
 use prost::Message;

--- a/packages/core-bridge/ts/errors.ts
+++ b/packages/core-bridge/ts/errors.ts
@@ -12,7 +12,15 @@ export class ShutdownError extends Error {}
  * once this error is encountered
  */
 @SymbolBasedInstanceOfError('TransportError')
-export class TransportError extends Error {}
+export class TransportError extends Error {
+  constructor(
+    message: string,
+    public readonly code?: number,
+    public readonly metadata?: Record<string, ArrayBuffer | string>
+  ) {
+    super(message);
+  }
+}
 
 /**
  * Something unexpected happened, considered fatal
@@ -39,7 +47,7 @@ export function convertFromNamedError(e: unknown, keepStackTrace: boolean): unkn
     let newerr: Error;
     switch (e.name) {
       case 'TransportError':
-        newerr = new TransportError(e.message);
+        newerr = new TransportError(e.message, (e as any).code, (e as any).metadata);
         newerr.stack = keepStackTrace ? e.stack : undefined;
         return newerr;
 

--- a/packages/core-bridge/ts/index.ts
+++ b/packages/core-bridge/ts/index.ts
@@ -43,6 +43,29 @@ export interface RetryOptions {
   maxRetries: number;
 }
 
+export interface RpcCall {
+  /**
+   * gRPC method name.
+   */
+  rpc: string;
+  /**
+   * Protobuf request input encoded into an ArrayBuffer.
+   */
+  req: ArrayBuffer;
+  /**
+   * A boolean indicating whether this call should be auto-retried.
+   */
+  retry: boolean;
+  /**
+   * Metadata to attach to the call.
+   */
+  metadata: Record<string, string>;
+  /**
+   * Request timeout in milliseconds.
+   */
+  timeoutMs?: number;
+}
+
 export interface ClientOptions {
   /**
    * The URL of the Temporal server to connect to
@@ -552,7 +575,7 @@ export interface ReplayWorker {
 }
 
 export declare type Callback<T> = (err: Error, result: T) => void;
-export declare type PollCallback = (err: Error, result: ArrayBuffer) => void;
+export declare type BufferCallback = (err: Error, result: ArrayBuffer) => void;
 export declare type WorkerCallback = (err: Error, result: Worker) => void;
 export declare type ReplayWorkerCallback = (err: Error, worker: ReplayWorker) => void;
 export declare type ClientCallback = (err: Error, result: Client) => void;
@@ -592,13 +615,15 @@ export declare function clientUpdateHeaders(
 
 export declare function clientUpdateApiKey(client: Client, apiKey: string, callback: VoidCallback): void;
 
+export declare function clientSendRequest(client: Client, call: RpcCall, callback: BufferCallback): void;
+
 export declare function clientClose(client: Client): void;
 
 export declare function runtimeShutdown(runtime: Runtime, callback: VoidCallback): void;
 
 export declare function pollLogs(runtime: Runtime, callback: LogsCallback): void;
 
-export declare function workerPollWorkflowActivation(worker: Worker, callback: PollCallback): void;
+export declare function workerPollWorkflowActivation(worker: Worker, callback: BufferCallback): void;
 
 export declare function workerCompleteWorkflowActivation(
   worker: Worker,
@@ -606,7 +631,7 @@ export declare function workerCompleteWorkflowActivation(
   callback: VoidCallback
 ): void;
 
-export declare function workerPollActivityTask(worker: Worker, callback: PollCallback): void;
+export declare function workerPollActivityTask(worker: Worker, callback: BufferCallback): void;
 
 export declare function workerCompleteActivityTask(worker: Worker, result: ArrayBuffer, callback: VoidCallback): void;
 

--- a/packages/test/src/run-a-workflow.ts
+++ b/packages/test/src/run-a-workflow.ts
@@ -1,20 +1,23 @@
 import arg from 'arg';
-import { WorkflowClient, Connection } from '@temporalio/client';
+import { NativeConnection } from '@temporalio/worker';
+import { Connection, WorkflowClient } from '@temporalio/client';
 import * as workflows from './workflows';
 
 async function main() {
   const argv = arg({
     '--workflow-id': String,
+    '--use-native': Boolean,
   });
   const [workflowType, ...argsRaw] = argv._;
   const args = argsRaw.map((v) => JSON.parse(v));
   const workflowId = argv['--workflow-id'] ?? 'test';
+  const useNative = !!argv['--use-native'];
   if (!Object.prototype.hasOwnProperty.call(workflows, workflowType)) {
     throw new TypeError(`Invalid workflowType ${workflowType}`);
   }
   console.log('running', { workflowType, args });
 
-  const connection = await Connection.connect();
+  const connection = useNative ? await NativeConnection.connect() : await Connection.connect();
   const client = new WorkflowClient({ connection });
   const result = await client.execute(workflowType, {
     workflowId,

--- a/packages/test/src/test-native-connection.ts
+++ b/packages/test/src/test-native-connection.ts
@@ -1,11 +1,14 @@
+import { randomUUID } from 'node:crypto';
 import util from 'node:util';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import test from 'ava';
 import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
+import { Client, NamespaceNotFoundError, WorkflowNotFoundError } from '@temporalio/client';
 import { IllegalStateError, NativeConnection, TransportError } from '@temporalio/worker';
 import { temporal } from '@temporalio/proto';
+import { TestWorkflowEnvironment } from '@temporalio/testing';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
 
 const workflowServicePackageDefinition = protoLoader.loadSync(
@@ -99,7 +102,7 @@ test('NativeConnection can connect using "[ipv6]:port" address', async (t) => {
   const server = new grpc.Server();
   server.addService(workflowServiceProtoDescriptor.temporal.api.workflowservice.v1.WorkflowService.service, {
     getSystemInfo(
-      call: grpc.ServerUnaryCall<
+      _call: grpc.ServerUnaryCall<
         temporal.api.workflowservice.v1.IGetSystemInfoRequest,
         temporal.api.workflowservice.v1.IGetSystemInfoResponse
       >,
@@ -115,7 +118,7 @@ test('NativeConnection can connect using "[ipv6]:port" address', async (t) => {
   });
   t.true(gotRequest);
   await connection.close();
-  await server.forceShutdown();
+  server.forceShutdown();
 });
 
 test('Can configure TLS + call credentials', async (t) => {
@@ -123,7 +126,7 @@ test('Can configure TLS + call credentials', async (t) => {
   const server = new grpc.Server();
   server.addService(workflowServiceProtoDescriptor.temporal.api.workflowservice.v1.WorkflowService.service, {
     getSystemInfo(
-      call: grpc.ServerUnaryCall<
+      _call: grpc.ServerUnaryCall<
         temporal.api.workflowservice.v1.IGetSystemInfoRequest,
         temporal.api.workflowservice.v1.IGetSystemInfoResponse
       >,
@@ -149,5 +152,120 @@ test('Can configure TLS + call credentials', async (t) => {
 
   t.true(gotRequest);
   await connection.close();
-  await server.forceShutdown();
+  server.forceShutdown();
+});
+
+test('withMetadata and withDeadline propagate metadata and deadline', async (t) => {
+  const requests = new Array<{ metadata: grpc.Metadata; deadline: grpc.Deadline }>();
+  const server = new grpc.Server();
+  server.addService(workflowServiceProtoDescriptor.temporal.api.workflowservice.v1.WorkflowService.service, {
+    getSystemInfo(
+      call: grpc.ServerUnaryCall<
+        temporal.api.workflowservice.v1.IGetSystemInfoRequest,
+        temporal.api.workflowservice.v1.IGetSystemInfoResponse
+      >,
+      callback: grpc.sendUnaryData<temporal.api.workflowservice.v1.IGetSystemInfoResponse>
+    ) {
+      requests.push({ metadata: call.metadata, deadline: call.getDeadline() });
+      call.getDeadline();
+      callback(null, {});
+    },
+  });
+
+  const port = await util.promisify(server.bindAsync.bind(server))(
+    'localhost:0',
+    grpc.ServerCredentials.createInsecure()
+  );
+  const connection = await NativeConnection.connect({
+    address: `127.0.0.1:${port}`,
+  });
+
+  await connection.withDeadline(Date.now() + 10_000, () =>
+    connection.withMetadata({ test: 'true' }, () => connection.workflowService.getSystemInfo({}))
+  );
+  t.is(requests.length, 2);
+  t.is(requests[1].metadata.get('test').toString(), 'true');
+  t.true(typeof requests[1].deadline === 'number' && requests[1].deadline > 5_000);
+  await connection.close();
+  server.forceShutdown();
+});
+
+test('all WorkflowService methods are implemented', async (t) => {
+  const server = new grpc.Server();
+  const calledMethods = new Set<string>();
+  server.addService(
+    workflowServiceProtoDescriptor.temporal.api.workflowservice.v1.WorkflowService.service,
+    new Proxy(
+      {},
+      {
+        get() {
+          return (
+            call: grpc.ServerUnaryCall<any, any>,
+            callback: grpc.sendUnaryData<temporal.api.workflowservice.v1.IGetSystemInfoResponse>
+          ) => {
+            const parts = call.getPath().split('/');
+            const method = parts[parts.length - 1];
+            calledMethods.add(method[0].toLowerCase() + method.slice(1));
+            callback(null, {});
+          };
+        },
+      }
+    )
+  );
+
+  const port = await util.promisify(server.bindAsync.bind(server))(
+    'localhost:0',
+    grpc.ServerCredentials.createInsecure()
+  );
+  const connection = await NativeConnection.connect({
+    address: `127.0.0.1:${port}`,
+  });
+
+  // Transform all methods from pascal case to lower case.
+  const methods = Object.keys(
+    workflowServiceProtoDescriptor.temporal.api.workflowservice.v1.WorkflowService.service
+  ).map((k) => k[0].toLowerCase() + k.slice(1));
+  methods.sort();
+  for (const method of methods) {
+    await (connection.workflowService as any)[method]({});
+    t.true(calledMethods.has(method), `method ${method} not called`);
+  }
+
+  await connection.close();
+  server.forceShutdown();
+});
+
+test('can power client calls', async (t) => {
+  const env = await TestWorkflowEnvironment.createLocal();
+  try {
+    {
+      const client = new Client({ connection: env.nativeConnection });
+      const handle = await client.workflow.start('dont-care', {
+        workflowId: t.title + '-' + randomUUID(),
+        taskQueue: 'dont-care',
+      });
+      await handle.terminate();
+      const err = await t.throwsAsync(() => handle.terminate(), {
+        instanceOf: WorkflowNotFoundError,
+      });
+      t.is(err?.workflowId, handle.workflowId);
+    }
+    {
+      const client = new Client({ connection: env.nativeConnection, namespace: 'non-existing' });
+      const err = await t.throwsAsync(
+        () =>
+          client.workflow.start('dont-care', {
+            workflowId: 'dont-care',
+            taskQueue: 'dont-care',
+          }),
+        {
+          instanceOf: NamespaceNotFoundError,
+          message: "Namespace not found: 'non-existing'",
+        }
+      );
+      t.is(err?.namespace, 'non-existing');
+    }
+  } finally {
+    await env.teardown();
+  }
 });

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -13,6 +13,7 @@
   "author": "Temporal Technologies Inc. <sdk@temporal.io>",
   "license": "MIT",
   "dependencies": {
+    "@grpc/grpc-js": "^1.12.4",
     "@swc/core": "^1.3.102",
     "@temporalio/activity": "file:../activity",
     "@temporalio/client": "file:../client",
@@ -23,6 +24,7 @@
     "abort-controller": "^3.0.0",
     "heap-js": "^2.3.0",
     "memfs": "^4.6.0",
+    "protobufjs": "^7.2.5",
     "rxjs": "^7.8.1",
     "source-map": "^0.7.4",
     "source-map-loader": "^4.0.2",


### PR DESCRIPTION
This work enables both Nexus handlers and activities to get a `Client` powered by the `NativeConnection` of the `Worker` they are run in.

I left a TODO to support request cancelation via `withAbortSignal`, I may wait for @mjameswh's refactor before adding that.