### PR TITLE
fix for pinned versioning behavior on server version >=1.28.0

### DIFF
--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -142,6 +142,7 @@ function versioningOverrideToProto(
   return {
     pinned: {
       version: vo.pinnedTo,
+      behavior: temporal.api.workflow.v1.VersioningOverride.PinnedOverrideBehavior.PINNED_OVERRIDE_BEHAVIOR_PINNED,
     },
     behavior: temporal.api.enums.v1.VersioningBehavior.VERSIONING_BEHAVIOR_PINNED,
     pinnedVersion: toCanonicalString(vo.pinnedTo),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added missing v0.32 attribute to pinned override in workflow-options.ts

## Why?
https://github.com/temporalio/sdk-typescript/issues/1753

## Checklist

1. Closes https://github.com/temporalio/sdk-typescript/issues/1753

2. How was this tested:
Covered by existing integration test (test-worker-deployment-versioning.ts)
- Before my change, on server version 1.27.1, this integration test passes
- Before my change, on server version 1.28.0, this integration test fails:
```
@temporalio/test:   worker-deployment-versioning › Workflow versioningOverride overrides default versioning behavior
@temporalio/test:   Rejected promise returned by test. Reason:
@temporalio/test:   ServiceError {
@temporalio/test:     cause: Error {
@temporalio/test:       code: 3,
@temporalio/test:       details: 'must specify pinned override behavior if override is pinned.',
@temporalio/test:       metadata: Metadata {
@temporalio/test:         internalRepr: Map { … },
@temporalio/test:         options: {},
@temporalio/test:       },
@temporalio/test:       message: '3 INVALID_ARGUMENT: must specify pinned override behavior if override is pinned.',
@temporalio/test:     },
@temporalio/test:     message: 'Failed to start Workflow',
@temporalio/test:   }
@temporalio/test:   › TimeSkippingWorkflowClient.rethrowGrpcError (/Users/johnbrody/github/sdk-typescript/packages/client/src/workflow-client.ts:911:13)
@temporalio/test:   › TimeSkippingWorkflowClient._startWorkflowHandler (/Users/johnbrody/github/sdk-typescript/packages/client/src/workflow-client.ts:1264:12)
@temporalio/test:   › async TimeSkippingWorkflowClient.start (/Users/johnbrody/github/sdk-typescript/packages/client/src/workflow-client.ts:566:19)
@temporalio/test:   › async <anonymous> (src/test-worker-deployment-versioning.ts:393:20)
@temporalio/test:   ─
@temporalio/test:   1 test failed
@temporalio/test:   1 test skipped
@temporalio/test:   9 tests todo
```
- After my change, on both server version 1.27.1 and 1.28.0, this integration test passes

3. Any docs updates needed?
No