### PR TITLE
fix: pin ms dependency to avoid breaking change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18287,7 +18287,7 @@
       "dependencies": {
         "@temporalio/proto": "file:../proto",
         "long": "^5.2.3",
-        "ms": "^3.0.0-canary.1",
+        "ms": "3.0.0-canary.1",
         "nexus-rpc": "^0.0.1",
         "proto3-json-serializer": "^2.0.0"
       },
@@ -20532,7 +20532,7 @@
       "requires": {
         "@temporalio/proto": "file:../proto",
         "long": "^5.2.3",
-        "ms": "^3.0.0-canary.1",
+        "ms": "3.0.0-canary.1",
         "nexus-rpc": "^0.0.1",
         "proto3-json-serializer": "^2.0.0",
         "protobufjs": "^7.2.5"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@temporalio/proto": "file:../proto",
     "long": "^5.2.3",
-    "ms": "^3.0.0-canary.1",
+    "ms": "3.0.0-canary.1",
     "nexus-rpc": "^0.0.1",
     "proto3-json-serializer": "^2.0.0"
   },


### PR DESCRIPTION
Vercel introduced a breaking change to the `ms` package last night, causing a breaking change for the Typescript SDK due to us requiring `"ms": "^3.0.0-canary.1”`. Subsequently, users are getting bumped onto `ms@3.0.0-canary.202508252038` and encountering dependency issue `TypeError: (0 , ms_1.default) is not a function`.
