### PR TITLE
update macos-13 runner to macos-15-intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             out-file: libtemporal_sdk_typescript_bridge.so
           - platform: macos-x64
-            runner: macos-13
+            runner: macos-15-intel
             target: x86_64-apple-darwin
             out-file: libtemporal_sdk_typescript_bridge.dylib
           - platform: macos-arm
@@ -128,7 +128,7 @@ jobs:
             runner: ubuntu-24.04-arm64-2-core
             reuse-v8-context: true
           - platform: macos-x64
-            runner: macos-13
+            runner: macos-15-intel
             reuse-v8-context: true
           - platform: macos-arm
             runner: macos-14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
             out-file: libtemporal_sdk_typescript_bridge.so
             protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-aarch_64.zip
           - platform: macos-x64
-            runner: macos-13
+            runner: macos-15-intel
             target: x86_64-apple-darwin
             out-file: libtemporal_sdk_typescript_bridge.dylib
           - platform: macos-arm


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Update our intel macos runners to `macos-15-intel`

Encountered this on https://github.com/temporalio/sdk-typescript/pull/1793

## Why?
EOL is start of December
https://github.com/actions/runner-images/issues/13046

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
CI

3. Any docs updates needed?
N/A
