### PR TITLE
Bump uuid to 13.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3143,12 +3143,6 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
-    "node_modules/@types/uuid": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
-      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
-      "dev": true
-    },
     "node_modules/@types/validate-npm-package-name": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
@@ -17346,15 +17340,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -18254,7 +18249,7 @@
         "@temporalio/proto": "file:../proto",
         "abort-controller": "^3.0.0",
         "long": "^5.2.3",
-        "uuid": "^9.0.1"
+        "uuid": "^13.0.0"
       },
       "devDependencies": {
         "protobufjs": "^7.2.5"
@@ -18432,6 +18427,7 @@
         "@temporalio/client": "file:../client",
         "@temporalio/common": "file:../common",
         "@temporalio/interceptors-opentelemetry": "file:../interceptors-opentelemetry",
+        "@temporalio/nexus": "file:../nexus",
         "@temporalio/proto": "file:../proto",
         "@temporalio/testing": "file:../testing",
         "@temporalio/worker": "file:../worker",
@@ -18538,7 +18534,7 @@
         "protobufjs-cli": "^1.1.2",
         "rxjs": "7.8.1",
         "stack-utils": "^2.0.6",
-        "uuid": "^9.0.1"
+        "uuid": "^13.0.0"
       },
       "devDependencies": {
         "@types/async-retry": "^1.4.8",
@@ -18547,7 +18543,6 @@
         "@types/ms": "^0.7.34",
         "@types/node-fetch": "^2.6.10",
         "@types/pidusage": "^2.0.5",
-        "@types/uuid": "^9.0.7",
         "fs-extra": "^11.2.0",
         "npm-run-all": "^4.1.5",
         "pidusage": "^3.0.2"
@@ -20514,7 +20509,7 @@
         "abort-controller": "^3.0.0",
         "long": "^5.2.3",
         "protobufjs": "^7.2.5",
-        "uuid": "^9.0.1"
+        "uuid": "^13.0.0"
       }
     },
     "@temporalio/cloud": {
@@ -20673,7 +20668,6 @@
         "@types/ms": "^0.7.34",
         "@types/node-fetch": "^2.6.10",
         "@types/pidusage": "^2.0.5",
-        "@types/uuid": "^9.0.7",
         "arg": "^5.0.2",
         "async-retry": "^1.3.3",
         "ava": "^5.3.1",
@@ -20691,7 +20685,7 @@
         "protobufjs-cli": "^1.1.2",
         "rxjs": "7.8.1",
         "stack-utils": "^2.0.6",
-        "uuid": "^9.0.1"
+        "uuid": "^13.0.0"
       },
       "dependencies": {
         "node-fetch": {
@@ -21071,12 +21065,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true
-    },
-    "@types/uuid": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
-      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
       "dev": true
     },
     "@types/validate-npm-package-name": {
@@ -30417,6 +30405,7 @@
         "@temporalio/client": "file:../client",
         "@temporalio/common": "file:../common",
         "@temporalio/interceptors-opentelemetry": "file:../interceptors-opentelemetry",
+        "@temporalio/nexus": "file:../nexus",
         "@temporalio/proto": "file:../proto",
         "@temporalio/testing": "file:../testing",
         "@temporalio/worker": "file:../worker",
@@ -31041,9 +31030,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,7 +18,7 @@
     "@temporalio/proto": "file:../proto",
     "abort-controller": "^3.0.0",
     "long": "^5.2.3",
-    "uuid": "^9.0.1"
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "protobufjs": "^7.2.5"

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -58,7 +58,7 @@
     "protobufjs-cli": "^1.1.2",
     "rxjs": "7.8.1",
     "stack-utils": "^2.0.6",
-    "uuid": "^9.0.1"
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@types/async-retry": "^1.4.8",
@@ -67,7 +67,6 @@
     "@types/ms": "^0.7.34",
     "@types/node-fetch": "^2.6.10",
     "@types/pidusage": "^2.0.5",
-    "@types/uuid": "^9.0.7",
     "fs-extra": "^11.2.0",
     "npm-run-all": "^4.1.5",
     "pidusage": "^3.0.2"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Bumped `uuid` dependency from 9.0.1 to 13.0.0 and removed `@types/uuid` dependency

## Why?
<!-- Tell your future self why have you made these changes -->

`uuid` started being packaged with its own types in 10.0.0. We've been having weird issues with a tool that is trying to use `@types/uuid` to check types for `uuid@13.0.0`. Rather than trying to fix the tool, it seems reasonable to upgrade `uuid` so we can remove the dependency on `@types/uuid`. Temporal is our last dependency that depends on an old version of `uuid`.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A (I didn't create an issue, can create one if needed)

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

I tried to run `npm run build` and `npm run test`, but both failed for seemingly unrelated reasons.

Every import of this package is `import { v4 as uuid4 } from 'uuid'` which is still the same in 13.0.0, so it shouldn't change anything.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

No