### PR TITLE
fix(bridge): `instanceof Promise` was not giving correct results when run with Jest

### DIFF
--- a/packages/core-bridge/index.js
+++ b/packages/core-bridge/index.js
@@ -1,3 +1,4 @@
+const { isPromise } = require('node:util/types');
 const { getPrebuiltPath } = require('./common');
 const typescriptExports = require('./lib/index');
 const { convertFromNamedError } = require('./lib/errors');
@@ -9,7 +10,7 @@ function wrapErrors(fn) {
   return (...args) => {
     try {
       let res = fn(...args);
-      if (res instanceof Promise) {
+      if (isPromise(res)) {
         return res.catch((e) => {
           throw convertFromNamedError(e, false);
         });
@@ -55,7 +56,7 @@ if (process.env.TEMPORAL_TRACE_NATIVE_CALLS?.toLowerCase() === 'true') {
 
         let res = fn(...args);
 
-        if (res instanceof Promise) {
+        if (isPromise(res)) {
           log(callid, `${fnname}() - received promise`);
           return res.then(
             (x) => {


### PR DESCRIPTION
## What was changed

- Bridge's error conversion logic now uses the `isPromise` node's utility function instead of an `instanceof Promise` check.

  The later is prone to [Jest's globals differ from Node globals](https://github.com/jestjs/jest/issues/2549) bug (i.e. `somePromise instanceof Promise` may evaluate to `false` in some contexts), which would result in not converting errors thrown from the Rust side when Worker is run in Jest.

  This has been causing Jest tests to fail with `ShutdownError: Worker has been shutdown` errors, using TS SDK 1.12.0.
