### PR TITLE
fix(workflow): do not import @temporalio/proto from workflow code

### DIFF
--- a/packages/test/src/test-bundler.ts
+++ b/packages/test/src/test-bundler.ts
@@ -207,7 +207,7 @@ if (RUN_INTEGRATION_TESTS) {
     t.true(
       codeSizeKB < 600,
       `Bundle code size (${codeSizeKB.toFixed(0)} KB) exceeds 600 KB — ` +
-      `either @temporalio/proto was pulled in, or another unexpectedly large dependency was added`
+        `either @temporalio/proto was pulled in, or another unexpectedly large dependency was added`
     );
 
     // Parse the inline source map to enumerate bundled source files.
@@ -221,13 +221,7 @@ if (RUN_INTEGRATION_TESTS) {
     }
 
     // Ensure there is no trace of @temporalio/proto in the bundle.
-    const protoSources = sources.filter(
-      (s) => s.includes('/packages/proto/') || s.includes('@temporalio/proto')
-    );
-    t.deepEqual(
-      protoSources,
-      [],
-      `@temporalio/proto must not appear in workflow bundle sources.}`
-    );
+    const protoSources = sources.filter((s) => s.includes('/packages/proto/') || s.includes('@temporalio/proto'));
+    t.deepEqual(protoSources, [], `@temporalio/proto must not appear in workflow bundle sources.}`);
   });
 }

--- a/packages/test/src/test-bundler.ts
+++ b/packages/test/src/test-bundler.ts
@@ -184,4 +184,50 @@ if (RUN_INTEGRATION_TESTS) {
       }
     );
   });
+
+  // Regression test: workflow bundles must not include @temporalio/proto sources.
+  test('Workflow bundle does not include @temporalio/proto sources and fits within size limit', async (t) => {
+    const bundle = await bundleWorkflowCode({
+      workflowsPath: require.resolve('./workflows/workflow-with-standard-api-usage'),
+    });
+
+    // The bundle has an inline source map appended as a single-line comment; separate them.
+    const SOURCEMAP_LINE_PREFIX = '//# sourceMappingURL=data:application/json;charset=utf-8;base64,';
+    const smLineStart = bundle.code.lastIndexOf('\n' + SOURCEMAP_LINE_PREFIX);
+    t.not(smLineStart, -1, 'Bundle should contain an inline source map');
+    const codeOnly = bundle.code.slice(0, smLineStart);
+    const sourcemapBase64 = bundle.code.slice(smLineStart + 1 + SOURCEMAP_LINE_PREFIX.length).trimEnd();
+
+    // Check code size (excluding inline source map).
+    // As of April 2026, I get ~440 KB for the bundle excluding inlined source map.
+    // Some increase is expected over time as we'll continue adding more features to the SDK, but
+    // large sudden increases likely indicate we're importing in the bundle something we shouldn't.
+    const codeSizeKB = Buffer.byteLength(codeOnly, 'utf-8') / 1024;
+    t.log(`Bundle code size: ${codeSizeKB.toFixed(0)} KB`);
+    t.true(
+      codeSizeKB < 600,
+      `Bundle code size (${codeSizeKB.toFixed(0)} KB) exceeds 600 KB — ` +
+      `either @temporalio/proto was pulled in, or another unexpectedly large dependency was added`
+    );
+
+    // Parse the inline source map to enumerate bundled source files.
+    const sourceMap: { sources: string[] } = JSON.parse(Buffer.from(sourcemapBase64, 'base64').toString('utf-8'));
+    const sources = sourceMap.sources.slice().sort();
+
+    // Log the full list for manual review (visible in verbose mode or on test failure).
+    t.log(`\nSources included in bundle (${sources.length} files):`);
+    for (const source of sources) {
+      t.log(`  ${source}`);
+    }
+
+    // Ensure there is no trace of @temporalio/proto in the bundle.
+    const protoSources = sources.filter(
+      (s) => s.includes('/packages/proto/') || s.includes('@temporalio/proto')
+    );
+    t.deepEqual(
+      protoSources,
+      [],
+      `@temporalio/proto must not appear in workflow bundle sources.}`
+    );
+  });
 }

--- a/packages/test/src/test-otel.ts
+++ b/packages/test/src/test-otel.ts
@@ -518,7 +518,7 @@ if (RUN_INTEGRATION_TESTS) {
           tracer,
           spanName: `test-thrown-${String(thrown)}`,
           fn: () => {
-            throw thrown; // eslint-disable-line no-throw-literal
+            throw thrown;
           },
         });
         t.fail('expected instrumentSync to throw');

--- a/packages/test/src/workflows/workflow-with-standard-api-usage.ts
+++ b/packages/test/src/workflows/workflow-with-standard-api-usage.ts
@@ -1,0 +1,76 @@
+/**
+ * Workflow exercising the major @temporalio/workflow API surfaces.
+ * Used in test-bundler.ts to validate bundle contents and size.
+ * Not intended to be run as a standalone integration test.
+ */
+import {
+  proxyActivities,
+  proxyLocalActivities,
+  sleep,
+  defineSignal,
+  defineQuery,
+  defineUpdate,
+  setHandler,
+  condition,
+  CancellationScope,
+  continueAsNew,
+  workflowInfo,
+  patched,
+  deprecatePatch,
+  uuid4,
+  upsertSearchAttributes,
+  ApplicationFailure,
+  ActivityCancellationType,
+} from '@temporalio/workflow';
+
+interface MyActivities {
+  greet(name: string): Promise<string>;
+}
+
+const { greet } = proxyActivities<MyActivities>({
+  startToCloseTimeout: '1 minute',
+  cancellationType: ActivityCancellationType.TRY_CANCEL,
+});
+
+const { greet: greetLocal } = proxyLocalActivities<MyActivities>({
+  startToCloseTimeout: '1 minute',
+});
+
+const nameSignal = defineSignal<[string]>('name');
+const resultQuery = defineQuery<string | undefined>('result');
+const uppercaseUpdate = defineUpdate<string, [string]>('uppercase');
+
+export async function workflowWithStandardApiUsage(): Promise<string> {
+  let name: string | undefined;
+
+  setHandler(nameSignal, (value: string) => void (name = value));
+  setHandler(resultQuery, () => name);
+  setHandler(uppercaseUpdate, (value: string) => value.toUpperCase());
+
+  await condition(() => name !== undefined, '10 seconds');
+
+  if (patched('new-logic')) {
+    name = await greet(name!);
+  } else {
+    deprecatePatch('old-logic');
+    name = await greetLocal(name!);
+  }
+
+  await CancellationScope.nonCancellable(async () => {
+    await sleep(1);
+  });
+
+  upsertSearchAttributes({ WorkflowId: [workflowInfo().workflowId] });
+
+  const id = uuid4();
+
+  if (workflowInfo().continueAsNewSuggested) {
+    await continueAsNew<typeof workflowWithStandardApiUsage>();
+  }
+
+  if (name === 'throw') {
+    throw ApplicationFailure.nonRetryable('test error');
+  }
+
+  return `${id}: ${name}`;
+}

--- a/packages/workflow/src/errors.ts
+++ b/packages/workflow/src/errors.ts
@@ -1,6 +1,6 @@
 import { ActivityFailure, CancelledFailure, ChildWorkflowFailure, NexusOperationFailure } from '@temporalio/common';
 import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
-import { coresdk } from '@temporalio/proto';
+import type { coresdk } from '@temporalio/proto';
 
 /**
  * Base class for all workflow errors

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -5,7 +5,7 @@
  */
 import { encodeVersioningBehavior, IllegalStateError, WorkflowFunctionWithOptions } from '@temporalio/common';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
-import { coresdk } from '@temporalio/proto';
+import type { coresdk } from '@temporalio/proto';
 import type { WorkflowInterceptorsFactory } from './interceptors';
 import type { WorkflowCreateOptionsInternal } from './interfaces';
 import { Activator } from './internals';

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -34,7 +34,7 @@ import {
 import { versioningIntentToProto } from '@temporalio/common/lib/versioning-intent-enum';
 import { Duration, msOptionalToTs, msToNumber, msToTs, requiredTsToMs } from '@temporalio/common/lib/time';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
-import { temporal } from '@temporalio/proto';
+import type { temporal } from '@temporalio/proto';
 import { deepMerge } from '@temporalio/common/lib/internal-workflow';
 import { throwIfReservedName } from '@temporalio/common/lib/reserved';
 import { CancellationScope, registerSleepImplementation } from './cancellation-scope';


### PR DESCRIPTION
## What changed

- Replace three normal imports to `@temporalio/proto` from workflow code by type-only imports.
- Add a test to catch future addition of such imports.