### PR TITLE
feat(worker): Expose Poller Automation

### DIFF
--- a/packages/core-bridge/ts/native.ts
+++ b/packages/core-bridge/ts/native.ts
@@ -179,8 +179,8 @@ export interface WorkerOptions {
   namespace: string;
   tuner: WorkerTunerOptions;
   nonStickyToStickyPollRatio: number;
-  maxConcurrentWorkflowTaskPolls: number;
-  maxConcurrentActivityTaskPolls: number;
+  workflowTaskPollerBehavior: PollerBehavior;
+  activityTaskPollerBehavior: PollerBehavior;
   enableNonLocalActivities: boolean;
   stickyQueueScheduleToStartTimeout: number;
   maxCachedWorkflows: number;
@@ -190,6 +190,18 @@ export interface WorkerOptions {
   maxActivitiesPerSecond: Option<number>;
   shutdownGraceTime: number;
 }
+
+export type PollerBehavior =
+  | {
+      type: 'simple-maximum';
+      maximum: number;
+    }
+  | {
+      type: 'autoscaling';
+      minimum: number;
+      maximum: number;
+      initial: number;
+    };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Worker Tuner

--- a/packages/test/src/test-bridge.ts
+++ b/packages/test/src/test-bridge.ts
@@ -277,8 +277,16 @@ const GenericConfigs = {
         },
       },
       nonStickyToStickyPollRatio: 0.5,
-      maxConcurrentWorkflowTaskPolls: 1,
-      maxConcurrentActivityTaskPolls: 1,
+      workflowTaskPollerBehavior: {
+        type: 'simple-maximum',
+        maximum: 1,
+      },
+      activityTaskPollerBehavior: {
+        type: 'autoscaling',
+        minimum: 1,
+        initial: 5,
+        maximum: 100,
+      },
       enableNonLocalActivities: false,
       stickyQueueScheduleToStartTimeout: 1000,
       maxCachedWorkflows: 1000,

--- a/packages/test/src/test-worker-poller-autoscale.ts
+++ b/packages/test/src/test-worker-poller-autoscale.ts
@@ -1,0 +1,83 @@
+import { v4 as uuid } from 'uuid';
+import fetch from 'node-fetch';
+import test from 'ava';
+import { Runtime, Worker } from '@temporalio/worker';
+import { getRandomPort, TestWorkflowEnvironment } from './helpers';
+import * as activities from './activities';
+import * as workflows from './workflows';
+
+test.serial('Can run autoscaling polling worker', async (t) => {
+  const port = await getRandomPort();
+  Runtime.install({
+    telemetryOptions: {
+      metrics: {
+        prometheus: {
+          bindAddress: `127.0.0.1:${port}`,
+        },
+      },
+    },
+  });
+  const localEnv = await TestWorkflowEnvironment.createLocal();
+
+  try {
+    const taskQueue = `autoscale-pollers-${uuid()}`;
+    const worker = await Worker.create({
+      workflowsPath: require.resolve('./workflows'),
+      activities,
+      connection: localEnv.nativeConnection,
+      taskQueue,
+      workflowTaskPollerBehavior: {
+        type: 'autoscaling',
+        initial: 2,
+      },
+      activityTaskPollerBehavior: {
+        type: 'autoscaling',
+        initial: 2,
+      },
+    });
+    const workerPromise = worker.run();
+
+    // Give pollers a beat to start
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    const resp = await fetch(`http://127.0.0.1:${port}/metrics`);
+    const metricsText = await resp.text();
+    const metricsLines = metricsText.split('\n');
+
+    const matches = metricsLines.filter((l) => l.includes('temporal_num_pollers'));
+    const activity_pollers = matches.filter((l) => l.includes('activity_task'));
+    t.is(activity_pollers.length, 1, 'Should have exactly one activity poller metric');
+    t.true(activity_pollers[0].endsWith('2'), 'Activity poller count should be 2');
+    const workflow_pollers = matches.filter((l) => l.includes('workflow_task'));
+    t.is(workflow_pollers.length, 2, 'Should have exactly two workflow poller metrics (sticky and non-sticky)');
+
+    // There's sticky & non-sticky pollers, and they may have a count of 1 or 2 depending on
+    // initialization timing.
+    t.true(
+      workflow_pollers[0].endsWith('2') || workflow_pollers[0].endsWith('1'),
+      'First workflow poller count should be 1 or 2'
+    );
+    t.true(
+      workflow_pollers[1].endsWith('2') || workflow_pollers[1].endsWith('1'),
+      'Second workflow poller count should be 1 or 2'
+    );
+
+    const workflowPromises = Array(20)
+      .fill(0)
+      .map(async (_) => {
+        const handle = await localEnv.client.workflow.start(workflows.waitOnSignalThenActivity, {
+          taskQueue,
+          workflowId: `resource-based-${uuid()}`,
+        });
+        await handle.signal('my-signal', 'finish');
+        return handle.result();
+      });
+
+    await Promise.all(workflowPromises);
+    worker.shutdown();
+    await workerPromise;
+    t.pass();
+  } finally {
+    await localEnv.teardown();
+  }
+});

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -91,3 +91,4 @@ export * from './wait-on-user';
 export * from './workflow-cancellation-scenarios';
 export * from './upsert-and-read-memo';
 export * from './updates-ordering';
+export * from './wait-on-signal-then-activity';

--- a/packages/test/src/workflows/wait-on-signal-then-activity.ts
+++ b/packages/test/src/workflows/wait-on-signal-then-activity.ts
@@ -1,0 +1,15 @@
+import * as wf from '@temporalio/workflow';
+import type * as activities from '../activities';
+
+const { echo } = wf.proxyActivities<typeof activities>({ startToCloseTimeout: '5s' });
+export const mySignal = wf.defineSignal<[string]>('my-signal');
+export async function waitOnSignalThenActivity(): Promise<void> {
+  let lastSignal = '<none>';
+
+  wf.setHandler(mySignal, (value: string) => {
+    lastSignal = value;
+  });
+
+  await wf.condition(() => lastSignal === 'finish');
+  await echo('hi');
+}


### PR DESCRIPTION
*This is a cherry-pick of #1691, to get rid of dependency on #1679 and rebase over #1698.*

## What was changed
Expose options to opt-in to new poller autoscaling behavior

## Why?
Poller autoscaling is cool!

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
 Added simple test. More meaningful tests are in Core, we just need to make sure option is passed properly here.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
