### PR TITLE
fix: respect pre-loaded LoadedDataConverter in Worker.create()

### DIFF
--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -11,7 +11,7 @@ import {
   WorkerDeploymentVersion,
 } from '@temporalio/common';
 import { Duration, msOptionalToNumber, msToNumber } from '@temporalio/common/lib/time';
-import { loadDataConverter } from '@temporalio/common/lib/internal-non-workflow';
+import { isLoadedDataConverter, loadDataConverter } from '@temporalio/common/lib/internal-non-workflow';
 import { LoggerSinks } from '@temporalio/workflow';
 import { Context } from '@temporalio/activity';
 import { native } from '@temporalio/core-bridge';
@@ -166,12 +166,16 @@ export interface WorkerOptions {
   shutdownForceTime?: Duration;
 
   /**
-   * Provide a custom {@link DataConverter}.
+   * Provide a custom {@link DataConverter} or a pre-loaded {@link LoadedDataConverter}.
    *
    * When bundling workflows ahead of time, make sure to provide custom payload and failure
    * converter paths as options to `bundleWorkflowCode`.
+   *
+   * Passing a pre-loaded {@link LoadedDataConverter} avoids the `require()`-based loading
+   * path, which is useful when running under ESM where `require()` creates a separate module
+   * cache from `import`, causing `instanceof` checks to silently fail.
    */
-  dataConverter?: DataConverter;
+  dataConverter?: DataConverter | LoadedDataConverter;
 
   /**
    * Provide a custom {@link WorkerTuner}.
@@ -1056,7 +1060,9 @@ export function compileWorkerOptions(
     isolateExecutionTimeoutMs: msToNumber(opts.isolateExecutionTimeout),
     maxHeartbeatThrottleIntervalMs: msToNumber(opts.maxHeartbeatThrottleInterval),
     defaultHeartbeatThrottleIntervalMs: msToNumber(opts.defaultHeartbeatThrottleInterval),
-    loadedDataConverter: loadDataConverter(opts.dataConverter),
+    loadedDataConverter: isLoadedDataConverter(opts.dataConverter)
+      ? opts.dataConverter
+      : loadDataConverter(opts.dataConverter),
     activities,
     nexusServiceRegistry: nexusServiceRegistryFromOptions(opts),
     enableNonLocalActivities: opts.enableNonLocalActivities && activities.size > 0,


### PR DESCRIPTION
## What was changed

`Worker.create()` now checks if the `dataConverter` option is already a pre-loaded `LoadedDataConverter` before calling `loadDataConverter()`. This applies the same `isLoadedDataConverter` guard that `BaseClient` already uses in `base-client.ts`.

Changes in `packages/worker/src/worker-options.ts`:
- Import `isLoadedDataConverter` alongside `loadDataConverter`
- Update `WorkerOptions.dataConverter` type to accept `DataConverter | LoadedDataConverter`
- Guard the `loadDataConverter()` call with `isLoadedDataConverter()` check

## Why?

`loadDataConverter()` uses `require()` to load converter modules. Under ESM (`--import=tsx`, etc.), `require()` creates a separate CJS module cache from `import`-loaded code. This means the same class (e.g. `Decimal` from `decimal.js`) exists as two different objects — one in the CJS cache used by the worker's converter, and one in the ESM cache used by activity code. All `instanceof`-based type detection silently breaks, with no error or warning.

The `Client` already handles this correctly:

```ts
// @temporalio/client/src/base-client.ts
this.loadedDataConverter = isLoadedDataConverter(dataConverter)
  ? dataConverter
  : loadDataConverter(dataConverter);
```

The Worker was missing this same guard.

## Checklist

1. Closes #1953
2. How was this tested: Verified the fix matches the pattern already used and tested in `base-client.ts`. The `isLoadedDataConverter` function checks for the `payloadConverter` property which is present on `LoadedDataConverter` but not on `DataConverter`.
3. Any docs updates needed? No

---

**Transparency note:** This PR was authored by Claude Opus 4.6, an AI model by Anthropic, operating under the direction of a human supervisor. See https://maxcalkin.com/ai for details.