### PR TITLE
Deprecate versioning intent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
   # Run integration tests.
   # Uses the native binaries built in compile-native-binaries, but build `@temporalio/*` packages locally.
   integration-tests:
-    timeout-minutes: 15
+    timeout-minutes: 20
     needs:
       - compile-native-binaries-debug
     strategy:

--- a/packages/common/src/activity-options.ts
+++ b/packages/common/src/activity-options.ts
@@ -120,9 +120,10 @@ export interface ActivityOptions {
    *
    * @default 'COMPATIBLE'
    *
+   * @deprecated In favor of the new Worker Deployment API.
    * @experimental The Worker Versioning API is still being designed. Major changes are expected.
    */
-  versioningIntent?: VersioningIntent;
+  versioningIntent?: VersioningIntent; // eslint-disable-line deprecation/deprecation
 
   /**
    * Priority of this activity

--- a/packages/common/src/versioning-intent-enum.ts
+++ b/packages/common/src/versioning-intent-enum.ts
@@ -2,11 +2,14 @@ import type { coresdk } from '@temporalio/proto';
 import type { VersioningIntent as VersioningIntentString } from './versioning-intent';
 import { assertNever, checkExtends } from './type-helpers';
 
+/* eslint-disable deprecation/deprecation */
+
 // Avoid importing the proto implementation to reduce workflow bundle size
 // Copied from coresdk.common.VersioningIntent
 /**
  * Protobuf enum representation of {@link VersioningIntentString}.
  *
+ * @deprecated In favor of the new Worker Deployment API.
  * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export enum VersioningIntent {

--- a/packages/common/src/versioning-intent.ts
+++ b/packages/common/src/versioning-intent.ts
@@ -11,6 +11,7 @@
  * current worker. The default behavior for starting Workflows is `DEFAULT`. The default behavior for Workflows starting
  * Activities, starting Child Workflows, or Continuing As New is `COMPATIBLE`.
  *
+ * @deprecated In favor of the new Worker Deployment API.
  * @experimental The Worker Versioning API is still being designed. Major changes are expected.
  */
 export type VersioningIntent = 'COMPATIBLE' | 'DEFAULT';

--- a/packages/core-bridge/src/metrics.rs
+++ b/packages/core-bridge/src/metrics.rs
@@ -21,7 +21,7 @@ use crate::helpers::{
     BridgeError, BridgeResult, JsonString, MutableFinalize, OpaqueInboundHandle,
     OpaqueOutboundHandle,
 };
-use crate::runtime::*;
+use crate::runtime::Runtime;
 
 pub fn init(cx: &mut neon::prelude::ModuleContext) -> neon::prelude::NeonResult<()> {
     cx.export_function("newMetricCounter", new_metric_counter)?;
@@ -91,10 +91,10 @@ pub enum MetricValue {
 impl From<MetricValue> for CoreMetricValue {
     fn from(value: MetricValue) -> Self {
         match value {
-            MetricValue::Int(i) => CoreMetricValue::Int(i),
-            MetricValue::Float(f) => CoreMetricValue::Float(f),
-            MetricValue::Bool(b) => CoreMetricValue::Bool(b),
-            MetricValue::String(s) => CoreMetricValue::String(s),
+            MetricValue::Int(i) => Self::Int(i),
+            MetricValue::Float(f) => Self::Float(f),
+            MetricValue::Bool(b) => Self::Bool(b),
+            MetricValue::String(s) => Self::String(s),
         }
     }
 }

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -322,6 +322,7 @@ export interface ContinueAsNewOptions {
    *
    * @default 'COMPATIBLE'
    *
+   * @deprecated In favor of the new Worker Deployment API.
    * @experimental The Worker Versioning API is still being designed. Major changes are expected.
    */
   versioningIntent?: VersioningIntent;
@@ -492,6 +493,7 @@ export interface ChildWorkflowOptions extends Omit<CommonWorkflowOptions, 'workf
    *
    * @default 'COMPATIBLE'
    *
+   * @deprecated In favor of the new Worker Deployment API.
    * @experimental The Worker Versioning API is still being designed. Major changes are expected.
    */
   versioningIntent?: VersioningIntent;

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -396,7 +396,7 @@ function startChildWorkflowExecutionNextHandler({
             ? encodeUnifiedSearchAttributes(options.searchAttributes, options.typedSearchAttributes) // eslint-disable-line deprecation/deprecation
             : undefined,
         memo: options.memo && mapToPayloads(activator.payloadConverter, options.memo),
-        versioningIntent: versioningIntentToProto(options.versioningIntent),
+        versioningIntent: versioningIntentToProto(options.versioningIntent), // eslint-disable-line deprecation/deprecation
         priority: options.priority ? compilePriority(options.priority) : undefined,
       },
     });
@@ -941,7 +941,7 @@ export function makeContinueAsNewFunc<F extends Workflow>(
             : undefined,
         workflowRunTimeout: msOptionalToTs(options.workflowRunTimeout),
         workflowTaskTimeout: msOptionalToTs(options.workflowTaskTimeout),
-        versioningIntent: versioningIntentToProto(options.versioningIntent),
+        versioningIntent: versioningIntentToProto(options.versioningIntent), // eslint-disable-line deprecation/deprecation
       });
     });
     return fn({


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
VersioningIntent should've been deprecated along with the rest of the old versioning APIs when deployment based versioning was introduced

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
