### PR TITLE
VLN-497: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - main
       - releases/*
 
+permissions:
+  contents: read
+  actions: write
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Is it the official main branch, or an official release branches?

--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -3,6 +3,10 @@ name: Conventions
 on:
   workflow_call:
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,10 @@ on:
         required: false
         description: The Vercel token. Required if 'publish_target' is set.
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/nightly-throughput-stress.yml
+++ b/.github/workflows/nightly-throughput-stress.yml
@@ -25,6 +25,10 @@ on:
         default: 360
         type: number
 
+permissions:
+  contents: read
+  actions: write
+
 env:
   # Workflow configuration
   TEST_DURATION: ${{ inputs.duration || vars.NIGHTLY_TEST_DURATION || '5h' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,10 @@ on:
     - cron: '00 08 * * *'
     # (1 AM PST)
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   nightly:
     uses: ./.github/workflows/stress.yml

--- a/.github/workflows/omes.yml
+++ b/.github/workflows/omes.yml
@@ -6,6 +6,10 @@ on:
       - main
       - 'releases/*'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   omes-image-build:
     uses: temporalio/omes/.github/workflows/docker-images.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - main
       - 'releases/*'
 
+permissions:
+  contents: read
+  actions: write
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Is it the official main branch, or an official release branches?

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -38,6 +38,10 @@ on:
         required: true
         type: boolean
 
+permissions:
+  contents: read
+  actions: write
+
 env:
   TEMPORAL_TESTING_LOG_DIR: /tmp/worker-logs
   TEMPORAL_TESTING_MEM_LOG_DIR: /tmp/worker-mem-logs


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: Defined workflow-level permissions limiting the GITHUB_TOKEN to contents read and actions write so CI jobs can check out code while still saving caches and uploading artifacts.
- `.github/workflows/conventions.yml`: Added explicit permissions (contents read, actions read) for the reusable lint workflow which only checks out the repo and restores caches.
- `.github/workflows/docs.yml`: Set workflow permissions to contents read and actions read, matching the documentation build job’s need to restore caches without granting write scopes.
- `.github/workflows/release.yml`: Specified contents read and actions write permissions so release jobs can access the repo and perform cache and artifact upload operations without broader scope.
- `.github/workflows/stress.yml`: Declared contents read and actions write permissions required for stress runs that restore/save caches and upload test artifacts.
- `.github/workflows/nightly-throughput-stress.yml`: Introduced contents read and actions write permissions to support nightly throughput stress runs that rebuild artifacts, manage caches, and upload logs.
- `.github/workflows/nightly.yml`: Added contents read and actions write permissions so the nightly wrapper workflow passes the required scopes to the reusable stress workflow it invokes.
- `.github/workflows/omes.yml`: Set workflow permissions to contents read and packages write, allowing the OMES reusable workflow to access the repo and push container images while keeping other scopes disabled.