### PR TITLE
Map AggegateError and Error.cause to ApplicationFailureInfo

### DIFF
--- a/packages/common/src/converter/failure-converter.ts
+++ b/packages/common/src/converter/failure-converter.ts
@@ -329,6 +329,17 @@ export class DefaultFailureConverter implements FailureConverter {
         message: String(err.message) ?? '',
         stackTrace: cutoffStackTrace(err.stack),
         cause: this.optionalErrorToOptionalFailure((err as any).cause, payloadConverter),
+        applicationFailureInfo:
+          'errors' in err && Array.isArray(err.errors)
+            ? {
+                details: {
+                  payloads: toPayloads(
+                    payloadConverter,
+                    err.errors.map((errInner) => this.optionalErrorToOptionalFailure(errInner, payloadConverter))
+                  ),
+                },
+              }
+            : undefined,
       };
     }
 

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -1,4 +1,5 @@
 import type { temporal } from '@temporalio/proto';
+import { cutoffStackTrace } from '../lib';
 import { errorMessage, isRecord, SymbolBasedInstanceOfError } from './type-helpers';
 import { Duration } from './time';
 import { makeProtoEnumConverters } from './internal-workflow';
@@ -412,9 +413,31 @@ export function ensureApplicationFailure(error: unknown): ApplicationFailure {
     return error;
   }
 
+  function toDetails(error: unknown): Record<string, unknown> | undefined {
+    if (isRecord(error)) {
+      return {
+        message: String(error.message),
+        type: error.constructor?.name ?? error.name,
+        stack: cutoffStackTrace(String(error.stack)),
+        cause: toDetails(error.cause),
+        details: Array.isArray(error.errors) ? error.errors.map(toDetails) : undefined,
+      };
+    } else if (error != null) {
+      return { message: String(error) };
+    } else {
+      return undefined;
+    }
+  }
+
   const message = (isRecord(error) && String(error.message)) || String(error);
   const type = (isRecord(error) && (error.constructor?.name ?? error.name)) || undefined;
-  const failure = ApplicationFailure.create({ message, type, nonRetryable: false });
+  const failure = ApplicationFailure.create({
+    message,
+    type,
+    cause: isRecord(error) && error.cause instanceof Error ? error.cause : undefined,
+    details: isRecord(error) && Array.isArray(error.errors) ? error.errors.map(toDetails) : undefined,
+    nonRetryable: false,
+  });
   failure.stack = (isRecord(error) && String(error.stack)) || '';
   return failure;
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Change how `ensureApplicationFailure` and the `DefaultFailureConverter` handle `Error.cause` and `AggregateError.errors`.

## Why?
<!-- Tell your future self why have you made these changes -->

- `ensureApplicationFailure` was not providing `Error.cause` to `ApplicationFailure.create` which meant that cause information was not being built

- `AggegateError.errors` wasn't being handled in either `ensureApplicationFailure` or the `DefaultFailureConverter`. It is not possible to map that directly to an `IFailure`, so that information is added to then `ApplicationFailureInfo.details` field.

## Checklist
<!--- add/delete as needed --->

1. Closes #1675 

2. How was this tested:
I was using an activity that looks like this:
```typescript
export async function failHard( ): Promise<void> {
  throw new AggregateError(
    [
      new Error('Analyze workflow gets all the love.', {
        cause: new Error('Analyze workflow is the money machine.'),
      }),
      new AggregateError(
        [
          new Error('Everyone knows acquire does the hard work'),
          new Error('Everyone can see what acquire does'),
        ],
        'Acquire workflow gets all the praise.',
      ),
    ],
    'Scrape workflow quits!',
    {
      cause: new AggregateError(
        [
          new Error('Scrape workflow is a drama queen'),
          new Error('Did I mention, scrape workflow is a drama queen?'),
        ],
        'Scrape workflow is a drama queen x2.',
      ),
    },
  )
}
```

Previously, this was all the information available in the Temporal web site for the error:
```json
{
  "type": "workflowExecutionFailedEventAttributes",
  "failure":
    {
      "message": "Activity task failed",
      "cause":
        {
          "message": "Scrape workflow quits!",
          "source": "TypeScriptSDK",
          "stackTrace": "AggregateError: Scrape workflow quits!\n    at getLastScrape (file:///Users/matthew/adology/adology-backend/packages/ad-scraper/src/activities/last-scrape.ts:16:9)",
          "applicationFailureInfo": { "type": "AggregateError" },
        },
      "activityFailureInfo":
        {
          "scheduledEventId": "5",
          "startedEventId": "6",
          "identity": "714@camilla.local",
          "activityType": { "name": "getLastScrape" },
          "activityId": "1",
          "retryState": "RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED",
        },
    },
  "retryState": "RETRY_STATE_RETRY_POLICY_NOT_SET",
  "workflowTaskCompletedEventId": "10",
}

```

After this PR, this is how the failed activity is reported:
```json
{
  "type": "workflowExecutionFailedEventAttributes",
  "failure": {
    "message": "Activity task failed",
    "cause": {
      "message": "Scrape workflow quits!",
      "source": "TypeScriptSDK",
      "stackTrace": "AggregateError: Scrape workflow quits!\n    at getLastScrape (file:///Users/matthew/adology/adology-backend/packages/ad-scraper/src/activities/last-scrape.ts:16:9)",
      "cause": {
        "message": "Scrape workflow is a drama queen x2.",
        "source": "TypeScriptSDK",
        "stackTrace": "AggregateError: Scrape workflow is a drama queen x2.\n    at getLastScrape (file:///Users/matthew/adology/adology-backend/packages/ad-scraper/src/activities/last-scrape.ts:31:14)",
        "applicationFailureInfo": {
          "details": {
            "payloads": [
              [
                {
                  "source": "TypeScriptSDK",
                  "message": "Scrape workflow is a drama queen",
                  "stackTrace": "Error: Scrape workflow is a drama queen\n    at getLastScrape (file:///Users/matthew/adology/adology-backend/packages/ad-scraper/src/activities/last-scrape.ts:33:11)"
                },
                {
                  "source": "TypeScriptSDK",
                  "message": "Did I mention, scrape workflow is a drama queen?",
                  "stackTrace": "Error: Did I mention, scrape workflow is a drama queen?\n    at getLastScrape (file:///Users/matthew/adology/adology-backend/packages/ad-scraper/src/activities/last-scrape.ts:34:11)"
                }
              ]
            ]
          }
        }
      },
      "applicationFailureInfo": {
        "type": "AggregateError",
        "details": {
          "payloads": [
            {
              "message": "Analyze workflow gets all the love.",
              "type": "Error",
              "stack": "Error: Analyze workflow gets all the love.\n    at getLastScrape (file:///Users/matthew/adology/adology-backend/packages/ad-scraper/src/activities/last-scrape.ts:18:7)",
              "cause": {
                "message": "Analyze workflow is the money machine.",
                "type": "Error",
                "stack": "Error: Analyze workflow is the money machine.\n    at getLastScrape (file:///Users/matthew/adology/adology-backend/packages/ad-scraper/src/activities/last-scrape.ts:19:16)"
              }
            },
            {
              "message": "Acquire workflow gets all the praise.",
              "type": "AggregateError",
              "stack": "AggregateError: Acquire workflow gets all the praise.\n    at getLastScrape (file:///Users/matthew/adology/adology-backend/packages/ad-scraper/src/activities/last-scrape.ts:21:7)",
              "details": [
                {
                  "message": "Everyone knows acquire does the hard work",
                  "type": "Error",
                  "stack": "Error: Everyone knows acquire does the hard work\n    at getLastScrape (file:///Users/matthew/adology/adology-backend/packages/ad-scraper/src/activities/last-scrape.ts:23:11)"
                },
                {
                  "message": "Everyone can see what acquire does",
                  "type": "Error",
                  "stack": "Error: Everyone can see what acquire does\n    at getLastScrape (file:///Users/matthew/adology/adology-backend/packages/ad-scraper/src/activities/last-scrape.ts:24:11)"
                }
              ]
            }
          ]
        }
      }
    },
    "activityFailureInfo": {
      "scheduledEventId": "5",
      "startedEventId": "6",
      "identity": "98241@camilla.local",
      "activityType": { "name": "getLastScrape" },
      "activityId": "1",
      "retryState": "RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED"
    }
  },
  "retryState": "RETRY_STATE_RETRY_POLICY_NOT_SET",
  "workflowTaskCompletedEventId": "10"
}
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
