### PR TITLE
Make search attribute type more lenient when parsing

### DIFF
--- a/packages/common/src/search-attributes.ts
+++ b/packages/common/src/search-attributes.ts
@@ -269,20 +269,29 @@ export class TypedSearchAttributes {
   }
 
   static toSearchAttributeType(type: string): SearchAttributeType | undefined {
+    // The type metadata is usually in PascalCase (e.g. "KeywordList") but in
+    // rare cases may be in SCREAMING_SNAKE_CASE (e.g. "INDEXED_VALUE_TYPE_KEYWORD_LIST").
     switch (type) {
       case 'Text':
+      case 'INDEXED_VALUE_TYPE_TEXT':
         return SearchAttributeType.TEXT;
       case 'Keyword':
+      case 'INDEXED_VALUE_TYPE_KEYWORD':
         return SearchAttributeType.KEYWORD;
       case 'Int':
+      case 'INDEXED_VALUE_TYPE_INT':
         return SearchAttributeType.INT;
       case 'Double':
+      case 'INDEXED_VALUE_TYPE_DOUBLE':
         return SearchAttributeType.DOUBLE;
       case 'Bool':
+      case 'INDEXED_VALUE_TYPE_BOOL':
         return SearchAttributeType.BOOL;
       case 'Datetime':
+      case 'INDEXED_VALUE_TYPE_DATETIME':
         return SearchAttributeType.DATETIME;
       case 'KeywordList':
+      case 'INDEXED_VALUE_TYPE_KEYWORD_LIST':
         return SearchAttributeType.KEYWORD_LIST;
       default:
         return;


### PR DESCRIPTION
## What was changed

There was a case in Core where we used SCREAMING_SNAKE_CASE for metadata type instead of PascalCase, see https://github.com/temporalio/features/issues/741. This adjusts TypeScript to be a bit more lenient (but no great way to test the Core issue that's already fixed).
