### PR TITLE
feat(testing): make address of test server public

### DIFF
--- a/packages/test/src/test-ephemeral-server.ts
+++ b/packages/test/src/test-ephemeral-server.ts
@@ -147,3 +147,14 @@ test("TestEnvironment doesn't hang on fail to download", async (t) => {
     t.pass();
   }
 });
+
+test('TestEnvironment.createLocal correctly populates address', async (t) => {
+  const testEnv = await RealTestWorkflowEnvironment.createLocal();
+  t.teardown(() => testEnv.teardown());
+  await t.notThrowsAsync(async () => {
+    await Connection.connect({
+      address: testEnv.address,
+      connectTimeout: 500,
+    });
+  }, 'should be able to connect to test server');
+});

--- a/packages/testing/src/testing-workflow-environment.ts
+++ b/packages/testing/src/testing-workflow-environment.ts
@@ -90,7 +90,11 @@ export class TestWorkflowEnvironment {
     protected readonly server: native.EphemeralServer | 'existing',
     connection: Connection,
     nativeConnection: NativeConnection,
-    namespace: string | undefined
+    namespace: string | undefined,
+    /**
+     * Address used when constructing `connection` and `nativeConnection`
+     */
+    public readonly address: string
   ) {
     this.connection = connection;
     this.nativeConnection = nativeConnection;
@@ -238,7 +242,16 @@ export class TestWorkflowEnvironment {
       [InternalConnectionOptionsSymbol]: { supportsTestService: supportsTimeSkipping },
     });
 
-    return new this(runtime, optsWithDefaults, supportsTimeSkipping, server, connection, nativeConnection, namespace);
+    return new this(
+      runtime,
+      optsWithDefaults,
+      supportsTimeSkipping,
+      server,
+      connection,
+      nativeConnection,
+      namespace,
+      address
+    );
   }
 
   /**


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Make the address that was used for creating connections publicly available

## Why?
There are valid reasons for wanting to know what address the test environment selected such as looking for a free port or wanting to create a new connection.

This feature is needed for eventually updating core as some tests require multiple connections. Split out of https://github.com/temporalio/sdk-typescript/pull/1807

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-typescript/issues/1787

2. How was this tested:

Added unit test just to verify that address gets populated correctly when using `createLocal`

4. Any docs updates needed?

I believe doc comment addition is sufficient
