### PR TITLE
[BREAKING CHANGE] Change RawValue API - create RawValue directly from Payload

### DIFF
--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -122,8 +122,12 @@ export class RawValue<T = unknown> {
   private readonly _payload: Payload;
   private readonly [rawPayloadTypeBrand]: T = undefined as T;
 
-  constructor(value: T, payloadConverter: PayloadConverter = defaultPayloadConverter) {
-    this._payload = payloadConverter.toPayload(value);
+  private constructor(payload: Payload) {
+    this._payload = payload;
+  }
+
+  static fromValue<T>(value: T, converter: PayloadConverter = defaultPayloadConverter): RawValue<T> {
+    return new RawValue<T>(converter.toPayload(value));
   }
 
   get payload(): Payload {

--- a/packages/test/src/test-integration-workflows.ts
+++ b/packages/test/src/test-integration-workflows.ts
@@ -1320,7 +1320,7 @@ test.serial('can register search attributes to dev server', async (t) => {
 
 export async function rawValueWorkflow(value: unknown): Promise<RawValue> {
   const { rawValueActivity } = workflow.proxyActivities({ startToCloseTimeout: '10s' });
-  return await rawValueActivity(new RawValue(value));
+  return await rawValueActivity(RawValue.fromValue(value));
 }
 
 test('workflow and activity can receive/return RawValue', async (t) => {
@@ -1328,14 +1328,14 @@ test('workflow and activity can receive/return RawValue', async (t) => {
   const worker = await createWorker({
     activities: {
       async rawValueActivity(value: unknown): Promise<RawValue> {
-        return new RawValue(value);
+        return RawValue.fromValue(value);
       },
     },
   });
 
   await worker.runUntil(async () => {
     const testValue = 'test';
-    const rawValue = new RawValue(testValue);
+    const rawValue = RawValue.fromValue(testValue);
     const res = await executeWorkflow(rawValueWorkflow, {
       args: [rawValue],
     });

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -280,7 +280,7 @@ export class Activator implements ActivationHandler {
       STACK_TRACE_QUERY_NAME,
       {
         handler: () => {
-          return new RawValue<string>(
+          return RawValue.fromValue(
             this.getStackTraces()
               .map((s) => s.formatted)
               .join('\n\n')
@@ -312,7 +312,7 @@ export class Activator implements ActivationHandler {
               }
             }
           }
-          return new RawValue<EnhancedStackTrace>({ sdk, stacks, sources });
+          return RawValue.fromValue({ sdk, stacks, sources });
         },
         description: 'Returns a stack trace annotated with source information.',
       },
@@ -334,7 +334,7 @@ export class Activator implements ActivationHandler {
             name,
             description: value.description,
           }));
-          return new RawValue<temporal.api.sdk.v1.IWorkflowMetadata>({
+          return RawValue.fromValue({
             definition: {
               type: workflowType,
               queryDefinitions,


### PR DESCRIPTION
## What was changed
Changes the `RawValue` API. Formerly, you could create a `RawValue` from any given value via the constructor. However, it was not possible to create a `RawValue` directly with a payload.

This PR changes the API to instead:
- allow `RawValue` to be created directly from a payload, via its constructor (changing the constructor signature is the breaking change)
- all `RawValue` to still be created with any given value, via a static method `fromValue`

## Why?
Imo, this API makes more sense. If we wanted to keep the old API, but expand it to include a static for `fromPayload` it would probably look something like this:
```
  static fromPayload<T = unknown>(payload: Payload): RawValue<T> {
      const instance = Object.create(RawValue.prototype) as RawValue<T>;
      (instance as any)._payload = payload;
      return instance;
  }
```
which isn't very nice, despite being a basic case.

alternatively, we could expand the type of the value in the constructor to `T | Payload` and add some type guard checks. Also not very nice, imo.

2. How was this tested:
Updated existing tests.

3. Any docs updates needed?
Not sure