### PR TITLE
Expose Temporal Nexus operation info to Temporal Nexus operation

### DIFF
--- a/packages/nexus/src/context.ts
+++ b/packages/nexus/src/context.ts
@@ -33,6 +33,23 @@ export interface HandlerContext {
   taskQueue: string;
 }
 
+/**
+ * Holds information about the current Nexus Operation Execution.
+ *
+ * @experimental Nexus support in Temporal SDK is experimental.
+ */
+export interface OperationInfo {
+  /**
+   * Namespace this Nexus Operation is executing in
+   */
+  readonly namespace: string;
+
+  /**
+   * Task Queue this Nexus Operation is executing on
+   */
+  readonly taskQueue: string;
+}
+
 // Basic APIs //////////////////////////////////////////////////////////////////////////////////////
 
 /**
@@ -100,4 +117,19 @@ export const metricMeter: MetricMeter = {
  */
 export function getClient(): Client {
   return getHandlerContext().client;
+}
+
+/**
+ * Get information about the current Nexus Operation.
+ *
+ * @return OperationInfo for the current Nexus Operation being executed
+ *
+ * @experimental Nexus support in Temporal SDK is experimental.
+ */
+export function operationInfo(): OperationInfo {
+  const ctx = getHandlerContext();
+  return {
+    namespace: ctx.namespace,
+    taskQueue: ctx.taskQueue,
+  };
 }

--- a/packages/nexus/src/index.ts
+++ b/packages/nexus/src/index.ts
@@ -9,6 +9,8 @@ export {
   log,
   getClient,
   metricMeter,
+  operationInfo,
+  type OperationInfo,
 } from './context';
 
 export {


### PR DESCRIPTION
Expose Temporal Nexus operation info to Temporal Nexus operation. 

https://github.com/temporalio/features/issues/673

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a minimal API to retrieve execution context for Nexus Operations.
> 
> - Introduces `OperationInfo` and `operationInfo()` to access current operation `namespace` and `taskQueue` from handler context (`context.ts`)
> - Re-exports `operationInfo` and `OperationInfo` from `index.ts`
> - Adds test verifying `operationInfo()` returns correct namespace and task queue (`test-nexus-handler.ts`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c48d76c6c45ee26b563522edbf653ef154d74eaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->