### PR TITLE
chore(prettier): ignore bridge macros target dir

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 node_modules
 build
 packages/core-bridge/target
+packages/core-bridge/bridge-macros/target
 sdk-core
 lib
 es2020


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
TSIA

## Why?
Before
```
Benchmark 1: npm exec prettier -- --end-of-line auto --check .
  Time (mean ± σ):     11.859 s ±  0.458 s    [User: 14.062 s, System: 2.327 s]
  Range (min … max):   11.107 s … 12.511 s    10 runs
```
After
```
Benchmark 1: npm exec prettier -- --end-of-line auto --check .
  Time (mean ± σ):      2.839 s ±  0.028 s    [User: 5.754 s, System: 0.668 s]
  Range (min … max):    2.806 s …  2.898 s    10 runs
```

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
N/A

3. Any docs updates needed?
N/A
