### PR TITLE
feat(worker): Custom Metrics

### DIFF
--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -70,7 +70,7 @@
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { Logger, Duration, LogLevel, LogMetadata, Priority } from '@temporalio/common';
+import { Logger, Duration, LogLevel, LogMetadata, MetricMeter, Priority } from '@temporalio/common';
 import { msToNumber } from '@temporalio/common/lib/time';
 import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 
@@ -282,6 +282,14 @@ export class Context {
   public log: Logger;
 
   /**
+   * Get the metric meter for this activity with activity-specific tags.
+   *
+   * To add custom tags, register a {@link ActivityOutboundCallsInterceptor} that
+   * intercepts the `getMetricTags()` method.
+   */
+  public readonly metricMeter: MetricMeter;
+
+  /**
    * **Not** meant to instantiated by Activity code, used by the worker.
    *
    * @ignore
@@ -291,13 +299,15 @@ export class Context {
     cancelled: Promise<never>,
     cancellationSignal: AbortSignal,
     heartbeat: (details?: any) => void,
-    log: Logger
+    log: Logger,
+    metricMeter: MetricMeter
   ) {
     this.info = info;
     this.cancelled = cancelled;
     this.cancellationSignal = cancellationSignal;
     this.heartbeatFn = heartbeat;
     this.log = log;
+    this.metricMeter = metricMeter;
   }
 
   /**
@@ -434,3 +444,26 @@ export function cancelled(): Promise<never> {
 export function cancellationSignal(): AbortSignal {
   return Context.current().cancellationSignal;
 }
+
+/**
+ * Get the metric meter for the current activity, with activity-specific tags.
+ *
+ * To add custom tags, register a {@link ActivityOutboundCallsInterceptor} that
+ * intercepts the `getMetricTags()` method.
+ *
+ * This is a shortcut for `Context.current().metricMeter` (see {@link Context.metricMeter}).
+ */
+export const metricMeter: MetricMeter = {
+  createCounter(name, unit, description) {
+    return Context.current().metricMeter.createCounter(name, unit, description);
+  },
+  createHistogram(name, valueType = 'int', unit, description) {
+    return Context.current().metricMeter.createHistogram(name, valueType, unit, description);
+  },
+  createGauge(name, valueType = 'int', unit, description) {
+    return Context.current().metricMeter.createGauge(name, valueType, unit, description);
+  },
+  withTags(tags) {
+    return Context.current().metricMeter.withTags(tags);
+  },
+};

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -1,10 +1,7 @@
 import { status as grpcStatus } from '@grpc/grpc-js';
 import { ensureTemporalFailure } from '@temporalio/common';
-import {
-  encodeErrorToFailure,
-  encodeToPayloads,
-  filterNullAndUndefined,
-} from '@temporalio/common/lib/internal-non-workflow';
+import { encodeErrorToFailure, encodeToPayloads } from '@temporalio/common/lib/internal-non-workflow';
+import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 import {
   BaseClient,

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,4 +1,4 @@
-import { filterNullAndUndefined } from '@temporalio/common/lib/internal-non-workflow';
+import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { AsyncCompletionClient } from './async-completion-client';
 import { BaseClient, BaseClientOptions, defaultBaseClientOptions, LoadedWithDefaults } from './base-client';
 import { ClientInterceptors } from './interceptors';

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -2,11 +2,11 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import * as grpc from '@grpc/grpc-js';
 import type * as proto from 'protobufjs';
 import {
-  filterNullAndUndefined,
   normalizeTlsConfig,
   TLSConfig,
   normalizeGrpcEndpointAddress,
 } from '@temporalio/common/lib/internal-non-workflow';
+import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { Duration, msOptionalToNumber } from '@temporalio/common/lib/time';
 import { type temporal } from '@temporalio/proto';
 import { isGrpcServiceError, ServiceError } from './errors';

--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -7,11 +7,8 @@ import {
   encodeUnifiedSearchAttributes,
 } from '@temporalio/common/lib/converter/payload-search-attributes';
 import { composeInterceptors, Headers } from '@temporalio/common/lib/interceptors';
-import {
-  encodeMapToPayloads,
-  decodeMapFromPayloads,
-  filterNullAndUndefined,
-} from '@temporalio/common/lib/internal-non-workflow';
+import { encodeMapToPayloads, decodeMapFromPayloads } from '@temporalio/common/lib/internal-non-workflow';
+import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { temporal } from '@temporalio/proto';
 import {
   optionalDateToTs,

--- a/packages/client/src/task-queue-client.ts
+++ b/packages/client/src/task-queue-client.ts
@@ -1,7 +1,6 @@
 import { status } from '@grpc/grpc-js';
-import { filterNullAndUndefined } from '@temporalio/common/lib/internal-non-workflow';
 import { assertNever, SymbolBasedInstanceOfError, RequireAtLeastOne } from '@temporalio/common/lib/type-helpers';
-import { makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow';
+import { filterNullAndUndefined, makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow';
 import { temporal } from '@temporalio/proto';
 import { BaseClient, BaseClientOptions, defaultBaseClientOptions, LoadedWithDefaults } from './base-client';
 import { WorkflowService } from './types';

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -34,8 +34,8 @@ import {
   decodeOptionalFailureToOptionalError,
   encodeMapToPayloads,
   encodeToPayloads,
-  filterNullAndUndefined,
 } from '@temporalio/common/lib/internal-non-workflow';
+import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { temporal } from '@temporalio/proto';
 import {
   ServiceError,

--- a/packages/cloud/src/cloud-operations-client.ts
+++ b/packages/cloud/src/cloud-operations-client.ts
@@ -2,11 +2,11 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import * as grpc from '@grpc/grpc-js';
 import type { RPCImpl } from 'protobufjs';
 import {
-  filterNullAndUndefined,
   normalizeTlsConfig,
   TLSConfig,
   normalizeGrpcEndpointAddress,
 } from '@temporalio/common/lib/internal-non-workflow';
+import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { Duration, msOptionalToNumber } from '@temporalio/common/lib/time';
 import {
   CallContext,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -20,6 +20,7 @@ export { Headers, Next } from './interceptors';
 export * from './interfaces';
 export * from './logger';
 export * from './priority';
+export * from './metrics';
 export * from './retry-policy';
 export type { Timestamp, Duration, StringValue } from './time';
 export * from './worker-deployments';

--- a/packages/common/src/internal-non-workflow/index.ts
+++ b/packages/common/src/internal-non-workflow/index.ts
@@ -9,4 +9,3 @@ export * from './data-converter-helpers';
 export * from './parse-host-uri';
 export * from './proxy-config';
 export * from './tls-config';
-export * from './utils';

--- a/packages/common/src/internal-non-workflow/utils.ts
+++ b/packages/common/src/internal-non-workflow/utils.ts
@@ -1,6 +1,0 @@
-/**
- * Helper to prevent undefined and null values overriding defaults when merging maps
- */
-export function filterNullAndUndefined<T extends Record<string, any>>(obj: T): T {
-  return Object.fromEntries(Object.entries(obj).filter(([_k, v]) => v != null)) as any;
-}

--- a/packages/common/src/internal-workflow/index.ts
+++ b/packages/common/src/internal-workflow/index.ts
@@ -1,1 +1,2 @@
 export * from './enums-helpers';
+export * from './objects-helpers';

--- a/packages/common/src/internal-workflow/objects-helpers.ts
+++ b/packages/common/src/internal-workflow/objects-helpers.ts
@@ -1,0 +1,37 @@
+/**
+ * Helper to prevent `undefined` and `null` values overriding defaults when merging maps.
+ */
+export function filterNullAndUndefined<T extends Record<string, any>>(obj: T): T {
+  return Object.fromEntries(Object.entries(obj).filter(([_k, v]) => v != null)) as any;
+}
+
+/**
+ * Merge two objects, possibly removing keys.
+ *
+ * More specifically:
+ * - Any key/value pair in `delta` overrides the corresponding key/value pair in `original`;
+ * - A key present in `delta` with value `undefined` removes the key from the resulting object;
+ * - If `original` is `undefined` or empty, return `delta`;
+ * - If `delta` is `undefined` or empty, return `original` (or undefined if `original` is also undefined);
+ * - If there are no changes, then return `original`.
+ */
+export function mergeObjects<T extends Record<string, any>>(original: T, delta: T | undefined): T;
+export function mergeObjects<T extends Record<string, any>>(
+  original: T | undefined,
+  delta: T | undefined
+): T | undefined {
+  if (original == null) return delta;
+  if (delta == null) return original;
+
+  const merged: Record<string, any> = { ...original };
+  let changed = false;
+  for (const [k, v] of Object.entries(delta)) {
+    if (v !== merged[k]) {
+      if (v == null) delete merged[k];
+      else merged[k] = v;
+      changed = true;
+    }
+  }
+
+  return changed ? (merged as T) : original;
+}

--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -1,3 +1,5 @@
+import { filterNullAndUndefined, mergeObjects } from './internal-workflow';
+
 export type LogLevel = 'TRACE' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
 
 export type LogMetadata = Record<string | symbol, any>;
@@ -52,4 +54,110 @@ export enum SdkComponent {
    * Component name for all messages emitted by the Rust Core SDK library.
    */
   core = 'core',
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @internal
+ * @hidden
+ */
+export type LogMetaOrFunc = LogMetadata | (() => LogMetadata);
+
+/**
+ * A logger implementation that adds metadata before delegating calls to a parent logger.
+ *
+ * @internal
+ * @hidden
+ */
+export class LoggerWithComposedMetadata implements Logger {
+  /**
+   * Return a {@link Logger} that adds metadata before delegating calls to a parent logger.
+   *
+   * New metadata may either be specified statically as a delta object, or as a function evaluated
+   * every time a log is emitted that will return a delta object.
+   *
+   * Some optimizations are performed to avoid creating unnecessary objects and to keep runtime
+   * overhead associated with resolving metadata as low as possible.
+   */
+  public static compose(logger: Logger, metaOrFunc: LogMetaOrFunc): Logger {
+    // Flatten recursive LoggerWithComposedMetadata instances
+    if (logger instanceof LoggerWithComposedMetadata) {
+      const contributors = appendToChain(logger.contributors, metaOrFunc);
+      // If the new contributor results in no actual change to the chain, then we don't need a new logger
+      if (contributors === undefined) return logger;
+      return new LoggerWithComposedMetadata(logger.parentLogger, contributors);
+    } else {
+      const contributors = appendToChain(undefined, metaOrFunc);
+      if (contributors === undefined) return logger;
+      return new LoggerWithComposedMetadata(logger, contributors);
+    }
+  }
+
+  constructor(
+    private readonly parentLogger: Logger,
+    private readonly contributors: LogMetaOrFunc[]
+  ) {}
+
+  log(level: LogLevel, message: string, extraMeta?: LogMetadata): void {
+    this.parentLogger.log(level, message, resolveMetadata(this.contributors, extraMeta));
+  }
+
+  trace(message: string, extraMeta?: LogMetadata): void {
+    this.parentLogger.trace(message, resolveMetadata(this.contributors, extraMeta));
+  }
+
+  debug(message: string, extraMeta?: LogMetadata): void {
+    this.parentLogger.debug(message, resolveMetadata(this.contributors, extraMeta));
+  }
+
+  info(message: string, extraMeta?: LogMetadata): void {
+    this.parentLogger.info(message, resolveMetadata(this.contributors, extraMeta));
+  }
+
+  warn(message: string, extraMeta?: LogMetadata): void {
+    this.parentLogger.warn(message, resolveMetadata(this.contributors, extraMeta));
+  }
+
+  error(message: string, extraMeta?: LogMetadata): void {
+    this.parentLogger.error(message, resolveMetadata(this.contributors, extraMeta));
+  }
+}
+
+function resolveMetadata(contributors: LogMetaOrFunc[], extraMeta?: LogMetadata): LogMetadata {
+  const resolved = {};
+  for (const contributor of contributors) {
+    Object.assign(resolved, typeof contributor === 'function' ? contributor() : contributor);
+  }
+  Object.assign(resolved, extraMeta);
+  return filterNullAndUndefined(resolved);
+}
+
+/**
+ * Append a metadata contributor to the chain, merging it with the former last contributor if both are plain objects
+ */
+function appendToChain(
+  existingContributors: LogMetaOrFunc[] | undefined,
+  newContributor: LogMetaOrFunc
+): LogMetaOrFunc[] | undefined {
+  // If the new contributor is an empty object, then it results in no actual change to the chain
+  if (typeof newContributor === 'object' && Object.keys(newContributor).length === 0) {
+    return existingContributors;
+  }
+
+  // If existing chain is empty, then the new contributor is the chain
+  if (existingContributors == null || existingContributors.length === 0) {
+    return [newContributor];
+  }
+
+  // If both last contributor and new contributor are plain objects, merge them to a single object.
+  const last = existingContributors[existingContributors.length - 1];
+  if (typeof last === 'object' && typeof newContributor === 'object') {
+    const merged = mergeObjects(last, newContributor);
+    if (merged === last) return existingContributors;
+    return [...existingContributors.slice(0, -1), merged];
+  }
+
+  // Otherwise, just append the new contributor to the chain.
+  return [...existingContributors, newContributor];
 }

--- a/packages/common/src/metrics.ts
+++ b/packages/common/src/metrics.ts
@@ -1,0 +1,443 @@
+import { filterNullAndUndefined, mergeObjects } from './internal-workflow';
+
+/**
+ * A meter for creating metrics to record values on.
+ *
+ * @experimental The Metric API is an experimental feature and may be subject to change.
+ */
+export interface MetricMeter {
+  /**
+   * Create a new counter metric that supports adding values.
+   *
+   * @param name Name for the counter metric.
+   * @param unit Unit for the counter metric. Optional.
+   * @param description Description for the counter metric. Optional.
+   */
+  createCounter(name: string, unit?: string, description?: string): MetricCounter;
+
+  /**
+   * Create a new histogram metric that supports recording values.
+   *
+   * @param name Name for the histogram metric.
+   * @param valueType Type of value to record. Defaults to `int`.
+   * @param unit Unit for the histogram metric. Optional.
+   * @param description Description for the histogram metric. Optional.
+   */
+  createHistogram(
+    name: string,
+    valueType?: NumericMetricValueType,
+    unit?: string,
+    description?: string
+  ): MetricHistogram;
+
+  /**
+   * Create a new gauge metric that supports setting values.
+   *
+   * @param name Name for the gauge metric.
+   * @param valueType Type of value to set. Defaults to `int`.
+   * @param unit Unit for the gauge metric. Optional.
+   * @param description Description for the gauge metric. Optional.
+   */
+  createGauge(name: string, valueType?: NumericMetricValueType, unit?: string, description?: string): MetricGauge;
+
+  /**
+   * Return a clone of this meter, with additional tags. All metrics created off the meter will
+   * have the tags.
+   *
+   * @param tags Tags to append.
+   */
+  withTags(tags: MetricTags): MetricMeter;
+}
+
+/**
+ * Base interface for all metrics.
+ *
+ * @experimental The Metric API is an experimental feature and may be subject to change.
+ */
+export interface Metric {
+  /**
+   * The name of the metric.
+   */
+  name: string;
+
+  /**
+   * The unit of the metric, if any.
+   */
+  unit?: string;
+
+  /**
+   * The description of the metric, if any.
+   */
+  description?: string;
+}
+
+/**
+ * A metric that supports adding values as a counter.
+ *
+ * @experimental The Metric API is an experimental feature and may be subject to change.
+ */
+export interface MetricCounter extends Metric {
+  /**
+   * Add the given value to the counter.
+   *
+   * @param value Value to add.
+   * @param extraTags Extra tags if any.
+   */
+  add(value: number, extraTags?: MetricTags): void;
+
+  /**
+   * Return a clone of this counter, with additional tags.
+   *
+   * @param tags Tags to append to existing tags.
+   */
+  withTags(tags: MetricTags): MetricCounter;
+}
+
+/**
+ * A metric that supports recording values on a histogram.
+ *
+ * @experimental The Metric API is an experimental feature and may be subject to change.
+ */
+export interface MetricHistogram extends Metric {
+  /**
+   * The type of value to record. Either `int` or `float`.
+   */
+  valueType: NumericMetricValueType;
+
+  /**
+   * Record the given value on the histogram.
+   *
+   * @param value Value to record. Must be a non-negative number. Value will be casted to the given
+   *              {@link valueType}. Loss of precision may occur if the value is not already of the
+   *              correct type.
+   * @param extraTags Extra tags if any.
+   */
+  record(value: number, extraTags?: MetricTags): void;
+
+  /**
+   * Return a clone of this histogram, with additional tags.
+   *
+   * @param tags Tags to append to existing tags.
+   */
+  withTags(tags: MetricTags): MetricHistogram;
+}
+
+/**
+ * A metric that supports setting values.
+ *
+ * @experimental The Metric API is an experimental feature and may be subject to change.
+ */
+export interface MetricGauge extends Metric {
+  /**
+   * The type of value to set. Either `int` or `float`.
+   */
+  valueType: NumericMetricValueType;
+
+  /**
+   * Set the given value on the gauge.
+   *
+   * @param value Value to set.
+   * @param extraTags Extra tags if any.
+   */
+  set(value: number, extraTags?: MetricTags): void;
+
+  /**
+   * Return a clone of this gauge, with additional tags.
+   *
+   * @param tags Tags to append to existing tags.
+   */
+  withTags(tags: MetricTags): MetricGauge;
+}
+
+/**
+ * Tags to be attached to some metrics.
+ *
+ * @experimental The Metric API is an experimental feature and may be subject to change.
+ */
+export type MetricTags = Record<string, string | number | boolean>;
+
+export type NumericMetricValueType = 'int' | 'float';
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * A meter implementation that does nothing.
+ */
+class NoopMetricMeter implements MetricMeter {
+  createCounter(name: string, unit?: string, description?: string): MetricCounter {
+    return {
+      name,
+      unit,
+      description,
+
+      add(_value, _extraTags) {},
+
+      withTags(_extraTags) {
+        return this;
+      },
+    };
+  }
+
+  createHistogram(
+    name: string,
+    valueType: NumericMetricValueType = 'int',
+    unit?: string,
+    description?: string
+  ): MetricHistogram {
+    return {
+      name,
+      valueType,
+      unit,
+      description,
+
+      record(_value, _extraTags) {},
+
+      withTags(_extraTags) {
+        return this;
+      },
+    };
+  }
+
+  createGauge(name: string, valueType?: NumericMetricValueType, unit?: string, description?: string): MetricGauge {
+    return {
+      name,
+      valueType: valueType ?? 'int',
+      unit,
+      description,
+
+      set(_value, _extraTags) {},
+
+      withTags(_extraTags) {
+        return this;
+      },
+    };
+  }
+
+  withTags(_extraTags: MetricTags): MetricMeter {
+    return this;
+  }
+}
+
+export const noopMetricMeter = new NoopMetricMeter();
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export type MetricTagsOrFunc = MetricTags | (() => MetricTags);
+
+/**
+ * A meter implementation that adds tags before delegating calls to a parent meter.
+ *
+ * @experimental The Metric API is an experimental feature and may be subject to change.
+ * @internal
+ * @hidden
+ */
+export class MetricMeterWithComposedTags implements MetricMeter {
+  /**
+   * Return a {@link MetricMeter} that adds tags before delegating calls to a parent meter.
+   *
+   * New tags may either be specified statically as a delta object, or as a function evaluated
+   * every time a metric is recorded that will return a delta object.
+   *
+   * Some optimizations are performed to avoid creating unnecessary objects and to keep runtime
+   * overhead associated with resolving tags as low as possible.
+   *
+   * @param meter The parent meter to delegate calls to.
+   * @param tagsOrFunc New tags may either be specified statically as a delta object, or as a function
+   *                   evaluated every time a metric is recorded that will return a delta object.
+   * @param force if `true`, then a `MetricMeterWithComposedTags` will be created even if there
+   *              is no tags to add. This is useful to add tags support to an underlying meter
+   *              implementation that does not support tags directly.
+   */
+  public static compose(meter: MetricMeter, tagsOrFunc: MetricTagsOrFunc, force: boolean = false): MetricMeter {
+    if (meter instanceof MetricMeterWithComposedTags) {
+      const contributors = appendToChain(meter.contributors, tagsOrFunc);
+      // If the new contributor results in no actual change to the chain, then we don't need a new meter
+      if (contributors === undefined && !force) return meter;
+      return new MetricMeterWithComposedTags(meter.parentMeter, contributors ?? []);
+    } else {
+      const contributors = appendToChain(undefined, tagsOrFunc);
+      if (contributors === undefined && !force) return meter;
+      return new MetricMeterWithComposedTags(meter, contributors ?? []);
+    }
+  }
+
+  private constructor(
+    private readonly parentMeter: MetricMeter,
+    private readonly contributors: MetricTagsOrFunc[]
+  ) {}
+
+  createCounter(name: string, unit?: string, description?: string): MetricCounter {
+    const parentCounter = this.parentMeter.createCounter(name, unit, description);
+    return new MetricCounterWithComposedTags(parentCounter, this.contributors);
+  }
+
+  createHistogram(
+    name: string,
+    valueType: NumericMetricValueType = 'int',
+    unit?: string,
+    description?: string
+  ): MetricHistogram {
+    const parentHistogram = this.parentMeter.createHistogram(name, valueType, unit, description);
+    return new MetricHistogramWithComposedTags(parentHistogram, this.contributors);
+  }
+
+  createGauge(
+    name: string,
+    valueType: NumericMetricValueType = 'int',
+    unit?: string,
+    description?: string
+  ): MetricGauge {
+    const parentGauge = this.parentMeter.createGauge(name, valueType, unit, description);
+    return new MetricGaugeWithComposedTags(parentGauge, this.contributors);
+  }
+
+  withTags(tags: MetricTags): MetricMeter {
+    return MetricMeterWithComposedTags.compose(this, tags);
+  }
+}
+
+/**
+ * @experimental The Metric API is an experimental feature and may be subject to change.
+ */
+class MetricCounterWithComposedTags implements MetricCounter {
+  constructor(
+    private parentCounter: MetricCounter,
+    private contributors: MetricTagsOrFunc[]
+  ) {}
+
+  add(value: number, extraTags?: MetricTags | undefined): void {
+    this.parentCounter.add(value, resolveTags(this.contributors, extraTags));
+  }
+
+  withTags(extraTags: MetricTags): MetricCounter {
+    const contributors = appendToChain(this.contributors, extraTags);
+    if (contributors === undefined) return this;
+    return new MetricCounterWithComposedTags(this.parentCounter, contributors);
+  }
+
+  get name(): string {
+    return this.parentCounter.name;
+  }
+
+  get unit(): string | undefined {
+    return this.parentCounter.unit;
+  }
+
+  get description(): string | undefined {
+    return this.parentCounter.description;
+  }
+}
+
+/**
+ * @experimental The Metric API is an experimental feature and may be subject to change.
+ */
+class MetricHistogramWithComposedTags implements MetricHistogram {
+  constructor(
+    private parentHistogram: MetricHistogram,
+    private contributors: MetricTagsOrFunc[]
+  ) {}
+
+  record(value: number, extraTags?: MetricTags): void {
+    this.parentHistogram.record(value, resolveTags(this.contributors, extraTags));
+  }
+
+  withTags(extraTags: MetricTags): MetricHistogram {
+    const contributors = appendToChain(this.contributors, extraTags);
+    if (contributors === undefined) return this;
+    return new MetricHistogramWithComposedTags(this.parentHistogram, contributors);
+  }
+
+  get name(): string {
+    return this.parentHistogram.name;
+  }
+
+  get valueType(): NumericMetricValueType {
+    return this.parentHistogram.valueType;
+  }
+
+  get unit(): string | undefined {
+    return this.parentHistogram.unit;
+  }
+
+  get description(): string | undefined {
+    return this.parentHistogram.description;
+  }
+}
+
+/**
+ * @internal
+ * @hidden
+ */
+class MetricGaugeWithComposedTags implements MetricGauge {
+  constructor(
+    private parentGauge: MetricGauge,
+    private contributors: MetricTagsOrFunc[]
+  ) {}
+
+  set(value: number, extraTags?: MetricTags): void {
+    this.parentGauge.set(value, resolveTags(this.contributors, extraTags));
+  }
+
+  withTags(extraTags: MetricTags): MetricGauge {
+    const contributors = appendToChain(this.contributors, extraTags);
+    if (contributors === undefined) return this;
+    return new MetricGaugeWithComposedTags(this.parentGauge, contributors);
+  }
+
+  get name(): string {
+    return this.parentGauge.name;
+  }
+
+  get valueType(): NumericMetricValueType {
+    return this.parentGauge.valueType;
+  }
+
+  get unit(): string | undefined {
+    return this.parentGauge.unit;
+  }
+
+  get description(): string | undefined {
+    return this.parentGauge.description;
+  }
+}
+
+function resolveTags(contributors: MetricTagsOrFunc[], extraTags?: MetricTags): MetricTags {
+  const resolved = {};
+  for (const contributor of contributors) {
+    Object.assign(resolved, typeof contributor === 'function' ? contributor() : contributor);
+  }
+  Object.assign(resolved, extraTags);
+  return filterNullAndUndefined(resolved);
+}
+
+/**
+ * Append a tags contributor to the chain, merging it with the former last contributor if possible.
+ *
+ * If appending the new contributor results in no actual change to the chain of contributors, return
+ * `existingContributors`; in that case, the caller should avoid creating a new object if possible.
+ */
+function appendToChain(
+  existingContributors: MetricTagsOrFunc[] | undefined,
+  newContributor: MetricTagsOrFunc
+): MetricTagsOrFunc[] | undefined {
+  // If the new contributor is an empty object, then it results in no actual change to the chain
+  if (typeof newContributor === 'object' && Object.keys(newContributor).length === 0) {
+    return existingContributors;
+  }
+
+  // If existing chain is empty, then the new contributor is the chain
+  if (existingContributors == null || existingContributors.length === 0) {
+    return [newContributor];
+  }
+
+  // If both last contributor and new contributor are plain objects, merge them to a single object.
+  const last = existingContributors[existingContributors.length - 1];
+  if (typeof last === 'object' && typeof newContributor === 'object') {
+    const merged = mergeObjects(last, newContributor);
+    if (merged === last) return existingContributors;
+    return [...existingContributors.slice(0, -1), merged!];
+  }
+
+  // Otherwise, just append the new contributor to the chain.
+  return [...existingContributors, newContributor];
+}

--- a/packages/core-bridge/src/helpers/abort_controller.rs
+++ b/packages/core-bridge/src/helpers/abort_controller.rs
@@ -57,9 +57,9 @@ struct AbortControllerJsCounterpart {
 }
 
 const STATE_UNINITIALIZED: u8 = 0;
-const STATE_ARMED: u8 = 1;
-const STATE_ABORTED: u8 = 2;
-const STATE_DISARMED: u8 = 3;
+const STATE_ARMED: u8 = 1 << 0;
+const STATE_ABORTED: u8 = 1 << 1;
+const STATE_DISARMED: u8 = STATE_ARMED | STATE_ABORTED;
 
 impl AbortController {
     /// Create a new `AbortController`.

--- a/packages/core-bridge/src/helpers/json_string.rs
+++ b/packages/core-bridge/src/helpers/json_string.rs
@@ -1,10 +1,13 @@
-use std::marker::PhantomData;
-
-use neon::{prelude::Context, result::JsResult, types::JsString};
-use serde::Serialize;
+use neon::{
+    handle::Handle,
+    prelude::Context,
+    result::JsResult,
+    types::{JsString, JsValue},
+};
+use serde::{Serialize, de::DeserializeOwned};
 use serde_json;
 
-use super::{BridgeError, TryIntoJs};
+use super::{BridgeError, BridgeResult, TryFromJs, TryIntoJs};
 
 /// A newtype wrapper for a T serialized as a JSON string.
 ///
@@ -15,31 +18,41 @@ use super::{BridgeError, TryIntoJs};
 /// (claim from the Neon's author, circa April 2025).
 ///
 /// This newtype wrapper allows specifying values that will be serialized to a JSON string
-/// when being transferred to JS using the `TryIntoJs` trait. The JSON serialization happens
-/// on the caller Rust thread, therefore limiting the time spent in the JS thread.
+/// when being transferred to JS using the `TryIntoJs` trait, and to be deserialized from JSON
+/// when being transferred from JS using the `TryFromJs` trait.
 #[derive(Debug, Clone)]
 pub struct JsonString<T> {
-    json: String,
-    _phantom: PhantomData<T>,
+    pub json: String,
+    pub value: T,
 }
 
-impl<T> JsonString<T>
-where
-    T: Serialize,
-{
-    pub fn try_from_value(value: T) -> Result<Self, BridgeError> {
-        let json = serde_json::to_string(&value)
-            .map_err(|e| BridgeError::Other(anyhow::Error::from(e)))?;
-        Ok(Self {
-            json,
-            _phantom: PhantomData,
-        })
-    }
-}
-
-impl<T> TryIntoJs for JsonString<T> {
+impl<T: Serialize> TryIntoJs for JsonString<T> {
     type Output = JsString;
     fn try_into_js<'a>(self, cx: &mut impl Context<'a>) -> JsResult<'a, JsString> {
         Ok(cx.string(&self.json))
+    }
+}
+
+impl<T: Serialize> JsonString<T> {
+    pub fn try_from_value(value: T) -> Result<Self, BridgeError> {
+        let json = serde_json::to_string(&value)
+            .map_err(|e| BridgeError::Other(anyhow::Error::from(e)))?;
+        Ok(Self { json, value })
+    }
+}
+
+impl<T: DeserializeOwned> TryFromJs for JsonString<T> {
+    fn try_from_js<'cx, 'b>(
+        cx: &mut impl Context<'cx>,
+        js_value: Handle<'b, JsValue>,
+    ) -> BridgeResult<Self> {
+        let json = js_value.downcast::<JsString, _>(cx)?.value(cx);
+        match serde_json::from_str(&json) {
+            Ok(value) => Ok(Self { json, value }),
+            Err(e) => Err(BridgeError::TypeError {
+                field: None,
+                message: e.to_string(),
+            }),
+        }
     }
 }

--- a/packages/core-bridge/src/lib.rs
+++ b/packages/core-bridge/src/lib.rs
@@ -17,6 +17,7 @@ pub mod helpers;
 
 mod client;
 mod logs;
+mod metrics;
 mod runtime;
 mod testing;
 mod worker;
@@ -25,6 +26,7 @@ mod worker;
 fn main(mut cx: neon::prelude::ModuleContext) -> neon::prelude::NeonResult<()> {
     client::init(&mut cx)?;
     logs::init(&mut cx)?;
+    metrics::init(&mut cx)?;
     runtime::init(&mut cx)?;
     testing::init(&mut cx)?;
     worker::init(&mut cx)?;

--- a/packages/core-bridge/src/metrics.rs
+++ b/packages/core-bridge/src/metrics.rs
@@ -1,0 +1,325 @@
+use std::{collections::HashMap, sync::Arc};
+
+use anyhow::Context as _;
+use neon::prelude::*;
+use serde::Deserialize;
+
+use temporal_sdk_core::api::telemetry::metrics::{
+    CoreMeter, Counter as CoreCounter, Gauge as CoreGauge, Histogram as CoreHistogram,
+    MetricParametersBuilder, NewAttributes, TemporalMeter,
+};
+use temporal_sdk_core::api::telemetry::metrics::{
+    GaugeF64 as CoreGaugeF64, HistogramF64 as CoreHistogramF64,
+};
+use temporal_sdk_core::api::telemetry::metrics::{
+    MetricKeyValue as CoreMetricKeyValue, MetricValue as CoreMetricValue,
+};
+
+use bridge_macros::js_function;
+
+use crate::helpers::{
+    BridgeError, BridgeResult, JsonString, MutableFinalize, OpaqueInboundHandle,
+    OpaqueOutboundHandle,
+};
+use crate::runtime::*;
+
+pub fn init(cx: &mut neon::prelude::ModuleContext) -> neon::prelude::NeonResult<()> {
+    cx.export_function("newMetricCounter", new_metric_counter)?;
+    cx.export_function("newMetricHistogram", new_metric_histogram)?;
+    cx.export_function("newMetricHistogramF64", new_metric_histogram_f64)?;
+    cx.export_function("newMetricGauge", new_metric_gauge)?;
+    cx.export_function("newMetricGaugeF64", new_metric_gauge_f64)?;
+
+    cx.export_function("addMetricCounterValue", add_metric_counter_value)?;
+    cx.export_function("recordMetricHistogramValue", record_metric_histogram_value)?;
+    cx.export_function(
+        "recordMetricHistogramF64Value",
+        record_metric_histogram_f64_value,
+    )?;
+    cx.export_function("setMetricGaugeValue", set_metric_gauge_value)?;
+    cx.export_function("setMetricGaugeF64Value", set_metric_gauge_f64_value)?;
+
+    Ok(())
+}
+
+pub struct Counter {
+    pub(crate) meter: TemporalMeter,
+    pub(crate) counter: Arc<dyn CoreCounter>,
+}
+
+impl MutableFinalize for Counter {}
+
+pub struct Histogram {
+    pub(crate) meter: TemporalMeter,
+    pub(crate) histogram: Arc<dyn CoreHistogram>,
+}
+impl MutableFinalize for Histogram {}
+
+pub struct HistogramF64 {
+    pub(crate) meter: TemporalMeter,
+    pub(crate) histogram: Arc<dyn CoreHistogramF64>,
+}
+impl MutableFinalize for HistogramF64 {}
+
+pub struct Gauge {
+    pub(crate) meter: TemporalMeter,
+    pub(crate) gauge: Arc<dyn CoreGauge>,
+}
+impl MutableFinalize for Gauge {}
+
+pub struct GaugeF64 {
+    pub(crate) meter: TemporalMeter,
+    pub(crate) gauge: Arc<dyn CoreGaugeF64>,
+}
+impl MutableFinalize for GaugeF64 {}
+
+#[derive(Debug, Deserialize)]
+pub struct MetricAttributes {
+    #[serde(flatten)]
+    pub attributes: HashMap<String, MetricValue>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum MetricValue {
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    String(String),
+}
+
+impl From<MetricValue> for CoreMetricValue {
+    fn from(value: MetricValue) -> Self {
+        match value {
+            MetricValue::Int(i) => CoreMetricValue::Int(i),
+            MetricValue::Float(f) => CoreMetricValue::Float(f),
+            MetricValue::Bool(b) => CoreMetricValue::Bool(b),
+            MetricValue::String(s) => CoreMetricValue::String(s),
+        }
+    }
+}
+
+/// Create a new metric counter
+#[js_function]
+pub fn new_metric_counter(
+    runtime: OpaqueInboundHandle<Runtime>,
+    name: String,
+    unit: String,
+    description: String,
+) -> BridgeResult<OpaqueOutboundHandle<Counter>> {
+    let core_runtime = runtime.borrow()?.core_runtime.clone();
+    let meter = core_runtime
+        .telemetry()
+        .get_metric_meter()
+        .ok_or(BridgeError::UnexpectedError(
+            "Failed to get metric meter".into(),
+        ))?;
+
+    let counter = meter.inner.counter(
+        MetricParametersBuilder::default()
+            .name(name)
+            .unit(unit)
+            .description(description)
+            .build()
+            .context("Failed to build metric parameters")?,
+    );
+
+    Ok(OpaqueOutboundHandle::new(Counter { meter, counter }))
+}
+
+#[js_function]
+pub fn new_metric_histogram(
+    runtime: OpaqueInboundHandle<Runtime>,
+    name: String,
+    unit: String,
+    description: String,
+) -> BridgeResult<OpaqueOutboundHandle<Histogram>> {
+    let core_runtime = runtime.borrow()?.core_runtime.clone();
+    let meter = core_runtime
+        .telemetry()
+        .get_metric_meter()
+        .ok_or(BridgeError::UnexpectedError(
+            "Failed to get metric meter".into(),
+        ))?;
+
+    let histogram = meter.inner.histogram(
+        MetricParametersBuilder::default()
+            .name(name)
+            .unit(unit)
+            .description(description)
+            .build()
+            .context("Failed to build metric parameters")?,
+    );
+
+    Ok(OpaqueOutboundHandle::new(Histogram { meter, histogram }))
+}
+
+#[js_function]
+pub fn new_metric_histogram_f64(
+    runtime: OpaqueInboundHandle<Runtime>,
+    name: String,
+    unit: String,
+    description: String,
+) -> BridgeResult<OpaqueOutboundHandle<HistogramF64>> {
+    let core_runtime = runtime.borrow()?.core_runtime.clone();
+    let meter = core_runtime
+        .telemetry()
+        .get_metric_meter()
+        .ok_or(BridgeError::UnexpectedError(
+            "Failed to get metric meter".into(),
+        ))?;
+
+    let histogram = meter.inner.histogram_f64(
+        MetricParametersBuilder::default()
+            .name(name)
+            .unit(unit)
+            .description(description)
+            .build()
+            .context("Failed to build metric parameters")?,
+    );
+
+    Ok(OpaqueOutboundHandle::new(HistogramF64 { meter, histogram }))
+}
+
+#[js_function]
+pub fn new_metric_gauge(
+    runtime: OpaqueInboundHandle<Runtime>,
+    name: String,
+    unit: String,
+    description: String,
+) -> BridgeResult<OpaqueOutboundHandle<Gauge>> {
+    let core_runtime = runtime.borrow()?.core_runtime.clone();
+    let meter = core_runtime
+        .telemetry()
+        .get_metric_meter()
+        .ok_or(BridgeError::UnexpectedError(
+            "Failed to get metric meter".into(),
+        ))?;
+
+    let gauge = meter.inner.gauge(
+        MetricParametersBuilder::default()
+            .name(name)
+            .unit(unit)
+            .description(description)
+            .build()
+            .context("Failed to build metric parameters")?,
+    );
+
+    Ok(OpaqueOutboundHandle::new(Gauge { meter, gauge }))
+}
+
+#[js_function]
+pub fn new_metric_gauge_f64(
+    runtime: OpaqueInboundHandle<Runtime>,
+    name: String,
+    unit: String,
+    description: String,
+) -> BridgeResult<OpaqueOutboundHandle<GaugeF64>> {
+    let core_runtime = runtime.borrow()?.core_runtime.clone();
+    let meter = core_runtime
+        .telemetry()
+        .get_metric_meter()
+        .ok_or(BridgeError::UnexpectedError(
+            "Failed to get metric meter".into(),
+        ))?;
+
+    let gauge = meter.inner.gauge_f64(
+        MetricParametersBuilder::default()
+            .name(name)
+            .unit(unit)
+            .description(description)
+            .build()
+            .context("Failed to build metric parameters")?,
+    );
+
+    Ok(OpaqueOutboundHandle::new(GaugeF64 { meter, gauge }))
+}
+
+#[js_function]
+pub fn add_metric_counter_value(
+    counter_handle: OpaqueInboundHandle<Counter>,
+    value: f64,
+    attributes: JsonString<MetricAttributes>,
+) -> BridgeResult<()> {
+    let counter_handle = counter_handle.borrow()?;
+    let attributes = counter_handle
+        .meter
+        .inner
+        .new_attributes(parse_metric_attributes(attributes.value));
+    counter_handle.counter.add(value as u64, &attributes);
+    Ok(())
+}
+
+#[js_function]
+pub fn record_metric_histogram_value(
+    histogram_handle: OpaqueInboundHandle<Histogram>,
+    value: u64,
+    attributes: JsonString<MetricAttributes>,
+) -> BridgeResult<()> {
+    let histogram_handle = histogram_handle.borrow()?;
+    let attributes = histogram_handle
+        .meter
+        .inner
+        .new_attributes(parse_metric_attributes(attributes.value));
+    histogram_handle.histogram.record(value, &attributes);
+    Ok(())
+}
+
+#[js_function]
+pub fn record_metric_histogram_f64_value(
+    histogram_handle: OpaqueInboundHandle<HistogramF64>,
+    value: f64,
+    attributes: JsonString<MetricAttributes>,
+) -> BridgeResult<()> {
+    let histogram_handle = histogram_handle.borrow()?;
+    let attributes = histogram_handle
+        .meter
+        .inner
+        .new_attributes(parse_metric_attributes(attributes.value));
+    histogram_handle.histogram.record(value, &attributes);
+    Ok(())
+}
+
+#[js_function]
+pub fn set_metric_gauge_value(
+    gauge_handle: OpaqueInboundHandle<Gauge>,
+    value: u64,
+    attributes: JsonString<MetricAttributes>,
+) -> BridgeResult<()> {
+    let gauge_handle = gauge_handle.borrow()?;
+    let attributes = gauge_handle
+        .meter
+        .inner
+        .new_attributes(parse_metric_attributes(attributes.value));
+    gauge_handle.gauge.record(value, &attributes);
+    Ok(())
+}
+
+#[js_function]
+pub fn set_metric_gauge_f64_value(
+    gauge_handle: OpaqueInboundHandle<GaugeF64>,
+    value: f64,
+    attributes: JsonString<MetricAttributes>,
+) -> BridgeResult<()> {
+    let gauge_handle = gauge_handle.borrow()?;
+    let attributes = gauge_handle
+        .meter
+        .inner
+        .new_attributes(parse_metric_attributes(attributes.value));
+    gauge_handle.gauge.record(value, &attributes);
+    Ok(())
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+fn parse_metric_attributes(attrs: MetricAttributes) -> NewAttributes {
+    let attrs = attrs
+        .attributes
+        .into_iter()
+        .map(|(key, value)| CoreMetricKeyValue {
+            key,
+            value: value.into(),
+        })
+        .collect();
+    NewAttributes { attributes: attrs }
+}

--- a/packages/core-bridge/ts/native.ts
+++ b/packages/core-bridge/ts/native.ts
@@ -404,3 +404,93 @@ type LogLevel = 'TRACE' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
 type LogEntryMetadata = {
   [key: string]: string | number | boolean | LogEntryMetadata;
 };
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Custom Metrics
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export interface MetricMeter {
+  type: 'metric-meter';
+}
+
+export interface MetricCounter {
+  type: 'metric-counter';
+}
+
+export interface MetricHistogram {
+  type: 'metric-histogram';
+}
+
+export interface MetricHistogramF64 {
+  type: 'metric-histogram-f64';
+}
+
+export interface MetricGauge {
+  type: 'metric-gauge';
+}
+
+export interface MetricGaugeF64 {
+  type: 'metric-gauge-f64';
+}
+
+export type MetricAttributes = Record<string, string | number | boolean>;
+
+export declare function newMetricCounter(
+  runtime: Runtime,
+  name: string,
+  unit: string,
+  description: string
+): MetricCounter;
+
+export declare function newMetricHistogram(
+  runtime: Runtime,
+  name: string,
+  unit: string,
+  description: string
+): MetricHistogram;
+
+export declare function newMetricHistogramF64(
+  runtime: Runtime,
+  name: string,
+  unit: string,
+  description: string
+): MetricHistogramF64;
+
+export declare function newMetricGauge(runtime: Runtime, name: string, unit: string, description: string): MetricGauge;
+
+export declare function newMetricGaugeF64(
+  runtime: Runtime,
+  name: string,
+  unit: string,
+  description: string
+): MetricGaugeF64;
+
+export declare function addMetricCounterValue(
+  counter: MetricCounter,
+  value: number,
+  attrs: JsonString<MetricAttributes>
+): void;
+
+export declare function recordMetricHistogramValue(
+  histogram: MetricHistogram,
+  value: number,
+  attrs: JsonString<MetricAttributes>
+): void;
+
+export declare function recordMetricHistogramF64Value(
+  histogram: MetricHistogramF64,
+  value: number,
+  attrs: JsonString<MetricAttributes>
+): void;
+
+export declare function setMetricGaugeValue(
+  gauge: MetricGauge,
+  value: number,
+  attrs: JsonString<MetricAttributes>
+): void;
+
+export declare function setMetricGaugeF64Value(
+  gauge: MetricGaugeF64,
+  value: number,
+  attrs: JsonString<MetricAttributes>
+): void;

--- a/packages/test/src/helpers-integration.ts
+++ b/packages/test/src/helpers-integration.ts
@@ -19,6 +19,7 @@ import {
   LogLevel,
   ReplayWorkerOptions,
   Runtime,
+  RuntimeOptions,
   WorkerOptions,
   WorkflowBundle,
   WorkflowBundleWithSourceMap,
@@ -48,7 +49,7 @@ const defaultDynamicConfigOptions = [
   'worker.removableBuildIdDurationSinceDefault=1',
 ];
 
-function setupRuntime(recordedLogs?: { [workflowId: string]: LogEntry[] }) {
+function setupRuntime(recordedLogs?: { [workflowId: string]: LogEntry[] }, runtimeOpts?: Partial<RuntimeOptions>) {
   const logger = recordedLogs
     ? new DefaultLogger('DEBUG', (entry) => {
         const workflowId = (entry.meta as any)?.workflowInfo?.workflowId ?? (entry.meta as any)?.workflowId;
@@ -57,9 +58,12 @@ function setupRuntime(recordedLogs?: { [workflowId: string]: LogEntry[] }) {
       })
     : new DefaultLogger((process.env.TEST_LOG_LEVEL || 'WARN').toUpperCase() as LogLevel);
   Runtime.install({
+    ...runtimeOpts,
     logger,
     telemetryOptions: {
+      ...runtimeOpts?.telemetryOptions,
       logging: {
+        ...runtimeOpts?.telemetryOptions?.logging,
         filter: makeTelemetryFilterString({
           core: (process.env.TEST_LOG_LEVEL || 'INFO').toUpperCase() as LogLevel,
         }),
@@ -114,11 +118,14 @@ export function makeConfigurableEnvironmentTestFn<T>(opts: {
   recordedLogs?: { [workflowId: string]: LogEntry[] };
   createTestContext: (t: ExecutionContext) => Promise<T>;
   teardown: (t: T) => Promise<void>;
+  runtimeOpts?: Partial<RuntimeOptions> | (() => Promise<[Partial<RuntimeOptions>, Partial<T>]>) | undefined;
 }): TestFn<T> {
   const test = anyTest as TestFn<T>;
   test.before(async (t) => {
-    setupRuntime(opts.recordedLogs);
-    t.context = await opts.createTestContext(t);
+    const [runtimeOpts, extraContext] =
+      typeof opts.runtimeOpts === 'function' ? await opts.runtimeOpts() : [opts.runtimeOpts, {}];
+    setupRuntime(opts.recordedLogs, runtimeOpts);
+    t.context = { ...(await opts.createTestContext(t)), ...extraContext };
   });
   test.after.always(async (t) => {
     await opts.teardown(t.context);
@@ -126,15 +133,17 @@ export function makeConfigurableEnvironmentTestFn<T>(opts: {
   return test;
 }
 
-export function makeTestFunction(opts: {
+export function makeTestFunction<C extends Context = Context>(opts: {
   workflowsPath: string;
   workflowEnvironmentOpts?: LocalTestWorkflowEnvironmentOptions;
   workflowInterceptorModules?: string[];
   recordedLogs?: { [workflowId: string]: LogEntry[] };
-}): TestFn<Context> {
-  return makeConfigurableEnvironmentTestFn<Context>({
+  runtimeOpts?: Partial<RuntimeOptions> | (() => Promise<[Partial<RuntimeOptions>, Partial<C>]>) | undefined;
+}): TestFn<C> {
+  return makeConfigurableEnvironmentTestFn<C>({
     recordedLogs: opts.recordedLogs,
-    createTestContext: async (_t: ExecutionContext): Promise<Context> => {
+    runtimeOpts: opts.runtimeOpts,
+    createTestContext: async (_t: ExecutionContext): Promise<C> => {
       let env: TestWorkflowEnvironment;
       if (process.env.TEMPORAL_SERVICE_ADDRESS) {
         env = await TestWorkflowEnvironment.createFromExistingServer({
@@ -149,9 +158,9 @@ export function makeTestFunction(opts: {
           workflowInterceptorModules: opts.workflowInterceptorModules,
         }),
         env,
-      };
+      } as unknown as C;
     },
-    teardown: async (c: Context) => {
+    teardown: async (c: C) => {
       await c.env.teardown();
     },
   });

--- a/packages/test/src/mock-native-worker.ts
+++ b/packages/test/src/mock-native-worker.ts
@@ -6,7 +6,8 @@ import { coresdk } from '@temporalio/proto';
 import { DefaultLogger, Runtime, ShutdownError } from '@temporalio/worker';
 import { byteArrayToBuffer } from '@temporalio/worker/lib/utils';
 import { NativeReplayHandle, NativeWorkerLike, Worker as RealWorker } from '@temporalio/worker/lib/worker';
-import { withMetadata } from '@temporalio/worker/lib/logger';
+import { LoggerWithComposedMetadata } from '@temporalio/common/lib/logger';
+import { MetricMeterWithComposedTags } from '@temporalio/common/lib/metrics';
 import { CompiledWorkerOptions, compileWorkerOptions, WorkerOptions } from '@temporalio/worker/lib/worker-options';
 import type { WorkflowCreator } from '@temporalio/worker/lib/workflow/interface';
 import * as activities from './activities';
@@ -160,12 +161,12 @@ export class Worker extends RealWorker {
 
   public constructor(workflowCreator: WorkflowCreator, opts: CompiledWorkerOptions) {
     const runtime = Runtime.instance();
-    const logger = withMetadata(runtime.logger, {
+    const logger = LoggerWithComposedMetadata.compose(runtime.logger, {
       sdkComponent: SdkComponent.worker,
       taskQueue: opts.taskQueue,
     });
     const nativeWorker = new MockNativeWorker();
-    super(runtime, nativeWorker, workflowCreator, opts, logger);
+    super(runtime, nativeWorker, workflowCreator, opts, logger, runtime.metricMeter);
   }
 
   public runWorkflows(...args: Parameters<Worker['workflow$']>): Promise<void> {
@@ -181,8 +182,13 @@ export const defaultOptions: WorkerOptions = {
 };
 
 export function isolateFreeWorker(options: WorkerOptions = defaultOptions): Worker {
-  const logger = withMetadata(Runtime.instance().logger, {
+  const runtime = Runtime.instance();
+  const logger = LoggerWithComposedMetadata.compose(runtime.logger, {
     sdkComponent: SdkComponent.worker,
+    taskQueue: options.taskQueue ?? 'default',
+  });
+  const metricMeter = MetricMeterWithComposedTags.compose(runtime.metricMeter, {
+    namespace: options.namespace ?? 'default',
     taskQueue: options.taskQueue ?? 'default',
   });
   return new Worker(
@@ -194,6 +200,6 @@ export function isolateFreeWorker(options: WorkerOptions = defaultOptions): Work
         /* Nothing to destroy */
       },
     },
-    compileWorkerOptions(options, logger)
+    compileWorkerOptions(options, logger, metricMeter)
   );
 }

--- a/packages/test/src/test-metrics-custom.ts
+++ b/packages/test/src/test-metrics-custom.ts
@@ -1,0 +1,374 @@
+import { ExecutionContext } from 'ava';
+import { ActivityInboundCallsInterceptor, ActivityOutboundCallsInterceptor, Runtime } from '@temporalio/worker';
+import * as workflow from '@temporalio/workflow';
+import { MetricTags } from '@temporalio/common';
+import { Context as ActivityContext, metricMeter as activityMetricMeter } from '@temporalio/activity';
+import { Context as BaseContext, helpers, makeTestFunction } from './helpers-integration';
+import { getRandomPort } from './helpers';
+
+interface Context extends BaseContext {
+  port: number;
+}
+
+const test = makeTestFunction<Context>({
+  workflowsPath: __filename,
+  workflowInterceptorModules: [__filename],
+  runtimeOpts: async () => {
+    const port = await getRandomPort();
+    return [
+      {
+        telemetryOptions: {
+          metrics: {
+            metricPrefix: 'foo_',
+            prometheus: {
+              bindAddress: `127.0.0.1:${port}`,
+              histogramBucketOverrides: {
+                'my-float-histogram': [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1],
+                'workflow-float-histogram': [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1],
+              },
+            },
+          },
+        },
+      },
+      { port },
+    ];
+  },
+});
+
+async function assertMetricReported(t: ExecutionContext<Context>, regexp: RegExp) {
+  const resp = await fetch(`http://127.0.0.1:${t.context.port}/metrics`);
+  const text = await resp.text();
+  const matched = t.regex(text, regexp);
+  if (!matched) {
+    t.log(text);
+  }
+}
+
+/**
+ * Asserts custom metrics works properly at the bridge level.
+ */
+test('Custom Metrics - Bridge supports works properly (no tags)', async (t) => {
+  const meter = Runtime.instance().metricMeter;
+
+  // Counter
+  const counter = meter.createCounter('my-counter', 'my-counter-unit', 'my-counter-description');
+  counter.add(1);
+  counter.add(1);
+  counter.add(40); // 1+1+40 => 42
+  await assertMetricReported(t, /my_counter 42/);
+
+  // Int Gauge
+  const gaugeInt = meter.createGauge('my-int-gauge', 'int', 'my-int-gauge-description');
+  gaugeInt.set(1);
+  gaugeInt.set(40);
+  await assertMetricReported(t, /my_int_gauge 40/);
+
+  // Float Gauge
+  const gaugeFloat = meter.createGauge('my-float-gauge', 'float', 'my-float-gauge-description');
+  gaugeFloat.set(1.1);
+  gaugeFloat.set(1.1);
+  gaugeFloat.set(40.1);
+  await assertMetricReported(t, /my_float_gauge 40.1/);
+
+  // Int Histogram
+  const histogramInt = meter.createHistogram('my-int-histogram', 'int', 'my-int-histogram-description');
+  histogramInt.record(20);
+  histogramInt.record(200);
+  histogramInt.record(2000);
+  await assertMetricReported(t, /my_int_histogram_bucket{le="50"} 1/);
+  await assertMetricReported(t, /my_int_histogram_bucket{le="500"} 2/);
+  await assertMetricReported(t, /my_int_histogram_bucket{le="10000"} 3/);
+
+  // Float Histogram
+  const histogramFloat = meter.createHistogram('my-float-histogram', 'float', 'my-float-histogram-description');
+  histogramFloat.record(0.02);
+  histogramFloat.record(0.07);
+  histogramFloat.record(0.99);
+  await assertMetricReported(t, /my_float_histogram_bucket{le="0.05"} 1/);
+  await assertMetricReported(t, /my_float_histogram_bucket{le="0.1"} 2/);
+  await assertMetricReported(t, /my_float_histogram_bucket{le="1"} 3/);
+});
+
+/**
+ * Asserts custom metrics tags composition works properly
+ */
+test('Custom Metrics - Tags composition works properly', async (t) => {
+  const meter = Runtime.instance().metricMeter;
+
+  // Counter
+  const counter = meter.createCounter('my-counter', 'my-counter-unit', 'my-counter-description');
+  counter.add(1, { labelA: 'value-a', labelB: true, labelC: 123, labelD: 123.456 });
+  await assertMetricReported(t, /my_counter{labelA="value-a",labelB="true",labelC="123",labelD="123.456"} 1/);
+
+  // Int Gauge
+  const gaugeInt = meter.createGauge('my-int-gauge', 'int', 'my-int-gauge-description');
+  gaugeInt.set(1, { labelA: 'value-a', labelB: true, labelC: 123, labelD: 123.456 });
+  await assertMetricReported(t, /my_int_gauge{labelA="value-a",labelB="true",labelC="123",labelD="123.456"} 1/);
+
+  // Float Gauge
+  const gaugeFloat = meter.createGauge('my-float-gauge', 'float', 'my-float-gauge-description');
+  gaugeFloat.set(1.2, { labelA: 'value-a', labelB: true, labelC: 123, labelD: 123.456 });
+  await assertMetricReported(t, /my_float_gauge{labelA="value-a",labelB="true",labelC="123",labelD="123.456"} 1.2/);
+
+  // Int Histogram
+  const histogramInt = meter.createHistogram('my-int-histogram', 'int', 'my-int-histogram-description');
+  histogramInt.record(1, { labelA: 'value-a', labelB: true, labelC: 123, labelD: 123.456 });
+  await assertMetricReported(
+    t,
+    /my_int_histogram_bucket{labelA="value-a",labelB="true",labelC="123",labelD="123.456",le="50"} 1/
+  );
+
+  // Float Histogram
+  const histogramFloat = meter.createHistogram('my-float-histogram', 'float', 'my-float-histogram-description');
+  histogramFloat.record(0.4, { labelA: 'value-a', labelB: true, labelC: 123, labelD: 123.456 });
+  await assertMetricReported(
+    t,
+    /my_float_histogram_bucket{labelA="value-a",labelB="true",labelC="123",labelD="123.456",le="0.5"} 1/
+  );
+});
+
+export async function metricWorksWorkflow(): Promise<void> {
+  const metricMeter = workflow.metricMeter;
+
+  const myCounterMetric = metricMeter.createCounter(
+    'workflow-counter',
+    'workflow-counter-unit',
+    'workflow-counter-description'
+  );
+  const myHistogramMetric = metricMeter.createHistogram(
+    'workflow-histogram',
+    'int',
+    'workflow-histogram-unit',
+    'workflow-histogram-description'
+  );
+  const myFloatHistogramMetric = metricMeter.createHistogram(
+    'workflow-float-histogram',
+    'float',
+    'workflow-float-histogram-unit',
+    'workflow-float-histogram-description'
+  );
+  const myGaugeMetric = metricMeter.createGauge(
+    'workflow-gauge',
+    'int',
+    'workflow-gauge-unit',
+    'workflow-gauge-description'
+  );
+  const myFloatGaugeMetric = metricMeter.createGauge(
+    'workflow-float-gauge',
+    'float',
+    'workflow-float-gauge-unit',
+    'workflow-float-gauge-description'
+  );
+
+  myCounterMetric.add(1);
+  myHistogramMetric.record(1);
+  myFloatHistogramMetric.record(0.01);
+  myGaugeMetric.set(1);
+  myFloatGaugeMetric.set(0.1);
+
+  // Pause here, so that we can force replay to a distinct worker
+  let signalReceived = false;
+  workflow.setHandler(workflow.defineUpdate('checkpoint'), () => {});
+  workflow.setHandler(workflow.defineSignal('unblock'), () => {
+    signalReceived = true;
+  });
+  await workflow.condition(() => signalReceived);
+
+  myCounterMetric.add(3);
+  myHistogramMetric.record(3);
+  myFloatHistogramMetric.record(0.03);
+  myGaugeMetric.set(3);
+  myFloatGaugeMetric.set(0.3);
+}
+
+test('Metric in Workflow works and are not replayed', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+  const worker = await createWorker({
+    // Avoid delay when transitioning to the second worker
+    stickyQueueScheduleToStartTimeout: '100ms',
+  });
+
+  const [handle1, handle2] = await worker.runUntil(async () => {
+    // Start two workflows, and wait for both to reach the checkpoint.
+    // Why two workflows? To confirm that there's no problem in having multiple
+    // workflows and sink reinstantiating a same metric.
+    return await Promise.all([
+      // FIXME: Add support for Update with Start to our internal test helpers
+      startWorkflow(metricWorksWorkflow).then(async (handle) => {
+        await handle.executeUpdate('checkpoint');
+        return handle;
+      }),
+      startWorkflow(metricWorksWorkflow).then(async (handle) => {
+        await handle.executeUpdate('checkpoint');
+        return handle;
+      }),
+    ]);
+  });
+
+  await assertMetricReported(t, /workflow_counter{[^}]+} 2/); // 1 + 1
+  await assertMetricReported(t, /workflow_histogram_bucket{[^}]+?,le="50"} 2/);
+  await assertMetricReported(t, /workflow_float_histogram_bucket{[^}]+?,le="0.05"} 2/);
+  await assertMetricReported(t, /workflow_gauge{[^}]+} 1/);
+  await assertMetricReported(t, /workflow_float_gauge{[^}]+} 0.1/);
+
+  const worker2 = await createWorker();
+  await worker2.runUntil(async () => {
+    await Promise.all([handle1.signal('unblock'), handle2.signal('unblock')]);
+    await Promise.all([handle1.result(), handle2.result()]);
+  });
+
+  await assertMetricReported(t, /workflow_counter{[^}]+} 8/); // 1 + 1 + 3 + 3
+  await assertMetricReported(t, /workflow_histogram_bucket{[^}]+?,le="50"} 4/);
+  await assertMetricReported(t, /workflow_float_histogram_bucket{[^}]+?,le="0.05"} 4/);
+  await assertMetricReported(t, /workflow_gauge{[^}]+} 3/);
+  await assertMetricReported(t, /workflow_float_gauge{[^}]+} 0.3/);
+});
+
+export async function MetricTagsWorkflow(): Promise<void> {
+  const metricMeter = workflow.metricMeter.withTags({ labelX: 'value-x', labelY: 'value-y' });
+
+  const myCounterMetric = metricMeter.createCounter(
+    'workflow2-counter',
+    'workflow2-counter-unit',
+    'workflow2-counter-description'
+  );
+  const myHistogramMetric = metricMeter.createHistogram(
+    'workflow2-histogram',
+    'int',
+    'workflow2-histogram-unit',
+    'workflow2-histogram-description'
+  );
+  const myGaugeMetric = metricMeter.createGauge(
+    'workflow2-gauge',
+    'int',
+    'workflow2-gauge-unit',
+    'workflow2-gauge-description'
+  );
+
+  myCounterMetric
+    .withTags({ labelA: 'value-a', labelB: 'value-b' })
+    .withTags({ labelC: 'value-c', labelB: 'value-b2' })
+    .add(2, { labelD: 'value-d' });
+
+  myHistogramMetric
+    .withTags({ labelA: 'value-a', labelB: 'value-b' })
+    .withTags({ labelC: 'value-c', labelB: 'value-b2' })
+    .record(2, { labelD: 'value-d' });
+
+  myGaugeMetric
+    .withTags({ labelA: 'value-a', labelB: 'value-b' })
+    .withTags({ labelC: 'value-c', labelB: 'value-b2' })
+    .set(2, { labelD: 'value-d' });
+}
+
+test('Metric tags in Workflow works', async (t) => {
+  const { createWorker, executeWorkflow, taskQueue } = helpers(t);
+  const tags = `labelA="value-a",labelB="value-b2",labelC="value-c",labelD="value-d",labelX="value-x",labelY="value-y",namespace="default",taskQueue="${taskQueue}",workflowType="MetricTagsWorkflow"`;
+
+  const worker = await createWorker();
+  await worker.runUntil(executeWorkflow(MetricTagsWorkflow));
+
+  await assertMetricReported(t, new RegExp(`workflow2_counter{${tags}} 2`));
+  await assertMetricReported(t, new RegExp(`workflow2_histogram_bucket{${tags},le="50"} 1`));
+  await assertMetricReported(t, new RegExp(`workflow2_gauge{${tags}} 2`));
+});
+
+// Define workflow interceptor for metrics
+export const interceptors = (): workflow.WorkflowInterceptors => ({
+  outbound: [
+    {
+      getMetricTags(tags: MetricTags): MetricTags {
+        if (!workflow.workflowInfo().workflowType.includes('Interceptor')) return tags;
+        return {
+          ...tags,
+          intercepted: 'workflow-interceptor',
+        };
+      },
+    },
+  ],
+});
+
+// Define activity interceptor for metrics
+export function activityInterceptorFactory(_ctx: ActivityContext): {
+  inbound?: ActivityInboundCallsInterceptor;
+  outbound?: ActivityOutboundCallsInterceptor;
+} {
+  return {
+    outbound: {
+      getMetricTags(tags: MetricTags): MetricTags {
+        return {
+          ...tags,
+          intercepted: 'activity-interceptor',
+        };
+      },
+    },
+  };
+}
+
+// Activity that uses metrics
+export async function metricActivity(): Promise<void> {
+  const { metricMeter } = ActivityContext.current();
+
+  const counter = metricMeter.createCounter('activity-counter');
+  counter.add(5);
+
+  const histogram = metricMeter.createHistogram('activity-histogram');
+  histogram.record(10);
+
+  // Use the `metricMeter` exported from the top level of the activity module rather than the one in the context
+  const gauge = activityMetricMeter.createGauge('activity-gauge');
+  gauge.set(15);
+}
+
+// Workflow that uses metrics and calls the activity
+export async function metricsInterceptorWorkflow(): Promise<void> {
+  const metricMeter = workflow.metricMeter;
+
+  // Use workflow metrics
+  const counter = metricMeter.createCounter('intercepted-workflow-counter');
+  counter.add(3);
+
+  const histogram = metricMeter.createHistogram('intercepted-workflow-histogram');
+  histogram.record(6);
+
+  const gauge = metricMeter.createGauge('intercepted-workflow-gauge');
+  gauge.set(9);
+
+  // Call activity with metrics
+  await workflow
+    .proxyActivities({
+      startToCloseTimeout: '1 minute',
+    })
+    .metricActivity();
+}
+
+// Test for workflow metrics interceptor
+test('Workflow and Activity Context metrics interceptors add tags', async (t) => {
+  const { createWorker, executeWorkflow, taskQueue } = helpers(t);
+
+  const worker = await createWorker({
+    taskQueue,
+    workflowsPath: __filename,
+    activities: {
+      metricActivity,
+    },
+    interceptors: {
+      activity: [activityInterceptorFactory],
+    },
+  });
+
+  await worker.runUntil(executeWorkflow(metricsInterceptorWorkflow));
+
+  // Verify workflow metrics have interceptor tag
+  await assertMetricReported(t, /intercepted_workflow_counter{[^}]*intercepted="workflow-interceptor"[^}]*} 3/);
+  await assertMetricReported(
+    t,
+    /intercepted_workflow_histogram_bucket{[^}]*intercepted="workflow-interceptor"[^}]*} \d+/
+  );
+  await assertMetricReported(t, /intercepted_workflow_gauge{[^}]*intercepted="workflow-interceptor"[^}]*} 9/);
+
+  // Verify activity metrics have interceptor tag
+  await assertMetricReported(t, /activity_counter{[^}]*intercepted="activity-interceptor"[^}]*} 5/);
+  await assertMetricReported(t, /activity_histogram_bucket{[^}]*intercepted="activity-interceptor"[^}]*} \d+/);
+  await assertMetricReported(t, /activity_gauge{[^}]*intercepted="activity-interceptor"[^}]*} 15/);
+});

--- a/packages/testing/src/mocking-activity-environment.ts
+++ b/packages/testing/src/mocking-activity-environment.ts
@@ -7,14 +7,17 @@ import {
   SdkComponent,
   defaultFailureConverter,
   defaultPayloadConverter,
+  MetricMeter,
+  noopMetricMeter,
 } from '@temporalio/common';
+import { LoggerWithComposedMetadata } from '@temporalio/common/lib/logger';
 import { ActivityInterceptorsFactory, DefaultLogger } from '@temporalio/worker';
-import { withMetadata } from '@temporalio/worker/lib/logger';
 import { Activity } from '@temporalio/worker/lib/activity';
 
 export interface MockActivityEnvironmentOptions {
   interceptors?: ActivityInterceptorsFactory[];
   logger?: Logger;
+  metricMeter?: MetricMeter;
 }
 
 /**
@@ -44,7 +47,8 @@ export class MockActivityEnvironment extends events.EventEmitter {
       undefined,
       loadedDataConverter,
       heartbeatCallback,
-      withMetadata(opts?.logger ?? new DefaultLogger(), { sdkComponent: SdkComponent.worker }),
+      LoggerWithComposedMetadata.compose(opts?.logger ?? new DefaultLogger(), { sdkComponent: SdkComponent.worker }),
+      opts?.metricMeter ?? noopMetricMeter,
       opts?.interceptors ?? []
     );
     this.context = this.activity.context;

--- a/packages/testing/src/testing-workflow-environment.ts
+++ b/packages/testing/src/testing-workflow-environment.ts
@@ -4,7 +4,7 @@ import { Duration, TypedSearchAttributes } from '@temporalio/common';
 import { msToNumber, msToTs, tsToMs } from '@temporalio/common/lib/time';
 import { NativeConnection, Runtime } from '@temporalio/worker';
 import { native } from '@temporalio/core-bridge';
-import { filterNullAndUndefined } from '@temporalio/common/lib/internal-non-workflow';
+import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { Connection } from './connection';
 import { toNativeEphemeralServerConfig, DevServerConfig, TimeSkippingServerConfig } from './ephemeral-server';
 import { ClientOptionsForTestEnv, TestEnvClient } from './client';

--- a/packages/worker/src/interceptors.ts
+++ b/packages/worker/src/interceptors.ts
@@ -7,7 +7,7 @@
  */
 
 import { Context as ActivityContext } from '@temporalio/activity';
-import { Headers, Next } from '@temporalio/common';
+import { Headers, MetricTags, Next } from '@temporalio/common';
 
 export { Next, Headers };
 
@@ -41,6 +41,9 @@ export interface ActivityInboundCallsInterceptorFactory {
 /** Input for ActivityOutboundCallsInterceptor.getLogAttributes */
 export type GetLogAttributesInput = Record<string, unknown>;
 
+/** Input for ActivityOutboundCallsInterceptor.getMetricTags */
+export type GetMetricTagsInput = MetricTags;
+
 /**
  * Implement any of these methods to intercept Activity outbound calls
  */
@@ -51,6 +54,15 @@ export interface ActivityOutboundCallsInterceptor {
    * The attributes returned in this call are attached to every log message.
    */
   getLogAttributes?: (input: GetLogAttributesInput, next: Next<this, 'getLogAttributes'>) => Record<string, unknown>;
+
+  /**
+   * Called once every time a metric is emitted from an Activity metric
+   * (ie. a metric created from {@link activity.metricMeter}).
+   *
+   * Tags returned by this hook are _prepended_ to tags defined at the metric level and tags defined
+   * on the emitter function itself.
+   */
+  getMetricTags?: (input: GetMetricTagsInput, next: Next<this, 'getMetricTags'>) => MetricTags;
 }
 
 export interface ActivityInterceptors {

--- a/packages/worker/src/logger.ts
+++ b/packages/worker/src/logger.ts
@@ -28,13 +28,6 @@ export interface LogEntry {
   meta?: LogMetadata;
 }
 
-/**
- * @internal
- */
-interface LoggerWithColorSupport extends Logger {
-  [loggerHasColorsSymbol]?: boolean;
-}
-
 export const LogTimestamp = Symbol.for('log_timestamp');
 
 const severities: LogLevel[] = ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR'];
@@ -112,74 +105,15 @@ export class DefaultLogger implements Logger {
 /**
  * @internal
  */
+interface LoggerWithColorSupport extends Logger {
+  [loggerHasColorsSymbol]?: boolean;
+}
+
+/**
+ * @internal
+ */
 export function hasColorSupport(logger: Logger): boolean {
   return (logger as LoggerWithColorSupport)[loggerHasColorsSymbol] ?? false;
-}
-
-export function withMetadata(logger: Logger, meta: LogMetadata | (() => LogMetadata)): Logger {
-  return new LoggerWithMetadata(logger, meta);
-}
-
-class LoggerWithMetadata implements Logger {
-  private parentLogger: Logger;
-  private metaChain: (LogMetadata | (() => LogMetadata))[];
-
-  constructor(parent: Logger, meta: LogMetadata | (() => LogMetadata)) {
-    // Flatten recusive LoggerWithMetadata instances
-    if (parent instanceof LoggerWithMetadata) {
-      this.parentLogger = parent.parentLogger;
-      this.metaChain = LoggerWithMetadata.appendToChain(parent.metaChain, meta);
-    } else {
-      this.parentLogger = parent;
-      this.metaChain = [meta];
-    }
-    (this as LoggerWithColorSupport)[loggerHasColorsSymbol] = hasColorSupport(parent);
-  }
-
-  log(level: LogLevel, message: string, meta?: LogMetadata): void {
-    this.parentLogger.log(level, message, this.resolveMetadata(meta));
-  }
-
-  trace(message: string, meta?: LogMetadata): void {
-    this.parentLogger.trace(message, this.resolveMetadata(meta));
-  }
-
-  debug(message: string, meta?: LogMetadata): void {
-    this.parentLogger.debug(message, this.resolveMetadata(meta));
-  }
-
-  info(message: string, meta?: LogMetadata): void {
-    this.parentLogger.info(message, this.resolveMetadata(meta));
-  }
-
-  warn(message: string, meta?: LogMetadata): void {
-    this.parentLogger.warn(message, this.resolveMetadata(meta));
-  }
-
-  error(message: string, meta?: LogMetadata): void {
-    this.parentLogger.error(message, this.resolveMetadata(meta));
-  }
-
-  private resolveMetadata(meta?: LogMetadata): LogMetadata {
-    const resolved = {};
-    for (const contributor of this.metaChain) {
-      Object.assign(resolved, typeof contributor === 'function' ? contributor() : contributor);
-    }
-    Object.assign(resolved, meta);
-    return resolved;
-  }
-
-  /**
-   * Append a metadata contributor to the chain, merging it with the former last contributor if both are plain objects
-   */
-  private static appendToChain(chain: (LogMetadata | (() => LogMetadata))[], meta: LogMetadata | (() => LogMetadata)) {
-    if (chain.length === 0) return [meta];
-    const last = chain[chain.length - 1];
-    if (typeof last === 'object' && typeof meta === 'object') {
-      return [...chain.slice(0, -1), { ...last, ...meta }];
-    }
-    return [...chain, meta];
-  }
 }
 
 export interface FlushableLogger extends Logger {

--- a/packages/worker/src/runtime-logger.ts
+++ b/packages/worker/src/runtime-logger.ts
@@ -10,6 +10,7 @@ import { DefaultLogger, LogEntry, Logger, LogTimestamp } from './logger';
  * logger, in the right order.
  *
  * @internal
+ * @hidden
  */
 export class NativeLogCollector {
   /**

--- a/packages/worker/src/runtime-metrics.ts
+++ b/packages/worker/src/runtime-metrics.ts
@@ -1,0 +1,172 @@
+import {
+  MetricCounter,
+  MetricGauge,
+  MetricHistogram,
+  MetricMeter,
+  MetricTags,
+  NumericMetricValueType,
+} from '@temporalio/common';
+import { native } from '@temporalio/core-bridge';
+
+export class RuntimeMetricMeter implements MetricMeter {
+  public constructor(protected runtime: native.Runtime) {}
+
+  createCounter(name: string, unit: string = '', description: string = ''): MetricCounter {
+    const nativeMetric = native.newMetricCounter(this.runtime, name, unit, description);
+    return new RuntimeMetricCounter(nativeMetric, name, unit, description);
+  }
+
+  createHistogram(
+    name: string,
+    valueType: NumericMetricValueType = 'int',
+    unit: string = '',
+    description: string = ''
+  ): MetricHistogram {
+    switch (valueType) {
+      case 'int': {
+        const nativeMetric = native.newMetricHistogram(this.runtime, name, unit, description);
+        return new RuntimeMetricHistogram(nativeMetric, name, unit, description);
+      }
+      case 'float': {
+        const nativeMetric = native.newMetricHistogramF64(this.runtime, name, unit, description);
+        return new RuntimeMetricHistogramF64(nativeMetric, name, unit, description);
+      }
+    }
+  }
+
+  createGauge(
+    name: string,
+    valueType: NumericMetricValueType = 'int',
+    unit: string = '',
+    description: string = ''
+  ): MetricGauge {
+    switch (valueType) {
+      case 'int': {
+        const nativeMetric = native.newMetricGauge(this.runtime, name, unit, description);
+        return new RuntimeMetricGauge(nativeMetric, name, unit, description);
+      }
+      case 'float': {
+        const nativeMetric = native.newMetricGaugeF64(this.runtime, name, unit, description);
+        return new RuntimeMetricGaugeF64(nativeMetric, name, unit, description);
+      }
+    }
+  }
+
+  withTags(_extraTags: MetricTags): MetricMeter {
+    // Tags composition is handled by a MetricMeterWithComposedTags wrapper over this one
+    throw new Error('withTags is not supported directly on RuntimeMetricMeter');
+  }
+}
+
+class RuntimeMetricCounter implements MetricCounter {
+  public constructor(
+    private readonly native: native.MetricCounter,
+    public readonly name: string,
+    public readonly unit: string,
+    public readonly description: string
+  ) {}
+
+  add(value: number, tags: MetricTags = {}): void {
+    if (value < 0) {
+      throw new Error(`MetricCounter value must be non-negative (got ${value})`);
+    }
+    native.addMetricCounterValue(this.native, value, JSON.stringify(tags));
+  }
+
+  withTags(_tags: MetricTags): MetricCounter {
+    // Tags composition is handled by a MetricMeterWithComposedTags wrapper over this one
+    throw new Error('withTags is not supported directly on RuntimeMetricCounter');
+  }
+}
+
+class RuntimeMetricHistogram implements MetricHistogram {
+  public readonly valueType = 'int';
+
+  public constructor(
+    private readonly native: native.MetricHistogram,
+    public readonly name: string,
+    public readonly unit: string,
+    public readonly description: string
+  ) {}
+
+  record(value: number, tags: MetricTags = {}): void {
+    if (value < 0) {
+      throw new Error(`MetricHistogram value must be non-negative (got ${value})`);
+    }
+    native.recordMetricHistogramValue(this.native, value, JSON.stringify(tags));
+  }
+
+  withTags(_tags: MetricTags): MetricHistogram {
+    // Tags composition is handled by a MetricMeterWithComposedTags wrapper over this one
+    throw new Error('withTags is not supported directly on RuntimeMetricHistogram');
+  }
+}
+
+class RuntimeMetricHistogramF64 implements MetricHistogram {
+  public readonly valueType = 'float';
+
+  public constructor(
+    private readonly native: native.MetricHistogramF64,
+    public readonly name: string,
+    public readonly unit: string,
+    public readonly description: string
+  ) {}
+
+  record(value: number, tags: MetricTags = {}): void {
+    if (value < 0) {
+      throw new Error(`MetricHistogram value must be non-negative (got ${value})`);
+    }
+    native.recordMetricHistogramF64Value(this.native, value, JSON.stringify(tags));
+  }
+
+  withTags(_tags: MetricTags): MetricHistogram {
+    // Tags composition is handled by a MetricMeterWithComposedTags wrapper over this one
+    throw new Error('withTags is not supported directly on RuntimeMetricHistogramF64');
+  }
+}
+
+class RuntimeMetricGauge implements MetricGauge {
+  public readonly valueType = 'int';
+
+  public constructor(
+    private readonly native: native.MetricGauge,
+    public readonly name: string,
+    public readonly unit: string,
+    public readonly description: string
+  ) {}
+
+  set(value: number, tags: MetricTags = {}): void {
+    if (value < 0) {
+      throw new Error(`MetricGauge value must be non-negative (got ${value})`);
+    }
+    native.setMetricGaugeValue(this.native, value, JSON.stringify(tags));
+  }
+
+  withTags(_tags: MetricTags): MetricGauge {
+    // Tags composition is handled by a MetricMeterWithComposedTags wrapper over this one
+    throw new Error('withTags is not supported directly on RuntimeMetricGauge');
+  }
+}
+
+class RuntimeMetricGaugeF64 implements MetricGauge {
+  public readonly valueType = 'float';
+
+  public constructor(
+    private readonly native: native.MetricGaugeF64,
+    public readonly name: string,
+    public readonly unit: string,
+    public readonly description: string
+  ) {}
+
+  set(value: number, tags: MetricTags = {}): void {
+    if (value < 0) {
+      throw new Error(`MetricGauge value must be non-negative (got ${value})`);
+    }
+    native.setMetricGaugeF64Value(this.native, value, JSON.stringify(tags));
+  }
+
+  withTags(_tags: MetricTags): MetricGauge {
+    // Tags composition is handled by a MetricMeterWithComposedTags wrapper over this one
+    throw new Error('withTags is not supported directly on RuntimeMetricGaugeF64');
+  }
+}

--- a/packages/worker/src/runtime-options.ts
+++ b/packages/worker/src/runtime-options.ts
@@ -2,7 +2,7 @@ import { native } from '@temporalio/core-bridge';
 import { Logger, LogLevel } from '@temporalio/common';
 import { Duration, msToNumber } from '@temporalio/common/lib/time';
 import { DefaultLogger } from './logger';
-import { NativeLogCollector } from './native-log-forward';
+import { NativeLogCollector } from './runtime-logger';
 
 /**
  * Options used to create a Temporal Runtime.

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -32,6 +32,7 @@ import {
   ensureApplicationFailure,
   TypedSearchAttributes,
   decodePriority,
+  MetricMeter,
 } from '@temporalio/common';
 import {
   decodeArrayFromPayloads,
@@ -50,6 +51,7 @@ import {
   tsToDate,
   tsToMs,
 } from '@temporalio/common/lib/time';
+import { LoggerWithComposedMetadata } from '@temporalio/common/lib/logger';
 import { errorMessage, NonNullableObject, OmitFirstParam } from '@temporalio/common/lib/type-helpers';
 import { workflowLogAttributes } from '@temporalio/workflow/lib/logs';
 import { native } from '@temporalio/core-bridge';
@@ -58,7 +60,7 @@ import { type SinkCall, type WorkflowInfo } from '@temporalio/workflow';
 import { Activity, CancelReason, activityLogAttributes } from './activity';
 import { extractNativeClient, extractReferenceHolders, InternalNativeConnection, NativeConnection } from './connection';
 import { ActivityExecuteInput } from './interceptors';
-import { Logger, withMetadata } from './logger';
+import { Logger } from './logger';
 import pkg from './pkg';
 import {
   EvictionReason,
@@ -149,8 +151,12 @@ export interface NativeReplayHandle {
 }
 
 interface NativeWorkerConstructor {
-  create(connection: NativeConnection, options: CompiledWorkerOptionsWithBuildId): Promise<NativeWorkerLike>;
-  createReplay(options: CompiledWorkerOptionsWithBuildId): Promise<NativeReplayHandle>;
+  create(
+    runtime: Runtime,
+    connection: NativeConnection,
+    options: CompiledWorkerOptionsWithBuildId
+  ): Promise<NativeWorkerLike>;
+  createReplay(runtime: Runtime, options: CompiledWorkerOptionsWithBuildId): Promise<NativeReplayHandle>;
 }
 
 interface WorkflowWithLogAttributes {
@@ -177,16 +183,18 @@ export class NativeWorker implements NativeWorkerLike {
   public readonly initiateShutdown: OmitFirstParam<typeof native.workerInitiateShutdown>;
 
   public static async create(
+    runtime: Runtime,
     connection: NativeConnection,
     options: CompiledWorkerOptionsWithBuildId
   ): Promise<NativeWorkerLike> {
-    const runtime = Runtime.instance();
     const nativeWorker = await runtime.registerWorker(extractNativeClient(connection), toNativeWorkerOptions(options));
     return new NativeWorker(runtime, nativeWorker);
   }
 
-  public static async createReplay(options: CompiledWorkerOptionsWithBuildId): Promise<NativeReplayHandle> {
-    const runtime = Runtime.instance();
+  public static async createReplay(
+    runtime: Runtime,
+    options: CompiledWorkerOptionsWithBuildId
+  ): Promise<NativeReplayHandle> {
     const [worker, historyPusher] = await runtime.createReplayWorker(toNativeWorkerOptions(options));
     return {
       worker: new NativeWorker(runtime, worker),
@@ -460,12 +468,16 @@ export class Worker {
    */
   public static async create(options: WorkerOptions): Promise<Worker> {
     const runtime = Runtime.instance();
-    const logger = withMetadata(runtime.logger, {
+    const logger = LoggerWithComposedMetadata.compose(runtime.logger, {
       sdkComponent: SdkComponent.worker,
       taskQueue: options.taskQueue ?? 'default',
     });
+    const metricMeter = runtime.metricMeter.withTags({
+      namespace: options.namespace ?? 'default',
+      taskQueue: options.taskQueue ?? 'default',
+    });
     const nativeWorkerCtor: NativeWorkerConstructor = this.nativeWorkerCtor;
-    const compiledOptions = compileWorkerOptions(options, logger);
+    const compiledOptions = compileWorkerOptions(options, logger, metricMeter);
     logger.debug('Creating worker', {
       options: {
         ...compiledOptions,
@@ -490,7 +502,7 @@ export class Worker {
     let nativeWorker: NativeWorkerLike;
     const compiledOptionsWithBuildId = addBuildIdIfMissing(compiledOptions, bundle?.code);
     try {
-      nativeWorker = await nativeWorkerCtor.create(connection, compiledOptionsWithBuildId);
+      nativeWorker = await nativeWorkerCtor.create(runtime, connection, compiledOptionsWithBuildId);
     } catch (err) {
       // We just created this connection, close it
       if (!options.connection) {
@@ -499,7 +511,15 @@ export class Worker {
       throw err;
     }
     extractReferenceHolders(connection).add(nativeWorker);
-    return new this(runtime, nativeWorker, workflowCreator, compiledOptionsWithBuildId, logger, connection);
+    return new this(
+      runtime,
+      nativeWorker,
+      workflowCreator,
+      compiledOptionsWithBuildId,
+      logger,
+      metricMeter,
+      connection
+    );
   }
 
   protected static async createWorkflowCreator(
@@ -567,7 +587,7 @@ export class Worker {
     histories: ReplayHistoriesIterable
   ): AsyncIterableIterator<ReplayResult> {
     const [worker, pusher] = await this.constructReplayWorker(options);
-    const rt = Runtime.instance();
+    const rt = worker.runtime;
     const evictions = on(worker.evictionsEmitter, 'eviction') as AsyncIterableIterator<[EvictionWithRunID]>;
     const runPromise = worker.run().then(() => {
       throw new ShutdownError('Worker was shutdown');
@@ -648,19 +668,26 @@ export class Worker {
     };
     this.replayWorkerCount++;
     const runtime = Runtime.instance();
-    const logger = withMetadata(runtime.logger, {
+    const logger = LoggerWithComposedMetadata.compose(runtime.logger, {
       sdkComponent: 'worker',
       taskQueue: fixedUpOptions.taskQueue,
     });
-    const compiledOptions = compileWorkerOptions(fixedUpOptions, logger);
+    const metricMeter = runtime.metricMeter.withTags({
+      namespace: 'default',
+      taskQueue: fixedUpOptions.taskQueue,
+    });
+    const compiledOptions = compileWorkerOptions(fixedUpOptions, logger, metricMeter);
     const bundle = await this.getOrCreateBundle(compiledOptions, logger);
     if (!bundle) {
       throw new TypeError('ReplayWorkerOptions must contain workflowsPath or workflowBundle');
     }
     const workflowCreator = await this.createWorkflowCreator(bundle, compiledOptions, logger);
-    const replayHandle = await nativeWorkerCtor.createReplay(addBuildIdIfMissing(compiledOptions, bundle.code));
+    const replayHandle = await nativeWorkerCtor.createReplay(
+      runtime,
+      addBuildIdIfMissing(compiledOptions, bundle.code)
+    );
     return [
-      new this(runtime, replayHandle.worker, workflowCreator, compiledOptions, logger, undefined, true),
+      new this(runtime, replayHandle.worker, workflowCreator, compiledOptions, logger, metricMeter, undefined, true),
       replayHandle.historyPusher,
     ];
   }
@@ -727,6 +754,7 @@ export class Worker {
     public readonly options: CompiledWorkerOptions,
     /** Logger bound to 'sdkComponent: worker' */
     protected readonly logger: Logger,
+    protected readonly metricMeter: MetricMeter,
     protected readonly connection?: NativeConnection,
     protected readonly isReplayWorker: boolean = false
   ) {
@@ -964,6 +992,7 @@ export class Worker {
                           },
                         }),
                       this.logger,
+                      this.metricMeter,
                       this.options.interceptors.activity
                     );
                     output = { type: 'run', activity, input };

--- a/packages/worker/src/workflow/logger.ts
+++ b/packages/worker/src/workflow/logger.ts
@@ -1,13 +1,14 @@
 import { type LoggerSinksInternal } from '@temporalio/workflow/lib/logs';
 import { SdkComponent } from '@temporalio/common';
+import { LoggerWithComposedMetadata } from '@temporalio/common/lib/logger';
 import { type InjectedSinks } from '../sinks';
-import { withMetadata, type Logger } from '../logger';
+import { type Logger } from '../logger';
 
 /**
  * Injects a logger sink that forwards to the worker's logger
  */
 export function initLoggerSink(logger: Logger): InjectedSinks<LoggerSinksInternal> {
-  logger = withMetadata(logger, { sdkComponent: SdkComponent.workflow });
+  logger = LoggerWithComposedMetadata.compose(logger, { sdkComponent: SdkComponent.workflow });
   return {
     __temporal_logger: {
       trace: {

--- a/packages/worker/src/workflow/metrics.ts
+++ b/packages/worker/src/workflow/metrics.ts
@@ -1,0 +1,72 @@
+import { NumericMetricValueType, type MetricMeter, type MetricTags, Metric } from '@temporalio/common';
+import { MetricSinks } from '@temporalio/workflow/lib/metrics';
+import { InjectedSinks } from '../sinks';
+
+export function initMetricSink(metricMeter: MetricMeter): InjectedSinks<MetricSinks> {
+  // Creation of a new metric object isn't quite cheap, requiring a call down the bridge to the
+  // actual Metric Meter. Unfortunately, the workflow sandbox execution model doesn't allow to
+  // reuse metric objects from the caller side. We therefore maintain local caches of metric
+  // objects to avoid creating a new one for every single metric value being emitted.
+  const cache = new Map<string, WeakRef<Metric>>();
+
+  function getOrCreate<T extends Metric>(key: string, create: () => T): T {
+    let value = cache.get(key)?.deref();
+    if (value === undefined) {
+      value = create();
+      cache.set(key, new WeakRef(value));
+    }
+    return value as T;
+  }
+
+  return {
+    __temporal_metrics: {
+      addMetricCounterValue: {
+        fn(
+          _,
+          metricName: string,
+          unit: string | undefined,
+          description: string | undefined,
+          value: number,
+          attrs: MetricTags
+        ) {
+          const cacheKey = `${metricName}:counter`;
+          const createFn = () => metricMeter.createCounter(metricName, unit, description);
+          getOrCreate(cacheKey, createFn).add(value, attrs);
+        },
+        callDuringReplay: false,
+      },
+      recordMetricHistogramValue: {
+        fn(
+          _,
+          metricName: string,
+          valueType: NumericMetricValueType,
+          unit: string | undefined,
+          description: string | undefined,
+          value: number,
+          attrs: MetricTags
+        ) {
+          const cacheKey = `histogram:${valueType}:${metricName}`;
+          const createFn = () => metricMeter.createHistogram(metricName, valueType, unit, description);
+          getOrCreate(cacheKey, createFn).record(value, attrs);
+        },
+        callDuringReplay: false,
+      },
+      setMetricGaugeValue: {
+        fn(
+          _,
+          metricName: string,
+          valueType: NumericMetricValueType,
+          unit: string | undefined,
+          description: string | undefined,
+          value: number,
+          attrs: MetricTags
+        ) {
+          const cacheKey = `gauge:${valueType}:${metricName}`;
+          const createFn = () => metricMeter.createGauge(metricName, valueType, unit, description);
+          getOrCreate(cacheKey, createFn).set(value, attrs);
+        },
+        callDuringReplay: false,
+      },
+    },
+  };
+}

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -107,6 +107,7 @@ export { log } from './logs';
 export { Trigger } from './trigger';
 export * from './workflow';
 export { ChildWorkflowHandle, ExternalWorkflowHandle } from './workflow-handle';
+export { metricMeter } from './metrics';
 
 // Anything below this line is deprecated
 

--- a/packages/workflow/src/interceptors.ts
+++ b/packages/workflow/src/interceptors.ts
@@ -6,7 +6,15 @@
  * @module
  */
 
-import { ActivityOptions, Headers, LocalActivityOptions, Next, Timestamp, WorkflowExecution } from '@temporalio/common';
+import {
+  ActivityOptions,
+  Headers,
+  LocalActivityOptions,
+  MetricTags,
+  Next,
+  Timestamp,
+  WorkflowExecution,
+} from '@temporalio/common';
 import type { coresdk } from '@temporalio/proto';
 import { ChildWorkflowOptionsWithDefaults, ContinueAsNewOptions } from './interfaces';
 
@@ -139,6 +147,9 @@ export interface SignalWorkflowInput {
 /** Input for WorkflowOutboundCallsInterceptor.getLogAttributes */
 export type GetLogAttributesInput = Record<string, unknown>;
 
+/** Input for WorkflowOutboundCallsInterceptor.getMetricTags */
+export type GetMetricTagsInput = MetricTags;
+
 /**
  * Implement any of these methods to intercept Workflow code calls to the Temporal APIs, like scheduling an activity and starting a timer
  */
@@ -189,6 +200,15 @@ export interface WorkflowOutboundCallsInterceptor {
    * The attributes returned in this call are attached to every log message.
    */
   getLogAttributes?: (input: GetLogAttributesInput, next: Next<this, 'getLogAttributes'>) => Record<string, unknown>;
+
+  /**
+   * Called once every time a metric is emitted from a Workflow metric (ie. a metric created
+   * from {@link workflow.metricMeter}).
+   *
+   * Tags returned by this hook are _prepended_ to tags defined at the metric level and tags
+   * defined on the emitter function itself.
+   */
+  getMetricTags?: (input: GetMetricTagsInput, next: Next<this, 'getMetricTags'>) => MetricTags;
 }
 
 /** Input for WorkflowInternalsInterceptor.concludeActivation */

--- a/packages/workflow/src/metrics.ts
+++ b/packages/workflow/src/metrics.ts
@@ -1,0 +1,191 @@
+import {
+  MetricCounter,
+  MetricGauge,
+  MetricHistogram,
+  MetricMeter,
+  MetricMeterWithComposedTags,
+  MetricTags,
+  NumericMetricValueType,
+} from '@temporalio/common';
+import { composeInterceptors } from '@temporalio/common/lib/interceptors';
+import { proxySinks, Sink, Sinks } from './sinks';
+import { workflowInfo } from './workflow';
+import { assertInWorkflowContext } from './global-attributes';
+
+class WorkflowMetricMeterImpl implements MetricMeter {
+  constructor() {}
+
+  createCounter(name: string, unit?: string, description?: string): MetricCounter {
+    assertInWorkflowContext("Workflow's `metricMeter` can only be used while in Workflow Context");
+    return new WorkflowMetricCounter(name, unit, description);
+  }
+
+  createHistogram(
+    name: string,
+    valueType: NumericMetricValueType = 'int',
+    unit?: string,
+    description?: string
+  ): MetricHistogram {
+    assertInWorkflowContext("Workflow's `metricMeter` can only be used while in Workflow Context");
+    return new WorkflowMetricHistogram(name, valueType, unit, description);
+  }
+
+  createGauge(
+    name: string,
+    valueType: NumericMetricValueType = 'int',
+    unit?: string,
+    description?: string
+  ): MetricGauge {
+    assertInWorkflowContext("Workflow's `metricMeter` can only be used while in Workflow Context");
+    return new WorkflowMetricGauge(name, valueType, unit, description);
+  }
+
+  withTags(_tags: MetricTags): MetricMeter {
+    assertInWorkflowContext("Workflow's `metricMeter` can only be used while in Workflow Context");
+    // Tags composition is handled by a MetricMeterWithComposedTags wrapper over this one
+    throw new Error(`withTags is not supported directly on WorkflowMetricMeter`);
+  }
+}
+
+class WorkflowMetricCounter implements MetricCounter {
+  constructor(
+    public readonly name: string,
+    public readonly unit: string | undefined,
+    public readonly description: string | undefined
+  ) {}
+
+  add(value: number, extraTags: MetricTags = {}): void {
+    if (value < 0) {
+      throw new Error(`MetricCounter value must be non-negative (got ${value})`);
+    }
+    if (!workflowInfo().unsafe.isReplaying) {
+      metricSink.addMetricCounterValue(this.name, this.unit, this.description, value, extraTags);
+    }
+  }
+
+  withTags(_tags: MetricTags): MetricCounter {
+    // Tags composition is handled by a MetricMeterWithComposedTags wrapper over this one
+    throw new Error(`withTags is not supported directly on WorkflowMetricCounter`);
+  }
+}
+
+class WorkflowMetricHistogram implements MetricHistogram {
+  constructor(
+    public readonly name: string,
+    public readonly valueType: NumericMetricValueType,
+    public readonly unit: string | undefined,
+    public readonly description: string | undefined
+  ) {}
+
+  record(value: number, extraTags: MetricTags = {}): void {
+    if (value < 0) {
+      throw new Error(`MetricHistogram value must be non-negative (got ${value})`);
+    }
+    if (!workflowInfo().unsafe.isReplaying) {
+      metricSink.recordMetricHistogramValue(this.name, this.valueType, this.unit, this.description, value, extraTags);
+    }
+  }
+
+  withTags(_tags: MetricTags): MetricHistogram {
+    // Tags composition is handled by a MetricMeterWithComposedTags wrapper over this one
+    throw new Error(`withTags is not supported directly on WorkflowMetricHistogram`);
+  }
+}
+
+class WorkflowMetricGauge implements MetricGauge {
+  constructor(
+    public readonly name: string,
+    public readonly valueType: NumericMetricValueType,
+    public readonly unit: string | undefined,
+    public readonly description: string | undefined
+  ) {}
+
+  set(value: number, tags?: MetricTags): void {
+    if (value < 0) {
+      throw new Error(`MetricGauge value must be non-negative (got ${value})`);
+    }
+    if (!workflowInfo().unsafe.isReplaying) {
+      metricSink.setMetricGaugeValue(this.name, this.valueType, this.unit, this.description, value, tags ?? {});
+    }
+  }
+
+  withTags(_tags: MetricTags): MetricGauge {
+    // Tags composition is handled by a MetricMeterWithComposedTags wrapper over this one
+    throw new Error(`withTags is not supported directly on WorkflowMetricGauge`);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Note: given that forwarding metrics outside of the sanbox can be quite chatty and add non
+// negligeable overhead, we eagerly check for `isReplaying` and completely skip doing sink
+// calls if we are replaying.
+const metricSink = proxySinks<MetricSinks>().__temporal_metrics;
+
+/**
+ * Sink interface for forwarding metrics from the Workflow sandbox to the Worker.
+ *
+ * These sink functions are not intended to be called directly from workflow code; instead,
+ * developers should use the `metricMeter` object exposed to workflow code by the SDK, which
+ * provides an API that is easier to work with.
+ *
+ * This sink interface is also not meant to be implemented by user.
+ *
+ * @hidden
+ * @internal Users should not implement this interface, nor use it directly. Use `metricMeter` instead.
+ */
+export interface MetricSinks extends Sinks {
+  __temporal_metrics: WorkflowMetricMeter;
+}
+
+/**
+ * @hidden
+ * @internal Users should not implement this interface, nor use it directly. Use `metricMeter` instead.
+ */
+export interface WorkflowMetricMeter extends Sink {
+  addMetricCounterValue(
+    metricName: string,
+    unit: string | undefined,
+    description: string | undefined,
+    value: number,
+    attrs: MetricTags
+  ): void;
+
+  recordMetricHistogramValue(
+    metricName: string,
+    valueType: NumericMetricValueType,
+    unit: string | undefined,
+    description: string | undefined,
+    value: number,
+    attrs: MetricTags
+  ): void;
+
+  setMetricGaugeValue(
+    metricName: string,
+    valueType: NumericMetricValueType,
+    unit: string | undefined,
+    description: string | undefined,
+    value: number,
+    attrs: MetricTags
+  ): void;
+}
+
+/**
+ * A MetricMeter that can be used to emit metrics from within a Workflow.
+ *
+ * @experimental The Metric API is an experimental feature and may be subject to change.
+ */
+export const metricMeter: MetricMeter = MetricMeterWithComposedTags.compose(
+  new WorkflowMetricMeterImpl(),
+  () => {
+    const activator = assertInWorkflowContext('Workflow.metricMeter may only be used from workflow context.');
+    const getMetricTags = composeInterceptors(activator.interceptors.outbound, 'getMetricTags', (a) => a);
+
+    const info = activator.info;
+    return getMetricTags({
+      // namespace and taskQueue will be added by the Worker
+      workflowType: info.workflowType,
+    });
+  },
+  true
+);


### PR DESCRIPTION
## What was changed

- Add support for custom metrics. Fixes #1229.

## Example usage:

### From a workflow

```
import * as wf from `@temporalio/workflow`;

async function myWorkflow() {
  const myHistogramMetric = wf.metricMeter.createHistogram(
    'my-custom-histogram',
    'int', // or 'float'
    'ms', // Units (optional)
    'description' // (optional)
  );

  myHistogramMetric.record(50);
  myHistogramMetric.record(50, { tag1: 'tag-value' });
}
```

### From an activity

```
import * as act from `@temporalio/activity`

const myCounterMetric = metricMeter.createCounter('activity-counter');

async function myActivity() {
  const myCounterMetric.add(1);
}
```

