### PR TITLE
Set default `workflowExecution.runId` to a UUID in `MockActivityEnvironment`

### DIFF
--- a/packages/testing/src/mocking-activity-environment.ts
+++ b/packages/testing/src/mocking-activity-environment.ts
@@ -81,7 +81,7 @@ export const defaultActivityInfo: activity.Info = {
   heartbeatDetails: undefined,
   activityNamespace: 'default',
   workflowNamespace: 'default',
-  workflowExecution: { workflowId: 'test', runId: 'dead-beef' },
+  workflowExecution: { workflowId: 'test', runId: '00000000-0000-0000-0000-000000000000' },
   scheduledTimestampMs: 1,
   startToCloseTimeoutMs: 1000,
   scheduleToCloseTimeoutMs: 1000,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Set the default value of `MockActivityEnvironment`'s `workflowExecution.runId` to a UUID to better match the real implementation.

## Why?
<!-- Tell your future self why have you made these changes -->

Makes the mock environment closer to the real environment.

## Checklist
<!--- add/delete as needed --->

1. Closes #1706

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Made the change in my local environment and I was able to use `workflowExecution.runId` with UUID v5.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

I don't think so