### PR TITLE
chore: use macos-15-intel runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
           - platform: linux-arm
             runner: ubuntu-24.04-arm64-2-core
           - platform: macos-x64
-            runner: macos-13
+            runner: macos-15-intel
           - platform: macos-arm
             runner: macos-14
           - platform: windows-x64


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Update to `macos-15-intel` for our intel based runners

## Why?
https://github.com/actions/runner-images/issues/13046

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
