### PR TITLE
chore: add top level script for ava usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "lint.prune": "ts-prune --error -p tsconfig.prune.json --ignore \"used in module\" --skip \".d.ts\"",
     "format": "prettier --write . && lerna run --no-bail --stream format",
     "clean": "node ./scripts/clean.mjs",
-    "docs": "cd packages/docs && pnpm run maybe-install-deps-and-build-docs"
+    "docs": "cd packages/docs && pnpm run maybe-install-deps-and-build-docs",
+    "ava": "pnpm -C packages/test exec ava"
   },
   "dependencies": {
     "@temporalio/client": "workspace:*",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add a top level script that invokes `ava` from the test package.

Usage: `pnpm ava lib/test-flags.js`

## Why?
Make it easy to run `ava` directly for individual tests similar to `npx ava` that we had when using `npm`

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Ran `pnpm ava lib/test-flags.js` from root

3. Any docs updates needed?
N/A
