### PR TITLE
💥 Rename NexusClient to NexusServiceClient

### DIFF
--- a/packages/test/src/test-nexus-codec-converter-errors.ts
+++ b/packages/test/src/test-nexus-codec-converter-errors.ts
@@ -16,7 +16,7 @@ const testService = nexus.service('codec-converter-test', {
 });
 
 export async function nexusEchoCaller(endpoint: string): Promise<string> {
-  const client = workflow.createNexusClient({
+  const client = workflow.createNexusServiceClient({
     endpoint,
     service: testService,
   });

--- a/packages/test/src/test-nexus-operation-timeouts.ts
+++ b/packages/test/src/test-nexus-operation-timeouts.ts
@@ -22,7 +22,7 @@ const scheduleToStartService = nexus.service('nexus-schedule-to-start-timeout-te
 });
 
 export async function scheduleToStartTimeoutCallerWorkflow(endpoint: string): Promise<string> {
-  const client = workflow.createNexusClient({
+  const client = workflow.createNexusServiceClient({
     endpoint,
     service: scheduleToStartService,
   });
@@ -72,7 +72,7 @@ const startToCloseService = nexus.service('nexus-start-to-close-timeout-test-ser
 });
 
 export async function startToCloseTimeoutCallerWorkflow(endpoint: string): Promise<string> {
-  const client = workflow.createNexusClient({
+  const client = workflow.createNexusServiceClient({
     endpoint,
     service: startToCloseService,
   });

--- a/packages/test/src/test-nexus-workflow-caller.ts
+++ b/packages/test/src/test-nexus-workflow-caller.ts
@@ -25,7 +25,7 @@ export async function caller(
   action: string,
   cancellationType?: workflow.NexusOperationCancellationType
 ): Promise<string> {
-  const client = workflow.createNexusClient({
+  const client = workflow.createNexusServiceClient({
     endpoint,
     service,
   });
@@ -199,7 +199,7 @@ const clientOperationTypeSafetyCheckerService = nexus.service('test', {
 export async function clientOperationTypeSafetyCheckerWorkflow(endpoint: string): Promise<void> {
   const Service = clientOperationTypeSafetyCheckerService;
   const operations = Service.operations;
-  const client = workflow.createNexusClient({
+  const client = workflow.createNexusServiceClient({
     endpoint,
     service: Service,
   });
@@ -276,7 +276,7 @@ const nonExistentService = nexus.service('nonExistentService', {
 });
 
 export async function callNonExistentService(endpoint: string): Promise<string> {
-  const client = workflow.createNexusClient({
+  const client = workflow.createNexusServiceClient({
     endpoint,
     service: nonExistentService,
   });
@@ -445,9 +445,7 @@ test('inbound executeCancelOperation interceptor can modify input', async (t) =>
   }
 });
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-test('NexusClient is type-safe in regard to Operation Definitions', async (t) => {
+test('NexusServiceClient is type-safe in regard to Operation Definitions', async (t) => {
   const { createWorker, executeWorkflow, registerNexusEndpoint } = helpers(t);
   const { endpointName, endpointIdentifier } = await registerNexusEndpoint();
   try {

--- a/packages/test/src/test-workflow-nexus-cancellation.ts
+++ b/packages/test/src/test-workflow-nexus-cancellation.ts
@@ -43,7 +43,7 @@ export async function cancellationTestCallerWorkflow(
 ): Promise<void> {
   const { cancellationType, operationName: nexusOperationName } = scenario;
   try {
-    const client = workflow.createNexusClient({ endpoint, service });
+    const client = workflow.createNexusServiceClient({ endpoint, service });
     await client.executeOperation(nexusOperationName, scenario, { cancellationType });
     throw ApplicationFailure.nonRetryable('Unexpected Success');
   } catch (err) {

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -109,9 +109,9 @@ export * from './workflow';
 export { ChildWorkflowHandle, ExternalWorkflowHandle } from './workflow-handle';
 export { metricMeter } from './metrics';
 export {
-  createNexusClient,
-  NexusClientOptions,
-  NexusClient,
+  createNexusServiceClient,
+  NexusServiceClientOptions,
+  NexusServiceClient,
   NexusOperationHandle,
   NexusOperationCancellationType,
 } from './nexus';

--- a/packages/workflow/src/nexus.ts
+++ b/packages/workflow/src/nexus.ts
@@ -14,7 +14,7 @@ import { StartNexusOperationInput, StartNexusOperationOutput, StartNexusOperatio
  *
  * @experimental Nexus support in Temporal SDK is experimental.
  */
-export interface NexusClient<T extends nexus.ServiceDefinition> {
+export interface NexusServiceClient<T extends nexus.ServiceDefinition> {
   /**
    * Start a Nexus Operation and wait for its completion taking a {@link nexus.operation}.
    * Returns the operation's result.
@@ -104,9 +104,9 @@ export interface NexusOperationHandle<T> {
 }
 
 /**
- * Options for {@link createNexusClient}.
+ * Options for {@link createNexusServiceClient}.
  */
-export interface NexusClientOptions<T> {
+export interface NexusServiceClientOptions<T> {
   endpoint: string;
   service: T;
 }
@@ -116,8 +116,10 @@ export interface NexusClientOptions<T> {
  *
  * @experimental Nexus support in Temporal SDK is experimental.
  */
-export function createNexusClient<T extends nexus.ServiceDefinition>(options: NexusClientOptions<T>): NexusClient<T> {
-  class NexusClientImpl<T extends nexus.ServiceDefinition> implements NexusClient<T> {
+export function createNexusServiceClient<T extends nexus.ServiceDefinition>(
+  options: NexusServiceClientOptions<T>
+): NexusServiceClient<T> {
+  class NexusServiceClientImpl<T extends nexus.ServiceDefinition> implements NexusServiceClient<T> {
     async executeOperation<O extends T['operations'][keyof T['operations']]>(
       operation: string | T['operations'][nexus.OperationKey<T['operations']>],
       input: nexus.OperationInput<T['operations'][nexus.OperationKey<T['operations']>]>,
@@ -176,7 +178,7 @@ export function createNexusClient<T extends nexus.ServiceDefinition>(options: Ne
     }
   }
 
-  return new NexusClientImpl<T>();
+  return new NexusServiceClientImpl<T>();
 }
 
 function startNexusOperationNextHandler({


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
- Rename NexusClient to NexusServiceClient in preparation for Nexus Standalone Operations

## Why?
<!-- Tell your future self why have you made these changes -->
With the upcoming Nexus Standalone Operations feature there's a need to differentiate between the current functionality of `NexusClient` and a more basic client that allows for listing/counting/etc Nexus Operations. The plan for this is to rename existing functionality to `NexusServiceClient` and use the name `NexusClient` for the more basic client.

## Checklist

1. How was this tested:
- Existing test suite

3. Any docs updates needed?
- Yes all TS Nexus docs will need updates to the new name
- Samples will need updates as well

