### PR TITLE
Fix worker logs not getting fliushed in Core log level set to ERROR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9300,9 +9300,10 @@
       }
     },
     "node_modules/heap-js": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.3.0.tgz",
-      "integrity": "sha512-E5303mzwQ+4j/n2J0rDvEPBN7GKjhis10oHiYOgjxsmxYgqG++hz9NyLLOXttzH8as/DyiBHYpUrJTZWYaMo8Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.6.0.tgz",
+      "integrity": "sha512-trFMIq3PATiFRiQmNNeHtsrkwYRByIXUbYNbotiY9RLVfMkdwZdd2eQ38mGt7BRiCKBaj1DyBAIHmm7mmXPuuw==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -18604,7 +18605,7 @@
         "@temporalio/proto": "file:../proto",
         "@temporalio/workflow": "file:../workflow",
         "abort-controller": "^3.0.0",
-        "heap-js": "^2.3.0",
+        "heap-js": "^2.6.0",
         "memfs": "^4.6.0",
         "nexus-rpc": "^0.0.1",
         "proto3-json-serializer": "^2.0.0",
@@ -20730,7 +20731,7 @@
         "@temporalio/workflow": "file:../workflow",
         "@types/supports-color": "^8.1.3",
         "abort-controller": "^3.0.0",
-        "heap-js": "^2.3.0",
+        "heap-js": "^2.6.0",
         "memfs": "^4.6.0",
         "nexus-rpc": "^0.0.1",
         "proto3-json-serializer": "^2.0.0",
@@ -25368,9 +25369,9 @@
       }
     },
     "heap-js": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.3.0.tgz",
-      "integrity": "sha512-E5303mzwQ+4j/n2J0rDvEPBN7GKjhis10oHiYOgjxsmxYgqG++hz9NyLLOXttzH8as/DyiBHYpUrJTZWYaMo8Q=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.6.0.tgz",
+      "integrity": "sha512-trFMIq3PATiFRiQmNNeHtsrkwYRByIXUbYNbotiY9RLVfMkdwZdd2eQ38mGt7BRiCKBaj1DyBAIHmm7mmXPuuw=="
     },
     "hosted-git-info": {
       "version": "7.0.2",

--- a/packages/test/src/helpers.ts
+++ b/packages/test/src/helpers.ts
@@ -141,6 +141,7 @@ export const bundlerOptions = {
     'timers',
     'timers/promises',
     require.resolve('./activities'),
+    require.resolve('./mock-native-worker'),
   ],
 };
 

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -23,7 +23,7 @@
     "@temporalio/proto": "file:../proto",
     "@temporalio/workflow": "file:../workflow",
     "abort-controller": "^3.0.0",
-    "heap-js": "^2.3.0",
+    "heap-js": "^2.6.0",
     "memfs": "^4.6.0",
     "nexus-rpc": "^0.0.1",
     "proto3-json-serializer": "^2.0.0",

--- a/packages/worker/src/logger.ts
+++ b/packages/worker/src/logger.ts
@@ -118,6 +118,7 @@ export function hasColorSupport(logger: Logger): boolean {
 
 export interface FlushableLogger extends Logger {
   flush(): void;
+  close?(): void;
 }
 
 export function isFlushableLogger(logger: Logger): logger is FlushableLogger {

--- a/packages/worker/src/runtime-logger.ts
+++ b/packages/worker/src/runtime-logger.ts
@@ -1,7 +1,7 @@
 import { Heap } from 'heap-js';
 import { SdkComponent } from '@temporalio/common';
 import { native } from '@temporalio/core-bridge';
-import { DefaultLogger, LogEntry, Logger, LogTimestamp } from './logger';
+import { DefaultLogger, FlushableLogger, LogEntry, Logger, LogTimestamp } from './logger';
 
 /**
  * A log collector that accepts log entries either through the TS `Logger` interface (e.g. used by
@@ -25,10 +25,60 @@ export class NativeLogCollector {
 
   protected buffer = new Heap<LogEntry>((a, b) => Number(a.timestampNanos - b.timestampNanos));
 
+  /**
+   * A timer that periodically flushes the buffer to the downstream logger.
+   */
+  protected flushIntervalTimer: NodeJS.Timeout;
+
+  /**
+   * The minimum time an entry should be buffered before getting flushed.
+   *
+   * Increasing this value allows the buffer to do a better job of correctly reordering messages
+   * emitted from different sources (notably from Workflow executions through Sinks, and from Core)
+   * based on their absolute timestamps, but also increases latency of logs.
+   *
+   * The minimum buffer time requirement only applies as long as the buffer is not full. Once the
+   * buffer reaches its maximum size, older messages are unconditionally flushed, to prevent
+   * unbounded growth of the buffer.
+   *
+   * TODO(JWH): Is 100ms a reasonable compromise? That might seem a little high on latency, but to
+   *            be useful, that value needs to exceed the time it typically takes to process
+   *            Workflow Activations, let's say above the expected P90, but that's highly variable
+   *            across our user base, and we don't really have field data anyway.
+   *            We can revisit depending on user feedback.
+   */
+  protected readonly minBufferTimeMs = 100;
+
+  /**
+   * Interval between flush passes checking for expired messages.
+   *
+   * This really is redundant, since Core itself is expected to flush its buffer every 10 ms, and
+   * we're checking for expired messages when it does. However, Core will only flush if it has
+   * accumulated at least one message; when Core's log level is set to WARN or higher, it may be
+   * many seconds, and even minutes, between Core's log messages, resulting in very rare flush
+   * from that end, which cause considerable delay on flushing log messages from other sources.
+   */
+  protected readonly flushPassIntervalMs = 100;
+
+  /**
+   * The maximum number of log messages to buffer before flushing.
+   *
+   * When the buffer reaches this limit, older messages are unconditionally flushed (i.e. without
+   * regard to the minimum buffer time requirement), to prevent unbounded growth of the buffer.
+   */
+  protected readonly maxBufferSize = 2000;
+
   constructor(downstream: Logger) {
-    this.logger = new DefaultLogger('TRACE', (entry) => this.buffer.add(entry));
+    this.logger = new DefaultLogger('TRACE', this.appendOne.bind(this));
+    (this.logger as FlushableLogger).flush = this.flush.bind(this);
+    (this.logger as FlushableLogger).close = this.close.bind(this);
+
     this.downstream = downstream;
     this.receive = this.receive.bind(this);
+
+    // Flush the buffer every so often.
+    // Unref'ed so that it doesn't prevent the process from exiting.
+    this.flushIntervalTimer = setInterval(this.flushExpired.bind(this), this.flushPassIntervalMs).unref();
   }
 
   /**
@@ -44,12 +94,18 @@ export class NativeLogCollector {
           this.buffer.add(log);
         }
       }
-      this.flush();
+      this.flushUnconditionally();
+      this.flushExpired();
     } catch (_e) {
       // We're not allowed to throw from here, and conversion errors have already been handled in
       // convertFromNativeLogEntry(), so an error at this point almost certainly indicates a problem
       // with the downstream logger. Just swallow it, there's really nothing else we can do.
     }
+  }
+
+  private appendOne(entry: LogEntry): void {
+    this.buffer.add(entry);
+    this.flushUnconditionally();
   }
 
   private convertFromNativeLogEntry(entry: native.JsonString<native.LogEntry>): LogEntry | undefined {
@@ -78,15 +134,49 @@ export class NativeLogCollector {
   }
 
   /**
-   * Flush all buffered logs into the logger supplied to the constructor/
+   * Flush messages that have exceeded their required minimal buffering time.
    */
-  flush(): void {
-    for (const entry of this.buffer) {
+  private flushExpired(): void {
+    const threadholdTimeNanos = BigInt(Date.now() - this.minBufferTimeMs) * 1_000_000n;
+    for (;;) {
+      const entry = this.buffer.peek();
+      if (!entry || entry.timestampNanos > threadholdTimeNanos) break;
+      this.buffer.pop();
+
       this.downstream.log(entry.level, entry.message, {
         [LogTimestamp]: entry.timestampNanos,
         ...entry.meta,
       });
     }
-    this.buffer.clear();
+  }
+
+  /**
+   * Flush messages without regard to the time threshold, up to a given number of messages.
+   *
+   * If no limit is provided, flushes messages in excess to the maximum buffer size.
+   */
+  private flushUnconditionally(maxFlushCount?: number): void {
+    if (maxFlushCount === undefined) {
+      maxFlushCount = this.buffer.size() - this.maxBufferSize;
+    }
+
+    while (maxFlushCount-- > 0) {
+      const entry = this.buffer.pop();
+      if (!entry) break;
+
+      this.downstream.log(entry.level, entry.message, {
+        [LogTimestamp]: entry.timestampNanos,
+        ...entry.meta,
+      });
+    }
+  }
+
+  public flush(): void {
+    this.flushUnconditionally(Number.MAX_SAFE_INTEGER);
+  }
+
+  public close(): void {
+    this.flush();
+    clearInterval(this.flushIntervalTimer);
   }
 }

--- a/packages/worker/src/runtime-options.ts
+++ b/packages/worker/src/runtime-options.ts
@@ -69,7 +69,7 @@ export interface TelemetryOptions {
    * ### Log Forwarding
    *
    * By default, logs emitted by the native side of the SDK are printed directly to the console,
-   * _independently of `RuntimeOptions.logger`_. To enable forwarding of those logs messages to the
+   * _independently of `RuntimeOptions.logger`_. To enable forwarding of those log messages to the
    * TS side logger, add the `forward` property to the `logging` object.
    *
    * For example:
@@ -86,10 +86,14 @@ export interface TelemetryOptions {
    * });
    * ```
    *
-   * Note that forwarded log messages are internally throttled/buffered for a few milliseconds to
-   * reduce overhead incurred by Rust-to-JS calls. In rare cases, this may result in log messages
-   * appearing out of order by a few milliseconds. Users are discouraged from using log forwarding
-   * with verboseness sets to `DEBUG` or `TRACE`.
+   * Note that when log forwarding is enabled, all log messages sent to the runtime logger are
+   * internally buffered for 100 ms, to allow global sorting of messages from different sources
+   * based on their absolute timestamps. This helps reduce incoherencies in the order of messages,
+   * notably those emitted through the Workflow Logging API vs those emitted through Core.
+   *
+   * However, in some situations, log messages may still appear out of order, e.g. when a Workflow
+   * Activation takes longer than 100ms to complete or when log flow exceeds the buffer's capacity
+   * (2000 messages).
    */
   logging?: LogExporterConfig;
 

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -280,7 +280,9 @@ export class Runtime {
       this.teardownShutdownHook();
       // FIXME(JWH): I think we no longer need this, but will have to thoroughly validate.
       native.runtimeShutdown(this.native);
-      this.flushLogs();
+      if (isFlushableLogger(this.logger)) {
+        this.logger.close?.();
+      }
     } finally {
       delete (this as any).native;
     }


### PR DESCRIPTION
## What was changed

Considerably improved the `Runtime`'s `NativeLogCollector` logic.

- `NativeLogCollector` now starts its own interval timer to trigger log flushing.
- `NativeLogCollector` now ensures that the number of buffered log entries can't exceed 2000.
- `NativeLogCollector` now ensure that each message gets throttled by at least 100 ms. This is required to ensure correct global ordering of messages.

## Why?

- When `Runtime` is configured to forward logs from Core to the lang side, we use a lang-side buffer (`NativeLogCollector`) to reorder log entries coming from different sources (notably Workflow log APIs through Sinks, and Core) based on their absolute timestamp. This helps reduce incoherencies in log order.
- Since 1.12.0, `NativeLogCollector` was relying on Core periodic flushes to perform its own flushing to the downstream logger. However, it turns out that Core won't flush unless there has been at least one log message in the mean time, which can be a rare occurrence if Core's log level is set to WARN or ERROR.
- This has been causing considerable delays in propagation of workflow logs (fixes #1750), as well as memory leak as the log buffer may reach disproportionate size.