### PR TITLE
Fix workflow bundler warn due to non-workflow safe import in user-met…

### DIFF
--- a/packages/client/src/schedule-helpers.ts
+++ b/packages/client/src/schedule-helpers.ts
@@ -7,7 +7,7 @@ import {
   extractWorkflowType,
   LoadedDataConverter,
 } from '@temporalio/common';
-import { encodeUserMetadata, decodeUserMetadata } from '@temporalio/common/lib/user-metadata';
+import { encodeUserMetadata, decodeUserMetadata } from '@temporalio/common/lib/internal-non-workflow/codec-helpers';
 import {
   encodeUnifiedSearchAttributes,
   decodeSearchAttributes,

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -24,7 +24,7 @@ import {
   WorkflowIdConflictPolicy,
   compilePriority,
 } from '@temporalio/common';
-import { encodeUserMetadata } from '@temporalio/common/lib/user-metadata';
+import { encodeUserMetadata } from '@temporalio/common/lib/internal-non-workflow/codec-helpers';
 import { encodeUnifiedSearchAttributes } from '@temporalio/common/lib/converter/payload-search-attributes';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import { History } from '@temporalio/common/lib/proto-utils';

--- a/packages/common/src/internal-non-workflow/codec-helpers.ts
+++ b/packages/common/src/internal-non-workflow/codec-helpers.ts
@@ -1,9 +1,16 @@
+import type { temporal } from '@temporalio/proto';
 import { Payload } from '../interfaces';
-import { arrayFromPayloads, fromPayloadsAtIndex, toPayloads } from '../converter/payload-converter';
+import {
+  arrayFromPayloads,
+  convertOptionalToPayload,
+  fromPayloadsAtIndex,
+  toPayloads,
+} from '../converter/payload-converter';
 import { PayloadConverterError } from '../errors';
 import { PayloadCodec } from '../converter/payload-codec';
 import { ProtoFailure } from '../failure';
 import { LoadedDataConverter } from '../converter/data-converter';
+import { UserMetadata } from '../user-metadata';
 import { DecodedPayload, DecodedProtoFailure, EncodedPayload, EncodedProtoFailure } from './codec-types';
 
 /**
@@ -358,4 +365,33 @@ export function noopDecodeMap<K extends string>(
   map: Record<K, Payload> | null | undefined
 ): Record<K, DecodedPayload> | null | undefined {
   return map as Record<K, DecodedPayload> | null | undefined;
+}
+
+export async function encodeUserMetadata(
+  dataConverter: LoadedDataConverter,
+  staticSummary: string | undefined,
+  staticDetails: string | undefined
+): Promise<temporal.api.sdk.v1.IUserMetadata | undefined> {
+  if (staticSummary == null && staticDetails == null) return undefined;
+
+  const { payloadConverter, payloadCodecs } = dataConverter;
+  const summary = await encodeOptionalSingle(payloadCodecs, convertOptionalToPayload(payloadConverter, staticSummary));
+  const details = await encodeOptionalSingle(payloadCodecs, convertOptionalToPayload(payloadConverter, staticDetails));
+
+  if (summary == null && details == null) return undefined;
+
+  return { summary, details };
+}
+
+export async function decodeUserMetadata(
+  dataConverter: LoadedDataConverter,
+  metadata: temporal.api.sdk.v1.IUserMetadata | undefined | null
+): Promise<UserMetadata> {
+  const res = { staticSummary: undefined, staticDetails: undefined };
+  if (metadata == null) return res;
+
+  const staticSummary = (await decodeOptionalSinglePayload<string>(dataConverter, metadata.summary)) ?? undefined;
+  const staticDetails = (await decodeOptionalSinglePayload<string>(dataConverter, metadata.details)) ?? undefined;
+
+  return { staticSummary, staticDetails };
 }

--- a/packages/common/src/user-metadata.ts
+++ b/packages/common/src/user-metadata.ts
@@ -1,7 +1,5 @@
-import { temporal } from '@temporalio/proto';
+import type { temporal } from '@temporalio/proto';
 import { convertOptionalToPayload, PayloadConverter } from './converter/payload-converter';
-import { LoadedDataConverter } from './converter/data-converter';
-import { decodeOptionalSinglePayload, encodeOptionalSingle } from './internal-non-workflow';
 
 /**
  * User metadata that can be attached to workflow commands.
@@ -26,33 +24,4 @@ export function userMetadataToPayload(
   if (summary == null && details == null) return undefined;
 
   return { summary, details };
-}
-
-export async function encodeUserMetadata(
-  dataConverter: LoadedDataConverter,
-  staticSummary: string | undefined,
-  staticDetails: string | undefined
-): Promise<temporal.api.sdk.v1.IUserMetadata | undefined> {
-  if (staticSummary == null && staticDetails == null) return undefined;
-
-  const { payloadConverter, payloadCodecs } = dataConverter;
-  const summary = await encodeOptionalSingle(payloadCodecs, convertOptionalToPayload(payloadConverter, staticSummary));
-  const details = await encodeOptionalSingle(payloadCodecs, convertOptionalToPayload(payloadConverter, staticDetails));
-
-  if (summary == null && details == null) return undefined;
-
-  return { summary, details };
-}
-
-export async function decodeUserMetadata(
-  dataConverter: LoadedDataConverter,
-  metadata: temporal.api.sdk.v1.IUserMetadata | undefined | null
-): Promise<UserMetadata> {
-  const res = { staticSummary: undefined, staticDetails: undefined };
-  if (metadata == null) return res;
-
-  const staticSummary = (await decodeOptionalSinglePayload<string>(dataConverter, metadata.summary)) ?? undefined;
-  const staticDetails = (await decodeOptionalSinglePayload<string>(dataConverter, metadata.details)) ?? undefined;
-
-  return { staticSummary, staticDetails };
 }

--- a/packages/core-bridge/src/client.rs
+++ b/packages/core-bridge/src/client.rs
@@ -220,6 +220,7 @@ async fn client_invoke(mut retry_client: CoreClient, call: RpcCall) -> BridgeRes
             rpc_call!(retry_client, call, describe_workflow_rule)
         }
         "ExecuteMultiOperation" => rpc_call!(retry_client, call, execute_multi_operation),
+        "FetchWorkerConfig" => rpc_call!(retry_client, call, fetch_worker_config),
         "GetClusterInfo" => rpc_call!(retry_client, call, get_cluster_info),
         "GetCurrentDeployment" => rpc_call!(retry_client, call, get_current_deployment),
         "GetDeploymentReachability" => {


### PR DESCRIPTION
## What was changed

- User Metadata (#1657) introduced an import to Payload Codecs APIs from a file that is imported into the Workflow sandbox.

  This has been adding approx 350 KB to the size of workflow bundles, and  causing warning messages from the workflow bundler:

    ```
    WARNING in ../common/lib/internal-non-workflow/data-converter-helpers.js 28:17-30
    Critical dependency: the request of a dependency is an expression
        at CommonJsRequireContextDependency.getWarnings (main/node_modules/webpack/lib/dependencies/ContextDependency.js:109:18)
        at Compilation.reportDependencyErrorsAndWarnings (main/node_modules/webpack/lib/Compilation.js:3278:24)
        at main/node_modules/webpack/lib/Compilation.js:2863:28
        at _next2 (eval at create (main/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:16:1)
        at eval (eval at create (main/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:42:1)
        at main/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:395:10
        at main/node_modules/neo-async/async.js:2830:7
        at Object.each (main/node_modules/neo-async/async.js:2850:39)
        at main/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:366:17
        at main/node_modules/neo-async/async.js:2830:7
     @ ../common/lib/internal-non-workflow/index.js 24:13-48
     @ ../common/lib/user-metadata.js 7:32-66
     @ ../workflow/lib/workflow.js 36:24-71
     @ ../workflow/lib/global-overrides.js 14:19-40
     @ ./lib/workflows-autogenerated-entrypoint.cjs 5:28-83
    ```