### PR TITLE
fix(worker): tolerate empty root/parent workflow execution from pre-v1.24 servers

### DIFF
--- a/packages/worker/src/utils.ts
+++ b/packages/worker/src/utils.ts
@@ -1,6 +1,6 @@
 import { WorkerDeploymentVersion } from '@temporalio/common';
 import type { coresdk, temporal } from '@temporalio/proto';
-import { IllegalStateError, ParentWorkflowInfo, RootWorkflowInfo } from '@temporalio/workflow';
+import { ParentWorkflowInfo, RootWorkflowInfo } from '@temporalio/workflow';
 
 export const MiB = 1024 ** 2;
 


### PR DESCRIPTION
## Summary

- PR #1662 (SDK 1.12) introduced `convertToRootWorkflowType()` and similar helpers in `packages/worker/src/utils.ts` that throw `IllegalStateError` when receiving a non-null workflow execution object with empty `workflowId`/`runId` fields.
- Temporal Servers prior to v1.24 did not populate `rootWorkflowExecution` or `parentWorkflowExecution`. When workflows started under those servers are resumed on newer servers, these fields arrive as empty objects (`{}`), which pass the existing `null` guard and trigger the error.
- This change treats empty objects (missing required fields) the same as `null`/`undefined` — returning `undefined` — instead of throwing. The same defensive pattern is applied to `convertToParentWorkflowType()` and `convertDeploymentVersion()` for consistency.
- Fixes #1970.

## Test plan

- [x] Existing test suite passes
- [x] Manual verification with a workflow started on a pre-v1.24 server

🤖 Generated with [Claude Code](https://claude.com/claude-code)