### PR TITLE
fix(ai-sdk): use activityOptions in callTool proxy

### DIFF
--- a/packages/ai-sdk/src/mcp.ts
+++ b/packages/ai-sdk/src/mcp.ts
@@ -48,7 +48,7 @@ export class TemporalMCPClient {
             const activities = workflow.proxyActivities({
               summary: toolName,
               startToCloseTimeout: '10 minutes',
-              ...this.options,
+              ...this.options.activityOptions,
             });
             const callActivity = activities[this.options.name + '-callTool']!;
             return await callActivity({ name: toolName, input, options, clientArgs: this.options.clientArgs });


### PR DESCRIPTION
## Summary

The `callTool` activity proxy in `TemporalMCPClient` spreads `this.options` (the full `TemporalMCPClientOptions` object) instead of `this.options.activityOptions` into `workflow.proxyActivities()`.

This means any custom `activityOptions` (e.g. `startToCloseTimeout`, `retry`) passed to `TemporalMCPClient` are silently ignored for tool calls, while unrelated fields like `name` and `clientArgs` leak into the activity options.

The `listTools` proxy already correctly uses `this.options.activityOptions` — this is a one-line fix to make `callTool` consistent.

### Before (bug)
```typescript
// packages/ai-sdk/src/mcp.ts line 51
...this.options,  // spreads { name, clientArgs, activityOptions } — wrong
```

### After (fix)
```typescript
...this.options.activityOptions,  // spreads only ActivityOptions — correct
```

## Test plan
- Construct a `TemporalMCPClient` with custom `activityOptions` (e.g. `startToCloseTimeout: '1 minute'`)
- Verify `callTool` activities now respect the custom timeout instead of defaulting to 10 minutes
- Verify `listTools` continues to work as before (already correct)