### PR TITLE
docs: update CONTRIBUTING.md to use PNPM instead of NPM

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,10 +60,12 @@ For easier testing during development you may want to use a version manager, suc
 2. Install the [Rust toolchain](https://rustup.rs/).
 3. Install [Protocol Buffers](https://github.com/protocolbuffers/protobuf/releases/).
 4. Clone the [sdk-typescript](https://github.com/temporalio/sdk-typescript) repo:
+
    ```sh
    git clone https://github.com/temporalio/sdk-typescript.git
    cd sdk-typescript
    ```
+
 5. Initialize the Core SDK submodule:
 
    ```sh
@@ -73,22 +75,31 @@ For easier testing during development you may want to use a version manager, suc
    > If you get a `The authenticity of host 'github.com (192.30.252.123)' can't be established.`
    > error, run `ssh-keyscan github.com >> ~/.ssh/known_hosts` and retry.
 
-6. Install the dependencies:
+6. Install `pnpm`
+   TS SDK uses PNPM to manage dependencies. Corepack is the recommend way to install `pnpm` and is included in Node 14+
+
+```sh
+corepack enable
+```
+
+7. Install the dependencies:
+
    ```sh
-   npm ci
+   pnpm install --frozen-lockfile
    ```
+
    This may take a few minutes, as it involves downloading and compiling Rust dependencies.
 
 You should now be able to build:
 
 ```sh
-npm run build
+pnpm run build
 ```
 
 If building fails, resetting your environment may help:
 
 ```
-npx lerna clean -y && npm ci
+pnpm dlx lerna clean -y && pnpm install --frozen-lockfile
 ```
 
 If `npm ci` fails in `@temporalio/core-bridge` on the command `node ./scripts/build.js`, you may
@@ -103,14 +114,14 @@ To update to the latest version of the Core SDK, run `git submodule update` foll
 
 After your environment is set up, you can run these commands:
 
-- `npm run build` compiles protobuf definitions, Rust bridge, C++ isolate extension, and Typescript.
-- `npm run rebuild` deletes all generated files in the project and reruns build.
-- `npm run build.watch` watches filesystem for changes and incrementally compiles Typescript on change.
-- `npm run test` runs the test suite.
-- `npm run test.watch` runs the test suite on each change to Typescript files.
-- `npm run format` formats code with prettier.
-- `npm run lint` verifies code style with prettier and ES lint.
-- `npm run commitlint` validates [commit messages](#style-guide).
+- `pnpm run build` compiles protobuf definitions, Rust bridge, C++ isolate extension, and Typescript.
+- `pnpm run rebuild` deletes all generated files in the project and reruns build.
+- `pnpm run build.watch` watches filesystem for changes and incrementally compiles Typescript on change.
+- `pnpm run test` runs the test suite.
+- `pnpm run test.watch` runs the test suite on each change to Typescript files.
+- `pnpm run format` formats code with prettier.
+- `pnpm run lint` verifies code style with prettier and ES lint.
+- `pnpm run commitlint` validates [commit messages](#style-guide).
 
 ### Testing
 
@@ -134,8 +145,8 @@ To replicate the `test-npm-init` CI test locally, you can start with the below s
 
 ```
 rm -rf /tmp/registry
-npm ci
-npm run rebuild
+pnpm install --frozen-lockfile
+pnpm run rebuild
 node scripts/publish-to-verdaccio.js --registry-dir /tmp/registry
 node scripts/init-from-verdaccio.js --registry-dir /tmp/registry --sample hello-world
 cd /tmp/registry/example
@@ -233,8 +244,8 @@ We're [working on automating](https://github.com/temporalio/sdk-typescript/pull/
 set -euo pipefail
 
 git clean -fdx
-npm ci
-npm run build
+pnpm install --frozen-lockfile
+pnpm run build
 
 mkdir -p packages/core-bridge/releases
 
@@ -244,12 +255,12 @@ for f in ~/Downloads/packages-*.zip; do mkdir "$HOME/Downloads/$(basename -s .zi
 # we should now have all 5 build targets
 ls packages/core-bridge/releases/
 
-npx lerna version patch --force-publish='*' # or major|minor|etc, or leave out to be prompted. either way, you get a confirmation dialog.
+pnpm exec lerna version patch --force-publish='*' # or major|minor|etc, or leave out to be prompted. either way, you get a confirmation dialog.
 
 git checkout -B fix-deps
 node scripts/prepublish.mjs
 git commit -am 'Fix dependencies'
-npx lerna publish from-package # add `--dist-tag next` for pre-release versions
+pnpm exec lerna publish from-package # add `--dist-tag next` for pre-release versions
 git checkout -
 ```
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Updated command in contributing docs that reference `npm` command that should now be `pnpm` commands. 

Note this isn't all commands as `npm` can still be used for things such as installing packages globally or `npx` for one offs.

## Why?
Follow up of #1793 
Did a quick search of other files and didn't see any lingering references to npm commands

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
👀 

3. Any docs updates needed?
These are the docs
