### PR TITLE
chore: bump sdk-core and protobufjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "temporalio": "file:packages/meta"
   },
   "devDependencies": {
+    "@eslint/js": "^9.26.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.25.1",
     "@opentelemetry/sdk-node": "^0.52.1",
@@ -66,7 +67,6 @@
     "@types/node": "^20.10.8",
     "@types/stack-utils": "^2.0.3",
     "@types/supports-color": "^8.1.3",
-    "@eslint/js": "^9.26.0",
     "@typescript-eslint/eslint-plugin": "^8.10.0",
     "@typescript-eslint/parser": "^8.10.0",
     "arg": "^5.0.2",
@@ -93,6 +93,11 @@
       "name": "pnpm",
       "version": "10.27.0",
       "onFail": "warn"
+    }
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "protobufjs@7.5.5": "patches/protobufjs@7.5.5.patch"
     }
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/uuid": "^9.0.7",
-    "protobufjs": "^7.2.5"
+    "protobufjs": "^7.5.5"
   },
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -21,7 +21,7 @@
     "abort-controller": "^3.0.0"
   },
   "devDependencies": {
-    "protobufjs": "^7.2.5"
+    "protobufjs": "^7.5.5"
   },
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,7 +19,7 @@
     "proto3-json-serializer": "^2.0.0"
   },
   "devDependencies": {
-    "protobufjs": "^7.2.5"
+    "protobufjs": "^7.5.5"
   },
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"

--- a/packages/core-bridge/Cargo.lock
+++ b/packages/core-bridge/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -478,7 +478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1336,7 +1336,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1408,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http",
  "opentelemetry",
@@ -1468,7 +1468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2109,7 +2109,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2267,9 +2267,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -2447,7 +2447,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "temporalio-client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "temporalio-common"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "temporalio-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "derive_more",
  "proc-macro2",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "temporalio-sdk-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2587,9 +2587,6 @@ dependencies = [
  "itertools",
  "lru",
  "mockall",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
  "parking_lot",
  "pid",
  "pin-project",
@@ -2751,7 +2748,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -2765,18 +2762,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -3509,9 +3506,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"

--- a/packages/core-bridge/Cargo.toml
+++ b/packages/core-bridge/Cargo.toml
@@ -39,7 +39,9 @@ temporalio-sdk-core = { version = "*", path = "./sdk-core/crates/sdk-core", feat
   "ephemeral-server",
 ] }
 temporalio-client = { version = "*", path = "./sdk-core/crates/client" }
-temporalio-common = { version = "*", path = "./sdk-core/crates/common" }
+temporalio-common = { version = "*", path = "./sdk-core/crates/common", features = [
+  "otel",
+] }
 thiserror = "2"
 tokio = "1.13"
 tokio-stream = "0.1"

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "long": "^5.2.3",
-    "protobufjs": "^7.2.5"
+    "protobufjs": "7.5.5"
   },
   "devDependencies": {
     "glob": "^10.3.10",

--- a/packages/proto/src/patch-protobuf-root.ts
+++ b/packages/proto/src/patch-protobuf-root.ts
@@ -1,4 +1,8 @@
-const ROOT_PROPS = [
+// Properties used internally by protobufjs on Namespace/ReflectionObject instances.
+// A protobuf package component that happens to share one of these names must not be
+// promoted to a direct property, or it would corrupt protobufjs's internal state.
+// (Such types are still reachable via root.lookup() or root.nested traversal.)
+const ROOT_PROPS = new Set([
   'options',
   'parsedOptions',
   'name',
@@ -8,7 +12,7 @@ const ROOT_PROPS = [
   'filename',
   'nested',
   '_nestedArray',
-];
+]);
 
 /**
  * Create a version of `root` with non-nested namespaces to match the generated types.
@@ -18,26 +22,55 @@ const ROOT_PROPS = [
  * @returns A new patched `root`
  */
 export function patchProtobufRoot<T extends Record<string, unknown>>(root: T): T {
-  return _patchProtobufRoot(root);
+  const patched = _patchProtobufRoot(root);
+
+  // Protobufjs >=7.5.2 added a fast-path cache in Namespace#lookup() that accesses
+  // `this.root._fullyQualifiedObjects`. The `root` accessor is defined as a non-enumerable
+  // getter on `ReflectionObject.prototype`, so it is not copied by `for...in` loops.
+  // When the patched root is imported via `import * as proto from '@temporalio/proto'`,
+  // TypeScript's `__importStar` helper wraps the CJS module in a plain object by iterating
+  // own enumerable properties with `for...in` + `hasOwnProperty`. Because `root` is
+  // non-enumerable, it is skipped, the wrapper's `root` is `undefined`, and any subsequent
+  // `this.root._fullyQualifiedObjects` access crashes.
+  // Defining `root` as an own **enumerable** getter ensures `__importStar` includes it in
+  // the wrapper, so that `wrapper.root` delegates back to the patched root (which has the
+  // proper `_fullyQualifiedObjects` map and full prototype chain).
+  if (!Object.getOwnPropertyDescriptor(patched, 'root')) {
+    Object.defineProperty(patched, 'root', {
+      get(this: any) {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        let ptr = this;
+        while (ptr.parent !== null) ptr = ptr.parent;
+        return ptr;
+      },
+      enumerable: true,
+      configurable: true,
+    });
+  }
+
+  return patched;
 }
 
 function _patchProtobufRoot<T extends Record<string, unknown>>(root: T, name?: string): T {
   const newRoot = new (root.constructor as any)(isNamespace(root) ? name : {});
   for (const key in root) {
+    // 'root' is a getter-only accessor defined on ReflectionObject.prototype. Trying to
+    // assign it as a plain property on a new Root/Namespace instance throws in strict mode.
+    // It is also safe to skip because each object correctly resolves its own root at runtime
+    // by traversing the parent chain. The top-level own enumerable getter is added separately
+    // by patchProtobufRoot() after recursion completes.
+    if (key === 'root') continue;
     newRoot[key] = root[key];
   }
 
   if (isRecord(root.nested)) {
     for (const typeOrNamespace in root.nested) {
-      const value = root.nested[typeOrNamespace];
-      if (ROOT_PROPS.includes(typeOrNamespace)) {
-        console.log(
-          `patchProtobufRoot warning: overriding property '${typeOrNamespace}' that is used by protobufjs with the '${typeOrNamespace}' protobuf ${
-            isNamespace(value) ? 'namespace' : 'type'
-          }. This may result in protobufjs not working property.`
-        );
-      }
+      // Skip names that protobufjs uses internally — overriding them would corrupt
+      // the namespace object's internal state. Types/namespaces with these names are
+      // still reachable via root.lookup() or by traversing root.nested manually.
+      if (ROOT_PROPS.has(typeOrNamespace)) continue;
 
+      const value = root.nested[typeOrNamespace];
       if (isNamespace(value)) {
         newRoot[typeOrNamespace] = _patchProtobufRoot(value, typeOrNamespace);
       } else if (isType(value)) {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -63,7 +63,7 @@
     "long": "^5.2.3",
     "nexus-rpc": "^0.0.2",
     "proto3-json-serializer": "^2.0.0",
-    "protobufjs": "^7.2.5",
+    "protobufjs": "7.5.5",
     "protobufjs-cli": "^1.1.2",
     "rxjs": "7.8.1",
     "stack-utils": "^2.0.6",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -27,7 +27,7 @@
     "memfs": "^4.6.0",
     "nexus-rpc": "^0.0.2",
     "proto3-json-serializer": "^2.0.0",
-    "protobufjs": "^7.2.5",
+    "protobufjs": "^7.5.5",
     "rxjs": "^7.8.1",
     "source-map": "^0.7.4",
     "source-map-loader": "^4.0.2",

--- a/patches/protobufjs@7.5.5.patch
+++ b/patches/protobufjs@7.5.5.patch
@@ -1,0 +1,19 @@
+diff --git a/src/parse.js b/src/parse.js
+index 9c3cc27539f2cd555a1306fea0dfa0ef88eb8cc0..4317be0104461c876298579a5218c27a2e5ac474 100644
+--- a/src/parse.js
++++ b/src/parse.js
+@@ -722,8 +722,12 @@ function parse(source, root, options) {
+                     var lastValue;
+                     if (skip("[", true)) {
+                         do {
+-                            lastValue = readValue(true);
+-                            value.push(lastValue);
++                            if (peek() === "{")
++                                parseOptionValue({}, name + "." + token); // consume without recording
++                            else {
++                                lastValue = readValue(true);
++                                value.push(lastValue);
++                            }
+                         } while (skip(",", true));
+                         skip("]");
+                         if (typeof lastValue !== "undefined") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,11 @@ overrides:
   serialize-javascript: '>=7.0.3'
   handlebars: '>=4.7.9'
 
+patchedDependencies:
+  protobufjs@7.5.5:
+    hash: 0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1
+    path: patches/protobufjs@7.5.5.patch
+
 importers:
 
   .:
@@ -211,8 +216,8 @@ importers:
         specifier: ^9.0.7
         version: 9.0.8
       protobufjs:
-        specifier: ^7.2.5
-        version: 7.5.1
+        specifier: ^7.5.5
+        version: 7.5.5(patch_hash=0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1)
 
   packages/cloud:
     dependencies:
@@ -233,8 +238,8 @@ importers:
         version: 3.0.0
     devDependencies:
       protobufjs:
-        specifier: ^7.2.5
-        version: 7.5.1
+        specifier: ^7.5.5
+        version: 7.5.5(patch_hash=0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1)
 
   packages/common:
     dependencies:
@@ -255,8 +260,8 @@ importers:
         version: 2.0.0
     devDependencies:
       protobufjs:
-        specifier: ^7.2.5
-        version: 7.5.1
+        specifier: ^7.5.5
+        version: 7.5.5(patch_hash=0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1)
 
   packages/core-bridge:
     dependencies:
@@ -534,15 +539,15 @@ importers:
         specifier: ^5.2.3
         version: 5.2.3
       protobufjs:
-        specifier: ^7.2.5
-        version: 7.5.1
+        specifier: 7.5.5
+        version: 7.5.5(patch_hash=0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1)
     devDependencies:
       glob:
         specifier: ^10.3.10
         version: 10.5.0
       protobufjs-cli:
         specifier: ^1.1.2
-        version: 1.1.3(protobufjs@7.5.1)
+        version: 1.1.3(protobufjs@7.5.5(patch_hash=0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1))
 
   packages/test:
     dependencies:
@@ -661,11 +666,11 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       protobufjs:
-        specifier: ^7.2.5
-        version: 7.5.1
+        specifier: 7.5.5
+        version: 7.5.5(patch_hash=0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1)
       protobufjs-cli:
         specifier: ^1.1.2
-        version: 1.1.3(protobufjs@7.5.1)
+        version: 1.1.3(protobufjs@7.5.5(patch_hash=0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1))
       rxjs:
         specifier: 7.8.1
         version: 7.8.1
@@ -776,8 +781,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       protobufjs:
-        specifier: ^7.2.5
-        version: 7.5.1
+        specifier: ^7.5.5
+        version: 7.5.5(patch_hash=0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1)
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -4046,8 +4051,8 @@ packages:
     peerDependencies:
       protobufjs: ^7.0.0
 
-  protobufjs@7.5.1:
-    resolution: {integrity: sha512-3qx3IRjR9WPQKagdwrKjO3Gu8RgQR2qqw+1KnigWhoVjFqegIj1K3bP11sGqhxrO46/XL7lekuG4jmjL+4cLsw==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -5202,7 +5207,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.2.3
-      protobufjs: 7.5.1
+      protobufjs: 7.5.5(patch_hash=0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1)
       yargs: 17.7.2
 
   '@hono/node-server@1.19.11(hono@4.12.5)':
@@ -5388,7 +5393,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.52.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.25.1(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.1
+      protobufjs: 7.5.5(patch_hash=0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1)
 
   '@opentelemetry/propagator-b3@1.25.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -8391,9 +8396,9 @@ snapshots:
 
   proto3-json-serializer@2.0.0:
     dependencies:
-      protobufjs: 7.5.1
+      protobufjs: 7.5.5(patch_hash=0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1)
 
-  protobufjs-cli@1.1.3(protobufjs@7.5.1):
+  protobufjs-cli@1.1.3(protobufjs@7.5.5(patch_hash=0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1)):
     dependencies:
       chalk: 4.1.2
       escodegen: 1.14.3
@@ -8402,12 +8407,12 @@ snapshots:
       glob: 8.1.0
       jsdoc: 4.0.2
       minimist: 1.2.8
-      protobufjs: 7.5.1
+      protobufjs: 7.5.5(patch_hash=0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1)
       semver: 7.7.2
       tmp: 0.2.5
       uglify-js: 3.17.4
 
-  protobufjs@7.5.1:
+  protobufjs@7.5.5(patch_hash=0ede6d81e4e283d0a44203616b8935211e15e8326841cd4cd7427963385ea3c1):
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,4 +48,4 @@ overrides:
   handlebars: '>=4.7.9'
 
 patchedDependencies:
-  protobufjs@7.5.4: patches/protobufjs@7.5.4.patch
+  protobufjs@7.5.5: patches/protobufjs@7.5.5.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,3 +46,6 @@ overrides:
   'minimatch@>=7.0.0 <7.4.8': '>=7.4.8'
   serialize-javascript: '>=7.0.3'
   handlebars: '>=4.7.9'
+
+patchedDependencies:
+  protobufjs@7.5.4: patches/protobufjs@7.5.4.patch


### PR DESCRIPTION
## What changed

- Bump sdk-core submodule to 18615a (note that this is _NOT_ latest commit)
- Bump `protobufjs` to 7.5.5
- Fix a `protobufjs`' bug that was causing parse failure on latest Cloud Ops API drop due to addition of [protoc-gen-openapiv2 annotations](https://github.com/temporalio/sdk-core/pull/1172), which `protobufjs` doesn't support. The fix is implemented using PNPM's patch feature over protobufjs@7.5.4. An upstream ticket will be filed to request a proper fix, but this should be a reasonable solution until then.
- Fix `@temporalio/proto`'s "runtime root patching" script to make it compatible with `protobufjs` 7.5.2+ (fix #1717). See details below.

## Details on the `protobufjs@7.5.2` incompatibility

- `protobufjs@7.5.2` added a fast-path cache in `Namespace#lookup()` that accesses `this.root._fullyQualifiedObjects`.
- The `root` accessor is defined as a non-enumerable getter on `ReflectionObject.prototype`, so it is not copied by `for...in` loops.
- When the patched root is imported via `import * as proto from '@temporalio/proto'`, TypeScript's `__importStar` helper wraps the CJS module in a plain object by iterating own enumerable properties with `for...in` + `hasOwnProperty`.
- Because `root` is non-enumerable, it is skipped, the wrapper's `root` is `undefined`, and any subsequent `this.root._fullyQualifiedObjects` access crashes.
- Solution is to define `root` as an own **enumerable** getter ensures `__importStar` includes it in the wrapper, so that `wrapper.root` delegates back to the patched root (which has the proper `_fullyQualifiedObjects` map and full prototype chain).
