### PR TITLE
fix(client): expose `operatorService` on `ConnectionLike` interface

### DIFF
--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -123,6 +123,7 @@ export interface CallContext {
  */
 export interface ConnectionLike {
   workflowService: WorkflowService;
+  operatorService: OperatorService;
   plugins: ConnectionPlugin[];
   close(): Promise<void>;
   ensureConnected(): Promise<void>;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Expose `operatorService` on the `ConnectionLike` interface.

## Why?
Both `Connection` and `NativeConnection` always create an `operatorService` unconditionally, but the `ConnectionLike` interface did not expose it.

Unlike `testService` which is conditionally created based on server support, `operatorService` is always present on every connection instance.

## Checklist
<!--- add/delete as needed --->

1. Closes #1883

2. How was this tested:
Existing code compiles confirming that `operatorService` is present when setting a `ConnectionLike`

3. Any docs updates needed?
N/A
