### PR TITLE
Eager Workflow Start

### DIFF
--- a/packages/client/src/interceptor-adapters.ts
+++ b/packages/client/src/interceptor-adapters.ts
@@ -1,0 +1,42 @@
+import { WorkflowClientInterceptor, WorkflowStartInput, WorkflowStartOutput } from './interceptors';
+
+// Apply adapters to workflow client interceptor.
+export function adaptWorkflowClientInterceptor(i: WorkflowClientInterceptor): WorkflowClientInterceptor {
+  return adaptLegacyStartInterceptor(i);
+}
+
+// Adapt legacy `start` interceptors to the new `startWithDetails` interceptor.
+function adaptLegacyStartInterceptor(i: WorkflowClientInterceptor): WorkflowClientInterceptor {
+  // If it already has the new method, or doesn't have the legacy one, no adaptation is needed.
+  // eslint-disable-next-line deprecation/deprecation
+  if (i.startWithDetails || !i.start) {
+    return i;
+  }
+
+  // This interceptor has a legacy `start` but not `startWithDetails`. We'll adapt it.
+  return {
+    ...i,
+    startWithDetails: async (input, next): Promise<WorkflowStartOutput> => {
+      let downstreamOut: WorkflowStartOutput | undefined;
+
+      // Patched `next` for legacy `start` interceptors.
+      // Captures the full `WorkflowStartOutput` while returning `runId` as a string.
+      const patchedNext = async (patchedInput: WorkflowStartInput): Promise<string> => {
+        downstreamOut = await next(patchedInput);
+        return downstreamOut.runId;
+      };
+
+      const runIdFromLegacyInterceptor = await i.start!(input, patchedNext); // eslint-disable-line deprecation/deprecation
+
+      // If the interceptor short-circuited (didn't call `next`), `downstreamOut` will be undefined.
+      // In that case, we can't have an eager start.
+      if (downstreamOut === undefined) {
+        return { runId: runIdFromLegacyInterceptor, eagerlyStarted: false };
+      }
+
+      // If `next` was called, honor the `runId` from the legacy interceptor but preserve
+      // the `eagerlyStarted` status from the actual downstream call.
+      return { ...downstreamOut, runId: runIdFromLegacyInterceptor };
+    },
+  };
+}

--- a/packages/client/src/interceptor-adapters.ts
+++ b/packages/client/src/interceptor-adapters.ts
@@ -1,6 +1,5 @@
 import { WorkflowClientInterceptor, WorkflowStartInput, WorkflowStartOutput } from './interceptors';
 
-// Apply adapters to workflow client interceptor.
 export function adaptWorkflowClientInterceptor(i: WorkflowClientInterceptor): WorkflowClientInterceptor {
   return adaptLegacyStartInterceptor(i);
 }

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -124,6 +124,8 @@ export interface WorkflowClientInterceptor {
    *
    * If you implement this method,
    * {@link signalWithStart} most likely needs to be implemented too
+   *
+   * @deprecated in favour of {@link startWithDetails}
    */
   start?: (input: WorkflowStartInput, next: Next<this, 'start'>) => Promise<string /* runId */>;
 

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -132,8 +132,7 @@ export interface WorkflowClientInterceptor {
   /**
    * Intercept a service call to startWorkflowExecution
    *
-   * Successor to {@link start}. Unlike {@link start}, this method returns
-   * start details via {@link WorkflowStartOutput}.
+   * This method returns start details via {@link WorkflowStartOutput}.
    *
    * If you implement this method,
    * {@link signalWithStart} most likely needs to be implemented too

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -35,6 +35,12 @@ export interface WorkflowStartUpdateInput {
   readonly options: WorkflowUpdateOptions;
 }
 
+/** Output for WorkflowClientInterceptor.startWithDetails */
+export interface WorkflowStartOutput {
+  readonly runId: string;
+  readonly eagerlyStarted: boolean;
+}
+
 /** Output for WorkflowClientInterceptor.startUpdate */
 export interface WorkflowStartUpdateOutput {
   readonly updateId: string;
@@ -120,6 +126,18 @@ export interface WorkflowClientInterceptor {
    * {@link signalWithStart} most likely needs to be implemented too
    */
   start?: (input: WorkflowStartInput, next: Next<this, 'start'>) => Promise<string /* runId */>;
+
+  /**
+   * Intercept a service call to startWorkflowExecution
+   *
+   * Successor to {@link start}. Unlike {@link start}, this method returns
+   * start details via {@link WorkflowStartOutput}.
+   *
+   * If you implement this method,
+   * {@link signalWithStart} most likely needs to be implemented too
+   */
+  startWithDetails?: (input: WorkflowStartInput, next: Next<this, 'startWithDetails'>) => Promise<WorkflowStartOutput>;
+
   /**
    * Intercept a service call to updateWorkflowExecution
    */

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -162,6 +162,12 @@ export interface ConnectionLike {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
    */
   withAbortSignal<R>(abortSignal: AbortSignal, fn: () => Promise<R>): Promise<R>;
+
+  /**
+   * Capability flag that determines whether the connection supports eager workflow start.
+   * This will only be true if the underlying connection is a {@link NativeConnection}.
+   */
+  readonly supportsEagerStart?: boolean;
 }
 
 export const QueryRejectCondition = {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -162,13 +162,18 @@ export interface ConnectionLike {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
    */
   withAbortSignal<R>(abortSignal: AbortSignal, fn: () => Promise<R>): Promise<R>;
-
-  /**
-   * Capability flag that determines whether the connection supports eager workflow start.
-   * This will only be true if the underlying connection is a {@link NativeConnection}.
-   */
-  readonly supportsEagerStart?: boolean;
 }
+
+export const InternalConnectionLikeSymbol = Symbol('__temporal_internal_connection_like');
+export type InternalConnectionLike = ConnectionLike & {
+  [InternalConnectionLikeSymbol]?: {
+    /**
+     * Capability flag that determines whether the connection supports eager workflow start.
+     * This will only be true if the underlying connection is a {@link NativeConnection}.
+     */
+    readonly supportsEagerStart?: boolean;
+  };
+};
 
 export const QueryRejectCondition = {
   NONE: 'NONE',

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -61,6 +61,7 @@ import {
   WorkflowStartUpdateOutput,
   WorkflowStartUpdateWithStartInput,
   WorkflowStartUpdateWithStartOutput,
+  WorkflowStartOutput,
 } from './interceptors';
 import {
   CountWorkflowExecution,
@@ -261,6 +262,15 @@ export interface WorkflowHandleWithFirstExecutionRunId<T extends Workflow = Work
    * Run Id of the first Execution in the Workflow Execution Chain.
    */
   readonly firstExecutionRunId: string;
+}
+
+/**
+ * This interface is exactly the same as {@link WorkflowHandleWithFirstExecutionRunId} except it
+ * includes the `eagerlyStarted` returned from {@link WorkflowClient.start}.
+ */
+export interface WorkflowHandleWithStartDetails<T extends Workflow = Workflow>
+  extends WorkflowHandleWithFirstExecutionRunId<T> {
+  readonly eagerlyStarted: boolean;
 }
 
 /**
@@ -514,14 +524,22 @@ export class WorkflowClient extends BaseClient {
     workflowTypeOrFunc: string | T,
     options: WorkflowStartOptions<T>,
     interceptors: WorkflowClientInterceptor[]
-  ): Promise<string> {
+  ): Promise<WorkflowStartOutput> {
     const workflowType = extractWorkflowType(workflowTypeOrFunc);
     assertRequiredWorkflowOptions(options);
     const compiledOptions = compileWorkflowOptions(ensureArgs(options));
 
-    const start = composeInterceptors(interceptors, 'start', this._startWorkflowHandler.bind(this));
+    const adaptedInterceptors: WorkflowClientInterceptor[] = interceptors.map((i) =>
+      i.startWithDetails ? i : { ...i, startWithDetails: (input, next) => next(input) }
+    );
 
-    return start({
+    const startWithDetails = composeInterceptors(
+      adaptedInterceptors,
+      'startWithDetails',
+      this._startWorkflowHandler.bind(this)
+    );
+
+    return startWithDetails({
       options: compiledOptions,
       headers: {},
       workflowType,
@@ -537,7 +555,6 @@ export class WorkflowClient extends BaseClient {
     const { signal, signalArgs, ...rest } = options;
     assertRequiredWorkflowOptions(rest);
     const compiledOptions = compileWorkflowOptions(ensureArgs(rest));
-
     const signalWithStart = composeInterceptors(
       interceptors,
       'signalWithStart',
@@ -561,22 +578,25 @@ export class WorkflowClient extends BaseClient {
   public async start<T extends Workflow>(
     workflowTypeOrFunc: string | T,
     options: WorkflowStartOptions<T>
-  ): Promise<WorkflowHandleWithFirstExecutionRunId<T>> {
+  ): Promise<WorkflowHandleWithStartDetails<T>> {
     const { workflowId } = options;
     const interceptors = this.getOrMakeInterceptors(workflowId);
-    const runId = await this._start(workflowTypeOrFunc, { ...options, workflowId }, interceptors);
+    const wfStartOutput = await this._start(workflowTypeOrFunc, { ...options, workflowId }, interceptors);
     // runId is not used in handles created with `start*` calls because these
     // handles should allow interacting with the workflow if it continues as new.
-    const handle = this._createWorkflowHandle({
+    const baseHandle = this._createWorkflowHandle({
       workflowId,
       runId: undefined,
-      firstExecutionRunId: runId,
-      runIdForResult: runId,
+      firstExecutionRunId: wfStartOutput.runId,
+      runIdForResult: wfStartOutput.runId,
       interceptors,
       followRuns: options.followRuns ?? true,
-    }) as WorkflowHandleWithFirstExecutionRunId<T>; // Cast is safe because we know we add the firstExecutionRunId below
-    (handle as any) /* readonly */.firstExecutionRunId = runId;
-    return handle;
+    });
+    return {
+      ...baseHandle,
+      firstExecutionRunId: wfStartOutput.runId,
+      eagerlyStarted: wfStartOutput.eagerlyStarted,
+    };
   }
 
   /**
@@ -1246,7 +1266,7 @@ export class WorkflowClient extends BaseClient {
    *
    * Used as the final function of the start interceptor chain
    */
-  protected async _startWorkflowHandler(input: WorkflowStartInput): Promise<string> {
+  protected async _startWorkflowHandler(input: WorkflowStartInput): Promise<WorkflowStartOutput> {
     const req = await this.createStartWorkflowRequest(input);
     const { options: opts, workflowType } = input;
     const internalOptions = (opts as InternalWorkflowStartOptions)[InternalWorkflowStartOptionsSymbol];
@@ -1255,7 +1275,10 @@ export class WorkflowClient extends BaseClient {
       if (internalOptions != null) {
         internalOptions.backLink = response.link ?? undefined;
       }
-      return response.runId;
+      return {
+        runId: response.runId,
+        eagerlyStarted: response.eagerWorkflowTask != null,
+      };
     } catch (err: any) {
       if (err.code === grpcStatus.ALREADY_EXISTS) {
         throw new WorkflowExecutionAlreadyStartedError(
@@ -1272,6 +1295,13 @@ export class WorkflowClient extends BaseClient {
     const { options: opts, workflowType, headers } = input;
     const { identity, namespace } = this.options;
     const internalOptions = (opts as InternalWorkflowStartOptions)[InternalWorkflowStartOptionsSymbol];
+
+    if (opts.requestEagerStart && !('supportsEagerStart' in this.connection && this.connection.supportsEagerStart)) {
+      throw new Error(
+        'Eager workflow start requires a NativeConnection shared between client and worker. ' +
+          'Pass a NativeConnection via ClientOptions.connection, or disable requestEagerStart.'
+      );
+    }
 
     return {
       namespace,
@@ -1303,6 +1333,7 @@ export class WorkflowClient extends BaseClient {
       userMetadata: await encodeUserMetadata(this.dataConverter, opts.staticSummary, opts.staticDetails),
       priority: opts.priority ? compilePriority(opts.priority) : undefined,
       versioningOverride: opts.versioningOverride ?? undefined,
+      requestEagerExecution: opts.requestEagerStart,
       ...filterNullAndUndefined(internalOptions ?? {}),
     };
   }

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -1646,6 +1646,7 @@ export class WorkflowClient extends BaseClient {
     return decodeCountWorkflowExecutionsResponse(response);
   }
 
+  // eslint-disable-next-line deprecation/deprecation
   protected adaptInterceptors(): WorkflowClientInterceptors | WorkflowClientInterceptor[] {
     if (typeof this.options.interceptors === 'object' && 'calls' in this.options.interceptors) {
       // eslint-disable-next-line deprecation/deprecation

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -511,6 +511,7 @@ export class WorkflowClient extends BaseClient {
       ...filterNullAndUndefined(options ?? {}),
       loadedDataConverter: this.dataConverter,
     };
+    this.options.interceptors = this.adaptInterceptors();
   }
 
   /**
@@ -1645,17 +1646,30 @@ export class WorkflowClient extends BaseClient {
     return decodeCountWorkflowExecutionsResponse(response);
   }
 
+  protected adaptInterceptors(): WorkflowClientInterceptors | WorkflowClientInterceptor[] {
+    if (typeof this.options.interceptors === 'object' && 'calls' in this.options.interceptors) {
+      // eslint-disable-next-line deprecation/deprecation
+      const factories = (this.options.interceptors as WorkflowClientInterceptors).calls ?? [];
+      // Compose factory functions with adapters.
+      return {
+        calls: factories.map((ctor) => {
+          return (input) => adaptWorkflowClientInterceptor(ctor(input));
+        }),
+      };
+    }
+    const interceptors = Array.isArray(this.options.interceptors)
+      ? (this.options.interceptors as WorkflowClientInterceptor[])
+      : [];
+    return interceptors.map((i) => adaptWorkflowClientInterceptor(i));
+  }
+
   protected getOrMakeInterceptors(workflowId: string, runId?: string): WorkflowClientInterceptor[] {
     if (typeof this.options.interceptors === 'object' && 'calls' in this.options.interceptors) {
       // eslint-disable-next-line deprecation/deprecation
       const factories = (this.options.interceptors as WorkflowClientInterceptors).calls ?? [];
       return factories.map((ctor) => ctor({ workflowId, runId }));
     }
-    const interceptors = Array.isArray(this.options.interceptors)
-      ? (this.options.interceptors as WorkflowClientInterceptor[])
-      : [];
-    // Apply adapters to workflow client interceptors.
-    return interceptors.map((i) => adaptWorkflowClientInterceptor(i));
+    return Array.isArray(this.options.interceptors) ? (this.options.interceptors as WorkflowClientInterceptor[]) : [];
   }
 }
 

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -54,6 +54,12 @@ export interface WorkflowOptions extends CommonWorkflowOptions {
    * @experimental Deployment based versioning is experimental and may change in the future.
    */
   versioningOverride?: VersioningOverride;
+
+  /**
+   * Potentially reduce the latency to start this workflow by encouraging the server to
+   * start it on a local worker running with this same client.
+   */
+  requestEagerStart?: boolean;
 }
 
 export type WithCompiledWorkflowOptions<T extends WorkflowOptions> = Replace<
@@ -97,7 +103,8 @@ export type WorkflowSignalWithStartOptions<SignalArgs extends any[] = []> = Sign
   ? WorkflowSignalWithStartOptionsWithArgs<SignalArgs>
   : WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs>;
 
-export interface WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs extends any[]> extends WorkflowOptions {
+export interface WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs extends any[]>
+  extends Omit<WorkflowOptions, 'requestEagerStart'> {
   /**
    * SignalDefinition or name of signal
    */
@@ -109,7 +116,8 @@ export interface WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs extends an
   signalArgs?: SignalArgs;
 }
 
-export interface WorkflowSignalWithStartOptionsWithArgs<SignalArgs extends any[]> extends WorkflowOptions {
+export interface WorkflowSignalWithStartOptionsWithArgs<SignalArgs extends any[]>
+  extends Omit<WorkflowOptions, 'requestEagerStart'> {
   /**
    * SignalDefinition or name of signal
    */

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -56,7 +56,7 @@ export interface WorkflowOptions extends CommonWorkflowOptions {
   versioningOverride?: VersioningOverride;
 
   /**
-   * Potentially reduce the latency to start this workflow by encouraging the server to
+   * Potentially reduce the latency to start this workflow by requesting that the server
    * start it on a local worker running with this same client.
    */
   requestEagerStart?: boolean;

--- a/packages/core-bridge/src/worker.rs
+++ b/packages/core-bridge/src/worker.rs
@@ -672,10 +672,8 @@ mod config {
                 self.local_activity_task_slot_supplier
                     .into_slot_supplier(&mut rbo),
             );
-            tuner_holder.nexus_slot_options(
-                self.nexus_task_slot_supplier
-                    .into_slot_supplier(&mut rbo)
-            );
+            tuner_holder
+                .nexus_slot_options(self.nexus_task_slot_supplier.into_slot_supplier(&mut rbo));
             if let Some(rbo) = rbo {
                 tuner_holder.resource_based_options(rbo);
             }

--- a/packages/test/src/test-integration-workflows.ts
+++ b/packages/test/src/test-integration-workflows.ts
@@ -1763,23 +1763,17 @@ test('Workflow can be started eagerly with shared NativeConnection', async (t) =
 test('Error thrown when requestEagerStart is used with regular Connection', async (t) => {
   const { taskQueue } = helpers(t);
 
-  // Create a regular connection instead of native
-  const regularConnection = await Connection.connect();
-  const client = new WorkflowClient({ connection: regularConnection });
+  const client = new WorkflowClient({ connection: t.context.env.connection });
 
-  try {
-    await t.throwsAsync(
-      client.start(helloWorkflow, {
-        args: ['Temporal'],
-        workflowId: `eager-workflow-error-${randomUUID()}`,
-        taskQueue,
-        requestEagerStart: true,
-      }),
-      {
-        message: /Eager workflow start requires a NativeConnection/,
-      }
-    );
-  } finally {
-    await regularConnection.close();
-  }
+  await t.throwsAsync(
+    client.start(helloWorkflow, {
+      args: ['Temporal'],
+      workflowId: `eager-workflow-error-${randomUUID()}`,
+      taskQueue,
+      requestEagerStart: true,
+    }),
+    {
+      message: /Eager workflow start requires a NativeConnection/,
+    }
+  );
 });

--- a/packages/test/src/test-integration-workflows.ts
+++ b/packages/test/src/test-integration-workflows.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'crypto';
 import asyncRetry from 'async-retry';
 import { ExecutionContext } from 'ava';
 import { firstValueFrom, Subject } from 'rxjs';
-import { Client, Connection, WorkflowClient, WorkflowFailedError, WorkflowHandle } from '@temporalio/client';
+import { Client, WorkflowClient, WorkflowFailedError, WorkflowHandle } from '@temporalio/client';
 import * as activity from '@temporalio/activity';
 import { msToNumber, tsToMs } from '@temporalio/common/lib/time';
 import { TestWorkflowEnvironment } from '@temporalio/testing';

--- a/packages/test/src/test-integration-workflows.ts
+++ b/packages/test/src/test-integration-workflows.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'crypto';
 import asyncRetry from 'async-retry';
 import { ExecutionContext } from 'ava';
 import { firstValueFrom, Subject } from 'rxjs';
-import { WorkflowFailedError, WorkflowHandle } from '@temporalio/client';
+import { Client, Connection, WorkflowClient, WorkflowFailedError, WorkflowHandle } from '@temporalio/client';
 import * as activity from '@temporalio/activity';
 import { msToNumber, tsToMs } from '@temporalio/common/lib/time';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
@@ -1730,4 +1730,56 @@ test('Default handlers fail given reserved prefix', async (t) => {
     );
     await handle.terminate();
   });
+});
+
+export async function helloWorkflow(name: string): Promise<string> {
+  return `Hello, ${name}!`;
+}
+
+test('Workflow can be started eagerly with shared NativeConnection', async (t) => {
+  const { createWorker, taskQueue } = helpers(t);
+  const client = new Client({
+    connection: t.context.env.nativeConnection,
+    namespace: t.context.env.client.options.namespace,
+  });
+
+  const worker = await createWorker();
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(helloWorkflow, {
+      args: ['Temporal'],
+      workflowId: `eager-workflow-${randomUUID()}`,
+      taskQueue,
+      requestEagerStart: true,
+      workflowTaskTimeout: '1h', // hang if retry needed
+    });
+
+    t.true(handle.eagerlyStarted);
+
+    const result = await handle.result();
+    t.is(result, 'Hello, Temporal!');
+  });
+});
+
+test('Error thrown when requestEagerStart is used with regular Connection', async (t) => {
+  const { taskQueue } = helpers(t);
+
+  // Create a regular connection instead of native
+  const regularConnection = await Connection.connect();
+  const client = new WorkflowClient({ connection: regularConnection });
+
+  try {
+    await t.throwsAsync(
+      client.start(helloWorkflow, {
+        args: ['Temporal'],
+        workflowId: `eager-workflow-error-${randomUUID()}`,
+        taskQueue,
+        requestEagerStart: true,
+      }),
+      {
+        message: /Eager workflow start requires a NativeConnection/,
+      }
+    );
+  } finally {
+    await regularConnection.close();
+  }
 });

--- a/packages/worker/src/connection.ts
+++ b/packages/worker/src/connection.ts
@@ -11,7 +11,7 @@ import {
   OperatorService,
   HealthService,
   TestService,
-  InternalConnectionLikeSymbol
+  InternalConnectionLikeSymbol,
 } from '@temporalio/client';
 import { InternalConnectionOptions, InternalConnectionOptionsSymbol } from '@temporalio/client/lib/connection';
 import { TransportError } from './errors';

--- a/packages/worker/src/connection.ts
+++ b/packages/worker/src/connection.ts
@@ -25,6 +25,7 @@ import { Runtime } from './runtime';
  * This class can be used to power `@temporalio/client`'s Client objects.
  */
 export class NativeConnection implements ConnectionLike {
+  public readonly supportsEagerStart = true;
   /**
    * referenceHolders is used internally by the framework, it can be accessed with `extractReferenceHolders` (below)
    */

--- a/packages/worker/src/connection.ts
+++ b/packages/worker/src/connection.ts
@@ -11,6 +11,7 @@ import {
   OperatorService,
   HealthService,
   TestService,
+  InternalConnectionLikeSymbol
 } from '@temporalio/client';
 import { InternalConnectionOptions, InternalConnectionOptionsSymbol } from '@temporalio/client/lib/connection';
 import { TransportError } from './errors';
@@ -25,7 +26,6 @@ import { Runtime } from './runtime';
  * This class can be used to power `@temporalio/client`'s Client objects.
  */
 export class NativeConnection implements ConnectionLike {
-  public readonly supportsEagerStart = true;
   /**
    * referenceHolders is used internally by the framework, it can be accessed with `extractReferenceHolders` (below)
    */
@@ -94,6 +94,14 @@ export class NativeConnection implements ConnectionLike {
         false
       );
     }
+
+    // Set internal capability flag - not part of public API
+    Object.defineProperty(this, InternalConnectionLikeSymbol, {
+      value: { supportsEagerStart: true },
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
   }
 
   /**


### PR DESCRIPTION
## What was changed
The main change to accommodate eager workflow start was adding `startWithDetails` to `WorkflowClientInterceptor` to support a (new) return type of `WorkflowStartOutput`. This allows us to return an object, giving us the ability to add new fields without issue - we add `eagerlyStarted` in this PR. This new interceptor method is injected if not defined at the internal `_start` call, and adapts the existing `start` interceptor method to use `startWithDetails`. We also define a new handle called `WorkflowHandleWithStartDetails` which extends the existing `WorkflowHandleWithFirstExecutionRunId`, which now includes whether the workflow was started eagerly or not. Adding fields to the handle is an adopted pattern in the TS SDK.

## Why?
Support eager workflow start.

1. Closes #1348

2. How was this tested:
Existing integration tests and 2 new integration tests.

3. Any docs updates needed?
Probably
