### PR TITLE
Simplify the type of `MockActivityEnvironment.run`

### DIFF
--- a/packages/testing/src/mocking-activity-environment.ts
+++ b/packages/testing/src/mocking-activity-environment.ts
@@ -54,7 +54,7 @@ export class MockActivityEnvironment extends events.EventEmitter {
   /**
    * Run a function in Activity Context
    */
-  public async run<P extends any[], R, F extends ActivityFunction<P, R>>(fn: F, ...args: P): Promise<R> {
+  public async run<F extends ActivityFunction>(fn: F, ...args: Parameters<F>): ReturnType<F> {
     return this.activity.runNoEncoding(fn as ActivityFunction<any, any>, { args, headers: {} }) as Promise<R>;
   }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Simplified the type of `MockActivityEnvironment.run`

## Why?
<!-- Tell your future self why have you made these changes -->

Improves the type inference of the return type.

This example:

```typescript
async function foo(): Promise<string> {
  return "foo";
}
const result = await new MockActivityEnvironment().run(foo);
result.startsWith("foo");
```

Does not currently compile with strict types because `result` is inferred as `unknown` instead of `string`. This change makes the type inference work correctly.

## Checklist
<!--- add/delete as needed --->

1. Closes #1710

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Made the change on my local machine and saw the red squiggly lines disappear.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

I don't know, this is technically a breaking change if anyone is currently setting the type parameters.
