### PR TITLE
doc: Revisit doc on `[Activity|ChildWorkflow]CancellationTypes` + other minor lints

### DIFF
--- a/packages/client/src/schedule-types.ts
+++ b/packages/client/src/schedule-types.ts
@@ -31,7 +31,7 @@ export interface ScheduleOptions<A extends ScheduleOptionsAction = ScheduleOptio
      * running. This can be changed after a Schedule has taken some Actions, and some changes might produce
      * unintuitive results. In general, the later policy overrides the earlier policy.
      *
-     * @default {@link ScheduleOverlapPolicy.SKIP}
+     * @default ScheduleOverlapPolicy.SKIP
      */
     overlap?: ScheduleOverlapPolicy;
 

--- a/packages/client/src/task-queue-client.ts
+++ b/packages/client/src/task-queue-client.ts
@@ -173,6 +173,13 @@ export class TaskQueueClient extends BaseClient {
  */
 export type ReachabilityOptions = RequireAtLeastOne<BaseReachabilityOptions, 'buildIds' | 'taskQueues'>;
 
+/**
+ * There are different types of reachability:
+ *   - `NEW_WORKFLOWS`: The Build Id might be used by new workflows
+ *   - `EXISTING_WORKFLOWS` The Build Id might be used by open workflows and/or closed workflows.
+ *   - `OPEN_WORKFLOWS` The Build Id might be used by open workflows
+ *   - `CLOSED_WORKFLOWS` The Build Id might be used by closed workflows
+ */
 export const ReachabilityType = {
   /** The Build Id might be used by new workflows. */
   NEW_WORKFLOWS: 'NEW_WORKFLOWS',
@@ -186,14 +193,6 @@ export const ReachabilityType = {
   /** The Build Id might be used by closed workflows. */
   CLOSED_WORKFLOWS: 'CLOSED_WORKFLOWS',
 } as const;
-
-/**
- * There are different types of reachability:
- *   - `NEW_WORKFLOWS`: The Build Id might be used by new workflows
- *   - `EXISTING_WORKFLOWS` The Build Id might be used by open workflows and/or closed workflows.
- *   - `OPEN_WORKFLOWS` The Build Id might be used by open workflows
- *   - `CLOSED_WORKFLOWS` The Build Id might be used by closed workflows
- */
 export type ReachabilityType = (typeof ReachabilityType)[keyof typeof ReachabilityType];
 
 export const [encodeTaskReachability, decodeTaskReachability] = makeProtoEnumConverters<

--- a/packages/common/src/converter/failure-converter.ts
+++ b/packages/common/src/converter/failure-converter.ts
@@ -30,7 +30,6 @@ const NexusHandlerErrorRetryBehavior = {
   RETRYABLE: 'RETRYABLE',
   NON_RETRYABLE: 'NON_RETRYABLE',
 } as const;
-
 type NexusHandlerErrorRetryBehavior =
   (typeof NexusHandlerErrorRetryBehavior)[keyof typeof NexusHandlerErrorRetryBehavior];
 

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -112,7 +112,6 @@ export const [encodeRetryState, decodeRetryState] = makeProtoEnumConverters<
 export const ApplicationFailureCategory = {
   BENIGN: 'BENIGN',
 } as const;
-
 export type ApplicationFailureCategory = (typeof ApplicationFailureCategory)[keyof typeof ApplicationFailureCategory];
 
 export const [encodeApplicationFailureCategory, decodeApplicationFailureCategory] = makeProtoEnumConverters<

--- a/packages/common/src/internal-workflow/enums-helpers.ts
+++ b/packages/common/src/internal-workflow/enums-helpers.ts
@@ -10,12 +10,12 @@ import { Exact, RemovePrefix, UnionToIntersection } from '../type-helpers';
  * Newly introduced enums should follow the following pattern:
  *
  * ```ts
- *     type ParentClosePolicy = (typeof ParentClosePolicy)[keyof typeof ParentClosePolicy];
  *     const ParentClosePolicy = {
  *       TERMINATE: 'TERMINATE',
  *       ABANDON: 'ABANDON',
  *       REQUEST_CANCEL: 'REQUEST_CANCEL',
  *     } as const;
+ *     type ParentClosePolicy = (typeof ParentClosePolicy)[keyof typeof ParentClosePolicy];
  *
  *     const [encodeParentClosePolicy, decodeParentClosePolicy] = //
  *       makeProtoEnumConverters<

--- a/packages/common/src/search-attributes.ts
+++ b/packages/common/src/search-attributes.ts
@@ -17,7 +17,6 @@ export const SearchAttributeType = {
   DATETIME: 'DATETIME',
   KEYWORD_LIST: 'KEYWORD_LIST',
 } as const;
-
 export type SearchAttributeType = (typeof SearchAttributeType)[keyof typeof SearchAttributeType];
 
 // Note: encodeSearchAttributeIndexedValueType exported for use in tests to register search attributes

--- a/packages/common/src/workflow-options.ts
+++ b/packages/common/src/workflow-options.ts
@@ -93,7 +93,6 @@ export const [encodeWorkflowIdReusePolicy, decodeWorkflowIdReusePolicy] = makePr
  *
  * *Note: It is never possible to have two _actively running_ Workflows with the same ID.*
  */
-export type WorkflowIdConflictPolicy = (typeof WorkflowIdConflictPolicy)[keyof typeof WorkflowIdConflictPolicy];
 export const WorkflowIdConflictPolicy = {
   /**
    * Do not start a new Workflow. Instead raise a `WorkflowExecutionAlreadyStartedError`.
@@ -110,6 +109,7 @@ export const WorkflowIdConflictPolicy = {
    */
   TERMINATE_EXISTING: 'TERMINATE_EXISTING',
 } as const;
+export type WorkflowIdConflictPolicy = (typeof WorkflowIdConflictPolicy)[keyof typeof WorkflowIdConflictPolicy];
 
 export const [encodeWorkflowIdConflictPolicy, decodeWorkflowIdConflictPolicy] = makeProtoEnumConverters<
   temporal.api.enums.v1.WorkflowIdConflictPolicy,
@@ -133,7 +133,7 @@ export interface BaseWorkflowOptions {
    *
    * *Note: It is not possible to have two actively running Workflows with the same ID.*
    *
-   * @default {@link WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE}
+   * @default WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
    */
   workflowIdReusePolicy?: WorkflowIdReusePolicy;
 
@@ -142,7 +142,7 @@ export interface BaseWorkflowOptions {
    *
    * *Note: It is not possible to have two actively running Workflows with the same ID.*
    *
-   * @default {@link WorkflowIdConflictPolicy.WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED}
+   * @default WorkflowIdConflictPolicy.WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED
    */
   workflowIdConflictPolicy?: WorkflowIdConflictPolicy;
 

--- a/packages/nexus/src/token.ts
+++ b/packages/nexus/src/token.ts
@@ -1,4 +1,7 @@
 /**
+ * OperationTokenType is used to identify the type of Operation token.
+ * Currently, we only have one type of Operation token: WorkflowRun.
+ *
  * @internal
  * @hidden
  */
@@ -24,11 +27,6 @@ export interface WorkflowRunOperationToken {
    */
   wid: string;
 }
-
-/**
- * OperationTokenType is used to identify the type of Operation token.
- * Currently, we only have one type of Operation token: WorkflowRun.
- */
 type OperationTokenType = (typeof OperationTokenType)[keyof typeof OperationTokenType];
 
 /**

--- a/packages/test/src/test-enums-helpers.ts
+++ b/packages/test/src/test-enums-helpers.ts
@@ -4,13 +4,13 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
 
 // ASSERTION: There MUST be a corresponding `KEY: 'KEY'` in the const object of strings enum (must be present)
 {
-  type ParentClosePolicyMissingEntry =
-    (typeof ParentClosePolicyMissingEntry)[keyof typeof ParentClosePolicyMissingEntry];
   const ParentClosePolicyMissingEntry = {
     TERMINATE: 'TERMINATE',
     // ABANDON: 'ABANDON',  // Missing entry!
     REQUEST_CANCEL: 'REQUEST_CANCEL',
   } as const;
+  type ParentClosePolicyMissingEntry =
+    (typeof ParentClosePolicyMissingEntry)[keyof typeof ParentClosePolicyMissingEntry];
 
   makeProtoEnumConverters<
     coresdk.child_workflow.ParentClosePolicy,
@@ -30,13 +30,13 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
 
 // ASSERTION: There MUST be a corresponding `KEY: 'KEY'` in the const object of strings enum (must have correct value)
 {
-  type ParentClosePolicyIncorectEntry =
-    (typeof ParentClosePolicyIncorectEntry)[keyof typeof ParentClosePolicyIncorectEntry];
   const ParentClosePolicyIncorectEntry = {
     TERMINATE: 'TERMINATE',
     ABANDON: 'INCORRECT', // Incorrect entry!
     REQUEST_CANCEL: 'REQUEST_CANCEL',
   } as const;
+  type ParentClosePolicyIncorectEntry =
+    (typeof ParentClosePolicyIncorectEntry)[keyof typeof ParentClosePolicyIncorectEntry];
 
   makeProtoEnumConverters<
     coresdk.child_workflow.ParentClosePolicy,
@@ -57,8 +57,6 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
 
 // ASSERTION: There MAY be a corresponding `PREFIX_KEY: 'KEY'` in the const object of strings enum (may be present)
 {
-  type ParentClosePolicyWithPrefixedEntries =
-    (typeof ParentClosePolicyWithPrefixedEntries)[keyof typeof ParentClosePolicyWithPrefixedEntries];
   const ParentClosePolicyWithPrefixedEntries = {
     TERMINATE: 'TERMINATE',
     ABANDON: 'ABANDON',
@@ -68,6 +66,8 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
     PARENT_CLOSE_POLICY_ABANDON: 'ABANDON',
     PARENT_CLOSE_POLICY_REQUEST_CANCEL: 'REQUEST_CANCEL',
   } as const;
+  type ParentClosePolicyWithPrefixedEntries =
+    (typeof ParentClosePolicyWithPrefixedEntries)[keyof typeof ParentClosePolicyWithPrefixedEntries];
 
   makeProtoEnumConverters<
     coresdk.child_workflow.ParentClosePolicy,
@@ -88,13 +88,13 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
 
 // ASSERTION: There MAY be a corresponding `PREFIX_KEY: 'KEY'` in the const object of strings enum (may not be present)
 {
-  type ParentClosePolicyWithoutPrefixedEntries =
-    (typeof ParentClosePolicyWithoutPrefixedEntries)[keyof typeof ParentClosePolicyWithoutPrefixedEntries];
   const ParentClosePolicyWithoutPrefixedEntries = {
     TERMINATE: 'TERMINATE',
     ABANDON: 'ABANDON',
     REQUEST_CANCEL: 'REQUEST_CANCEL',
   } as const;
+  type ParentClosePolicyWithoutPrefixedEntries =
+    (typeof ParentClosePolicyWithoutPrefixedEntries)[keyof typeof ParentClosePolicyWithoutPrefixedEntries];
 
   makeProtoEnumConverters<
     coresdk.child_workflow.ParentClosePolicy,
@@ -115,8 +115,6 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
 
 // ASSERTION: There MAY be a corresponding `PREFIX_KEY: 'KEY'` in the const object of strings enum (if present, must have correct value)
 {
-  type ParentClosePolicyWithPrefixedEntries =
-    (typeof ParentClosePolicyWithPrefixedEntries)[keyof typeof ParentClosePolicyWithPrefixedEntries];
   const ParentClosePolicyWithPrefixedEntries = {
     TERMINATE: 'TERMINATE',
     ABANDON: 'ABANDON',
@@ -126,6 +124,8 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
     PARENT_CLOSE_POLICY_ABANDON: 'ABANDON',
     PARENT_CLOSE_POLICY_REQUEST_CANCEL: 'INCORRECT', // Incorrect entry!
   } as const;
+  type ParentClosePolicyWithPrefixedEntries =
+    (typeof ParentClosePolicyWithPrefixedEntries)[keyof typeof ParentClosePolicyWithPrefixedEntries];
 
   makeProtoEnumConverters<
     coresdk.child_workflow.ParentClosePolicy,
@@ -146,7 +146,6 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
 }
 
 {
-  type ParentClosePolicy = (typeof ParentClosePolicy)[keyof typeof ParentClosePolicy];
   const ParentClosePolicy = {
     TERMINATE: 'TERMINATE',
     ABANDON: 'ABANDON',
@@ -157,6 +156,7 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
     PARENT_CLOSE_POLICY_ABANDON: 'ABANDON',
     PARENT_CLOSE_POLICY_REQUEST_CANCEL: 'REQUEST_CANCEL',
   } as const;
+  type ParentClosePolicy = (typeof ParentClosePolicy)[keyof typeof ParentClosePolicy];
 
   // ASSERTION: There MUST be a corresponding `KEY: number` in the mapping table (must be there)
   makeProtoEnumConverters<
@@ -300,13 +300,13 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
 
 // ASSERTION: The const object of strings enum MUST NOT contain any other keys than the ones mandated or optionally allowed above.
 {
-  type ParentClosePolicyWithExtra = (typeof ParentClosePolicyWithExtra)[keyof typeof ParentClosePolicyWithExtra];
   const ParentClosePolicyWithExtra = {
     TERMINATE: 'TERMINATE',
     ABANDON: 'ABANDON',
     REQUEST_CANCEL: 'REQUEST_CANCEL',
     EXTRA: 'EXTRA', // Extra entry!
   } as const;
+  type ParentClosePolicyWithExtra = (typeof ParentClosePolicyWithExtra)[keyof typeof ParentClosePolicyWithExtra];
 
   makeProtoEnumConverters<
     coresdk.child_workflow.ParentClosePolicy,
@@ -327,7 +327,6 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
 }
 
 {
-  type ParentClosePolicy = (typeof ParentClosePolicy)[keyof typeof ParentClosePolicy];
   const ParentClosePolicy = {
     TERMINATE: 'TERMINATE',
     ABANDON: 'ABANDON',
@@ -338,6 +337,7 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
     PARENT_CLOSE_POLICY_ABANDON: 'ABANDON',
     PARENT_CLOSE_POLICY_REQUEST_CANCEL: 'REQUEST_CANCEL',
   } as const;
+  type ParentClosePolicy = (typeof ParentClosePolicy)[keyof typeof ParentClosePolicy];
 
   // ASSERTION: The mapping table MUST NOT contain any other keys than the ones mandated above
   makeProtoEnumConverters<
@@ -416,7 +416,6 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
 
 // Functionnal tests
 {
-  type ParentClosePolicy = (typeof ParentClosePolicy)[keyof typeof ParentClosePolicy];
   const ParentClosePolicy = {
     TERMINATE: 'TERMINATE',
     ABANDON: 'ABANDON',
@@ -427,6 +426,7 @@ import { makeProtoEnumConverters as makeProtoEnumConverters } from '@temporalio/
     PARENT_CLOSE_POLICY_ABANDON: 'ABANDON',
     PARENT_CLOSE_POLICY_REQUEST_CANCEL: 'REQUEST_CANCEL',
   } as const;
+  type ParentClosePolicy = (typeof ParentClosePolicy)[keyof typeof ParentClosePolicy];
 
   const [encodeParentClosePolicy, decodeParentClosePolicy] = //
     makeProtoEnumConverters<

--- a/packages/test/src/test-integration-update.ts
+++ b/packages/test/src/test-integration-update.ts
@@ -811,7 +811,7 @@ test('update result poll throws WorkflowUpdateRPCTimeoutOrCancelledError', async
 
 const updateThatShouldFail = wf.defineUpdate('updateThatShouldFail');
 
-export async function workflowThatWillBeCanceled(): Promise<void> {
+export async function workflowThatWillBeCancelled(): Promise<void> {
   wf.setHandler(updateThatShouldFail, async () => {
     await wf.condition(() => false);
   });
@@ -822,7 +822,7 @@ test('update caller gets update failed error on workflow cancellation', async (t
   const { createWorker, startWorkflow, assertWorkflowUpdateFailed } = helpers(t);
   const worker = await createWorker();
   await worker.runUntil(async () => {
-    const w = await startWorkflow(workflowThatWillBeCanceled);
+    const w = await startWorkflow(workflowThatWillBeCancelled);
     const u = await w.startUpdate(updateThatShouldFail, {
       waitForStage: WorkflowUpdateStage.ACCEPTED,
     });

--- a/packages/test/src/test-integration-workflows.ts
+++ b/packages/test/src/test-integration-workflows.ts
@@ -951,7 +951,7 @@ export async function cancellationScopeWithTimeoutTimerGetsCancelled(): Promise<
     // Fix enabled: this timer will get cancelled
   });
 
-  // Timer cancelation won't appear in history if it sent in the same WFT as workflow complete
+  // Timer cancellation won't appear in history if it sent in the same WFT as workflow complete
   await activitySleep(1);
 
   //@ts-expect-error TSC can't see that scope variables will be initialized synchronously
@@ -973,10 +973,10 @@ test('CancellationScope.withTimeout() - timer gets cancelled', async (t) => {
 
   const { events } = await handle.fetchHistory();
 
-  const timerCanceledEvents = events?.filter((ev) => ev.timerCanceledEventAttributes) ?? [];
-  t.is(timerCanceledEvents?.length, 1);
+  const timerCancelledEvents = events?.filter((ev) => ev.timerCanceledEventAttributes) ?? [];
+  t.is(timerCancelledEvents?.length, 1);
 
-  const timerStartedEventId = timerCanceledEvents[0].timerCanceledEventAttributes?.startedEventId;
+  const timerStartedEventId = timerCancelledEvents[0].timerCanceledEventAttributes?.startedEventId;
   const timerStartedEvent = events?.find((ev) => ev.eventId?.toNumber() === timerStartedEventId?.toNumber());
   t.is(tsToMs(timerStartedEvent?.timerStartedEventAttributes?.startToFireTimeout), msToNumber('12s'));
 });
@@ -1000,7 +1000,7 @@ export async function cancellationScopeWithTimeoutScopeGetCancelledOnTimeout(): 
     await activitySleep(7000);
   }).catch(() => undefined);
 
-  // Activity cancelation won't appear in history if it sent in the same WFT as workflow complete
+  // Activity cancellation won't appear in history if it sent in the same WFT as workflow complete
   await activitySleep(1);
 
   //@ts-expect-error TSC can't see that scope variables will be initialized synchronously

--- a/packages/test/src/test-nexus-handler.ts
+++ b/packages/test/src/test-nexus-handler.ts
@@ -127,7 +127,7 @@ test('sync Operation Handler happy path', async (t) => {
   });
 });
 
-test('Operation Handler cancelation', async (t) => {
+test('Operation Handler cancellation', async (t) => {
   const { env, taskQueue, httpPort, endpointId } = t.context;
   let p: Promise<never> | undefined;
 

--- a/packages/test/src/workflows/reusable-vm-disposal-bug.ts
+++ b/packages/test/src/workflows/reusable-vm-disposal-bug.ts
@@ -10,7 +10,7 @@ import { condition } from '@temporalio/workflow';
  * 4. rootScope.cancel() is called, failing the workflow with "Workflow cancelled"
  *
  * Actual failure happens on the second `condition` where when creating the new
- * cancellation scope, we see that the parent/root scope is already canceled.
+ * cancellation scope, we see that the parent/root scope is already cancelled.
  */
 export async function conditionWithTimeoutAfterDisposal(): Promise<string> {
   const alwaysFalse = false;

--- a/packages/workflow/src/cancellation-scope.ts
+++ b/packages/workflow/src/cancellation-scope.ts
@@ -35,7 +35,7 @@ export interface CancellationScopeOptions {
 
 /**
  * Cancellation Scopes provide the mechanic by which a Workflow may gracefully handle incoming requests for cancellation
- * (e.g. in response to {@link WorkflowHandle.cancel} or through the UI or CLI), as well as request cancelation of
+ * (e.g. in response to {@link WorkflowHandle.cancel} or through the UI or CLI), as well as request cancellation of
  * cancellable operations it owns (e.g. Activities, Timers, Child Workflows, etc).
  *
  * Cancellation Scopes form a tree, with the Workflow's main function running in the root scope of that tree.
@@ -57,7 +57,7 @@ export interface CancellationScopeOptions {
  * ```ts
  * async function myWorkflow(...): Promise<void> {
  *   try {
- *     // This activity runs in the root cancellation scope. Therefore, a cancelation request on
+ *     // This activity runs in the root cancellation scope. Therefore, a cancellation request on
  *     // the Workflow execution (e.g. through the UI or CLI) automatically propagates to this
  *     // activity. Assuming that the activity properly handle the cancellation request, then the
  *     // call below will throw an `ActivityFailure` exception, with `cause` sets to an

--- a/packages/workflow/src/global-overrides.ts
+++ b/packages/workflow/src/global-overrides.ts
@@ -42,7 +42,7 @@ export function overrideGlobals(): void {
 
   global.Date.prototype = OriginalDate.prototype;
 
-  const timeoutCancelationScopes = new Map<number, CancellationScope>();
+  const timeoutCancellationScopes = new Map<number, CancellationScope>();
 
   /**
    * @param ms sleep duration -  number of milliseconds. If given a negative number, value will be set to 1.
@@ -57,15 +57,15 @@ export function overrideGlobals(): void {
       const sleepPromise = timerScope.run(() => sleep(ms));
       sleepPromise.then(
         () => {
-          timeoutCancelationScopes.delete(seq);
+          timeoutCancellationScopes.delete(seq);
           cb(...args);
         },
         () => {
-          timeoutCancelationScopes.delete(seq);
+          timeoutCancellationScopes.delete(seq);
         }
       );
       untrackPromise(sleepPromise);
-      timeoutCancelationScopes.set(seq, timerScope);
+      timeoutCancellationScopes.set(seq, timerScope);
       return seq;
     } else {
       const seq = activator.nextSeqs.timer++;
@@ -88,9 +88,9 @@ export function overrideGlobals(): void {
 
   global.clearTimeout = function (handle: number): void {
     const activator = getActivator();
-    const timerScope = timeoutCancelationScopes.get(handle);
+    const timerScope = timeoutCancellationScopes.get(handle);
     if (timerScope) {
-      timeoutCancelationScopes.delete(handle);
+      timeoutCancellationScopes.delete(handle);
       timerScope.cancel();
     } else {
       activator.nextSeqs.timer++; // Shouldn't increase seq number, but that's the legacy behavior


### PR DESCRIPTION
## What was changed

- Revamped typedocs for `ActivityCancellationTypes` and `ChildWorkflowCancellationTypes`.
- Uniformize to "Cancellation" and "Cancelled" (with two Ls) everywhere that can be changed without breaking. Note that we unfortunately have some legacy inconsistencies in our protobuf APIs, so we can't fix 100% of cases.
- Uniformize coding pattern for the enum-as-const-object-of-strings idiom
  (typedoc should be on the `const` object, not on the `type` directive, and the `type`
  should come after the `const` object definition). 
- Fix some broken tsdoc `@default` tags (it can't be followed by `{@link ...}`).
