### PR TITLE
Uniformize Activity's Context class to the contructor-args-as-fields notation

### DIFF
--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -240,100 +240,82 @@ export class Context {
   }
 
   /**
-   * Holds information about the current executing Activity.
-   */
-  public readonly info: Info;
-
-  /**
-   * A Promise that fails with a {@link CancelledFailure} when cancellation of this activity is requested. The promise
-   * is guaranteed to never successfully resolve. Await this promise in an Activity to get notified of cancellation.
-   *
-   * Note that to get notified of cancellation, an activity must _also_ {@link Context.heartbeat}.
-   *
-   * @see [Cancellation](/api/namespaces/activity#cancellation)
-   */
-  public readonly cancelled: Promise<never>;
-
-  /**
-   * An {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal | `AbortSignal`} that can be used to react to
-   * Activity cancellation.
-   *
-   * This can be passed in to libraries such as
-   * {@link https://www.npmjs.com/package/node-fetch#request-cancellation-with-abortsignal | fetch} to abort an
-   * in-progress request and
-   * {@link https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options child_process}
-   * to abort a child process, as well as other built-in node modules and modules found on npm.
-   *
-   * Note that to get notified of cancellation, an activity must _also_ {@link Context.heartbeat}.
-   *
-   * @see [Cancellation](/api/namespaces/activity#cancellation)
-   */
-  public readonly cancellationSignal: AbortSignal;
-
-  /**
-   * The heartbeat implementation, injected via the constructor.
-   */
-  protected readonly heartbeatFn: (details?: any) => void;
-
-  /**
-   * The Worker's client, passed down through Activity context.
-   */
-  protected readonly _client: Client | undefined;
-
-  /**
-   * The logger for this Activity.
-   *
-   * This defaults to the `Runtime`'s Logger (see {@link Runtime.logger}). Attributes from the current Activity context
-   * are automatically included as metadata on every log entries. An extra `sdkComponent` metadata attribute is also
-   * added, with value `activity`; this can be used for fine-grained filtering of log entries further downstream.
-   *
-   * To customize log attributes, register a {@link ActivityOutboundCallsInterceptor} that intercepts the
-   * `getLogAttributes()` method.
-   *
-   * Modifying the context logger (eg. `context.log = myCustomLogger` or by an {@link ActivityInboundLogInterceptor}
-   * with a custom logger as argument) is deprecated. Doing so will prevent automatic inclusion of custom log attributes
-   * through the `getLogAttributes()` interceptor. To customize _where_ log messages are sent, set the
-   * {@link Runtime.logger} property instead.
-   */
-  public log: Logger;
-
-  /**
-   * Get the metric meter for this activity with activity-specific tags.
-   *
-   * To add custom tags, register a {@link ActivityOutboundCallsInterceptor} that
-   * intercepts the `getMetricTags()` method.
-   */
-  public readonly metricMeter: MetricMeter;
-
-  /**
-   * Holder object for activity cancellation details
-   */
-  private readonly _cancellationDetails: ActivityCancellationDetailsHolder;
-
-  /**
    * **Not** meant to instantiated by Activity code, used by the worker.
    *
    * @ignore
    */
   constructor(
-    info: Info,
-    cancelled: Promise<never>,
-    cancellationSignal: AbortSignal,
-    heartbeat: (details?: any) => void,
-    client: Client | undefined,
-    log: Logger,
-    metricMeter: MetricMeter,
-    details: ActivityCancellationDetailsHolder
-  ) {
-    this.info = info;
-    this.cancelled = cancelled;
-    this.cancellationSignal = cancellationSignal;
-    this.heartbeatFn = heartbeat;
-    this._client = client;
-    this.log = log;
-    this.metricMeter = metricMeter;
-    this._cancellationDetails = details;
-  }
+    /**
+     * Holds information about the current executing Activity.
+     */
+    public readonly info: Info,
+
+    /**
+     * A Promise that fails with a {@link CancelledFailure} when cancellation of this activity is requested. The promise
+     * is guaranteed to never successfully resolve. Await this promise in an Activity to get notified of cancellation.
+     *
+     * Note that to get notified of cancellation, an activity must _also_ {@link Context.heartbeat}.
+     *
+     * @see [Cancellation](/api/namespaces/activity#cancellation)
+     */
+    public readonly cancelled: Promise<never>,
+
+    /**
+     * An {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal | `AbortSignal`} that can be used to react to
+     * Activity cancellation.
+     *
+     * This can be passed in to libraries such as
+     * {@link https://www.npmjs.com/package/node-fetch#request-cancellation-with-abortsignal | fetch} to abort an
+     * in-progress request and
+     * {@link https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options child_process}
+     * to abort a child process, as well as other built-in node modules and modules found on npm.
+     *
+     * Note that to get notified of cancellation, an activity must _also_ {@link Context.heartbeat}.
+     *
+     * @see [Cancellation](/api/namespaces/activity#cancellation)
+     */
+    public readonly cancellationSignal: AbortSignal,
+
+    /**
+     * The heartbeat implementation, injected via the constructor.
+     */
+    protected readonly heartbeatFn: (details?: any) => void,
+
+    /**
+     * The Worker's client, passed down through Activity context.
+     */
+    protected readonly _client: Client | undefined,
+
+    /**
+     * The logger for this Activity.
+     *
+     * This defaults to the `Runtime`'s Logger (see {@link Runtime.logger}). Attributes from the current Activity context
+     * are automatically included as metadata on every log entries. An extra `sdkComponent` metadata attribute is also
+     * added, with value `activity`; this can be used for fine-grained filtering of log entries further downstream.
+     *
+     * To customize log attributes, register a {@link ActivityOutboundCallsInterceptor} that intercepts the
+     * `getLogAttributes()` method.
+     *
+     * Modifying the context logger (eg. `context.log = myCustomLogger` or by an {@link ActivityInboundLogInterceptor}
+     * with a custom logger as argument) is deprecated. Doing so will prevent automatic inclusion of custom log attributes
+     * through the `getLogAttributes()` interceptor. To customize _where_ log messages are sent, set the
+     * {@link Runtime.logger} property instead.
+     */
+    public log: Logger,
+
+    /**
+     * Get the metric meter for this activity with activity-specific tags.
+     *
+     * To add custom tags, register a {@link ActivityOutboundCallsInterceptor} that
+     * intercepts the `getMetricTags()` method.
+     */
+    public readonly metricMeter: MetricMeter,
+
+    /**
+     * Holder object for activity cancellation details
+     */
+    protected readonly _cancellationDetails: ActivityCancellationDetailsHolder
+  ) {}
 
   /**
    * Send a {@link https://docs.temporal.io/concepts/what-is-an-activity-heartbeat | heartbeat} from an Activity.


### PR DESCRIPTION
## What was changed

- Converted activity's Context class to contructor-args-as-fields notation. This slightly reduces boilerplate code.