### PR TITLE
include bridge macros rust package in core-bridge npm package

### DIFF
--- a/packages/core-bridge/package.json
+++ b/packages/core-bridge/package.json
@@ -41,6 +41,7 @@
     "node": ">= 18.0.0"
   },
   "files": [
+    "bridge-macros",
     "scripts",
     "src",
     "releases",


### PR DESCRIPTION
## What was changed

Include the `bridge-macros` rust package in the `@temporalio/core-bridge` npm package. 

## Why?

We run our application in Alpine images (I know, I know), and so we rely on being able to build the rust binary from source. This broke after 0.12.0, since the bridge-macros were refactored into a separate top level folder which is not included in the files in the package.json, and thus are not contained in the installed package.

I tried to patch them in, but there is an https://github.com/oven-sh/bun/issues/13330, bun, that prevents this from working. I've worked around it in our build pipeline by committing these files to our repo directly where they're needed, but it's less than ideal.

This PR includes the `bridge-macros` directory in the `files` attribute of the `package.json` so that these files are included. 

closes https://github.com/temporalio/sdk-typescript/issues/1856
