### PR TITLE
Fix failing CAN termination test

### DIFF
--- a/packages/test/src/test-integration-split-two.ts
+++ b/packages/test/src/test-integration-split-two.ts
@@ -664,8 +664,8 @@ test.serial('Handle from WorkflowClient.start terminates run after continue as n
   });
   await worker.runUntil(async () => {
     await t.throwsAsync(handleFromGet.result(), { instanceOf: WorkflowContinuedAsNewError });
-    await handleFromStart.terminate();
-    await t.throwsAsync(handleFromStart.result(), { message: 'Workflow execution terminated' });
+    await handleFromStart.terminate('Expect workflow to terminate due to CAN');
+    await t.throwsAsync(handleFromStart.result(), { message: 'Expect workflow to terminate due to CAN' });
   });
 });
 


### PR DESCRIPTION
Fixes a CAN test that was failing due to an assertion on an error message that changed.
Provided an error message to `terminate` that we assert on.