### PR TITLE
chore: enforce type only imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,7 +22,7 @@ export default tseslint.config(
     },
     rules: {
       eqeqeq: ['error', 'always', { null: 'ignore' }],
-      'no-duplicate-imports': 'error',
+      'no-duplicate-imports': ['error', { allowSeparateTypeImports: true }],
       'object-shorthand': ['error', 'always'],
       'no-restricted-imports': ['error', { patterns: ['@temporalio/*/src/*'] }],
       // TypeScript rules
@@ -30,6 +30,14 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/explicit-module-boundary-types': 'error',
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {
+          prefer: 'type-imports',
+          fixStyle: 'separate-type-imports',
+          disallowTypeAnnotations: false,
+        },
+      ],
       '@typescript-eslint/no-unused-vars': [
         'warn',
         {

--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -116,7 +116,7 @@
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
-import {
+import type {
   Logger,
   Duration,
   LogLevel,
@@ -124,13 +124,13 @@ import {
   MetricMeter,
   Priority,
   ActivityCancellationDetails,
-  IllegalStateError,
   RetryPolicy,
 } from '@temporalio/common';
+import { IllegalStateError } from '@temporalio/common';
 import { msToNumber } from '@temporalio/common/lib/time';
 
-import { ActivityCancellationDetailsHolder } from '@temporalio/common/lib/activity-cancellation-details';
-import { Client } from '@temporalio/client';
+import type { ActivityCancellationDetailsHolder } from '@temporalio/common/lib/activity-cancellation-details';
+import type { Client } from '@temporalio/client';
 
 export {
   ActivityFunction,

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -3,15 +3,10 @@ import { ensureTemporalFailure } from '@temporalio/common';
 import { encodeErrorToFailure, encodeToPayloads } from '@temporalio/common/lib/internal-non-workflow';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
-import {
-  BaseClient,
-  BaseClientOptions,
-  defaultBaseClientOptions,
-  LoadedWithDefaults,
-  WithDefaults,
-} from './base-client';
+import type { BaseClientOptions, LoadedWithDefaults, WithDefaults } from './base-client';
+import { BaseClient, defaultBaseClientOptions } from './base-client';
 import { isGrpcServiceError } from './errors';
-import { WorkflowService } from './types';
+import type { WorkflowService } from './types';
 import { rethrowKnownErrorTypes } from './helpers';
 
 /**

--- a/packages/client/src/base-client.ts
+++ b/packages/client/src/base-client.ts
@@ -1,9 +1,9 @@
 import os from 'node:os';
 import type * as _grpc from '@grpc/grpc-js'; // For JSDoc only
-import { DataConverter, LoadedDataConverter } from '@temporalio/common';
+import type { DataConverter, LoadedDataConverter } from '@temporalio/common';
 import { isLoadedDataConverter, loadDataConverter } from '@temporalio/common/lib/internal-non-workflow';
 import { Connection } from './connection';
-import { ConnectionLike, Metadata } from './types';
+import type { ConnectionLike, Metadata } from './types';
 
 export interface BaseClientOptions {
   /**

--- a/packages/client/src/build-id-types.ts
+++ b/packages/client/src/build-id-types.ts
@@ -1,4 +1,4 @@
-import { temporal } from '@temporalio/proto';
+import type { temporal } from '@temporalio/proto';
 
 /**
  * Operations that can be passed to {@link TaskQueueClient.updateBuildIdCompatibility}.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,9 +1,10 @@
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { AsyncCompletionClient } from './async-completion-client';
-import { BaseClient, BaseClientOptions, defaultBaseClientOptions, LoadedWithDefaults } from './base-client';
-import { ClientInterceptors } from './interceptors';
+import type { BaseClientOptions, LoadedWithDefaults } from './base-client';
+import { BaseClient, defaultBaseClientOptions } from './base-client';
+import type { ClientInterceptors } from './interceptors';
 import { ScheduleClient } from './schedule-client';
-import { QueryRejectCondition, WorkflowService } from './types';
+import type { QueryRejectCondition, WorkflowService } from './types';
 import { WorkflowClient } from './workflow-client';
 import { TaskQueueClient } from './task-queue-client';
 

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -1,18 +1,17 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import * as grpc from '@grpc/grpc-js';
 import type * as proto from 'protobufjs';
-import {
-  normalizeTlsConfig,
-  TLSConfig,
-  normalizeGrpcEndpointAddress,
-} from '@temporalio/common/lib/internal-non-workflow';
+import type { TLSConfig } from '@temporalio/common/lib/internal-non-workflow';
+import { normalizeTlsConfig, normalizeGrpcEndpointAddress } from '@temporalio/common/lib/internal-non-workflow';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
-import { Duration, msOptionalToNumber } from '@temporalio/common/lib/time';
+import type { Duration } from '@temporalio/common/lib/time';
+import { msOptionalToNumber } from '@temporalio/common/lib/time';
 import { type temporal } from '@temporalio/proto';
 import { isGrpcServiceError, ServiceError } from './errors';
 import { defaultGrpcRetryOptions, makeGrpcRetryInterceptor } from './grpc-retry';
 import pkg from './pkg';
-import { CallContext, HealthService, Metadata, OperatorService, TestService, WorkflowService } from './types';
+import type { CallContext, Metadata } from './types';
+import { HealthService, OperatorService, TestService, WorkflowService } from './types';
 
 /**
  * The default Temporal Server's TCP port for public gRPC connections.

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,5 +1,6 @@
-import { ServiceError as GrpcServiceError, status } from '@grpc/grpc-js';
-import { RetryState } from '@temporalio/common';
+import type { ServiceError as GrpcServiceError } from '@grpc/grpc-js';
+import { status } from '@grpc/grpc-js';
+import type { RetryState } from '@temporalio/common';
 import { isError, isRecord, SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 
 /**

--- a/packages/client/src/grpc-retry.ts
+++ b/packages/client/src/grpc-retry.ts
@@ -1,4 +1,5 @@
-import { InterceptingCall, Interceptor, ListenerBuilder, RequesterBuilder, StatusObject } from '@grpc/grpc-js';
+import type { Interceptor, StatusObject } from '@grpc/grpc-js';
+import { InterceptingCall, ListenerBuilder, RequesterBuilder } from '@grpc/grpc-js';
 import * as grpc from '@grpc/grpc-js';
 
 export interface GrpcRetryOptions {

--- a/packages/client/src/helpers.ts
+++ b/packages/client/src/helpers.ts
@@ -1,15 +1,17 @@
-import { ServiceError as GrpcServiceError, status as grpcStatus } from '@grpc/grpc-js';
-import { decodePriority, LoadedDataConverter, NamespaceNotFoundError } from '@temporalio/common';
+import type { ServiceError as GrpcServiceError } from '@grpc/grpc-js';
+import { status as grpcStatus } from '@grpc/grpc-js';
+import type { LoadedDataConverter } from '@temporalio/common';
+import { decodePriority, NamespaceNotFoundError } from '@temporalio/common';
 import {
   decodeSearchAttributes,
   decodeTypedSearchAttributes,
   searchAttributePayloadConverter,
 } from '@temporalio/common/lib/converter/payload-search-attributes';
-import { Replace } from '@temporalio/common/lib/type-helpers';
+import type { Replace } from '@temporalio/common/lib/type-helpers';
 import { optionalTsToDate, requiredTsToDate } from '@temporalio/common/lib/time';
 import { decodeMapFromPayloads } from '@temporalio/common/lib/internal-non-workflow/codec-helpers';
 import { temporal, google } from '@temporalio/proto';
-import {
+import type {
   CountWorkflowExecution,
   RawWorkflowExecutionInfo,
   WorkflowExecutionInfo,

--- a/packages/client/src/interceptor-adapters.ts
+++ b/packages/client/src/interceptor-adapters.ts
@@ -1,4 +1,4 @@
-import { WorkflowClientInterceptor, WorkflowStartInput, WorkflowStartOutput } from './interceptors';
+import type { WorkflowClientInterceptor, WorkflowStartInput, WorkflowStartOutput } from './interceptors';
 
 export function adaptWorkflowClientInterceptor(i: WorkflowClientInterceptor): WorkflowClientInterceptor {
   return adaptLegacyStartInterceptor(i);

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -5,15 +5,15 @@
  */
 
 import { Headers, Next } from '@temporalio/common';
-import { temporal } from '@temporalio/proto';
-import { CompiledScheduleOptions } from './schedule-types';
-import {
+import type { temporal } from '@temporalio/proto';
+import type { CompiledScheduleOptions } from './schedule-types';
+import type {
   DescribeWorkflowExecutionResponse,
   RequestCancelWorkflowExecutionResponse,
   TerminateWorkflowExecutionResponse,
   WorkflowExecution,
 } from './types';
-import { CompiledWorkflowOptions, WorkflowUpdateOptions } from './workflow-options';
+import type { CompiledWorkflowOptions, WorkflowUpdateOptions } from './workflow-options';
 
 export { Headers, Next };
 

--- a/packages/client/src/internal.ts
+++ b/packages/client/src/internal.ts
@@ -1,5 +1,5 @@
-import { temporal } from '@temporalio/proto';
-import { WorkflowOptions } from './workflow-options';
+import type { temporal } from '@temporalio/proto';
+import type { WorkflowOptions } from './workflow-options';
 
 /**
  * A symbol used to attach extra, SDK-internal options to the `WorkflowClient.start()` call.

--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -1,12 +1,13 @@
 import { status as grpcStatus } from '@grpc/grpc-js';
 import { v4 as uuid4 } from 'uuid';
-import { Workflow } from '@temporalio/common';
+import type { Workflow } from '@temporalio/common';
 import {
   decodeSearchAttributes,
   decodeTypedSearchAttributes,
   encodeUnifiedSearchAttributes,
 } from '@temporalio/common/lib/converter/payload-search-attributes';
-import { composeInterceptors, Headers } from '@temporalio/common/lib/interceptors';
+import type { Headers } from '@temporalio/common/lib/interceptors';
+import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import { encodeMapToPayloads, decodeMapFromPayloads } from '@temporalio/common/lib/internal-non-workflow';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { temporal } from '@temporalio/proto';
@@ -18,22 +19,20 @@ import {
   tsToDate,
 } from '@temporalio/common/lib/time';
 import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
-import { CreateScheduleInput, CreateScheduleOutput, ScheduleClientInterceptor } from './interceptors';
-import { WorkflowService } from './types';
+import type { CreateScheduleInput, CreateScheduleOutput, ScheduleClientInterceptor } from './interceptors';
+import type { WorkflowService } from './types';
 import { isGrpcServiceError, ServiceError } from './errors';
-import {
+import type {
   Backfill,
   CompiledScheduleUpdateOptions,
   ScheduleSummary,
   ScheduleDescription,
   ScheduleOptions,
-  ScheduleOverlapPolicy,
   ScheduleUpdateOptions,
   ScheduleOptionsAction,
   ScheduleOptionsStartWorkflowAction,
-  encodeScheduleOverlapPolicy,
-  decodeScheduleOverlapPolicy,
 } from './schedule-types';
+import { ScheduleOverlapPolicy, encodeScheduleOverlapPolicy, decodeScheduleOverlapPolicy } from './schedule-types';
 import {
   compileScheduleOptions,
   compileUpdatedScheduleOptions,
@@ -46,13 +45,8 @@ import {
   encodeScheduleSpec,
   encodeScheduleState,
 } from './schedule-helpers';
-import {
-  BaseClient,
-  BaseClientOptions,
-  defaultBaseClientOptions,
-  LoadedWithDefaults,
-  WithDefaults,
-} from './base-client';
+import type { BaseClientOptions, LoadedWithDefaults, WithDefaults } from './base-client';
+import { BaseClient, defaultBaseClientOptions } from './base-client';
 import { rethrowKnownErrorTypes } from './helpers';
 
 /**

--- a/packages/client/src/schedule-helpers.ts
+++ b/packages/client/src/schedule-helpers.ts
@@ -1,11 +1,11 @@
 import Long from 'long';
+import type { LoadedDataConverter } from '@temporalio/common';
 import {
   compilePriority,
   compileRetryPolicy,
   decodePriority,
   decompileRetryPolicy,
   extractWorkflowType,
-  LoadedDataConverter,
 } from '@temporalio/common';
 import { encodeUserMetadata, decodeUserMetadata } from '@temporalio/common/lib/internal-non-workflow/codec-helpers';
 import {
@@ -13,7 +13,7 @@ import {
   decodeSearchAttributes,
   decodeTypedSearchAttributes,
 } from '@temporalio/common/lib/converter/payload-search-attributes';
-import { Headers } from '@temporalio/common/lib/interceptors';
+import type { Headers } from '@temporalio/common/lib/interceptors';
 import {
   decodeArrayFromPayloads,
   decodeMapFromPayloads,
@@ -29,7 +29,7 @@ import {
   optionalTsToMs,
   requiredTsToDate,
 } from '@temporalio/common/lib/time';
-import {
+import type {
   CalendarSpec,
   CalendarSpecDescription,
   CompiledScheduleOptions,
@@ -38,9 +38,7 @@ import {
   ScheduleOptions,
   ScheduleUpdateOptions,
   DayOfWeek,
-  DAYS_OF_WEEK,
   Month,
-  MONTHS,
   LooseRange,
   ScheduleSpec,
   CompiledScheduleAction,
@@ -50,8 +48,8 @@ import {
   ScheduleExecutionActionResult,
   ScheduleExecutionResult,
   ScheduleExecutionStartWorkflowActionResult,
-  encodeScheduleOverlapPolicy,
 } from './schedule-types';
+import { DAYS_OF_WEEK, MONTHS, encodeScheduleOverlapPolicy } from './schedule-types';
 
 const [encodeSecond, decodeSecond] = makeCalendarSpecFieldCoders(
   'second',

--- a/packages/client/src/schedule-types.ts
+++ b/packages/client/src/schedule-types.ts
@@ -1,8 +1,15 @@
-import { checkExtends, Replace } from '@temporalio/common/lib/type-helpers';
-import { Duration, SearchAttributes, Workflow, TypedSearchAttributes, SearchAttributePair } from '@temporalio/common';
+import type { Replace } from '@temporalio/common/lib/type-helpers';
+import { checkExtends } from '@temporalio/common/lib/type-helpers';
+import type {
+  Duration,
+  SearchAttributes,
+  Workflow,
+  TypedSearchAttributes,
+  SearchAttributePair,
+} from '@temporalio/common';
 import { makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow';
 import type { temporal } from '@temporalio/proto';
-import { WorkflowStartOptions } from './workflow-options';
+import type { WorkflowStartOptions } from './workflow-options';
 
 /**
  * The specification of a Schedule to be created, as expected by {@link ScheduleClient.create}.

--- a/packages/client/src/task-queue-client.ts
+++ b/packages/client/src/task-queue-client.ts
@@ -1,10 +1,13 @@
 import { status } from '@grpc/grpc-js';
-import { assertNever, SymbolBasedInstanceOfError, RequireAtLeastOne } from '@temporalio/common/lib/type-helpers';
+import type { RequireAtLeastOne } from '@temporalio/common/lib/type-helpers';
+import { assertNever, SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 import { filterNullAndUndefined, makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow';
-import { temporal } from '@temporalio/proto';
-import { BaseClient, BaseClientOptions, defaultBaseClientOptions, LoadedWithDefaults } from './base-client';
-import { WorkflowService } from './types';
-import { BuildIdOperation, versionSetsFromProto, WorkerBuildIdVersionSets } from './build-id-types';
+import type { temporal } from '@temporalio/proto';
+import type { BaseClientOptions, LoadedWithDefaults } from './base-client';
+import { BaseClient, defaultBaseClientOptions } from './base-client';
+import type { WorkflowService } from './types';
+import type { BuildIdOperation, WorkerBuildIdVersionSets } from './build-id-types';
+import { versionSetsFromProto } from './build-id-types';
 import { isGrpcServiceError, ServiceError } from './errors';
 import { rethrowKnownErrorTypes } from './helpers';
 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -2,7 +2,7 @@ import type * as grpc from '@grpc/grpc-js';
 import type { TypedSearchAttributes, SearchAttributes, SearchAttributeValue, Priority } from '@temporalio/common';
 import { makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow';
 import * as proto from '@temporalio/proto';
-import { Replace } from '@temporalio/common/lib/type-helpers';
+import type { Replace } from '@temporalio/common/lib/type-helpers';
 import type { ConnectionPlugin } from './connection';
 
 export interface WorkflowExecution {

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -1,33 +1,35 @@
 import { status as grpcStatus } from '@grpc/grpc-js';
 import { v4 as uuid4 } from 'uuid';
-import {
+import type {
   BaseWorkflowHandle,
-  CancelledFailure,
-  compileRetryPolicy,
   HistoryAndWorkflowId,
   QueryDefinition,
-  RetryState,
   SignalDefinition,
   UpdateDefinition,
+  WithWorkflowArgs,
+  Workflow,
+  WorkflowResultType,
+  WorkflowIdConflictPolicy,
+} from '@temporalio/common';
+import {
+  CancelledFailure,
+  compileRetryPolicy,
+  RetryState,
   TerminatedFailure,
   TimeoutFailure,
   TimeoutType,
-  WithWorkflowArgs,
-  Workflow,
   WorkflowExecutionAlreadyStartedError,
   WorkflowNotFoundError,
-  WorkflowResultType,
   extractWorkflowType,
   encodeWorkflowIdReusePolicy,
   decodeRetryState,
   encodeWorkflowIdConflictPolicy,
-  WorkflowIdConflictPolicy,
   compilePriority,
 } from '@temporalio/common';
 import { encodeUserMetadata } from '@temporalio/common/lib/internal-non-workflow/codec-helpers';
 import { encodeUnifiedSearchAttributes } from '@temporalio/common/lib/converter/payload-search-attributes';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
-import { History } from '@temporalio/common/lib/proto-utils';
+import type { History } from '@temporalio/common/lib/proto-utils';
 import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 import {
   decodeArrayFromPayloads,
@@ -47,7 +49,7 @@ import {
   WorkflowUpdateRPCTimeoutOrCancelledError,
   isGrpcServiceError,
 } from './errors';
-import {
+import type {
   WorkflowCancelInput,
   WorkflowClientInterceptor,
   WorkflowClientInterceptors,
@@ -63,13 +65,11 @@ import {
   WorkflowStartUpdateWithStartOutput,
   WorkflowStartOutput,
 } from './interceptors';
-import {
+import type {
   CountWorkflowExecution,
   DescribeWorkflowExecutionResponse,
-  encodeQueryRejectCondition,
   GetWorkflowExecutionHistoryRequest,
   InternalConnectionLike,
-  InternalConnectionLikeSymbol,
   QueryRejectCondition,
   RequestCancelWorkflowExecutionResponse,
   StartWorkflowExecutionRequest,
@@ -79,24 +79,21 @@ import {
   WorkflowExecutionInfo,
   WorkflowService,
 } from './types';
-import {
-  compileWorkflowOptions,
+import { encodeQueryRejectCondition, InternalConnectionLikeSymbol } from './types';
+import type {
   WorkflowOptions,
   WorkflowSignalWithStartOptions,
   WorkflowStartOptions,
   WorkflowUpdateOptions,
 } from './workflow-options';
+import { compileWorkflowOptions } from './workflow-options';
 import { decodeCountWorkflowExecutionsResponse, executionInfoFromRaw, rethrowKnownErrorTypes } from './helpers';
-import {
-  BaseClient,
-  BaseClientOptions,
-  defaultBaseClientOptions,
-  LoadedWithDefaults,
-  WithDefaults,
-} from './base-client';
+import type { BaseClientOptions, LoadedWithDefaults, WithDefaults } from './base-client';
+import { BaseClient, defaultBaseClientOptions } from './base-client';
 import { mapAsyncIterable } from './iterators-utils';
 import { WorkflowUpdateStage, encodeWorkflowUpdateStage } from './workflow-update-stage';
-import { InternalWorkflowStartOptionsSymbol, InternalWorkflowStartOptions } from './internal';
+import type { InternalWorkflowStartOptions } from './internal';
+import { InternalWorkflowStartOptionsSymbol } from './internal';
 import { adaptWorkflowClientInterceptor } from './interceptor-adapters';
 
 const UpdateWorkflowExecutionLifecycleStage = temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage;

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -1,14 +1,16 @@
-import {
+import type {
   CommonWorkflowOptions,
   SignalDefinition,
   WithWorkflowArgs,
   Workflow,
   VersioningOverride,
-  toCanonicalString,
 } from '@temporalio/common';
-import { Duration, msOptionalToTs } from '@temporalio/common/lib/time';
-import { Replace } from '@temporalio/common/lib/type-helpers';
-import { google, temporal } from '@temporalio/proto';
+import { toCanonicalString } from '@temporalio/common';
+import type { Duration } from '@temporalio/common/lib/time';
+import { msOptionalToTs } from '@temporalio/common/lib/time';
+import type { Replace } from '@temporalio/common/lib/type-helpers';
+import type { google } from '@temporalio/proto';
+import { temporal } from '@temporalio/proto';
 
 export * from '@temporalio/common/lib/workflow-options';
 

--- a/packages/client/src/workflow-update-stage.ts
+++ b/packages/client/src/workflow-update-stage.ts
@@ -1,4 +1,4 @@
-import { temporal } from '@temporalio/proto';
+import type { temporal } from '@temporalio/proto';
 import { makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow';
 
 export const WorkflowUpdateStage = {

--- a/packages/cloud/src/cloud-operations-client.ts
+++ b/packages/cloud/src/cloud-operations-client.ts
@@ -1,20 +1,13 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import * as grpc from '@grpc/grpc-js';
 import type { RPCImpl } from 'protobufjs';
-import {
-  normalizeTlsConfig,
-  TLSConfig,
-  normalizeGrpcEndpointAddress,
-} from '@temporalio/common/lib/internal-non-workflow';
+import type { TLSConfig } from '@temporalio/common/lib/internal-non-workflow';
+import { normalizeTlsConfig, normalizeGrpcEndpointAddress } from '@temporalio/common/lib/internal-non-workflow';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
-import { Duration, msOptionalToNumber } from '@temporalio/common/lib/time';
-import {
-  CallContext,
-  HealthService,
-  Metadata,
-  defaultGrpcRetryOptions,
-  makeGrpcRetryInterceptor,
-} from '@temporalio/client';
+import type { Duration } from '@temporalio/common/lib/time';
+import { msOptionalToNumber } from '@temporalio/common/lib/time';
+import type { CallContext, Metadata } from '@temporalio/client';
+import { HealthService, defaultGrpcRetryOptions, makeGrpcRetryInterceptor } from '@temporalio/client';
 import pkg from './pkg';
 import { CloudService } from './types';
 

--- a/packages/common/src/activity-options.ts
+++ b/packages/common/src/activity-options.ts
@@ -1,9 +1,9 @@
 import type { coresdk } from '@temporalio/proto';
-import { RetryPolicy } from './retry-policy';
-import { Duration } from './time';
-import { VersioningIntent } from './versioning-intent';
+import type { RetryPolicy } from './retry-policy';
+import type { Duration } from './time';
+import type { VersioningIntent } from './versioning-intent';
 import { makeProtoEnumConverters } from './internal-workflow';
-import { Priority } from './priority';
+import type { Priority } from './priority';
 
 // Note: The types defined in this file are here for legacy reasons. They should have been defined
 // in the 'workflow' package, instead of 'common'. They are now reexported from the 'workflow'

--- a/packages/common/src/continue-as-new.ts
+++ b/packages/common/src/continue-as-new.ts
@@ -1,4 +1,4 @@
-import { temporal } from '@temporalio/proto';
+import type { temporal } from '@temporalio/proto';
 import { makeProtoEnumConverters } from './internal-workflow';
 
 /**

--- a/packages/common/src/converter/data-converter.ts
+++ b/packages/common/src/converter/data-converter.ts
@@ -1,6 +1,8 @@
-import { DefaultFailureConverter, FailureConverter } from './failure-converter';
-import { PayloadCodec } from './payload-codec';
-import { defaultPayloadConverter, PayloadConverter } from './payload-converter';
+import type { FailureConverter } from './failure-converter';
+import { DefaultFailureConverter } from './failure-converter';
+import type { PayloadCodec } from './payload-codec';
+import type { PayloadConverter } from './payload-converter';
+import { defaultPayloadConverter } from './payload-converter';
 
 /**
  * When your data (arguments and return values) is sent over the wire and stored by Temporal Server, it is encoded in

--- a/packages/common/src/converter/failure-converter.ts
+++ b/packages/common/src/converter/failure-converter.ts
@@ -1,6 +1,7 @@
 import * as nexus from 'nexus-rpc';
 import Long from 'long';
 import type { temporal } from '@temporalio/proto';
+import type { ProtoFailure } from '../failure';
 import {
   ActivityFailure,
   ApplicationFailure,
@@ -14,7 +15,6 @@ import {
   encodeTimeoutType,
   FAILURE_SOURCE,
   NexusOperationFailure,
-  ProtoFailure,
   ServerFailure,
   TemporalFailure,
   TerminatedFailure,
@@ -24,7 +24,8 @@ import { makeProtoEnumConverters } from '../internal-workflow';
 import { isError } from '../type-helpers';
 import { msOptionalToTs } from '../time';
 import { encode } from '../encoding';
-import { arrayFromPayloads, fromPayloadsAtIndex, PayloadConverter, toPayloads } from './payload-converter';
+import type { PayloadConverter } from './payload-converter';
+import { arrayFromPayloads, fromPayloadsAtIndex, toPayloads } from './payload-converter';
 
 // Can't import proto enums into the workflow sandbox, use this helper type and enum converter instead.
 const NexusHandlerErrorRetryBehavior = {

--- a/packages/common/src/converter/payload-codec.ts
+++ b/packages/common/src/converter/payload-codec.ts
@@ -1,4 +1,4 @@
-import { Payload } from '../interfaces';
+import type { Payload } from '../interfaces';
 
 /**
  * `PayloadCodec` is an optional step that happens between the wire and the {@link PayloadConverter}:

--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -1,6 +1,6 @@
 import { decode, encode } from '../encoding';
 import { PayloadConverterError, ValueError } from '../errors';
-import { Payload } from '../interfaces';
+import type { Payload } from '../interfaces';
 import { encodingKeys, encodingTypes, METADATA_ENCODING_KEY } from './types';
 
 /**

--- a/packages/common/src/converter/payload-search-attributes.ts
+++ b/packages/common/src/converter/payload-search-attributes.ts
@@ -1,17 +1,16 @@
 import { decode, encode } from '../encoding';
 import { ValueError } from '../errors';
-import { Payload } from '../interfaces';
+import type { Payload } from '../interfaces';
+import type { SearchAttributes, SearchAttributePair, SearchAttributeUpdatePair } from '../search-attributes';
 import {
   TypedSearchAttributes,
   SearchAttributeType,
-  SearchAttributes,
   isValidValueForType,
   TypedSearchAttributeValue,
-  SearchAttributePair,
-  SearchAttributeUpdatePair,
   TypedSearchAttributeUpdateValue,
 } from '../search-attributes';
-import { PayloadConverter, JsonPayloadConverter, mapFromPayloads, mapToPayloads } from './payload-converter';
+import type { PayloadConverter } from './payload-converter';
+import { JsonPayloadConverter, mapFromPayloads, mapToPayloads } from './payload-converter';
 
 /**
  * Converts Search Attribute values using JsonPayloadConverter

--- a/packages/common/src/converter/protobuf-payload-converters.ts
+++ b/packages/common/src/converter/protobuf-payload-converters.ts
@@ -2,13 +2,13 @@ import * as protoJsonSerializer from 'proto3-json-serializer';
 import type { Message, Namespace, Root, Type } from 'protobufjs';
 import { decode, encode } from '../encoding';
 import { PayloadConverterError, ValueError } from '../errors';
-import { Payload } from '../interfaces';
+import type { Payload } from '../interfaces';
 import { errorMessage, hasOwnProperties, hasOwnProperty, isRecord } from '../type-helpers';
+import type { PayloadConverterWithEncoding } from './payload-converter';
 import {
   BinaryPayloadConverter,
   CompositePayloadConverter,
   JsonPayloadConverter,
-  PayloadConverterWithEncoding,
   UndefinedPayloadConverter,
 } from './payload-converter';
 

--- a/packages/common/src/deprecated-time.ts
+++ b/packages/common/src/deprecated-time.ts
@@ -1,5 +1,6 @@
 import * as time from './time';
-import { type Timestamp, Duration } from './time';
+import type { Duration } from './time';
+import { type Timestamp } from './time';
 
 /**
  * Lossy conversion function from Timestamp to number due to possible overflow.

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -1,6 +1,6 @@
 import type { temporal } from '@temporalio/proto';
 import { errorMessage, isRecord, SymbolBasedInstanceOfError } from './type-helpers';
-import { Duration } from './time';
+import type { Duration } from './time';
 import { makeProtoEnumConverters } from './internal-workflow';
 
 export const FAILURE_SOURCE = 'TypeScriptSDK';

--- a/packages/common/src/interceptors.ts
+++ b/packages/common/src/interceptors.ts
@@ -1,5 +1,5 @@
-import { AnyFunc, OmitLastParam } from './type-helpers';
-import { Payload } from './interfaces';
+import type { AnyFunc, OmitLastParam } from './type-helpers';
+import type { Payload } from './interfaces';
 
 /**
  * Type of the next function for a given interceptor function

--- a/packages/common/src/internal-non-workflow/codec-helpers.ts
+++ b/packages/common/src/internal-non-workflow/codec-helpers.ts
@@ -1,5 +1,5 @@
 import type { temporal } from '@temporalio/proto';
-import { Payload } from '../interfaces';
+import type { Payload } from '../interfaces';
 import {
   arrayFromPayloads,
   convertOptionalToPayload,
@@ -7,11 +7,11 @@ import {
   toPayloads,
 } from '../converter/payload-converter';
 import { PayloadConverterError } from '../errors';
-import { PayloadCodec } from '../converter/payload-codec';
-import { ProtoFailure } from '../failure';
-import { LoadedDataConverter } from '../converter/data-converter';
-import { UserMetadata } from '../user-metadata';
-import { DecodedPayload, DecodedProtoFailure, EncodedPayload, EncodedProtoFailure } from './codec-types';
+import type { PayloadCodec } from '../converter/payload-codec';
+import type { ProtoFailure } from '../failure';
+import type { LoadedDataConverter } from '../converter/data-converter';
+import type { UserMetadata } from '../user-metadata';
+import type { DecodedPayload, DecodedProtoFailure, EncodedPayload, EncodedProtoFailure } from './codec-types';
 
 /**
  * Decode through each codec, starting with the last codec.

--- a/packages/common/src/internal-non-workflow/data-converter-helpers.ts
+++ b/packages/common/src/internal-non-workflow/data-converter-helpers.ts
@@ -1,6 +1,8 @@
-import { PayloadConverter, defaultPayloadConverter } from '../converter/payload-converter';
-import { DataConverter, defaultFailureConverter, LoadedDataConverter } from '../converter/data-converter';
-import { FailureConverter } from '../converter/failure-converter';
+import type { PayloadConverter } from '../converter/payload-converter';
+import { defaultPayloadConverter } from '../converter/payload-converter';
+import type { DataConverter, LoadedDataConverter } from '../converter/data-converter';
+import { defaultFailureConverter } from '../converter/data-converter';
+import type { FailureConverter } from '../converter/failure-converter';
 import { errorCode, hasOwnProperty, isRecord } from '../type-helpers';
 import { ValueError } from '../errors';
 

--- a/packages/common/src/internal-non-workflow/proxy-config.ts
+++ b/packages/common/src/internal-non-workflow/proxy-config.ts
@@ -1,4 +1,5 @@
-import { ProtoHostPort, splitProtoHostPort } from './parse-host-uri';
+import type { ProtoHostPort } from './parse-host-uri';
+import { splitProtoHostPort } from './parse-host-uri';
 
 /**
  * Configuration for HTTP CONNECT proxying.

--- a/packages/common/src/internal-workflow/enums-helpers.ts
+++ b/packages/common/src/internal-workflow/enums-helpers.ts
@@ -1,5 +1,5 @@
 import { ValueError } from '../errors';
-import { Exact, RemovePrefix, UnionToIntersection } from '../type-helpers';
+import type { Exact, RemovePrefix, UnionToIntersection } from '../type-helpers';
 
 /**
  * Create encoding and decoding functions to convert between the numeric `enum` types produced by our

--- a/packages/common/src/retry-policy.ts
+++ b/packages/common/src/retry-policy.ts
@@ -1,6 +1,7 @@
 import type { temporal } from '@temporalio/proto';
 import { ValueError } from './errors';
-import { Duration, msOptionalToNumber, msOptionalToTs, msToNumber, msToTs, optionalTsToMs } from './time';
+import type { Duration } from './time';
+import { msOptionalToNumber, msOptionalToTs, msToNumber, msToTs, optionalTsToMs } from './time';
 
 /**
  * Options for retrying Workflows and Activities

--- a/packages/common/src/time.ts
+++ b/packages/common/src/time.ts
@@ -1,5 +1,6 @@
 import Long from 'long';
-import ms, { StringValue } from 'ms';
+import type { StringValue } from 'ms';
+import ms from 'ms';
 import type { google } from '@temporalio/proto';
 import { ValueError } from './errors';
 

--- a/packages/common/src/user-metadata.ts
+++ b/packages/common/src/user-metadata.ts
@@ -1,5 +1,6 @@
 import type { temporal } from '@temporalio/proto';
-import { convertOptionalToPayload, PayloadConverter } from './converter/payload-converter';
+import type { PayloadConverter } from './converter/payload-converter';
+import { convertOptionalToPayload } from './converter/payload-converter';
 
 /**
  * User metadata that can be attached to workflow commands.

--- a/packages/common/src/workflow-definition-options.ts
+++ b/packages/common/src/workflow-definition-options.ts
@@ -1,4 +1,4 @@
-import { VersioningBehavior } from './worker-deployments';
+import type { VersioningBehavior } from './worker-deployments';
 
 /**
  * Options that can be used when defining a workflow via {@link setWorkflowOptions}.

--- a/packages/common/src/workflow-handle.ts
+++ b/packages/common/src/workflow-handle.ts
@@ -1,4 +1,4 @@
-import { Workflow, WorkflowResultType, SignalDefinition } from './interfaces';
+import type { Workflow, WorkflowResultType, SignalDefinition } from './interfaces';
 
 /**
  * Base WorkflowHandle interface, extended in workflow and client libs.

--- a/packages/common/src/workflow-options.ts
+++ b/packages/common/src/workflow-options.ts
@@ -1,11 +1,11 @@
 import type { temporal } from '@temporalio/proto';
-import { Workflow } from './interfaces';
-import { RetryPolicy } from './retry-policy';
-import { Duration } from './time';
+import type { Workflow } from './interfaces';
+import type { RetryPolicy } from './retry-policy';
+import type { Duration } from './time';
 import { makeProtoEnumConverters } from './internal-workflow';
-import { SearchAttributePair, SearchAttributes, TypedSearchAttributes } from './search-attributes';
-import { Priority } from './priority';
-import { WorkflowFunctionWithOptions } from './workflow-definition-options';
+import type { SearchAttributePair, SearchAttributes, TypedSearchAttributes } from './search-attributes';
+import type { Priority } from './priority';
+import type { WorkflowFunctionWithOptions } from './workflow-definition-options';
 
 /**
  * Defines what happens when trying to start a Workflow with the same ID as a *Closed* Workflow.

--- a/packages/create-project/src/create-project.ts
+++ b/packages/create-project/src/create-project.ts
@@ -7,13 +7,13 @@ import chalkTemplate from 'chalk-template';
 // eslint-disable-next-line import/no-named-as-default
 import prompts from 'prompts';
 
+import type { RepoInfo } from './helpers/samples.js';
 import {
   downloadAndExtractSample,
   downloadAndExtractRepo,
   getRepoInfo,
   hasSample,
   checkForPackageJson,
-  RepoInfo,
 } from './helpers/samples.js';
 import { makeDir } from './helpers/make-dir.js';
 import { tryGitInit } from './helpers/git.js';

--- a/packages/create-project/src/helpers/subprocess.ts
+++ b/packages/create-project/src/helpers/subprocess.ts
@@ -1,5 +1,6 @@
 // https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options
-import { ChildProcess, spawn as origSpawn, SpawnOptions } from 'child_process';
+import type { ChildProcess, SpawnOptions } from 'child_process';
+import { spawn as origSpawn } from 'child_process';
 
 export class ChildProcessError extends Error {
   public readonly name = 'ChildProcessError';

--- a/packages/envconfig/src/envconfig-toml.ts
+++ b/packages/envconfig/src/envconfig-toml.ts
@@ -1,10 +1,11 @@
 import { readFileSync } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { parse, stringify, TomlTable } from 'smol-toml';
+import type { TomlTable } from 'smol-toml';
+import { parse, stringify } from 'smol-toml';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow/objects-helpers';
 import { decode, encode } from '@temporalio/common/lib/encoding';
-import { ConfigDataSource, LoadClientConfigOptions, LoadClientProfileOptions } from './types';
+import type { ConfigDataSource, LoadClientConfigOptions, LoadClientProfileOptions } from './types';
 
 export function normalizeGrpcMetaKey(key: string): string {
   return key.toLocaleLowerCase().replace('_', '-');

--- a/packages/envconfig/src/envconfig.ts
+++ b/packages/envconfig/src/envconfig.ts
@@ -6,7 +6,7 @@ import {
   tomlLoadClientConfig,
   tomlLoadClientConfigProfile,
 } from './envconfig-toml';
-import {
+import type {
   ClientConfig,
   ClientConfigFromTomlOptions,
   ClientConfigProfile,

--- a/packages/envconfig/src/utils.ts
+++ b/packages/envconfig/src/utils.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from 'fs';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { encode, decode } from '@temporalio/common/lib/encoding';
-import { ClientConfigProfile, ClientConfigTLS, ClientConfig, ConfigDataSource } from './types';
-import { normalizeGrpcMetaKey, TomlClientConfig, TomlClientConfigProfile, TomlClientConfigTLS } from './envconfig-toml';
+import type { ClientConfigProfile, ClientConfigTLS, ClientConfig, ConfigDataSource } from './types';
+import type { TomlClientConfig, TomlClientConfigProfile, TomlClientConfigTLS } from './envconfig-toml';
+import { normalizeGrpcMetaKey } from './envconfig-toml';
 
 /**
  * Loads configuration data from a {@link ConfigDataSource} and returns it as a Uint8Array.

--- a/packages/interceptors-opentelemetry/src/plugin.ts
+++ b/packages/interceptors-opentelemetry/src/plugin.ts
@@ -1,8 +1,9 @@
-import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { Resource } from '@opentelemetry/resources';
+import type { SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import type { Resource } from '@opentelemetry/resources';
 import { SimplePlugin } from '@temporalio/plugin';
-import { InjectedSinks, ReplayWorkerOptions, WorkerOptions } from '@temporalio/worker';
-import { InterceptorOptions, OpenTelemetryWorkflowClientInterceptor } from './client';
+import type { InjectedSinks, ReplayWorkerOptions, WorkerOptions } from '@temporalio/worker';
+import type { InterceptorOptions } from './client';
+import { OpenTelemetryWorkflowClientInterceptor } from './client';
 import {
   makeWorkflowExporter,
   OpenTelemetryActivityInboundInterceptor,
@@ -10,7 +11,7 @@ import {
   OpenTelemetryNexusInboundInterceptor,
   OpenTelemetryNexusOutboundInterceptor,
 } from './worker';
-import { OpenTelemetrySinks } from './workflow';
+import type { OpenTelemetrySinks } from './workflow';
 
 /**
  * Configuration options for {@link OpenTelemetryPlugin}.

--- a/packages/interceptors-opentelemetry/src/workflow/definitions.ts
+++ b/packages/interceptors-opentelemetry/src/workflow/definitions.ts
@@ -1,6 +1,6 @@
-import * as otel from '@opentelemetry/api';
-import * as tracing from '@opentelemetry/sdk-trace-base';
-import { InstrumentationLibrary } from '@opentelemetry/core'; // eslint-disable @typescript-eslint/no-deprecated
+import type * as otel from '@opentelemetry/api';
+import type * as tracing from '@opentelemetry/sdk-trace-base';
+import type { InstrumentationLibrary } from '@opentelemetry/core'; // eslint-disable @typescript-eslint/no-deprecated
 import type { Sink, Sinks } from '@temporalio/workflow';
 
 /**

--- a/packages/interceptors-opentelemetry/src/workflow/span-exporter.ts
+++ b/packages/interceptors-opentelemetry/src/workflow/span-exporter.ts
@@ -1,6 +1,7 @@
-import * as tracing from '@opentelemetry/sdk-trace-base';
-import { ExportResult, ExportResultCode } from '@opentelemetry/core';
-import { OpenTelemetrySinks, SerializableSpan, SerializableSpanContext } from './definitions';
+import type * as tracing from '@opentelemetry/sdk-trace-base';
+import type { ExportResult } from '@opentelemetry/core';
+import { ExportResultCode } from '@opentelemetry/core';
+import type { OpenTelemetrySinks, SerializableSpan, SerializableSpanContext } from './definitions';
 import { proxySinks } from './workflow-imports';
 
 export class SpanExporter implements tracing.SpanExporter {

--- a/packages/nexus/src/context.ts
+++ b/packages/nexus/src/context.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { Logger, LogLevel, LogMetadata, MetricMeter } from '@temporalio/common';
-import { Client } from '@temporalio/client';
+import type { Logger, LogLevel, LogMetadata, MetricMeter } from '@temporalio/common';
+import type { Client } from '@temporalio/client';
 
 // Context Storage /////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/nexus/src/link-converter.ts
+++ b/packages/nexus/src/link-converter.ts
@@ -1,5 +1,5 @@
 import Long from 'long';
-import { Link as NexusLink } from 'nexus-rpc';
+import type { Link as NexusLink } from 'nexus-rpc';
 import { temporal } from '@temporalio/proto';
 
 const { EventType } = temporal.api.enums.v1;

--- a/packages/nexus/src/workflow-helpers.ts
+++ b/packages/nexus/src/workflow-helpers.ts
@@ -1,9 +1,10 @@
 import * as nexus from 'nexus-rpc';
-import { Workflow, WorkflowResultType } from '@temporalio/common';
-import { Replace } from '@temporalio/common/lib/type-helpers';
-import { WorkflowStartOptions as ClientWorkflowStartOptions } from '@temporalio/client';
+import type { Workflow, WorkflowResultType } from '@temporalio/common';
+import type { Replace } from '@temporalio/common/lib/type-helpers';
+import type { WorkflowStartOptions as ClientWorkflowStartOptions } from '@temporalio/client';
 import { type temporal } from '@temporalio/proto';
-import { InternalWorkflowStartOptionsSymbol, InternalWorkflowStartOptions } from '@temporalio/client/lib/internal';
+import type { InternalWorkflowStartOptions } from '@temporalio/client/lib/internal';
+import { InternalWorkflowStartOptionsSymbol } from '@temporalio/client/lib/internal';
 import { generateWorkflowRunOperationToken, loadWorkflowRunOperationToken } from './token';
 import { convertNexusLinkToWorkflowEventLink, convertWorkflowEventLinkToNexusLink } from './link-converter';
 import { getClient, getHandlerContext, log } from './context';

--- a/packages/nyc-test-coverage/src/globalCoverage.ts
+++ b/packages/nyc-test-coverage/src/globalCoverage.ts
@@ -1,4 +1,4 @@
-import { CoverageMapData } from 'istanbul-lib-coverage';
+import type { CoverageMapData } from 'istanbul-lib-coverage';
 
 declare global {
   var __coverage__: CoverageMapData;

--- a/packages/nyc-test-coverage/src/index.ts
+++ b/packages/nyc-test-coverage/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import * as libCoverage from 'istanbul-lib-coverage';
-import { InjectedSinks, BundleOptions, WorkerOptions } from '@temporalio/worker';
-import { CoverageSinks } from './sinks';
+import type { InjectedSinks, BundleOptions, WorkerOptions } from '@temporalio/worker';
+import type { CoverageSinks } from './sinks';
 
 // Pull `webpack.Configuration` type without needing to import Webpack
 type WebpackConfigType = ReturnType<NonNullable<BundleOptions['webpackConfigHook']>>;

--- a/packages/nyc-test-coverage/src/interceptors.ts
+++ b/packages/nyc-test-coverage/src/interceptors.ts
@@ -1,6 +1,7 @@
 import type { CoverageMapData } from 'istanbul-lib-coverage';
-import { proxySinks, WorkflowInterceptors } from '@temporalio/workflow';
-import { CoverageSinks } from './sinks';
+import type { WorkflowInterceptors } from '@temporalio/workflow';
+import { proxySinks } from '@temporalio/workflow';
+import type { CoverageSinks } from './sinks';
 
 const { coverage } = proxySinks<CoverageSinks>();
 

--- a/packages/nyc-test-coverage/src/sinks.ts
+++ b/packages/nyc-test-coverage/src/sinks.ts
@@ -1,4 +1,4 @@
-import { Sinks } from '@temporalio/workflow';
+import type { Sinks } from '@temporalio/workflow';
 
 export interface CoverageSinks extends Sinks {
   coverage: {

--- a/packages/test/src/activities/async-completer.ts
+++ b/packages/test/src/activities/async-completer.ts
@@ -1,5 +1,6 @@
-import { Observer } from 'rxjs';
-import { CompleteAsyncError, Context, Info } from '@temporalio/activity';
+import type { Observer } from 'rxjs';
+import type { Info } from '@temporalio/activity';
+import { CompleteAsyncError, Context } from '@temporalio/activity';
 
 export interface Activities {
   completeAsync(): Promise<string>;

--- a/packages/test/src/activities/heartbeat-cancellation-details.ts
+++ b/packages/test/src/activities/heartbeat-cancellation-details.ts
@@ -1,4 +1,4 @@
-import { ActivityCancellationDetails } from '@temporalio/common';
+import type { ActivityCancellationDetails } from '@temporalio/common';
 import * as activity from '@temporalio/activity';
 
 export interface ActivityState {

--- a/packages/test/src/activities/helpers.ts
+++ b/packages/test/src/activities/helpers.ts
@@ -1,5 +1,5 @@
-import { WorkflowHandle } from '@temporalio/client';
-import { QueryDefinition } from '@temporalio/common';
+import type { WorkflowHandle } from '@temporalio/client';
+import type { QueryDefinition } from '@temporalio/common';
 import { Context } from '@temporalio/activity';
 
 function getSchedulingWorkflowHandle(): WorkflowHandle {

--- a/packages/test/src/activities/index.ts
+++ b/packages/test/src/activities/index.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { activityInfo, Context } from '@temporalio/activity';
 import { ApplicationFailure, ApplicationFailureCategory } from '@temporalio/common';
-import { ProtoActivityInput, ProtoActivityResult } from '../../protos/root';
+import type { ProtoActivityInput } from '../../protos/root';
+import { ProtoActivityResult } from '../../protos/root';
 import { cancellableFetch as cancellableFetchInner } from './cancellable-fetch';
 import { fakeProgress as fakeProgressInner } from './fake-progress';
 import { signalSchedulingWorkflow } from './helpers';

--- a/packages/test/src/failing-payload-converter.ts
+++ b/packages/test/src/failing-payload-converter.ts
@@ -1,5 +1,6 @@
-import { defaultPayloadConverter, Payload } from '@temporalio/common';
-import { PayloadConverter } from '@temporalio/common/lib/converter/payload-converter';
+import type { Payload } from '@temporalio/common';
+import { defaultPayloadConverter } from '@temporalio/common';
+import type { PayloadConverter } from '@temporalio/common/lib/converter/payload-converter';
 
 export const payloadConverter: PayloadConverter = {
   toPayload<T>(value: T): Payload {

--- a/packages/test/src/helpers-integration-multi-codec.ts
+++ b/packages/test/src/helpers-integration-multi-codec.ts
@@ -1,15 +1,17 @@
 /* eslint @typescript-eslint/no-non-null-assertion: 0 */
-import { ExecutionContext, TestFn } from 'ava';
-import { defaultFailureConverter, defaultPayloadConverter, LoadedDataConverter } from '@temporalio/common';
-import { WorkerOptions, WorkflowBundle } from '@temporalio/worker';
+import type { ExecutionContext, TestFn } from 'ava';
+import type { LoadedDataConverter } from '@temporalio/common';
+import { defaultFailureConverter, defaultPayloadConverter } from '@temporalio/common';
+import type { WorkerOptions, WorkflowBundle } from '@temporalio/worker';
 
-import { TestWorkflowEnvironment } from '@temporalio/testing';
+import type { TestWorkflowEnvironment } from '@temporalio/testing';
 import {
   configurableHelpers,
   createTestWorkflowEnvironment,
   makeConfigurableEnvironmentTestFn,
 } from './helpers-integration';
-import { ByteSkewerPayloadCodec, Worker } from './helpers';
+import type { Worker } from './helpers';
+import { ByteSkewerPayloadCodec } from './helpers';
 
 // Note: re-export shared workflows (or long workflows)
 export * from './workflows';

--- a/packages/test/src/helpers-integration.ts
+++ b/packages/test/src/helpers-integration.ts
@@ -1,37 +1,30 @@
 import { randomUUID } from 'crypto';
 import { status as grpcStatus } from '@grpc/grpc-js';
-import { ErrorConstructor, ExecutionContext, TestFn } from 'ava';
-import {
-  isGrpcServiceError,
-  WorkflowFailedError,
-  WorkflowHandle,
-  WorkflowHandleWithFirstExecutionRunId,
-  WorkflowStartOptions,
-  WorkflowUpdateFailedError,
-} from '@temporalio/client';
-import {
-  LocalTestWorkflowEnvironmentOptions,
-  NexusEndpointIdentifier,
-  workflowInterceptorModules as defaultWorkflowInterceptorModules,
-} from '@temporalio/testing';
-import {
+import type { ErrorConstructor, ExecutionContext, TestFn } from 'ava';
+import type { WorkflowHandle, WorkflowHandleWithFirstExecutionRunId, WorkflowStartOptions } from '@temporalio/client';
+import { isGrpcServiceError, WorkflowFailedError, WorkflowUpdateFailedError } from '@temporalio/client';
+import type { LocalTestWorkflowEnvironmentOptions, NexusEndpointIdentifier } from '@temporalio/testing';
+import { workflowInterceptorModules as defaultWorkflowInterceptorModules } from '@temporalio/testing';
+import type {
   BundlerPlugin,
-  DefaultLogger,
   LogEntry,
   LogLevel,
-  NativeConnection,
   NativeConnectionOptions,
   ReplayWorkerOptions,
-  Runtime,
   RuntimeOptions,
   WorkerOptions,
   WorkflowBundle,
   WorkflowBundleWithSourceMap,
+} from '@temporalio/worker';
+import {
+  DefaultLogger,
+  NativeConnection,
+  Runtime,
   bundleWorkflowCode,
   makeTelemetryFilterString,
 } from '@temporalio/worker';
-import * as workflow from '@temporalio/workflow';
-import { temporal } from '@temporalio/proto';
+import type * as workflow from '@temporalio/workflow';
+import type { temporal } from '@temporalio/proto';
 import { defineSearchAttributeKey, SearchAttributeType } from '@temporalio/common/lib/search-attributes';
 import { Worker, TestWorkflowEnvironment, test as anyTest, bundlerOptions } from './helpers';
 

--- a/packages/test/src/helpers.ts
+++ b/packages/test/src/helpers.ts
@@ -3,21 +3,24 @@ import * as net from 'net';
 import path from 'path';
 import * as grpc from '@grpc/grpc-js';
 import asyncRetry from 'async-retry';
-import ava, { TestFn, ExecutionContext } from 'ava';
+import type { TestFn, ExecutionContext } from 'ava';
+import ava from 'ava';
 import StackUtils from 'stack-utils';
 import { v4 as uuid4 } from 'uuid';
-import { Client, Connection } from '@temporalio/client';
-import { Payload, PayloadCodec } from '@temporalio/common';
+import type { Connection } from '@temporalio/client';
+import { Client } from '@temporalio/client';
+import type { Payload, PayloadCodec } from '@temporalio/common';
 import { historyToJSON } from '@temporalio/common/lib/proto-utils';
 import * as iface from '@temporalio/proto';
-import {
+import type {
   ExistingServerTestWorkflowEnvironmentOptions,
   LocalTestWorkflowEnvironmentOptions,
-  TestWorkflowEnvironment as RealTestWorkflowEnvironment,
   TimeSkippingTestWorkflowEnvironmentOptions,
 } from '@temporalio/testing';
+import { TestWorkflowEnvironment as RealTestWorkflowEnvironment } from '@temporalio/testing';
 import * as worker from '@temporalio/worker';
-import { Worker as RealWorker, WorkerOptions } from '@temporalio/worker';
+import type { WorkerOptions } from '@temporalio/worker';
+import { Worker as RealWorker } from '@temporalio/worker';
 import { inWorkflowContext } from '@temporalio/workflow';
 
 export function u8(s: string): Uint8Array {

--- a/packages/test/src/load/all-in-one.ts
+++ b/packages/test/src/load/all-in-one.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { ChildProcess, spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import arg from 'arg';
 import { waitOnChild, shell, ChildProcessError, killIfExists } from './child-process';
 import { setupArgSpec, starterArgSpec, workerArgSpec, allInOneArgSpec } from './args';

--- a/packages/test/src/load/all-scenarios.ts
+++ b/packages/test/src/load/all-scenarios.ts
@@ -2,7 +2,7 @@ import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { msToNumber } from '@temporalio/common/lib/time';
 import * as workflows from '../workflows';
-import { Spec, AllInOneArgSpec } from './args';
+import type { Spec, AllInOneArgSpec } from './args';
 
 export type EvaluatedArgs<T extends Spec> = {
   [K in keyof T]?: ReturnType<T[K]>;

--- a/packages/test/src/load/args.ts
+++ b/packages/test/src/load/args.ts
@@ -1,7 +1,7 @@
 /**
  */
 
-import arg from 'arg';
+import type arg from 'arg';
 
 /**
  * Simplified version of `arg.Spec`, required to construct typed options

--- a/packages/test/src/load/child-process.ts
+++ b/packages/test/src/load/child-process.ts
@@ -1,5 +1,5 @@
 // TODO: this code is duplicated in the scripts directory, consider moving to external dependency
-import { ChildProcess } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 
 export class ChildProcessError extends Error {
   public readonly name = 'ChildProcessError';

--- a/packages/test/src/load/setup.ts
+++ b/packages/test/src/load/setup.ts
@@ -2,7 +2,8 @@ import { readFileSync } from 'fs';
 import arg from 'arg';
 import { Connection } from '@temporalio/client';
 import { createNamespace, waitOnNamespace } from '@temporalio/testing/lib/utils';
-import { SetupArgSpec, setupArgSpec, getRequired } from './args';
+import type { SetupArgSpec } from './args';
+import { setupArgSpec, getRequired } from './args';
 
 async function main() {
   const args = arg<SetupArgSpec>(setupArgSpec);

--- a/packages/test/src/load/starter.ts
+++ b/packages/test/src/load/starter.ts
@@ -4,11 +4,13 @@ import arg from 'arg';
 import pidusage from 'pidusage';
 import * as grpc from '@grpc/grpc-js';
 import { v4 as uuid4 } from 'uuid';
-import { interval, range, Observable, OperatorFunction, ReplaySubject, pipe, lastValueFrom } from 'rxjs';
+import type { Observable, OperatorFunction } from 'rxjs';
+import { interval, range, ReplaySubject, pipe, lastValueFrom } from 'rxjs';
 import { bufferTime, map, mergeMap, tap, takeUntil } from 'rxjs/operators';
 import { Connection, ServiceError, WorkflowClient, isGrpcServiceError } from '@temporalio/client';
 import { toMB } from '@temporalio/worker/lib/utils';
-import { StarterArgSpec, starterArgSpec, getRequired } from './args';
+import type { StarterArgSpec } from './args';
+import { starterArgSpec, getRequired } from './args';
 
 const ACCEPTABLE_QUERY_ERROR_CODES = [grpc.status.NOT_FOUND, grpc.status.DEADLINE_EXCEEDED];
 

--- a/packages/test/src/load/worker.ts
+++ b/packages/test/src/load/worker.ts
@@ -5,18 +5,11 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import * as opentelemetry from '@opentelemetry/sdk-node';
 import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import arg from 'arg';
-import {
-  DefaultLogger,
-  LogEntry,
-  LogLevel,
-  NativeConnection,
-  Runtime,
-  TelemetryOptions,
-  Worker,
-  makeTelemetryFilterString,
-} from '@temporalio/worker';
+import type { LogEntry, LogLevel, TelemetryOptions } from '@temporalio/worker';
+import { DefaultLogger, NativeConnection, Runtime, Worker, makeTelemetryFilterString } from '@temporalio/worker';
 import * as activities from '../activities';
-import { getRequired, WorkerArgSpec, workerArgSpec } from './args';
+import type { WorkerArgSpec } from './args';
+import { getRequired, workerArgSpec } from './args';
 
 /**
  * Optionally start the opentelemetry node SDK

--- a/packages/test/src/mock-internal-flags.ts
+++ b/packages/test/src/mock-internal-flags.ts
@@ -1,5 +1,5 @@
 import { getActivator } from '@temporalio/workflow/lib/global-attributes';
-import { SdkFlag } from '@temporalio/workflow/lib/flags';
+import type { SdkFlag } from '@temporalio/workflow/lib/flags';
 
 const defaultValueOverrides = new Map<number, boolean>();
 

--- a/packages/test/src/mock-native-worker.ts
+++ b/packages/test/src/mock-native-worker.ts
@@ -4,11 +4,13 @@ import { msToTs } from '@temporalio/common/lib/time';
 import { coresdk } from '@temporalio/proto';
 import { DefaultLogger, Runtime, ShutdownError } from '@temporalio/worker';
 import { byteArrayToBuffer } from '@temporalio/worker/lib/utils';
-import { native } from '@temporalio/core-bridge';
-import { NativeReplayHandle, NativeWorkerLike, Worker as RealWorker } from '@temporalio/worker/lib/worker';
+import type { native } from '@temporalio/core-bridge';
+import type { NativeReplayHandle, NativeWorkerLike } from '@temporalio/worker/lib/worker';
+import { Worker as RealWorker } from '@temporalio/worker/lib/worker';
 import { LoggerWithComposedMetadata } from '@temporalio/common/lib/logger';
 import { MetricMeterWithComposedTags } from '@temporalio/common/lib/metrics';
-import { CompiledWorkerOptions, compileWorkerOptions, WorkerOptions } from '@temporalio/worker/lib/worker-options';
+import type { CompiledWorkerOptions, WorkerOptions } from '@temporalio/worker/lib/worker-options';
+import { compileWorkerOptions } from '@temporalio/worker/lib/worker-options';
 import type { WorkflowCreator } from '@temporalio/worker/lib/workflow/interface';
 import * as activities from './activities';
 

--- a/packages/test/src/mocks/workflows-with-node-dependencies/issue-516.ts
+++ b/packages/test/src/mocks/workflows-with-node-dependencies/issue-516.ts
@@ -1,4 +1,5 @@
-import { ExampleModel, ExampleEnum, extractProperty } from './example/index';
+import type { ExampleModel } from './example/index';
+import { ExampleEnum, extractProperty } from './example/index';
 
 // Demonstrate issue #516
 export async function issue516(): Promise<string> {

--- a/packages/test/src/payload-converters/payload-converter-returns-undefined.ts
+++ b/packages/test/src/payload-converters/payload-converter-returns-undefined.ts
@@ -1,4 +1,5 @@
-import { Payload, PayloadConverter, ValueError } from '@temporalio/common';
+import type { Payload, PayloadConverter } from '@temporalio/common';
+import { ValueError } from '@temporalio/common';
 import { decode } from '@temporalio/common/lib/encoding';
 
 class TestPayloadConverter implements PayloadConverter {

--- a/packages/test/src/payload-converters/payload-converter-throws-from-payload.ts
+++ b/packages/test/src/payload-converters/payload-converter-throws-from-payload.ts
@@ -1,4 +1,5 @@
-import { encodingKeys, METADATA_ENCODING_KEY, Payload, PayloadConverter } from '@temporalio/common';
+import type { Payload, PayloadConverter } from '@temporalio/common';
+import { encodingKeys, METADATA_ENCODING_KEY } from '@temporalio/common';
 import { encode } from '@temporalio/common/lib/encoding';
 
 class TestPayloadConverter implements PayloadConverter {

--- a/packages/test/src/run-a-worker.ts
+++ b/packages/test/src/run-a-worker.ts
@@ -1,6 +1,7 @@
 import arg from 'arg';
 import * as nexus from 'nexus-rpc';
-import { Worker, Runtime, DefaultLogger, LogLevel, makeTelemetryFilterString } from '@temporalio/worker';
+import type { LogLevel } from '@temporalio/worker';
+import { Worker, Runtime, DefaultLogger, makeTelemetryFilterString } from '@temporalio/worker';
 import * as activities from './activities';
 
 async function main() {

--- a/packages/test/src/run-activation-perf-tests.ts
+++ b/packages/test/src/run-activation-perf-tests.ts
@@ -5,7 +5,8 @@ import { coresdk } from '@temporalio/proto';
 import { ReusableVMWorkflowCreator } from '@temporalio/worker/lib/workflow/reusable-vm';
 import { WorkflowCodeBundler } from '@temporalio/worker/lib/workflow/bundler';
 import { parseWorkflowCode } from '@temporalio/worker/lib/worker';
-import { VMWorkflow, VMWorkflowCreator } from '@temporalio/worker/lib/workflow/vm';
+import type { VMWorkflow } from '@temporalio/worker/lib/workflow/vm';
+import { VMWorkflowCreator } from '@temporalio/worker/lib/workflow/vm';
 import * as wf from '@temporalio/workflow';
 import { TypedSearchAttributes } from '@temporalio/common';
 

--- a/packages/test/src/test-activity-log-interceptor.ts
+++ b/packages/test/src/test-activity-log-interceptor.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
-import { ActivityInboundLogInterceptor, DefaultLogger, LogEntry, Runtime } from '@temporalio/worker';
+import type { LogEntry } from '@temporalio/worker';
+import { ActivityInboundLogInterceptor, DefaultLogger, Runtime } from '@temporalio/worker';
 import { activityLogAttributes } from '@temporalio/worker/lib/activity';
 import { MockActivityEnvironment, defaultActivityInfo } from '@temporalio/testing';
 import { isCancellation } from '@temporalio/workflow';

--- a/packages/test/src/test-ai-sdk.ts
+++ b/packages/test/src/test-ai-sdk.ts
@@ -29,15 +29,16 @@ import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
 import { AiSdkPlugin, createActivities } from '@temporalio/ai-sdk';
 import { temporal } from '@temporalio/proto';
 import { WorkflowClient } from '@temporalio/client';
+import type { OpenTelemetrySinks } from '@temporalio/interceptors-opentelemetry';
 import {
   makeWorkflowExporter,
   OpenTelemetryActivityInboundInterceptor,
   OpenTelemetryActivityOutboundInterceptor,
-  OpenTelemetrySinks,
   OpenTelemetryWorkflowClientCallsInterceptor,
   OpenTelemetryWorkflowClientInterceptor,
 } from '@temporalio/interceptors-opentelemetry';
-import { InjectedSinks, Runtime } from '@temporalio/worker';
+import type { InjectedSinks } from '@temporalio/worker';
+import { Runtime } from '@temporalio/worker';
 import {
   embeddingWorkflow,
   generateObjectWorkflow,

--- a/packages/test/src/test-async-completion.ts
+++ b/packages/test/src/test-async-completion.ts
@@ -1,5 +1,7 @@
-import anyTest, { TestFn, ExecutionContext } from 'ava';
-import { Observable, Subject, firstValueFrom } from 'rxjs';
+import type { TestFn, ExecutionContext } from 'ava';
+import anyTest from 'ava';
+import type { Observable } from 'rxjs';
+import { Subject, firstValueFrom } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { v4 as uuid4 } from 'uuid';
 import {
@@ -9,7 +11,7 @@ import {
   WorkflowFailedError,
   Connection,
 } from '@temporalio/client';
-import { Info } from '@temporalio/activity';
+import type { Info } from '@temporalio/activity';
 import { rootCause } from '@temporalio/common';
 import { isCancellation } from '@temporalio/workflow';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';

--- a/packages/test/src/test-bundler.ts
+++ b/packages/test/src/test-bundler.ts
@@ -5,10 +5,12 @@
 import { unlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import { join as pathJoin } from 'node:path';
-import test, { ExecutionContext } from 'ava';
+import type { ExecutionContext } from 'ava';
+import test from 'ava';
 import { v4 as uuid4 } from 'uuid';
 import { moduleMatches } from '@temporalio/worker/lib/workflow/bundler';
-import { bundleWorkflowCode, DefaultLogger, LogEntry, WorkerOptions } from '@temporalio/worker';
+import type { LogEntry, WorkerOptions } from '@temporalio/worker';
+import { bundleWorkflowCode, DefaultLogger } from '@temporalio/worker';
 import { WorkflowClient } from '@temporalio/client';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
 import { issue516 } from './mocks/workflows-with-node-dependencies/issue-516';

--- a/packages/test/src/test-client-connection.ts
+++ b/packages/test/src/test-client-connection.ts
@@ -4,7 +4,8 @@ import * as util from 'node:util';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import assert from 'node:assert';
-import test, { TestFn } from 'ava';
+import type { TestFn } from 'ava';
+import test from 'ava';
 import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
 import {
@@ -17,7 +18,8 @@ import {
   makeGrpcRetryInterceptor,
 } from '@temporalio/client';
 import pkg from '@temporalio/client/lib/pkg';
-import { temporal, grpc as grpcProto } from '@temporalio/proto';
+import type { temporal } from '@temporalio/proto';
+import { grpc as grpcProto } from '@temporalio/proto';
 
 const workflowServicePackageDefinition = protoLoader.loadSync(
   path.resolve(

--- a/packages/test/src/test-client-errors.ts
+++ b/packages/test/src/test-client-errors.ts
@@ -1,14 +1,12 @@
-import anyTest, { TestFn } from 'ava';
-import {
-  ApplicationFailure,
-  Client,
-  NamespaceNotFoundError,
+import type { TestFn } from 'ava';
+import anyTest from 'ava';
+import type {
   Next,
   TerminateWorkflowExecutionResponse,
-  ValueError,
   WorkflowClientInterceptor,
   WorkflowTerminateInput,
 } from '@temporalio/client';
+import { ApplicationFailure, Client, NamespaceNotFoundError, ValueError } from '@temporalio/client';
 import { TestWorkflowEnvironment } from './helpers';
 
 interface Context {

--- a/packages/test/src/test-custom-payload-codec.ts
+++ b/packages/test/src/test-custom-payload-codec.ts
@@ -1,13 +1,14 @@
 import test from 'ava';
 import { v4 as uuid4 } from 'uuid';
 import { WorkflowClient } from '@temporalio/client';
-import { Payload, PayloadCodec } from '@temporalio/common';
+import type { Payload, PayloadCodec } from '@temporalio/common';
 import { decode } from '@temporalio/common/lib/encoding';
-import { InjectedSinks } from '@temporalio/worker';
+import type { InjectedSinks } from '@temporalio/worker';
 import { createConcatActivity } from './activities/create-concat-activity';
 import { RUN_INTEGRATION_TESTS, u8, Worker } from './helpers';
 import { defaultOptions } from './mock-native-worker';
-import { LogSinks, twoStrings, twoStringsActivity } from './workflows';
+import type { LogSinks } from './workflows';
+import { twoStrings, twoStringsActivity } from './workflows';
 
 class TestEncodeCodec implements PayloadCodec {
   async encode(payloads: Payload[]): Promise<Payload[]> {

--- a/packages/test/src/test-custom-payload-converter.ts
+++ b/packages/test/src/test-custom-payload-converter.ts
@@ -1,4 +1,5 @@
-import test, { ExecutionContext } from 'ava';
+import type { ExecutionContext } from 'ava';
+import test from 'ava';
 import { v4 as uuid4 } from 'uuid';
 import { WorkflowClient } from '@temporalio/client';
 import { toPayloads } from '@temporalio/common';

--- a/packages/test/src/test-envconfig.ts
+++ b/packages/test/src/test-envconfig.ts
@@ -5,10 +5,8 @@ import test from 'ava';
 import dedent from 'dedent';
 import { Connection, Client } from '@temporalio/client';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
+import type { ClientConfig, ClientConfigProfile, ConfigDataSource } from '@temporalio/envconfig';
 import {
-  ClientConfig,
-  ClientConfigProfile,
-  ConfigDataSource,
   fromTomlConfig,
   fromTomlProfile,
   loadClientConfig,

--- a/packages/test/src/test-ephemeral-server.ts
+++ b/packages/test/src/test-ephemeral-server.ts
@@ -1,7 +1,9 @@
 import fs from 'fs/promises';
-import anyTest, { ExecutionContext, TestFn } from 'ava';
+import type { ExecutionContext, TestFn } from 'ava';
+import anyTest from 'ava';
 import { v4 as uuid4 } from 'uuid';
-import { bundleWorkflowCode, WorkflowBundle } from '@temporalio/worker';
+import type { WorkflowBundle } from '@temporalio/worker';
+import { bundleWorkflowCode } from '@temporalio/worker';
 import { Connection } from '@temporalio/client';
 import { TestWorkflowEnvironment as RealTestWorkflowEnvironment } from '@temporalio/testing';
 import {

--- a/packages/test/src/test-failure-converter.ts
+++ b/packages/test/src/test-failure-converter.ts
@@ -1,13 +1,8 @@
 import { randomUUID } from 'crypto';
-import {
-  DefaultFailureConverter,
-  ApplicationFailure,
-  DataConverter,
-  DefaultEncodedFailureAttributes,
-  TemporalFailure,
-} from '@temporalio/common';
+import type { DataConverter, DefaultEncodedFailureAttributes } from '@temporalio/common';
+import { DefaultFailureConverter, ApplicationFailure, TemporalFailure } from '@temporalio/common';
 import { proxyActivities } from '@temporalio/workflow';
-import { WorkflowFailedError } from '@temporalio/client';
+import type { WorkflowFailedError } from '@temporalio/client';
 import { decodeFromPayloadsAtIndex } from '@temporalio/common/lib/internal-non-workflow';
 import { test, bundlerOptions, ByteSkewerPayloadCodec, Worker, TestWorkflowEnvironment } from './helpers';
 

--- a/packages/test/src/test-integration-split-one.ts
+++ b/packages/test/src/test-integration-split-one.ts
@@ -9,21 +9,20 @@ import {
   QueryNotRegisteredError,
   WorkflowFailedError,
 } from '@temporalio/client';
+import type { SearchAttributes, WorkflowExecution } from '@temporalio/common';
 import {
   ApplicationFailure,
   CancelledFailure,
   RetryState,
-  SearchAttributes,
   TerminatedFailure,
   TimeoutFailure,
   TimeoutType,
-  WorkflowExecution,
   WorkflowExecutionAlreadyStartedError,
 } from '@temporalio/common';
 import { tsToMs } from '@temporalio/common/lib/time';
-import { InjectedSinks } from '@temporalio/worker';
+import type { InjectedSinks } from '@temporalio/worker';
 import pkg from '@temporalio/worker/lib/pkg';
-import { UnsafeWorkflowInfo, WorkflowInfo } from '@temporalio/workflow/lib/interfaces';
+import type { UnsafeWorkflowInfo, WorkflowInfo } from '@temporalio/workflow/lib/interfaces';
 
 import {
   CancellationScope,

--- a/packages/test/src/test-integration-split-two.ts
+++ b/packages/test/src/test-integration-split-two.ts
@@ -3,10 +3,10 @@ import asyncRetry from 'async-retry';
 import { v4 as uuid4 } from 'uuid';
 import * as iface from '@temporalio/proto';
 import { WorkflowContinuedAsNewError, WorkflowFailedError } from '@temporalio/client';
+import type { Payload } from '@temporalio/common';
 import {
   ApplicationFailure,
   defaultPayloadConverter,
-  Payload,
   WorkflowExecutionAlreadyStartedError,
   WorkflowNotFoundError,
 } from '@temporalio/common';

--- a/packages/test/src/test-integration-update-interceptors.ts
+++ b/packages/test/src/test-integration-update-interceptors.ts
@@ -1,14 +1,13 @@
 import { randomUUID } from 'crypto';
-import {
-  WithStartWorkflowOperation,
+import type {
   WorkflowStartUpdateInput,
   WorkflowStartUpdateOutput,
   WorkflowStartUpdateWithStartInput,
   WorkflowStartUpdateWithStartOutput,
-  WorkflowUpdateStage,
 } from '@temporalio/client';
+import { WithStartWorkflowOperation, WorkflowUpdateStage } from '@temporalio/client';
 import * as wf from '@temporalio/workflow';
-import { Next, UpdateInput, WorkflowInboundCallsInterceptor, WorkflowInterceptors } from '@temporalio/workflow';
+import type { Next, UpdateInput, WorkflowInboundCallsInterceptor, WorkflowInterceptors } from '@temporalio/workflow';
 import { helpers, makeTestFunction } from './helpers-integration';
 
 const test = makeTestFunction({

--- a/packages/test/src/test-integration-update.ts
+++ b/packages/test/src/test-integration-update.ts
@@ -10,7 +10,7 @@ import {
 } from '@temporalio/client';
 import * as wf from '@temporalio/workflow';
 import { temporal } from '@temporalio/proto';
-import { LogEntry } from '@temporalio/worker';
+import type { LogEntry } from '@temporalio/worker';
 import { helpers, makeTestFunction } from './helpers-integration';
 import { signalUpdateOrderingWorkflow } from './workflows/signal-update-ordering';
 import { signalsActivitiesTimersPromiseOrdering } from './workflows/signals-timers-activities-order';

--- a/packages/test/src/test-integration-workflows-with-recorded-logs.ts
+++ b/packages/test/src/test-integration-workflows-with-recorded-logs.ts
@@ -1,9 +1,10 @@
-import { ExecutionContext } from 'ava';
+import type { ExecutionContext } from 'ava';
 import * as workflow from '@temporalio/workflow';
 import { ApplicationFailureCategory, HandlerUnfinishedPolicy } from '@temporalio/common';
-import { LogEntry } from '@temporalio/worker';
+import type { LogEntry } from '@temporalio/worker';
 import { WorkflowFailedError, WorkflowUpdateFailedError } from '@temporalio/client';
-import { Context, helpers, makeTestFunction } from './helpers-integration';
+import type { Context } from './helpers-integration';
+import { helpers, makeTestFunction } from './helpers-integration';
 import { waitUntil } from './helpers';
 
 const recordedLogs: { [workflowId: string]: LogEntry[] } = {};

--- a/packages/test/src/test-integration-workflows.ts
+++ b/packages/test/src/test-integration-workflows.ts
@@ -1,13 +1,14 @@
 import { setTimeout as setTimeoutPromise } from 'timers/promises';
 import { randomUUID } from 'crypto';
 import asyncRetry from 'async-retry';
-import { ExecutionContext } from 'ava';
+import type { ExecutionContext } from 'ava';
 import { firstValueFrom, Subject } from 'rxjs';
-import { Client, WorkflowClient, WorkflowFailedError, WorkflowHandle } from '@temporalio/client';
+import type { WorkflowHandle } from '@temporalio/client';
+import { Client, WorkflowClient, WorkflowFailedError } from '@temporalio/client';
 import * as activity from '@temporalio/activity';
 import { msToNumber, tsToMs } from '@temporalio/common/lib/time';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
-import { CancelReason } from '@temporalio/worker/lib/activity';
+import type { CancelReason } from '@temporalio/worker/lib/activity';
 import * as workflow from '@temporalio/workflow';
 import {
   condition,
@@ -20,15 +21,14 @@ import {
   setHandler,
 } from '@temporalio/workflow';
 import { SdkFlags } from '@temporalio/workflow/lib/flags';
+import type { ActivityCancellationDetails, SearchAttributePair } from '@temporalio/common';
 import {
-  ActivityCancellationDetails,
   ActivityCancellationType,
   ApplicationFailure,
   defineSearchAttributeKey,
   encodingKeys,
   METADATA_ENCODING_KEY,
   RawValue,
-  SearchAttributePair,
   SearchAttributeType,
   TypedSearchAttributes,
   WorkflowExecutionAlreadyStartedError,
@@ -42,9 +42,11 @@ import { encode } from '@temporalio/common/lib/encoding';
 import { signalSchedulingWorkflow } from './activities/helpers';
 import { activityStartedSignal } from './workflows/definitions';
 import * as workflows from './workflows';
-import { Context, createLocalTestEnvironment, helpers, makeTestFunction } from './helpers-integration';
+import type { Context } from './helpers-integration';
+import { createLocalTestEnvironment, helpers, makeTestFunction } from './helpers-integration';
 import { overrideSdkInternalFlag } from './mock-internal-flags';
-import { ActivityState, heartbeatCancellationDetailsActivity } from './activities/heartbeat-cancellation-details';
+import type { ActivityState } from './activities/heartbeat-cancellation-details';
+import { heartbeatCancellationDetailsActivity } from './activities/heartbeat-cancellation-details';
 import { loadHistory, RUN_TIME_SKIPPING_TESTS, waitUntil } from './helpers';
 
 const test = makeTestFunction({

--- a/packages/test/src/test-interceptors.ts
+++ b/packages/test/src/test-interceptors.ts
@@ -11,7 +11,8 @@ import { v4 as uuid4 } from 'uuid';
 import { WorkflowClient, WorkflowFailedError } from '@temporalio/client';
 import { ApplicationFailure, TerminatedFailure } from '@temporalio/common';
 import { DefaultLogger, Runtime } from '@temporalio/worker';
-import { defaultPayloadConverter, WorkflowInfo } from '@temporalio/workflow';
+import type { WorkflowInfo } from '@temporalio/workflow';
+import { defaultPayloadConverter } from '@temporalio/workflow';
 import { isBun, cleanOptionalStackTrace, compareStackTrace, RUN_INTEGRATION_TESTS, Worker } from './helpers';
 import { defaultOptions } from './mock-native-worker';
 import {

--- a/packages/test/src/test-interface-type-safety.ts
+++ b/packages/test/src/test-interface-type-safety.ts
@@ -1,16 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import test from 'ava';
-import {
-  defineSignal,
-  defineQuery,
-  ExternalWorkflowHandle,
-  ChildWorkflowHandle,
-  Workflow,
-  defineUpdate,
-  ChildWorkflowOptions,
-} from '@temporalio/workflow';
-import { WorkflowHandle, WorkflowUpdateStage } from '@temporalio/client';
+import type { ExternalWorkflowHandle, ChildWorkflowHandle, Workflow, ChildWorkflowOptions } from '@temporalio/workflow';
+import { defineSignal, defineQuery, defineUpdate } from '@temporalio/workflow';
+import type { WorkflowHandle } from '@temporalio/client';
+import { WorkflowUpdateStage } from '@temporalio/client';
 
 test('SignalDefinition Name type safety', (t) => {
   // @ts-expect-error Assert expect a type error when generic and concrete names do not match

--- a/packages/test/src/test-isolation.ts
+++ b/packages/test/src/test-isolation.ts
@@ -1,8 +1,9 @@
-import { ExecutionContext, ImplementationFn } from 'ava';
+import type { ExecutionContext, ImplementationFn } from 'ava';
 import { ApplicationFailure, arrayFromPayloads } from '@temporalio/common';
 import * as wf from '@temporalio/workflow';
 import { WorkflowFailedError } from '@temporalio/client';
-import { makeTestFunction, Context, helpers } from './helpers-integration';
+import type { Context } from './helpers-integration';
+import { makeTestFunction, helpers } from './helpers-integration';
 import { isBun, REUSE_V8_CONTEXT } from './helpers';
 
 const test = makeTestFunction({

--- a/packages/test/src/test-local-activities.ts
+++ b/packages/test/src/test-local-activities.ts
@@ -1,26 +1,15 @@
 import { randomUUID } from 'crypto';
 import { firstValueFrom, Subject } from 'rxjs';
-import { ExecutionContext, TestFn } from 'ava';
+import type { ExecutionContext, TestFn } from 'ava';
 import { Context as ActivityContext } from '@temporalio/activity';
-import {
-  ApplicationFailure,
-  defaultPayloadConverter,
-  WorkflowFailedError,
-  WorkflowHandle,
-  WorkflowStartOptions,
-} from '@temporalio/client';
-import { LocalActivityOptions, RetryPolicy } from '@temporalio/common';
+import type { WorkflowHandle, WorkflowStartOptions } from '@temporalio/client';
+import { ApplicationFailure, defaultPayloadConverter, WorkflowFailedError } from '@temporalio/client';
+import type { LocalActivityOptions, RetryPolicy } from '@temporalio/common';
 import { msToNumber } from '@temporalio/common/lib/time';
 import { temporal } from '@temporalio/proto';
 import { workflowInterceptorModules } from '@temporalio/testing';
-import {
-  bundleWorkflowCode,
-  DefaultLogger,
-  LogLevel,
-  Runtime,
-  WorkflowBundle,
-  WorkerOptions,
-} from '@temporalio/worker';
+import type { LogLevel, WorkflowBundle, WorkerOptions } from '@temporalio/worker';
+import { bundleWorkflowCode, DefaultLogger, Runtime } from '@temporalio/worker';
 import * as workflow from '@temporalio/workflow';
 import { test as anyTest, bundlerOptions, Worker, TestWorkflowEnvironment } from './helpers';
 

--- a/packages/test/src/test-logger.ts
+++ b/packages/test/src/test-logger.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
-import { DefaultLogger, LogEntry } from '@temporalio/worker';
+import type { LogEntry } from '@temporalio/worker';
+import { DefaultLogger } from '@temporalio/worker';
 
 test('DefaultLogger logs messages according to configured level', (t) => {
   const logs: Array<Omit<LogEntry, 'timestampNanos'>> = [];

--- a/packages/test/src/test-metrics-custom.ts
+++ b/packages/test/src/test-metrics-custom.ts
@@ -1,9 +1,11 @@
-import { ExecutionContext } from 'ava';
-import { ActivityInboundCallsInterceptor, ActivityOutboundCallsInterceptor, Runtime } from '@temporalio/worker';
+import type { ExecutionContext } from 'ava';
+import type { ActivityInboundCallsInterceptor, ActivityOutboundCallsInterceptor } from '@temporalio/worker';
+import { Runtime } from '@temporalio/worker';
 import * as workflow from '@temporalio/workflow';
-import { MetricTags } from '@temporalio/common';
+import type { MetricTags } from '@temporalio/common';
 import { Context as ActivityContext, metricMeter as activityMetricMeter } from '@temporalio/activity';
-import { Context as BaseContext, helpers, makeTestFunction } from './helpers-integration';
+import type { Context as BaseContext } from './helpers-integration';
+import { helpers, makeTestFunction } from './helpers-integration';
 import { getRandomPort } from './helpers';
 
 interface Context extends BaseContext {

--- a/packages/test/src/test-native-connection-headers.ts
+++ b/packages/test/src/test-native-connection-headers.ts
@@ -6,7 +6,7 @@ import { Subject, firstValueFrom, skip } from 'rxjs';
 import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
 import { NativeConnection } from '@temporalio/worker';
-import { temporal } from '@temporalio/proto';
+import type { temporal } from '@temporalio/proto';
 import { Worker } from './helpers';
 
 const workflowServicePackageDefinition = protoLoader.loadSync(

--- a/packages/test/src/test-native-connection.ts
+++ b/packages/test/src/test-native-connection.ts
@@ -6,10 +6,12 @@ import test from 'ava';
 import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
 import { Client, NamespaceNotFoundError, WorkflowNotFoundError } from '@temporalio/client';
-import { InternalConnectionOptions, InternalConnectionOptionsSymbol } from '@temporalio/client/lib/connection';
-import { IllegalStateError, NativeConnection, NativeConnectionOptions, TransportError } from '@temporalio/worker';
+import type { InternalConnectionOptions } from '@temporalio/client/lib/connection';
+import { InternalConnectionOptionsSymbol } from '@temporalio/client/lib/connection';
+import type { NativeConnectionOptions } from '@temporalio/worker';
+import { IllegalStateError, NativeConnection, TransportError } from '@temporalio/worker';
 import { toNativeClientOptions } from '@temporalio/worker/lib/connection-options';
-import { temporal } from '@temporalio/proto';
+import type { temporal } from '@temporalio/proto';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
 

--- a/packages/test/src/test-nexus-codec-converter-errors.ts
+++ b/packages/test/src/test-nexus-codec-converter-errors.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import * as nexus from 'nexus-rpc';
-import { NexusOperationFailure, Payload } from '@temporalio/common';
+import type { Payload } from '@temporalio/common';
+import { NexusOperationFailure } from '@temporalio/common';
 import { Client, WorkflowFailedError } from '@temporalio/client';
 import type { PayloadCodec } from '@temporalio/common/lib/converter/payload-codec';
 import * as workflow from '@temporalio/workflow';

--- a/packages/test/src/test-nexus-handler.ts
+++ b/packages/test/src/test-nexus-handler.ts
@@ -1,19 +1,21 @@
 import { randomUUID } from 'node:crypto';
-import anyTest, { TestFn } from 'ava';
+import type { TestFn } from 'ava';
+import anyTest from 'ava';
 import * as nexus from 'nexus-rpc';
 import { status as grpcStatus } from '@grpc/grpc-js';
 import * as temporalnexus from '@temporalio/nexus';
-import * as temporalclient from '@temporalio/client';
+import type * as temporalclient from '@temporalio/client';
 import * as root from '@temporalio/proto';
 import * as testing from '@temporalio/testing';
-import { DefaultLogger, LogEntry, Runtime, Worker } from '@temporalio/worker';
+import type { LogEntry } from '@temporalio/worker';
+import { DefaultLogger, Runtime, Worker } from '@temporalio/worker';
+import type { ProtoFailure } from '@temporalio/common';
 import {
   ApplicationFailure,
   CancelledFailure,
   defaultFailureConverter,
   defaultPayloadConverter,
   defaultDataConverter,
-  ProtoFailure,
 } from '@temporalio/common';
 import { ServiceError } from '@temporalio/client';
 import { coerceToHandlerError, operationErrorToProto } from '@temporalio/worker/lib/nexus/conversions';

--- a/packages/test/src/test-nexus-workflow-caller.ts
+++ b/packages/test/src/test-nexus-workflow-caller.ts
@@ -4,7 +4,7 @@ import * as nexus from 'nexus-rpc';
 import * as root from '@temporalio/proto';
 import { ApplicationFailure, CancelledFailure, NexusOperationFailure, SdkComponent } from '@temporalio/common';
 import { WorkflowFailedError } from '@temporalio/client';
-import { LogEntry } from '@temporalio/worker';
+import type { LogEntry } from '@temporalio/worker';
 import * as temporalnexus from '@temporalio/nexus';
 import * as workflow from '@temporalio/workflow';
 import { helpers, makeTestFunction } from './helpers-integration';

--- a/packages/test/src/test-otel.ts
+++ b/packages/test/src/test-otel.ts
@@ -16,13 +16,8 @@ import { Subject, firstValueFrom } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import type * as workflowImportStub from '@temporalio/interceptors-opentelemetry/lib/workflow/workflow-imports';
 import type * as workflowImportImpl from '@temporalio/interceptors-opentelemetry/lib/workflow/workflow-imports-impl';
-import {
-  WorkflowClient,
-  WithStartWorkflowOperation,
-  WorkflowClientInterceptor,
-  Client,
-  Connection,
-} from '@temporalio/client';
+import type { WorkflowClientInterceptor } from '@temporalio/client';
+import { WorkflowClient, WithStartWorkflowOperation, Client, Connection } from '@temporalio/client';
 import { OpenTelemetryPlugin, OpenTelemetryWorkflowClientInterceptor } from '@temporalio/interceptors-opentelemetry';
 import {
   instrument,
@@ -30,32 +25,31 @@ import {
   NEXUS_SERVICE_ATTR_KEY,
   NEXUS_OPERATION_ATTR_KEY,
 } from '@temporalio/interceptors-opentelemetry/lib/instrumentation';
-import {
-  makeWorkflowExporter,
-  OpenTelemetryActivityInboundInterceptor,
-  OpenTelemetryActivityOutboundInterceptor,
+import type {
   OpenTelemetryNexusInboundInterceptor,
   OpenTelemetryNexusOutboundInterceptor,
 } from '@temporalio/interceptors-opentelemetry/lib/worker';
 import {
+  makeWorkflowExporter,
+  OpenTelemetryActivityInboundInterceptor,
+  OpenTelemetryActivityOutboundInterceptor,
+} from '@temporalio/interceptors-opentelemetry/lib/worker';
+import type {
   OpenTelemetrySinks,
-  SpanName,
-  SPAN_DELIMITER,
   OpenTelemetryOutboundInterceptor,
   OpenTelemetryInboundInterceptor,
 } from '@temporalio/interceptors-opentelemetry/lib/workflow';
-import {
+import { SpanName, SPAN_DELIMITER } from '@temporalio/interceptors-opentelemetry/lib/workflow';
+import type {
   ActivityInboundCallsInterceptor,
   ActivityOutboundCallsInterceptor,
-  bundleWorkflowCode,
-  DefaultLogger,
   InjectedSinks,
   NexusInboundCallsInterceptor,
   NexusOutboundCallsInterceptor,
-  Runtime,
 } from '@temporalio/worker';
-import { WorkflowInboundCallsInterceptor, WorkflowOutboundCallsInterceptor } from '@temporalio/workflow';
-import { Info } from '@temporalio/activity';
+import { bundleWorkflowCode, DefaultLogger, Runtime } from '@temporalio/worker';
+import type { WorkflowInboundCallsInterceptor, WorkflowOutboundCallsInterceptor } from '@temporalio/workflow';
+import type { Info } from '@temporalio/activity';
 import * as activities from './activities';
 import { createActivities as createAsyncActivities } from './activities/async-completer';
 import { bundlerOptions, loadHistory, RUN_INTEGRATION_TESTS, Worker } from './helpers';

--- a/packages/test/src/test-plugins.ts
+++ b/packages/test/src/test-plugins.ts
@@ -1,15 +1,16 @@
 import { randomUUID } from 'crypto';
-import anyTest, { TestFn } from 'ava';
-import { Client, ClientOptions, ConnectionPlugin, ClientPlugin as ClientPlugin } from '@temporalio/client';
-import {
+import type { TestFn } from 'ava';
+import anyTest from 'ava';
+import type { ClientOptions, ConnectionPlugin, ClientPlugin as ClientPlugin } from '@temporalio/client';
+import { Client } from '@temporalio/client';
+import type {
   WorkerOptions,
   WorkerPlugin as WorkerPlugin,
-  Worker,
   BundlerPlugin,
   BundleOptions,
-  bundleWorkflowCode,
   NativeConnectionPlugin,
 } from '@temporalio/worker';
+import { Worker, bundleWorkflowCode } from '@temporalio/worker';
 import { SimplePlugin } from '@temporalio/plugin';
 import { activityWorkflow, helloWorkflow } from './workflows/plugins';
 import { TestWorkflowEnvironment } from './helpers';

--- a/packages/test/src/test-replay.ts
+++ b/packages/test/src/test-replay.ts
@@ -1,6 +1,8 @@
-import anyTest, { TestFn } from 'ava';
-import { temporal } from '@temporalio/proto';
-import { bundleWorkflowCode, ReplayError, WorkflowBundle } from '@temporalio/worker';
+import type { TestFn } from 'ava';
+import anyTest from 'ava';
+import type { temporal } from '@temporalio/proto';
+import type { WorkflowBundle } from '@temporalio/worker';
+import { bundleWorkflowCode, ReplayError } from '@temporalio/worker';
 import { DeterminismViolationError } from '@temporalio/workflow';
 import { loadHistory, Worker } from './helpers';
 

--- a/packages/test/src/test-runtime.ts
+++ b/packages/test/src/test-runtime.ts
@@ -4,7 +4,8 @@
  */
 import { v4 as uuid4 } from 'uuid';
 import asyncRetry from 'async-retry';
-import { Runtime, DefaultLogger, LogEntry, makeTelemetryFilterString, NativeConnection } from '@temporalio/worker';
+import type { LogEntry } from '@temporalio/worker';
+import { Runtime, DefaultLogger, makeTelemetryFilterString, NativeConnection } from '@temporalio/worker';
 import { Client, WorkflowClient } from '@temporalio/client';
 import * as wf from '@temporalio/workflow';
 import { defaultOptions } from './mock-native-worker';

--- a/packages/test/src/test-schedules.ts
+++ b/packages/test/src/test-schedules.ts
@@ -1,24 +1,19 @@
 import { randomUUID } from 'node:crypto';
-import anyTest, { TestFn } from 'ava';
+import type { TestFn } from 'ava';
+import anyTest from 'ava';
 import asyncRetry from 'async-retry';
-import {
-  defaultPayloadConverter,
+import type {
   CalendarSpec,
   CalendarSpecDescription,
-  Client,
-  Connection,
   ScheduleHandle,
   ScheduleSummary,
   ScheduleUpdateOptions,
   ScheduleDescription,
 } from '@temporalio/client';
+import { defaultPayloadConverter, Client, Connection } from '@temporalio/client';
 import { msToNumber } from '@temporalio/common/lib/time';
-import {
-  SearchAttributeType,
-  SearchAttributes,
-  TypedSearchAttributes,
-  defineSearchAttributeKey,
-} from '@temporalio/common';
+import type { SearchAttributes } from '@temporalio/common';
+import { SearchAttributeType, TypedSearchAttributes, defineSearchAttributeKey } from '@temporalio/common';
 import { registerDefaultCustomSearchAttributes, RUN_INTEGRATION_TESTS, waitUntil } from './helpers';
 import { defaultSAKeys } from './helpers-integration';
 

--- a/packages/test/src/test-signals-are-always-delivered.ts
+++ b/packages/test/src/test-signals-are-always-delivered.ts
@@ -9,7 +9,8 @@
 import test from 'ava';
 import { v4 as uuid4 } from 'uuid';
 import { WorkflowClient } from '@temporalio/client';
-import { DefaultLogger, Runtime, InjectedSinks } from '@temporalio/worker';
+import type { InjectedSinks } from '@temporalio/worker';
+import { DefaultLogger, Runtime } from '@temporalio/worker';
 import { defaultOptions } from './mock-native-worker';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
 import * as workflows from './workflows';

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -2,10 +2,12 @@
 import test from 'ava';
 import { v4 as uuid4 } from 'uuid';
 import { Connection, WorkflowClient } from '@temporalio/client';
-import { DefaultLogger, InjectedSinks, Runtime, WorkerOptions, LogEntry, NativeConnection } from '@temporalio/worker';
-import { SearchAttributes, WorkflowInfo } from '@temporalio/workflow';
-import { UnsafeWorkflowInfo } from '@temporalio/workflow/lib/interfaces';
-import { SdkComponent, TypedSearchAttributes } from '@temporalio/common';
+import type { InjectedSinks, WorkerOptions, LogEntry } from '@temporalio/worker';
+import { DefaultLogger, Runtime, NativeConnection } from '@temporalio/worker';
+import type { SearchAttributes, WorkflowInfo } from '@temporalio/workflow';
+import type { UnsafeWorkflowInfo } from '@temporalio/workflow/lib/interfaces';
+import type { TypedSearchAttributes } from '@temporalio/common';
+import { SdkComponent } from '@temporalio/common';
 import { RUN_INTEGRATION_TESTS, Worker, registerDefaultCustomSearchAttributes } from './helpers';
 import { defaultOptions } from './mock-native-worker';
 import * as workflows from './workflows';

--- a/packages/test/src/test-temporal-cloud.ts
+++ b/packages/test/src/test-temporal-cloud.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import test from 'ava';
-import { Client, Connection, Metadata } from '@temporalio/client';
+import type { Metadata } from '@temporalio/client';
+import { Client, Connection } from '@temporalio/client';
 import { CloudOperationsClient, CloudOperationsConnection } from '@temporalio/cloud';
 import { NativeConnection, Worker } from '@temporalio/worker';
 import * as workflows from './workflows';

--- a/packages/test/src/test-testenvironment.ts
+++ b/packages/test/src/test-testenvironment.ts
@@ -1,9 +1,10 @@
 import * as process from 'process';
-import { TestFn } from 'ava';
+import type { TestFn } from 'ava';
 import { v4 as uuid4 } from 'uuid';
 import { WorkflowFailedError } from '@temporalio/client';
 import { workflowInterceptorModules } from '@temporalio/testing';
-import { bundleWorkflowCode, WorkflowBundleWithSourceMap } from '@temporalio/worker';
+import type { WorkflowBundleWithSourceMap } from '@temporalio/worker';
+import { bundleWorkflowCode } from '@temporalio/worker';
 import {
   assertFromWorkflow,
   asyncChildStarter,

--- a/packages/test/src/test-type-helpers.ts
+++ b/packages/test/src/test-type-helpers.ts
@@ -1,5 +1,6 @@
 import vm from 'vm';
-import anyTest, { TestFn } from 'ava';
+import type { TestFn } from 'ava';
+import anyTest from 'ava';
 import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 
 interface Context {

--- a/packages/test/src/test-typed-search-attributes.ts
+++ b/packages/test/src/test-typed-search-attributes.ts
@@ -1,27 +1,22 @@
 import { randomUUID } from 'crypto';
-import { ExecutionContext } from 'ava';
-import { ScheduleOptionsAction, WorkflowExecutionDescription } from '@temporalio/client';
-import {
-  TypedSearchAttributes,
-  SearchAttributes,
-  SearchAttributePair,
-  SearchAttributeType,
-  SearchAttributeUpdatePair,
-  defineSearchAttributeKey,
-} from '@temporalio/common';
+import type { ExecutionContext } from 'ava';
+import type { ScheduleOptionsAction, WorkflowExecutionDescription } from '@temporalio/client';
+import type { SearchAttributes, SearchAttributePair, SearchAttributeUpdatePair } from '@temporalio/common';
+import { TypedSearchAttributes, SearchAttributeType, defineSearchAttributeKey } from '@temporalio/common';
 import { temporal } from '@temporalio/proto';
+import type { WorkflowInfo } from '@temporalio/workflow';
 import {
   condition,
   defineQuery,
   defineSignal,
   setHandler,
   upsertSearchAttributes,
-  WorkflowInfo,
   workflowInfo,
 } from '@temporalio/workflow';
 import { encodeSearchAttributeIndexedValueType } from '@temporalio/common/lib/search-attributes';
 import { waitUntil } from './helpers';
-import { Context, helpers, makeTestFunction } from './helpers-integration';
+import type { Context } from './helpers-integration';
+import { helpers, makeTestFunction } from './helpers-integration';
 
 const test = makeTestFunction({
   workflowsPath: __filename,

--- a/packages/test/src/test-worker-activities.ts
+++ b/packages/test/src/test-worker-activities.ts
@@ -1,4 +1,5 @@
-import anyTest, { ExecutionContext, TestFn } from 'ava';
+import type { ExecutionContext, TestFn } from 'ava';
+import anyTest from 'ava';
 import dedent from 'dedent';
 import { v4 as uuid4 } from 'uuid';
 import { TemporalFailure, defaultPayloadConverter, toPayloads, ApplicationFailure } from '@temporalio/common';
@@ -6,7 +7,8 @@ import { coresdk, google } from '@temporalio/proto';
 import { msToTs } from '@temporalio/common/lib/time';
 import { httpGet } from './activities';
 import { cleanOptionalStackTrace, isBun } from './helpers';
-import { defaultOptions, isolateFreeWorker, Worker } from './mock-native-worker';
+import type { Worker } from './mock-native-worker';
+import { defaultOptions, isolateFreeWorker } from './mock-native-worker';
 import { withZeroesHTTPServer } from './zeroes-http-server';
 import Duration = google.protobuf.Duration;
 

--- a/packages/test/src/test-worker-deployment-versioning.ts
+++ b/packages/test/src/test-worker-deployment-versioning.ts
@@ -5,13 +5,15 @@
  */
 import { randomUUID } from 'crypto';
 import asyncRetry from 'async-retry';
-import { ExecutionContext } from 'ava';
-import { Client, WorkflowHandleWithFirstExecutionRunId } from '@temporalio/client';
-import { toCanonicalString, WorkerDeploymentVersion } from '@temporalio/common';
+import type { ExecutionContext } from 'ava';
+import type { Client, WorkflowHandleWithFirstExecutionRunId } from '@temporalio/client';
+import type { WorkerDeploymentVersion } from '@temporalio/common';
+import { toCanonicalString } from '@temporalio/common';
 import { temporal } from '@temporalio/proto';
-import { WorkerOptions } from '@temporalio/worker';
+import type { WorkerOptions } from '@temporalio/worker';
 import { Worker } from './helpers';
-import { Context, helpers, makeTestFunction } from './helpers-integration';
+import type { Context } from './helpers-integration';
+import { helpers, makeTestFunction } from './helpers-integration';
 import { unblockSignal, versionQuery } from './workflows';
 
 type WorkerDeploymentOptions = NonNullable<WorkerOptions['workerDeploymentOptions']>;

--- a/packages/test/src/test-worker-heartbeats.ts
+++ b/packages/test/src/test-worker-heartbeats.ts
@@ -1,9 +1,10 @@
 import test from 'ava';
 import { firstValueFrom, Subject } from 'rxjs';
 import { v4 as uuid4 } from 'uuid';
-import { coresdk } from '@temporalio/proto';
+import type { coresdk } from '@temporalio/proto';
 import { Context } from '@temporalio/activity';
-import { isolateFreeWorker, Worker } from './mock-native-worker';
+import type { Worker } from './mock-native-worker';
+import { isolateFreeWorker } from './mock-native-worker';
 
 async function runActivity(worker: Worker, callback?: (completion: coresdk.ActivityTaskCompletion) => void) {
   const taskToken = Buffer.from(uuid4());

--- a/packages/test/src/test-worker-tuner.ts
+++ b/packages/test/src/test-worker-tuner.ts
@@ -1,5 +1,5 @@
-import { ExecutionContext } from 'ava';
-import {
+import type { ExecutionContext } from 'ava';
+import type {
   CustomSlotSupplier,
   ResourceBasedTunerOptions,
   SlotInfo,

--- a/packages/test/src/test-worker-versioning.ts
+++ b/packages/test/src/test-worker-versioning.ts
@@ -5,7 +5,8 @@
  */
 import assert from 'assert';
 import { randomUUID } from 'crypto';
-import anyTest, { ImplementationFn, TestFn } from 'ava';
+import type { ImplementationFn, TestFn } from 'ava';
+import anyTest from 'ava';
 import { status } from '@grpc/grpc-js';
 import asyncRetry from 'async-retry';
 import { BuildIdNotFoundError, Client, UnversionedBuildId } from '@temporalio/client';

--- a/packages/test/src/test-workflow-cancellation.ts
+++ b/packages/test/src/test-workflow-cancellation.ts
@@ -1,8 +1,9 @@
-import { Macro, ErrorConstructor } from 'ava';
+import type { Macro, ErrorConstructor } from 'ava';
 import { CancellationScope, sleep } from '@temporalio/workflow';
 import { WorkflowFailedError } from '@temporalio/client';
 import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
-import { makeTestFunction, Context, helpers } from './helpers-integration';
+import type { Context } from './helpers-integration';
+import { makeTestFunction, helpers } from './helpers-integration';
 
 const test = makeTestFunction({
   workflowsPath: __filename,

--- a/packages/test/src/test-workflow-log-interceptor.ts
+++ b/packages/test/src/test-workflow-log-interceptor.ts
@@ -1,15 +1,9 @@
-import anyTest, { TestFn, ExecutionContext } from 'ava';
+import type { TestFn, ExecutionContext } from 'ava';
+import anyTest from 'ava';
 import { v4 as uuid4 } from 'uuid';
-import {
-  DefaultLogger,
-  InjectedSinks,
-  LogEntry,
-  LogLevel,
-  LoggerSinks,
-  Runtime,
-  defaultSinks,
-} from '@temporalio/worker';
-import { WorkflowInfo } from '@temporalio/workflow';
+import type { InjectedSinks, LogEntry, LogLevel, LoggerSinks } from '@temporalio/worker';
+import { DefaultLogger, Runtime, defaultSinks } from '@temporalio/worker';
+import type { WorkflowInfo } from '@temporalio/workflow';
 import * as workflows from './workflows';
 import { Worker, TestWorkflowEnvironment } from './helpers';
 

--- a/packages/test/src/test-workflow-nexus-cancellation.ts
+++ b/packages/test/src/test-workflow-nexus-cancellation.ts
@@ -1,13 +1,15 @@
 import assert from 'assert';
 import { randomUUID } from 'crypto';
-import { ExecutionContext } from 'ava';
+import type { ExecutionContext } from 'ava';
 import * as nexus from 'nexus-rpc';
 import { ApplicationFailure, NexusOperationFailure } from '@temporalio/common';
-import { WorkflowFailedError, WorkflowHandle } from '@temporalio/client';
-import { History } from '@temporalio/common/lib/proto-utils';
+import type { WorkflowHandle } from '@temporalio/client';
+import { WorkflowFailedError } from '@temporalio/client';
+import type { History } from '@temporalio/common/lib/proto-utils';
 import * as temporalnexus from '@temporalio/nexus';
 import * as workflow from '@temporalio/workflow';
-import { Context, helpers, makeTestFunction } from './helpers-integration';
+import type { Context } from './helpers-integration';
+import { helpers, makeTestFunction } from './helpers-integration';
 import { innermostHandlerError } from './helpers-nexus';
 import { waitUntil } from './helpers';
 

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -1,14 +1,15 @@
 import path from 'node:path';
-import vm from 'node:vm';
-import anyTest, { ExecutionContext, TestFn } from 'ava';
+import type vm from 'node:vm';
+import type { ExecutionContext, TestFn } from 'ava';
+import anyTest from 'ava';
 import dedent from 'dedent';
 import Long from 'long';
+import type { Payload } from '@temporalio/common';
 import {
   ApplicationFailure,
   defaultFailureConverter,
   defaultPayloadConverter,
   SdkComponent,
-  Payload,
   toPayloads,
   TypedSearchAttributes,
 } from '@temporalio/common';
@@ -16,13 +17,16 @@ import { msToTs } from '@temporalio/common/lib/time';
 import { coresdk, temporal } from '@temporalio/proto';
 import { LogTimestamp } from '@temporalio/worker';
 import { WorkflowCodeBundler } from '@temporalio/worker/lib/workflow/bundler';
-import { VMWorkflow, VMWorkflowCreator } from '@temporalio/worker/lib/workflow/vm';
-import { SdkFlag, SdkFlags } from '@temporalio/workflow/lib/flags';
-import { ReusableVMWorkflow, ReusableVMWorkflowCreator } from '@temporalio/worker/lib/workflow/reusable-vm';
+import type { VMWorkflow } from '@temporalio/worker/lib/workflow/vm';
+import { VMWorkflowCreator } from '@temporalio/worker/lib/workflow/vm';
+import type { SdkFlag } from '@temporalio/workflow/lib/flags';
+import { SdkFlags } from '@temporalio/workflow/lib/flags';
+import type { ReusableVMWorkflow } from '@temporalio/worker/lib/workflow/reusable-vm';
+import { ReusableVMWorkflowCreator } from '@temporalio/worker/lib/workflow/reusable-vm';
 import { parseWorkflowCode } from '@temporalio/worker/lib/worker';
 import * as activityFunctions from './activities';
 import { isBun, cleanStackTrace, compareStackTrace, REUSE_V8_CONTEXT, u8 } from './helpers';
-import { ProcessedSignal } from './workflows';
+import type { ProcessedSignal } from './workflows';
 
 export interface Context {
   workflow: VMWorkflow | ReusableVMWorkflow;

--- a/packages/test/src/workflows/configured-activities.ts
+++ b/packages/test/src/workflows/configured-activities.ts
@@ -1,5 +1,5 @@
 import { proxyActivities } from '@temporalio/workflow';
-import * as activityInterfaces from '../activities';
+import type * as activityInterfaces from '../activities';
 
 const activities = proxyActivities<typeof activityInterfaces>({
   startToCloseTimeout: '10m',

--- a/packages/test/src/workflows/continue-as-new-to-different-workflow.ts
+++ b/packages/test/src/workflows/continue-as-new-to-different-workflow.ts
@@ -2,8 +2,9 @@
  * Tests continueAsNew to another Workflow
  * @module
  */
-import { ContinueAsNewOptions, makeContinueAsNewFunc } from '@temporalio/workflow';
-import { sleeper } from './sleep';
+import type { ContinueAsNewOptions } from '@temporalio/workflow';
+import { makeContinueAsNewFunc } from '@temporalio/workflow';
+import type { sleeper } from './sleep';
 
 export async function continueAsNewToDifferentWorkflow(
   ms = 1,

--- a/packages/test/src/workflows/core-issue-589.ts
+++ b/packages/test/src/workflows/core-issue-589.ts
@@ -1,5 +1,5 @@
 import * as wf from '@temporalio/workflow';
-import { CustomLoggerSinks } from './log-sink-tester';
+import type { CustomLoggerSinks } from './log-sink-tester';
 import { unblockSignal } from './definitions';
 
 const { customLogger } = wf.proxySinks<CustomLoggerSinks>();

--- a/packages/test/src/workflows/default-activity-wf.ts
+++ b/packages/test/src/workflows/default-activity-wf.ts
@@ -1,5 +1,5 @@
 import { proxyActivities } from '@temporalio/workflow';
-import { NameAndArgs } from '../activities/default-and-defined';
+import type { NameAndArgs } from '../activities/default-and-defined';
 import type * as activities from '../activities/default-and-defined';
 
 const { definedActivity, nonExistentActivity } = proxyActivities<

--- a/packages/test/src/workflows/interceptor-example.ts
+++ b/packages/test/src/workflows/interceptor-example.ts
@@ -1,3 +1,4 @@
+import type { WorkflowInterceptors } from '@temporalio/workflow';
 import {
   ApplicationFailure,
   condition,
@@ -8,7 +9,6 @@ import {
   setHandler,
   sleep,
   startChild,
-  WorkflowInterceptors,
 } from '@temporalio/workflow';
 import { echo } from './configured-activities';
 

--- a/packages/test/src/workflows/internal-interceptor-dispose-global.ts
+++ b/packages/test/src/workflows/internal-interceptor-dispose-global.ts
@@ -1,4 +1,4 @@
-import { WorkflowInterceptors } from '@temporalio/workflow';
+import type { WorkflowInterceptors } from '@temporalio/workflow';
 
 const getOuterGlobal = globalThis.constructor.constructor;
 

--- a/packages/test/src/workflows/internals-interceptor-example.ts
+++ b/packages/test/src/workflows/internals-interceptor-example.ts
@@ -1,4 +1,5 @@
-import { proxySinks, WorkflowInterceptors, Sinks, sleep } from '@temporalio/workflow';
+import type { WorkflowInterceptors, Sinks } from '@temporalio/workflow';
+import { proxySinks, sleep } from '@temporalio/workflow';
 
 export interface MyLoggerSinks extends Sinks {
   logger: {

--- a/packages/test/src/workflows/otel-interceptors.ts
+++ b/packages/test/src/workflows/otel-interceptors.ts
@@ -1,6 +1,6 @@
 /** Not a workflow, just interceptors */
 
-import { WorkflowInterceptors } from '@temporalio/workflow';
+import type { WorkflowInterceptors } from '@temporalio/workflow';
 import {
   OpenTelemetryInboundInterceptor,
   OpenTelemetryOutboundInterceptor,

--- a/packages/test/src/workflows/query-and-validator-logging.ts
+++ b/packages/test/src/workflows/query-and-validator-logging.ts
@@ -1,5 +1,5 @@
 import * as wf from '@temporalio/workflow';
-import { CustomLoggerSinks } from './log-sink-tester';
+import type { CustomLoggerSinks } from './log-sink-tester';
 import { unblockSignal } from './definitions';
 
 const { customLogger } = wf.proxySinks<CustomLoggerSinks>();

--- a/packages/test/src/workflows/signals-are-always-processed.ts
+++ b/packages/test/src/workflows/signals-are-always-processed.ts
@@ -4,7 +4,8 @@
  * @module
  */
 
-import { proxySinks, Sinks, setHandler, defineSignal } from '@temporalio/workflow';
+import type { Sinks } from '@temporalio/workflow';
+import { proxySinks, setHandler, defineSignal } from '@temporalio/workflow';
 
 export const incrementSignal = defineSignal('increment');
 

--- a/packages/test/src/workflows/sinks.ts
+++ b/packages/test/src/workflows/sinks.ts
@@ -1,4 +1,5 @@
-import { proxySinks, Sinks } from '@temporalio/workflow';
+import type { Sinks } from '@temporalio/workflow';
+import { proxySinks } from '@temporalio/workflow';
 
 export interface TestSinks extends Sinks {
   success: {

--- a/packages/test/src/workflows/smorgasbord.ts
+++ b/packages/test/src/workflows/smorgasbord.ts
@@ -14,7 +14,7 @@ import {
   continueAsNew,
   proxyLocalActivities,
 } from '@temporalio/workflow';
-import * as activities from '../activities';
+import type * as activities from '../activities';
 import { signalTarget } from './signal-target';
 import { activityStartedSignal, unblockSignal } from './definitions';
 

--- a/packages/test/src/workflows/throw-maybe-benign.ts
+++ b/packages/test/src/workflows/throw-maybe-benign.ts
@@ -1,5 +1,5 @@
 import * as workflow from '@temporalio/workflow';
-import * as activities from '../activities';
+import type * as activities from '../activities';
 
 const { throwMaybeBenign } = workflow.proxyActivities<typeof activities>({
   startToCloseTimeout: '5s',

--- a/packages/test/src/workflows/two-strings.ts
+++ b/packages/test/src/workflows/two-strings.ts
@@ -1,4 +1,5 @@
-import { proxyActivities, proxySinks, Sinks } from '@temporalio/workflow';
+import type { Sinks } from '@temporalio/workflow';
+import { proxyActivities, proxySinks } from '@temporalio/workflow';
 import type { createConcatActivity } from '../activities/create-concat-activity';
 
 export interface LogSinks extends Sinks {

--- a/packages/test/src/workflows/upsert-and-read-memo.ts
+++ b/packages/test/src/workflows/upsert-and-read-memo.ts
@@ -1,5 +1,5 @@
 import { upsertMemo, workflowInfo, proxySinks } from '@temporalio/workflow';
-import { CustomLoggerSinks } from './log-sink-tester';
+import type { CustomLoggerSinks } from './log-sink-tester';
 
 const { customLogger } = proxySinks<CustomLoggerSinks>();
 

--- a/packages/test/src/workflows/upsert-and-read-search-attributes.ts
+++ b/packages/test/src/workflows/upsert-and-read-search-attributes.ts
@@ -1,5 +1,6 @@
-import { SearchAttributes, upsertSearchAttributes, workflowInfo, proxySinks } from '@temporalio/workflow';
-import { CustomLoggerSinks } from './log-sink-tester';
+import type { SearchAttributes } from '@temporalio/workflow';
+import { upsertSearchAttributes, workflowInfo, proxySinks } from '@temporalio/workflow';
+import type { CustomLoggerSinks } from './log-sink-tester';
 
 const { customLogger } = proxySinks<CustomLoggerSinks>();
 

--- a/packages/testing/src/assert-to-failure-interceptor.ts
+++ b/packages/testing/src/assert-to-failure-interceptor.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
-import { ApplicationFailure, WorkflowInterceptors } from '@temporalio/workflow';
+import type { WorkflowInterceptors } from '@temporalio/workflow';
+import { ApplicationFailure } from '@temporalio/workflow';
 
 /**
  * Simple interceptor that transforms {@link assert.AssertionError} into non retryable failures.

--- a/packages/testing/src/client.ts
+++ b/packages/testing/src/client.ts
@@ -1,13 +1,12 @@
 import 'abort-controller/polyfill'; // eslint-disable-line import/no-unassigned-import
-import {
-  Client,
+import type {
   ClientOptions,
   Connection,
   TestService,
-  WorkflowClient,
   WorkflowClientOptions,
   WorkflowResultOptions,
 } from '@temporalio/client';
+import { Client, WorkflowClient } from '@temporalio/client';
 
 /**
  * Subset of the "normal" client options that are used to create a client for the test environment.

--- a/packages/testing/src/ephemeral-server.ts
+++ b/packages/testing/src/ephemeral-server.ts
@@ -1,8 +1,8 @@
 import 'abort-controller/polyfill'; // eslint-disable-line import/no-unassigned-import
-import { Duration, SearchAttributeType } from '@temporalio/common';
+import type { Duration, SearchAttributeType } from '@temporalio/common';
 import { msToNumber } from '@temporalio/common/lib/time';
-import { native } from '@temporalio/core-bridge';
-import { SearchAttributeKey } from '@temporalio/common/lib/search-attributes';
+import type { native } from '@temporalio/core-bridge';
+import type { SearchAttributeKey } from '@temporalio/common/lib/search-attributes';
 import pkg from './pkg';
 
 /**

--- a/packages/testing/src/mocking-activity-environment.ts
+++ b/packages/testing/src/mocking-activity-environment.ts
@@ -1,20 +1,20 @@
 import 'abort-controller/polyfill'; // eslint-disable-line import/no-unassigned-import
 import events from 'node:events';
-import * as activity from '@temporalio/activity';
+import type * as activity from '@temporalio/activity';
+import type { ActivityFunction, Logger, MetricMeter } from '@temporalio/common';
 import {
-  ActivityFunction,
-  Logger,
   SdkComponent,
   defaultFailureConverter,
   defaultPayloadConverter,
-  MetricMeter,
   noopMetricMeter,
   ActivityCancellationDetails,
 } from '@temporalio/common';
 import { LoggerWithComposedMetadata } from '@temporalio/common/lib/logger';
-import { Client } from '@temporalio/client';
-import { ActivityInterceptorsFactory, DefaultLogger } from '@temporalio/worker';
-import { Activity, CancelReason } from '@temporalio/worker/lib/activity';
+import type { Client } from '@temporalio/client';
+import type { ActivityInterceptorsFactory } from '@temporalio/worker';
+import { DefaultLogger } from '@temporalio/worker';
+import type { CancelReason } from '@temporalio/worker/lib/activity';
+import { Activity } from '@temporalio/worker/lib/activity';
 
 export interface MockActivityEnvironmentOptions {
   interceptors?: ActivityInterceptorsFactory[];

--- a/packages/testing/src/testing-workflow-environment.ts
+++ b/packages/testing/src/testing-workflow-environment.ts
@@ -1,25 +1,20 @@
 import 'abort-controller/polyfill'; // eslint-disable-line import/no-unassigned-import
-import {
-  AsyncCompletionClient,
-  Client,
-  ClientPlugin,
-  Connection,
-  ConnectionPlugin,
-  WorkflowClient,
-} from '@temporalio/client';
-import {
-  ConnectionOptions,
-  InternalConnectionOptions,
-  InternalConnectionOptionsSymbol,
-} from '@temporalio/client/lib/connection';
-import { Duration, TypedSearchAttributes } from '@temporalio/common';
+import type { AsyncCompletionClient, ClientPlugin, ConnectionPlugin, WorkflowClient } from '@temporalio/client';
+import { Client, Connection } from '@temporalio/client';
+import type { ConnectionOptions, InternalConnectionOptions } from '@temporalio/client/lib/connection';
+import { InternalConnectionOptionsSymbol } from '@temporalio/client/lib/connection';
+import type { Duration } from '@temporalio/common';
+import { TypedSearchAttributes } from '@temporalio/common';
 import { msToNumber, msToTs, tsToMs } from '@temporalio/common/lib/time';
-import { NativeConnection, NativeConnectionPlugin, NativeConnectionOptions, Runtime } from '@temporalio/worker';
+import type { NativeConnectionPlugin, NativeConnectionOptions } from '@temporalio/worker';
+import { NativeConnection, Runtime } from '@temporalio/worker';
 import { native } from '@temporalio/core-bridge';
-import { temporal } from '@temporalio/proto';
+import type { temporal } from '@temporalio/proto';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
-import { toNativeEphemeralServerConfig, DevServerConfig, TimeSkippingServerConfig } from './ephemeral-server';
-import { ClientOptionsForTestEnv, TimeSkippingClient } from './client';
+import type { DevServerConfig, TimeSkippingServerConfig } from './ephemeral-server';
+import { toNativeEphemeralServerConfig } from './ephemeral-server';
+import type { ClientOptionsForTestEnv } from './client';
+import { TimeSkippingClient } from './client';
 
 /**
  * Options for {@link TestWorkflowEnvironment.createLocal}

--- a/packages/testing/src/utils.ts
+++ b/packages/testing/src/utils.ts
@@ -1,4 +1,4 @@
-import { Connection } from '@temporalio/client';
+import type { Connection } from '@temporalio/client';
 import { msToTs } from '@temporalio/common/lib/time';
 
 // Starting with 1.20, we should no longer need to wait on namespace

--- a/packages/worker/src/activity-log-interceptor.ts
+++ b/packages/worker/src/activity-log-interceptor.ts
@@ -1,7 +1,7 @@
-import { Context } from '@temporalio/activity';
+import type { Context } from '@temporalio/activity';
 import { SdkComponent } from '@temporalio/common';
-import { ActivityInboundCallsInterceptor, ActivityExecuteInput, Next } from './interceptors';
-import { Logger } from './logger';
+import type { ActivityInboundCallsInterceptor, ActivityExecuteInput, Next } from './interceptors';
+import type { Logger } from './logger';
 import { activityLogAttributes } from './activity';
 import { Runtime } from './runtime';
 

--- a/packages/worker/src/activity.ts
+++ b/packages/worker/src/activity.ts
@@ -1,28 +1,32 @@
 import 'abort-controller/polyfill'; // eslint-disable-line import/no-unassigned-import
-import { asyncLocalStorage, CompleteAsyncError, Context, Info } from '@temporalio/activity';
-import {
+import type { Info } from '@temporalio/activity';
+import { asyncLocalStorage, CompleteAsyncError, Context } from '@temporalio/activity';
+import type {
   ActivityCancellationDetails,
   ActivityFunction,
+  LoadedDataConverter,
+  MetricMeter,
+  MetricTags,
+} from '@temporalio/common';
+import {
   ApplicationFailure,
   ApplicationFailureCategory,
   CancelledFailure,
   ensureApplicationFailure,
   FAILURE_SOURCE,
   IllegalStateError,
-  LoadedDataConverter,
-  MetricMeter,
-  MetricTags,
   SdkComponent,
 } from '@temporalio/common';
 import { encodeErrorToFailure, encodeToPayload } from '@temporalio/common/lib/internal-non-workflow';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import { isAbortError } from '@temporalio/common/lib/type-helpers';
-import { Logger, LoggerWithComposedMetadata } from '@temporalio/common/lib/logger';
+import type { Logger } from '@temporalio/common/lib/logger';
+import { LoggerWithComposedMetadata } from '@temporalio/common/lib/logger';
 import { MetricMeterWithComposedTags } from '@temporalio/common/lib/metrics';
-import { Client } from '@temporalio/client';
-import { coresdk } from '@temporalio/proto';
-import { ActivityCancellationDetailsHolder } from '@temporalio/common/lib/activity-cancellation-details';
-import {
+import type { Client } from '@temporalio/client';
+import type { coresdk } from '@temporalio/proto';
+import type { ActivityCancellationDetailsHolder } from '@temporalio/common/lib/activity-cancellation-details';
+import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
   ActivityInterceptorsFactory,

--- a/packages/worker/src/connection-options.ts
+++ b/packages/worker/src/connection-options.ts
@@ -1,4 +1,4 @@
-import { native } from '@temporalio/core-bridge';
+import type { native } from '@temporalio/core-bridge';
 import {
   joinProtoHostPort,
   normalizeGrpcEndpointAddress,

--- a/packages/worker/src/connection.ts
+++ b/packages/worker/src/connection.ts
@@ -1,21 +1,20 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import * as grpc from '@grpc/grpc-js';
-import * as proto from 'protobufjs';
+import type * as grpc from '@grpc/grpc-js';
+import type * as proto from 'protobufjs';
 import { IllegalStateError } from '@temporalio/common';
 import { native } from '@temporalio/core-bridge';
+import type { ConnectionLike, Metadata, CallContext } from '@temporalio/client';
 import {
-  ConnectionLike,
-  Metadata,
-  CallContext,
   WorkflowService,
   OperatorService,
   HealthService,
   TestService,
   InternalConnectionLikeSymbol,
 } from '@temporalio/client';
-import { InternalConnectionOptions, InternalConnectionOptionsSymbol } from '@temporalio/client/lib/connection';
+import type { InternalConnectionOptions } from '@temporalio/client/lib/connection';
+import { InternalConnectionOptionsSymbol } from '@temporalio/client/lib/connection';
 import { TransportError } from './errors';
-import { NativeConnectionOptions } from './connection-options';
+import type { NativeConnectionOptions } from './connection-options';
 import { Runtime } from './runtime';
 
 /**

--- a/packages/worker/src/debug-replayer/inbound-interceptor.ts
+++ b/packages/worker/src/debug-replayer/inbound-interceptor.ts
@@ -4,7 +4,7 @@
  *
  * @module
  */
-import { WorkflowInterceptorsFactory } from '@temporalio/workflow';
+import type { WorkflowInterceptorsFactory } from '@temporalio/workflow';
 import { notifyRunner } from './workflow-notifier';
 
 export const interceptors: WorkflowInterceptorsFactory = () => ({

--- a/packages/worker/src/debug-replayer/index.ts
+++ b/packages/worker/src/debug-replayer/index.ts
@@ -1,6 +1,6 @@
 import worker_threads from 'node:worker_threads';
 import { temporal } from '@temporalio/proto';
-import { ReplayWorkerOptions } from '../worker-options';
+import type { ReplayWorkerOptions } from '../worker-options';
 import { Worker } from '../worker';
 import { Client } from './client';
 

--- a/packages/worker/src/debug-replayer/outbound-interceptor.ts
+++ b/packages/worker/src/debug-replayer/outbound-interceptor.ts
@@ -4,7 +4,7 @@
  *
  * @module
  */
-import { WorkflowInterceptorsFactory } from '@temporalio/workflow';
+import type { WorkflowInterceptorsFactory } from '@temporalio/workflow';
 import { notifyRunner } from './workflow-notifier';
 
 export const interceptors: WorkflowInterceptorsFactory = () => ({

--- a/packages/worker/src/interceptors.ts
+++ b/packages/worker/src/interceptors.ts
@@ -1,7 +1,8 @@
-import * as nexus from 'nexus-rpc';
-import { Context as ActivityContext } from '@temporalio/activity';
-import { ClientInterceptors } from '@temporalio/client';
-import { Headers, MetricTags, Next } from '@temporalio/common';
+import type * as nexus from 'nexus-rpc';
+import type { Context as ActivityContext } from '@temporalio/activity';
+import type { ClientInterceptors } from '@temporalio/client';
+import type { MetricTags } from '@temporalio/common';
+import { Headers, Next } from '@temporalio/common';
 
 export { Next, Headers };
 

--- a/packages/worker/src/nexus/conversions.ts
+++ b/packages/worker/src/nexus/conversions.ts
@@ -1,7 +1,8 @@
 import { status } from '@grpc/grpc-js';
 import * as nexus from 'nexus-rpc';
 import { isGrpcServiceError, ServiceError } from '@temporalio/client';
-import { ApplicationFailure, CancelledFailure, LoadedDataConverter, Payload, ProtoFailure } from '@temporalio/common';
+import type { LoadedDataConverter, Payload, ProtoFailure } from '@temporalio/common';
+import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
 import { encodeErrorToFailure, decodeOptionalSingle } from '@temporalio/common/lib/internal-non-workflow';
 import type { temporal } from '@temporalio/proto';
 

--- a/packages/worker/src/nexus/index.ts
+++ b/packages/worker/src/nexus/index.ts
@@ -1,24 +1,21 @@
 import * as nexus from 'nexus-rpc';
 
+import type { LoadedDataConverter, Payload, MetricMeter, MetricTags } from '@temporalio/common';
 import {
   CancelledFailure,
   IllegalStateError,
-  LoadedDataConverter,
-  Payload,
   SdkComponent,
   LoggerWithComposedMetadata,
-  MetricMeter,
   MetricMeterWithComposedTags,
-  MetricTags,
 } from '@temporalio/common';
-import { temporal, coresdk } from '@temporalio/proto';
+import type { temporal, coresdk } from '@temporalio/proto';
 import { asyncLocalStorage } from '@temporalio/nexus/lib/context';
 import { encodeToPayload } from '@temporalio/common/lib/internal-non-workflow';
 import { isAbortError } from '@temporalio/common/lib/type-helpers';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
-import { Client } from '@temporalio/client';
-import { Logger } from '../logger';
-import {
+import type { Client } from '@temporalio/client';
+import type { Logger } from '../logger';
+import type {
   NexusCancelOperationInput,
   NexusStartOperationInput,
   NexusInboundCallsInterceptor,

--- a/packages/worker/src/replay.ts
+++ b/packages/worker/src/replay.ts
@@ -1,4 +1,4 @@
-import { HistoryAndWorkflowId } from '@temporalio/client';
+import type { HistoryAndWorkflowId } from '@temporalio/client';
 import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 import { coresdk } from '@temporalio/proto';
 import { DeterminismViolationError } from '@temporalio/workflow';

--- a/packages/worker/src/runtime-logger.ts
+++ b/packages/worker/src/runtime-logger.ts
@@ -1,7 +1,8 @@
 import { Heap } from 'heap-js';
 import { SdkComponent } from '@temporalio/common';
-import { native } from '@temporalio/core-bridge';
-import { DefaultLogger, FlushableLogger, LogEntry, Logger, LogTimestamp } from './logger';
+import type { native } from '@temporalio/core-bridge';
+import type { FlushableLogger, LogEntry, Logger } from './logger';
+import { DefaultLogger, LogTimestamp } from './logger';
 
 /**
  * A log collector that accepts log entries either through the TS `Logger` interface (e.g. used by

--- a/packages/worker/src/runtime-metrics.ts
+++ b/packages/worker/src/runtime-metrics.ts
@@ -1,5 +1,4 @@
-import {
-  IllegalStateError,
+import type {
   Metric,
   MetricCounter,
   MetricGauge,
@@ -8,6 +7,7 @@ import {
   MetricTags,
   NumericMetricValueType,
 } from '@temporalio/common';
+import { IllegalStateError } from '@temporalio/common';
 import { native } from '@temporalio/core-bridge';
 import type { Runtime } from './runtime';
 

--- a/packages/worker/src/runtime-options.ts
+++ b/packages/worker/src/runtime-options.ts
@@ -1,9 +1,10 @@
-import { native } from '@temporalio/core-bridge';
-import { Logger, LogLevel } from '@temporalio/common';
-import { Duration, msToNumber } from '@temporalio/common/lib/time';
+import type { native } from '@temporalio/core-bridge';
+import type { Logger, LogLevel } from '@temporalio/common';
+import type { Duration } from '@temporalio/common/lib/time';
+import { msToNumber } from '@temporalio/common/lib/time';
 import { DefaultLogger } from './logger';
 import { NativeLogCollector } from './runtime-logger';
-import { MetricsBuffer } from './runtime-metrics';
+import type { MetricsBuffer } from './runtime-metrics';
 
 /**
  * Options used to create a Temporal Runtime.

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -3,15 +3,19 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import { native } from '@temporalio/core-bridge';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
-import { IllegalStateError, Logger, noopMetricMeter, SdkComponent, MetricMeter } from '@temporalio/common';
+import type { Logger, MetricMeter } from '@temporalio/common';
+import { IllegalStateError, noopMetricMeter, SdkComponent } from '@temporalio/common';
 import { coresdk, temporal } from '@temporalio/proto';
 import { History } from '@temporalio/common/lib/proto-utils';
 import { MetricMeterWithComposedTags } from '@temporalio/common/lib/metrics';
 import { isFlushableLogger } from './logger';
-import { RuntimeMetricMeter, MetricsBuffer } from './runtime-metrics';
-import { toNativeClientOptions, NativeConnectionOptions } from './connection-options';
+import type { MetricsBuffer } from './runtime-metrics';
+import { RuntimeMetricMeter } from './runtime-metrics';
+import type { NativeConnectionOptions } from './connection-options';
+import { toNativeClientOptions } from './connection-options';
 import { byteArrayToBuffer, toMB } from './utils';
-import { CompiledRuntimeOptions, compileOptions, RuntimeOptions } from './runtime-options';
+import type { CompiledRuntimeOptions, RuntimeOptions } from './runtime-options';
+import { compileOptions } from './runtime-options';
 
 export { History };
 

--- a/packages/worker/src/rxutils.ts
+++ b/packages/worker/src/rxutils.ts
@@ -1,4 +1,5 @@
-import { GroupedObservable, ObservableInput, OperatorFunction, pipe, Subject } from 'rxjs';
+import type { GroupedObservable, ObservableInput, OperatorFunction } from 'rxjs';
+import { pipe, Subject } from 'rxjs';
 import { groupBy, map, mergeScan, scan } from 'rxjs/operators';
 
 interface StateAndOptionalOutput<T, O> {

--- a/packages/worker/src/sinks.ts
+++ b/packages/worker/src/sinks.ts
@@ -14,7 +14,7 @@
  * @module
  */
 
-import { Sinks, Sink, SinkFunction, WorkflowInfo } from '@temporalio/workflow';
+import type { Sinks, Sink, SinkFunction, WorkflowInfo } from '@temporalio/workflow';
 
 /**
  * Registration of a {@link SinkFunction}, including per-sink-function options.

--- a/packages/worker/src/utils.ts
+++ b/packages/worker/src/utils.ts
@@ -1,6 +1,6 @@
-import { WorkerDeploymentVersion } from '@temporalio/common';
+import type { WorkerDeploymentVersion } from '@temporalio/common';
 import type { coresdk, temporal } from '@temporalio/proto';
-import { ParentWorkflowInfo, RootWorkflowInfo } from '@temporalio/workflow';
+import type { ParentWorkflowInfo, RootWorkflowInfo } from '@temporalio/workflow';
 
 export const MiB = 1024 ** 2;
 

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -1,8 +1,8 @@
 import * as os from 'node:os';
 import * as v8 from 'node:v8';
 import type { Configuration as WebpackConfiguration } from 'webpack';
-import * as nexus from 'nexus-rpc';
-import {
+import type * as nexus from 'nexus-rpc';
+import type {
   ActivityFunction,
   DataConverter,
   LoadedDataConverter,
@@ -10,23 +10,25 @@ import {
   VersioningBehavior,
   WorkerDeploymentVersion,
 } from '@temporalio/common';
-import { Duration, msOptionalToNumber, msToNumber } from '@temporalio/common/lib/time';
+import type { Duration } from '@temporalio/common/lib/time';
+import { msOptionalToNumber, msToNumber } from '@temporalio/common/lib/time';
 import { loadDataConverter } from '@temporalio/common/lib/internal-non-workflow';
-import { LoggerSinks } from '@temporalio/workflow';
-import { Context } from '@temporalio/activity';
-import { native } from '@temporalio/core-bridge';
+import type { LoggerSinks } from '@temporalio/workflow';
+import type { Context } from '@temporalio/activity';
+import type { native } from '@temporalio/core-bridge';
 import { throwIfReservedName } from '@temporalio/common/lib/reserved';
 import { ActivityInboundLogInterceptor } from './activity-log-interceptor';
-import { NativeConnection } from './connection';
-import { CompiledWorkerInterceptors, WorkerInterceptors } from './interceptors';
-import { Logger } from './logger';
+import type { NativeConnection } from './connection';
+import type { CompiledWorkerInterceptors, WorkerInterceptors } from './interceptors';
+import type { Logger } from './logger';
 import { initLoggerSink } from './workflow/logger';
 import { initMetricSink } from './workflow/metrics';
 import { Runtime } from './runtime';
-import { InjectedSinks } from './sinks';
+import type { InjectedSinks } from './sinks';
 import { MiB } from './utils';
-import { WorkflowBundleWithSourceMap } from './workflow/bundler';
-import { asNativeTuner, WorkerTuner } from './worker-tuner';
+import type { WorkflowBundleWithSourceMap } from './workflow/bundler';
+import type { WorkerTuner } from './worker-tuner';
+import { asNativeTuner } from './worker-tuner';
 import type { Worker } from './worker';
 
 /**

--- a/packages/worker/src/worker-tuner.ts
+++ b/packages/worker/src/worker-tuner.ts
@@ -1,6 +1,7 @@
-import { native } from '@temporalio/core-bridge';
-import { Duration, msToNumber } from '@temporalio/common/lib/time';
-import { Logger, WorkerDeploymentVersion } from '@temporalio/common';
+import type { native } from '@temporalio/core-bridge';
+import type { Duration } from '@temporalio/common/lib/time';
+import { msToNumber } from '@temporalio/common/lib/time';
+import type { Logger, WorkerDeploymentVersion } from '@temporalio/common';
 
 /**
  * A worker tuner allows the customization of the performance characteristics of workers by

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -4,49 +4,36 @@ import * as path from 'node:path';
 import * as vm from 'node:vm';
 import { EventEmitter, on } from 'node:events';
 import { setTimeout as setTimeoutCallback } from 'node:timers';
-import {
-  BehaviorSubject,
-  EMPTY,
-  from,
-  lastValueFrom,
-  merge,
-  MonoTypeOperatorFunction,
-  Observable,
-  OperatorFunction,
-  pipe,
-  race,
-  Subject,
-} from 'rxjs';
+import type { MonoTypeOperatorFunction, Observable, OperatorFunction } from 'rxjs';
+import { BehaviorSubject, EMPTY, from, lastValueFrom, merge, pipe, race, Subject } from 'rxjs';
 import { delay, filter, first, ignoreElements, last, map, mergeMap, takeUntil, takeWhile, tap } from 'rxjs/operators';
 import type { RawSourceMap } from 'source-map';
 import * as nexus from 'nexus-rpc';
-import { Info as ActivityInfo } from '@temporalio/activity';
+import type { Info as ActivityInfo } from '@temporalio/activity';
+import type { LoadedDataConverter, Payload, MetricMeter } from '@temporalio/common';
 import {
   DataConverter,
   decompileRetryPolicy,
   defaultPayloadConverter,
   IllegalStateError,
-  LoadedDataConverter,
   SdkComponent,
-  Payload,
   ApplicationFailure,
   ensureApplicationFailure,
   TypedSearchAttributes,
   decodePriority,
   CancelledFailure,
-  MetricMeter,
   ActivityCancellationDetails,
 } from '@temporalio/common';
+import type { Decoded } from '@temporalio/common/lib/internal-non-workflow';
 import {
   decodeArrayFromPayloads,
-  Decoded,
   decodeFromPayloadsAtIndex,
   encodeErrorToFailure,
   encodeToPayload,
 } from '@temporalio/common/lib/internal-non-workflow';
 import { historyFromJSON } from '@temporalio/common/lib/proto-utils';
+import type { Duration } from '@temporalio/common/lib/time';
 import {
-  Duration,
   msToNumber,
   optionalTsToDate,
   optionalTsToMs,
@@ -55,53 +42,51 @@ import {
   tsToMs,
 } from '@temporalio/common/lib/time';
 import { LoggerWithComposedMetadata } from '@temporalio/common/lib/logger';
-import { errorMessage, NonNullableObject, OmitFirstParam } from '@temporalio/common/lib/type-helpers';
+import type { NonNullableObject, OmitFirstParam } from '@temporalio/common/lib/type-helpers';
+import { errorMessage } from '@temporalio/common/lib/type-helpers';
 import { workflowLogAttributes } from '@temporalio/workflow/lib/logs';
 import { native } from '@temporalio/core-bridge';
 import { Client } from '@temporalio/client';
-import { coresdk, temporal } from '@temporalio/proto';
+import type { temporal } from '@temporalio/proto';
+import { coresdk } from '@temporalio/proto';
 import { type SinkCall, type WorkflowInfo } from '@temporalio/workflow';
 import { throwIfReservedName } from '@temporalio/common/lib/reserved';
 import { suggestContinueAsNewReasonsFromProto } from '@temporalio/common/lib/continue-as-new';
-import { Activity, CancelReason, activityLogAttributes } from './activity';
-import { extractNativeClient, extractReferenceHolders, InternalNativeConnection, NativeConnection } from './connection';
-import { ActivityExecuteInput } from './interceptors';
-import { Logger } from './logger';
+import type { CancelReason } from './activity';
+import { Activity, activityLogAttributes } from './activity';
+import type { NativeConnection } from './connection';
+import { extractNativeClient, extractReferenceHolders, InternalNativeConnection } from './connection';
+import type { ActivityExecuteInput } from './interceptors';
+import type { Logger } from './logger';
 import pkg from './pkg';
-import {
-  EvictionReason,
-  evictionReasonToReplayError,
-  RemoveFromCache,
-  ReplayHistoriesIterable,
-  ReplayResult,
-} from './replay';
-import { History, Runtime } from './runtime';
-import { CloseableGroupedObservable, closeableGroupBy, mapWithState, mergeMapWithState } from './rxutils';
+import type { RemoveFromCache, ReplayHistoriesIterable, ReplayResult } from './replay';
+import { EvictionReason, evictionReasonToReplayError } from './replay';
+import type { History } from './runtime';
+import { Runtime } from './runtime';
+import type { CloseableGroupedObservable } from './rxutils';
+import { closeableGroupBy, mapWithState, mergeMapWithState } from './rxutils';
 import {
   byteArrayToBuffer,
   convertDeploymentVersion,
   convertToParentWorkflowType,
   convertToRootWorkflowType,
 } from './utils';
-import {
+import type {
   CompiledWorkerOptions,
   CompiledWorkerOptionsWithBuildId,
-  compileWorkerOptions,
-  isCodeBundleOption,
-  isPathBundleOption,
   ReplayWorkerOptions,
-  toNativeWorkerOptions,
   WorkerOptions,
   WorkerPlugin,
   WorkflowBundle,
 } from './worker-options';
+import { compileWorkerOptions, isCodeBundleOption, isPathBundleOption, toNativeWorkerOptions } from './worker-options';
 import { WorkflowCodecRunner } from './workflow-codec-runner';
 import { defaultWorkflowInterceptorModules, WorkflowCodeBundler } from './workflow/bundler';
-import { Workflow, WorkflowCreator } from './workflow/interface';
+import type { Workflow, WorkflowCreator } from './workflow/interface';
 import { ReusableVMWorkflowCreator } from './workflow/reusable-vm';
 import { ThreadedVMWorkflowCreator } from './workflow/threaded-vm';
 import { VMWorkflowCreator } from './workflow/vm';
-import { WorkflowBundleWithSourceMapAndFilename } from './workflow/workflow-worker-thread/input';
+import type { WorkflowBundleWithSourceMapAndFilename } from './workflow/workflow-worker-thread/input';
 import {
   CombinedWorkerRunError,
   GracefulShutdownPeriodExpiredError,

--- a/packages/worker/src/workflow-codec-runner.ts
+++ b/packages/worker/src/workflow-codec-runner.ts
@@ -1,11 +1,10 @@
-import { PayloadCodec } from '@temporalio/common';
+import type { PayloadCodec } from '@temporalio/common';
+import type { Decoded, Encoded } from '@temporalio/common/lib/internal-non-workflow';
 import {
-  Decoded,
   decodeOptional,
   decodeOptionalFailure,
   decodeOptionalMap,
   decodeOptionalSingle,
-  Encoded,
   encodeMap,
   encodeOptional,
   encodeOptionalFailure,

--- a/packages/worker/src/workflow-log-interceptor.ts
+++ b/packages/worker/src/workflow-log-interceptor.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Next,
   WorkflowExecuteInput,
   WorkflowInboundCallsInterceptor,

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -4,8 +4,10 @@ import path from 'node:path';
 import util from 'node:util';
 import * as unionfs from 'unionfs';
 import * as memfs from 'memfs';
-import { Configuration, webpack, NormalModuleReplacementPlugin } from 'webpack';
-import { DefaultLogger, Logger, hasColorSupport } from '../logger';
+import type { Configuration } from 'webpack';
+import { webpack, NormalModuleReplacementPlugin } from 'webpack';
+import type { Logger } from '../logger';
+import { DefaultLogger, hasColorSupport } from '../logger';
 import { toMB } from '../utils';
 
 export const defaultWorkflowInterceptorModules = [require.resolve('../workflow-log-interceptor')];

--- a/packages/worker/src/workflow/metrics.ts
+++ b/packages/worker/src/workflow/metrics.ts
@@ -1,6 +1,7 @@
-import { NumericMetricValueType, type MetricMeter, type MetricTags, Metric } from '@temporalio/common';
-import { MetricSinks } from '@temporalio/workflow/lib/metrics';
-import { InjectedSinks } from '../sinks';
+import type { NumericMetricValueType, Metric } from '@temporalio/common';
+import { type MetricMeter, type MetricTags } from '@temporalio/common';
+import type { MetricSinks } from '@temporalio/workflow/lib/metrics';
+import type { InjectedSinks } from '../sinks';
 
 export function initMetricSink(metricMeter: MetricMeter): InjectedSinks<MetricSinks> {
   // Creation of a new metric object isn't quite cheap, requiring a call down the bridge to the

--- a/packages/worker/src/workflow/reusable-vm.ts
+++ b/packages/worker/src/workflow/reusable-vm.ts
@@ -1,9 +1,9 @@
 import vm from 'node:vm';
-import * as internals from '@temporalio/workflow/lib/worker-interface';
+import type * as internals from '@temporalio/workflow/lib/worker-interface';
 import { IllegalStateError } from '@temporalio/common';
 import { native } from '@temporalio/core-bridge';
-import { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interface';
-import { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
+import type { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interface';
+import type { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
 import { BaseVMWorkflow, globalHandlers, injectGlobals, setUnhandledRejectionHandler } from './vm-shared';
 import { isBun } from './bun';
 

--- a/packages/worker/src/workflow/threaded-vm.ts
+++ b/packages/worker/src/workflow/threaded-vm.ts
@@ -13,15 +13,15 @@ import { Worker as NodeWorker } from 'node:worker_threads';
 import { setTimeout } from 'node:timers/promises';
 import { coresdk } from '@temporalio/proto';
 import { IllegalStateError, type SinkCall } from '@temporalio/workflow';
-import { Logger } from '@temporalio/common';
+import type { Logger } from '@temporalio/common';
 import { UnexpectedError } from '../errors';
-import {
+import type {
   WorkflowBundleWithSourceMapAndFilename,
   WorkerThreadInput,
   WorkerThreadRequest,
 } from './workflow-worker-thread/input';
-import { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interface';
-import { WorkerThreadOutput, WorkerThreadResponse } from './workflow-worker-thread/output';
+import type { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interface';
+import type { WorkerThreadOutput, WorkerThreadResponse } from './workflow-worker-thread/output';
 import { isBun } from './bun';
 
 // https://nodejs.org/api/worker_threads.html#event-exit

--- a/packages/worker/src/workflow/vm-shared.ts
+++ b/packages/worker/src/workflow/vm-shared.ts
@@ -1,5 +1,5 @@
 import v8 from 'node:v8';
-import vm from 'node:vm';
+import type vm from 'node:vm';
 import { AsyncLocalStorage as AsyncLocalStorageOriginal } from 'node:async_hooks';
 import assert from 'node:assert';
 import { URL, URLSearchParams } from 'node:url';
@@ -11,13 +11,13 @@ import { tsToMs } from '@temporalio/common/lib/time';
 import { coresdk } from '@temporalio/proto';
 import type { StackTraceFileLocation } from '@temporalio/workflow';
 import { type SinkCall } from '@temporalio/workflow/lib/sinks';
-import * as internals from '@temporalio/workflow/lib/worker-interface';
-import { Activator } from '@temporalio/workflow/lib/internals';
+import type * as internals from '@temporalio/workflow/lib/worker-interface';
+import type { Activator } from '@temporalio/workflow/lib/internals';
 import { SdkFlags } from '@temporalio/workflow/lib/flags';
 import { UnhandledRejectionError } from '../errors';
 import { convertDeploymentVersion } from '../utils';
-import { Workflow } from './interface';
-import { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
+import type { Workflow } from './interface';
+import type { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
 
 // We need this import for the ambient global extensions
 import '@temporalio/workflow/lib/global-attributes'; // eslint-disable-line import/no-unassigned-import

--- a/packages/worker/src/workflow/vm.ts
+++ b/packages/worker/src/workflow/vm.ts
@@ -1,15 +1,10 @@
 import vm from 'node:vm';
 import { IllegalStateError } from '@temporalio/common';
 import { native } from '@temporalio/core-bridge';
-import { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interface';
-import { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
-import {
-  BaseVMWorkflow,
-  globalHandlers,
-  injectGlobals,
-  setUnhandledRejectionHandler,
-  WorkflowModule,
-} from './vm-shared';
+import type { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interface';
+import type { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
+import type { WorkflowModule } from './vm-shared';
+import { BaseVMWorkflow, globalHandlers, injectGlobals, setUnhandledRejectionHandler } from './vm-shared';
 import { isBun } from './bun';
 
 /**

--- a/packages/worker/src/workflow/workflow-worker-thread.ts
+++ b/packages/worker/src/workflow/workflow-worker-thread.ts
@@ -1,11 +1,11 @@
 import { isMainThread, parentPort as parentPortOrNull } from 'node:worker_threads';
 import { IllegalStateError } from '@temporalio/common';
 import { coresdk } from '@temporalio/proto';
-import { Workflow, WorkflowCreator } from './interface';
+import type { Workflow, WorkflowCreator } from './interface';
 import { ReusableVMWorkflowCreator } from './reusable-vm';
 import { VMWorkflowCreator } from './vm';
-import { WorkerThreadRequest } from './workflow-worker-thread/input';
-import { WorkerThreadResponse } from './workflow-worker-thread/output';
+import type { WorkerThreadRequest } from './workflow-worker-thread/input';
+import type { WorkerThreadResponse } from './workflow-worker-thread/output';
 import { isBun } from './bun';
 
 if (isMainThread) {

--- a/packages/worker/src/workflow/workflow-worker-thread/input.ts
+++ b/packages/worker/src/workflow/workflow-worker-thread/input.ts
@@ -1,6 +1,6 @@
 import type { RawSourceMap } from 'source-map';
-import { coresdk } from '@temporalio/proto';
-import { WorkflowCreateOptions } from '../interface';
+import type { coresdk } from '@temporalio/proto';
+import type { WorkflowCreateOptions } from '../interface';
 
 export interface WorkflowBundleWithSourceMapAndFilename {
   code: string;

--- a/packages/workflow/src/cancellation-scope.ts
+++ b/packages/workflow/src/cancellation-scope.ts
@@ -1,5 +1,6 @@
 import type { AsyncLocalStorage as ALS } from 'node:async_hooks';
-import { CancelledFailure, Duration, IllegalStateError } from '@temporalio/common';
+import type { Duration } from '@temporalio/common';
+import { CancelledFailure, IllegalStateError } from '@temporalio/common';
 import { msOptionalToNumber } from '@temporalio/common/lib/time';
 import { untrackPromise } from './stack-helpers';
 import { getActivator } from './global-attributes';

--- a/packages/workflow/src/interceptors.ts
+++ b/packages/workflow/src/interceptors.ts
@@ -4,16 +4,15 @@
  * @module
  */
 
-import {
+import type {
   ActivityOptions,
   Duration,
-  Headers,
   LocalActivityOptions,
   MetricTags,
-  Next,
   Timestamp,
   WorkflowExecution,
 } from '@temporalio/common';
+import { Headers, Next } from '@temporalio/common';
 import type { coresdk } from '@temporalio/proto';
 import type { ChildWorkflowOptionsWithDefaults, ContinueAsNewOptions } from './interfaces';
 import type { NexusOperationCancellationType } from './nexus';

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1,5 +1,5 @@
 import type { RawSourceMap } from 'source-map';
-import {
+import type {
   RetryPolicy,
   CommonWorkflowOptions,
   HandlerUnfinishedPolicy,

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -1,29 +1,31 @@
 import type { RawSourceMap } from 'source-map';
-import {
-  defaultFailureConverter,
+import type {
   FailureConverter,
   PayloadConverter,
+  Workflow,
+  WorkflowQueryAnnotatedType,
+  WorkflowSignalAnnotatedType,
+  WorkflowUpdateAnnotatedType,
+  ProtoFailure,
+  WorkflowUpdateType,
+  WorkflowUpdateValidatorType,
+  WorkflowFunctionWithOptions,
+  VersioningBehavior,
+  WorkflowDefinitionOptions,
+} from '@temporalio/common';
+import {
+  defaultFailureConverter,
   arrayFromPayloads,
   defaultPayloadConverter,
   ensureTemporalFailure,
   HandlerUnfinishedPolicy,
   IllegalStateError,
   TemporalFailure,
-  Workflow,
   WorkflowExecutionAlreadyStartedError,
-  WorkflowQueryAnnotatedType,
-  WorkflowSignalAnnotatedType,
-  WorkflowUpdateAnnotatedType,
-  ProtoFailure,
   ApplicationFailure,
-  WorkflowUpdateType,
-  WorkflowUpdateValidatorType,
   mapFromPayloads,
   fromPayloadsAtIndex,
   RawValue,
-  WorkflowFunctionWithOptions,
-  VersioningBehavior,
-  WorkflowDefinitionOptions,
 } from '@temporalio/common';
 import {
   decodeSearchAttributes,
@@ -37,11 +39,12 @@ import {
   STACK_TRACE_QUERY_NAME,
   ENHANCED_STACK_TRACE_QUERY_NAME,
 } from '@temporalio/common/lib/reserved';
-import { alea, RNG } from './alea';
+import type { RNG } from './alea';
+import { alea } from './alea';
 import { RootCancellationScope } from './cancellation-scope';
 import { UpdateScope } from './update-scope';
 import { DeterminismViolationError, LocalActivityDoBackoff, isCancellation } from './errors';
-import {
+import type {
   QueryInput,
   SignalInput,
   StartNexusOperationOutput,
@@ -49,8 +52,7 @@ import {
   WorkflowExecuteInput,
   WorkflowInterceptors,
 } from './interceptors';
-import {
-  ContinueAsNew,
+import type {
   DefaultSignalHandler,
   StackTraceSDKInfo,
   StackTraceFileSlice,
@@ -62,10 +64,12 @@ import {
   DefaultQueryHandler,
   EnhancedStackTrace,
 } from './interfaces';
+import { ContinueAsNew } from './interfaces';
 import { type SinkCall } from './sinks';
 import { untrackPromise } from './stack-helpers';
 import pkg from './pkg';
-import { SdkFlag, assertValidFlag } from './flags';
+import type { SdkFlag } from './flags';
+import { assertValidFlag } from './flags';
 import { executeWithLifecycleLogging, log } from './logs';
 
 const StartChildWorkflowExecutionFailedCause = {

--- a/packages/workflow/src/logs.ts
+++ b/packages/workflow/src/logs.ts
@@ -3,7 +3,8 @@ import { SdkComponent } from '@temporalio/common';
 import { untrackPromise } from './stack-helpers';
 import { type Sink, type Sinks, proxySinks } from './sinks';
 import { isCancellation } from './errors';
-import { WorkflowInfo, ContinueAsNew } from './interfaces';
+import type { WorkflowInfo } from './interfaces';
+import { ContinueAsNew } from './interfaces';
 import { assertInWorkflowContext } from './global-attributes';
 import { currentUpdateInfo, inWorkflowContext } from './workflow';
 

--- a/packages/workflow/src/metrics.ts
+++ b/packages/workflow/src/metrics.ts
@@ -1,14 +1,15 @@
-import {
+import type {
   MetricCounter,
   MetricGauge,
   MetricHistogram,
   MetricMeter,
-  MetricMeterWithComposedTags,
   MetricTags,
   NumericMetricValueType,
 } from '@temporalio/common';
+import { MetricMeterWithComposedTags } from '@temporalio/common';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
-import { proxySinks, Sink, Sinks } from './sinks';
+import type { Sink, Sinks } from './sinks';
+import { proxySinks } from './sinks';
 import { workflowInfo } from './workflow';
 import { assertInWorkflowContext } from './global-attributes';
 

--- a/packages/workflow/src/nexus.ts
+++ b/packages/workflow/src/nexus.ts
@@ -1,4 +1,4 @@
-import * as nexus from 'nexus-rpc';
+import type * as nexus from 'nexus-rpc';
 import { msOptionalToTs } from '@temporalio/common/lib/time';
 import { userMetadataToPayload } from '@temporalio/common/lib/user-metadata';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
@@ -7,7 +7,7 @@ import type { coresdk } from '@temporalio/proto';
 import { CancellationScope } from './cancellation-scope';
 import { getActivator } from './global-attributes';
 import { untrackPromise } from './stack-helpers';
-import { StartNexusOperationInput, StartNexusOperationOutput, StartNexusOperationOptions } from './interceptors';
+import type { StartNexusOperationInput, StartNexusOperationOutput, StartNexusOperationOptions } from './interceptors';
 
 /**
  * A Nexus client for invoking Nexus Operations for a specific service from a Workflow.

--- a/packages/workflow/src/sinks.ts
+++ b/packages/workflow/src/sinks.ts
@@ -14,7 +14,7 @@
  * @module
  */
 
-import { WorkflowInfo } from './interfaces';
+import type { WorkflowInfo } from './interfaces';
 import { assertInWorkflowContext } from './global-attributes';
 
 /**

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -3,7 +3,8 @@
  *
  * @module
  */
-import { encodeVersioningBehavior, IllegalStateError, WorkflowFunctionWithOptions } from '@temporalio/common';
+import type { WorkflowFunctionWithOptions } from '@temporalio/common';
+import { encodeVersioningBehavior, IllegalStateError } from '@temporalio/common';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import type { coresdk } from '@temporalio/proto';
 import type { WorkflowInterceptorsFactory } from './interceptors';

--- a/packages/workflow/src/workflow-handle.ts
+++ b/packages/workflow/src/workflow-handle.ts
@@ -1,4 +1,4 @@
-import { BaseWorkflowHandle, SignalDefinition, Workflow } from '@temporalio/common';
+import type { BaseWorkflowHandle, SignalDefinition, Workflow } from '@temporalio/common';
 
 /**
  * Handle representing an external Workflow Execution.

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1,20 +1,11 @@
-import {
+import type {
   ActivityFunction,
   ActivityOptions,
-  compileRetryPolicy,
-  compilePriority,
-  encodeActivityCancellationType,
-  encodeWorkflowIdReusePolicy,
-  extractWorkflowType,
-  HandlerUnfinishedPolicy,
   LocalActivityOptions,
-  mapToPayloads,
   QueryDefinition,
   SearchAttributes,
   SearchAttributeValue,
   SignalDefinition,
-  toPayloads,
-  TypedSearchAttributes,
   UntypedActivities,
   UpdateDefinition,
   WithWorkflowArgs,
@@ -24,6 +15,17 @@ import {
   WorkflowUpdateValidatorType,
   SearchAttributeUpdatePair,
   WorkflowDefinitionOptionsOrGetter,
+} from '@temporalio/common';
+import {
+  compileRetryPolicy,
+  compilePriority,
+  encodeActivityCancellationType,
+  encodeWorkflowIdReusePolicy,
+  extractWorkflowType,
+  HandlerUnfinishedPolicy,
+  mapToPayloads,
+  toPayloads,
+  TypedSearchAttributes,
   encodeInitialVersioningBehavior,
 } from '@temporalio/common';
 import { userMetadataToPayload } from '@temporalio/common/lib/user-metadata';
@@ -32,14 +34,15 @@ import {
   searchAttributePayloadConverter,
 } from '@temporalio/common/lib/converter/payload-search-attributes';
 import { versioningIntentToProto } from '@temporalio/common/lib/versioning-intent-enum';
-import { Duration, msOptionalToTs, msToNumber, msToTs, requiredTsToMs } from '@temporalio/common/lib/time';
+import type { Duration } from '@temporalio/common/lib/time';
+import { msOptionalToTs, msToNumber, msToTs, requiredTsToMs } from '@temporalio/common/lib/time';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import type { temporal } from '@temporalio/proto';
 import { deepMerge } from '@temporalio/common/lib/internal-workflow';
 import { throwIfReservedName } from '@temporalio/common/lib/reserved';
 import { CancellationScope, registerSleepImplementation } from './cancellation-scope';
 import { UpdateScope } from './update-scope';
-import {
+import type {
   ActivityInput,
   LocalActivityInput,
   SignalWorkflowInput,
@@ -47,11 +50,9 @@ import {
   TimerInput,
   TimerOptions,
 } from './interceptors';
-import {
-  ChildWorkflowCancellationType,
+import type {
   ChildWorkflowOptions,
   ChildWorkflowOptionsWithDefaults,
-  ContinueAsNew,
   ContinueAsNewOptions,
   DefaultSignalHandler,
   EnhancedStackTrace,
@@ -61,15 +62,19 @@ import {
   UpdateHandlerOptions,
   WorkflowInfo,
   UpdateInfo,
-  encodeChildWorkflowCancellationType,
-  encodeParentClosePolicy,
   DefaultUpdateHandler,
   DefaultQueryHandler,
+} from './interfaces';
+import {
+  ChildWorkflowCancellationType,
+  ContinueAsNew,
+  encodeChildWorkflowCancellationType,
+  encodeParentClosePolicy,
 } from './interfaces';
 import { LocalActivityDoBackoff } from './errors';
 import { assertInWorkflowContext, getActivator, maybeGetActivator } from './global-attributes';
 import { untrackPromise } from './stack-helpers';
-import { ChildWorkflowHandle, ExternalWorkflowHandle } from './workflow-handle';
+import type { ChildWorkflowHandle, ExternalWorkflowHandle } from './workflow-handle';
 
 // Avoid a circular dependency
 registerSleepImplementation(sleep);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Follow up for #2010, update our eslint settings to enforce identifiers only used for typing get imported as `import type`.

Done by enabling [consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports/)

## Why?
General good hygiene to use `import type` to identify what imports are not present at runtime.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Changes eslint config, then ran `pnpm run lint` to fixup the codebase.

3. Any docs updates needed?
N/A
