### PR TITLE
fix: env config path to match docs

### DIFF
--- a/packages/envconfig/src/envconfig-toml.ts
+++ b/packages/envconfig/src/envconfig-toml.ts
@@ -295,7 +295,7 @@ function envVarToBool(envVar?: string): boolean | undefined {
 }
 
 const DEFAULT_CONFIG_FILE_PROFILE = 'default';
-const DEFAULT_CONFIG_FILE = 'config.toml';
+const DEFAULT_CONFIG_FILE = 'temporal.toml';
 
 function getDefaultConfigFilePath(): string {
   const configDir = getUserConfigDir();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fix config path to match docs and other language implementations

## Why?
Correctness

## Checklist
<!--- add/delete as needed --->

1. Closes #1869

2. How was this tested:
Matches docs. Double checked other implementations point to `temporal.toml` and not `config.toml`:
- [Core](https://github.com/temporalio/sdk-core/blob/12bc359ba52caa0ddfe5c48c1c19e47c2a9a0305/crates/common/src/envconfig.rs#L60)
- [Go](https://github.com/cretz/temporal-sdk-go/blob/13ff29d79d5345c30f3e4109c0f94b737a19ad7a/contrib/envconfig/client_config_load.go#L259)
- [Java](https://github.com/temporalio/sdk-java/blob/2ff9c2c1f71f06ac81f64715573503eb9723beee/temporal-envconfig/src/main/java/io/temporal/envconfig/ClientConfig.java#L41) (I think this might always point to `~/.config/temporalio/temporal.toml` even on MacOS/Windows so impl might not match docs)

3. Any docs updates needed?
N/A, updating to match docs
