### PR TITLE
chore: remove generateObject usage

### DIFF
--- a/packages/test/src/workflows/ai-sdk.ts
+++ b/packages/test/src/workflows/ai-sdk.ts
@@ -1,7 +1,7 @@
 // Test workflow using AI model
 // eslint-disable-next-line import/no-unassigned-import
 import '@temporalio/ai-sdk/lib/load-polyfills';
-import { embedMany, generateObject, generateText, stepCountIs, tool, wrapLanguageModel } from 'ai';
+import { embedMany, generateText, Output, stepCountIs, tool, wrapLanguageModel } from 'ai';
 import { z } from 'zod';
 import type { LanguageModelV3Middleware } from '@ai-sdk/provider';
 import { proxyActivities } from '@temporalio/workflow';
@@ -41,18 +41,20 @@ export async function toolsWorkflow(question: string): Promise<string> {
 }
 
 export async function generateObjectWorkflow(): Promise<string> {
-  const { object } = await generateObject({
+  const { output } = await generateText({
     model: temporalProvider.languageModel('gpt-4o-mini'),
-    schema: z.object({
-      recipe: z.object({
-        name: z.string(),
-        ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
-        steps: z.array(z.string()),
+    output: Output.object({
+      schema: z.object({
+        recipe: z.object({
+          name: z.string(),
+          ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
+          steps: z.array(z.string()),
+        }),
       }),
     }),
     prompt: 'Generate a lasagna recipe.',
   });
-  return object.recipe.name;
+  return output.recipe.name;
 }
 
 export async function middlewareWorkflow(prompt: string): Promise<string> {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Remove usage of `generateObject` from a test workflow which was deprecated in AI SDK 6.0

See https://ai-sdk.dev/docs/reference/ai-sdk-core/output for usage

## Why?
This deprecation warning is failing CI lint. (Not locally for some reason, looking into why)

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Test using the workflow passes

3. Any docs updates needed?
N/A
