### PR TITLE
feat(workflow): Add support for failing workflow execution on some error types

### DIFF
--- a/packages/common/src/workflow-definition-options.ts
+++ b/packages/common/src/workflow-definition-options.ts
@@ -5,6 +5,29 @@ import type { VersioningBehavior } from './worker-deployments';
  */
 export interface WorkflowDefinitionOptions {
   versioningBehavior?: VersioningBehavior;
+
+  /**
+   * The types of errors that, if thrown by the Workflow function, a signal handler, or an update
+   * handler, will cause the Workflow Execution or the Update to fail instead of failing the
+   * Workflow Task (which would result in retrying the Workflow Task until it eventually succeeds).
+   *
+   * This is a per-Workflow-type equivalent of {@link WorkerOptions.workflowFailureErrorTypes}.
+   * Both settings are evaluated; an error matching either will cause Workflow failure.
+   * Unlike the string-based {@link WorkerOptions.workflowFailureErrorTypes}, this accepts
+   * actual class references, enabling subclass matching via `instanceof`, but doesn't allow
+   * failing the workflow execution on _non-determinism errors_. Failing the workflow execution on
+   * non-determinism errors can only be set via {@link WorkerOptions.workflowFailureErrorTypes}.
+   *
+   * Passing the `Error` class to this setting will fail the Workflow on any error, except
+   * non-determinism errors.
+   *
+   * Note that {@link TemporalFailure} subclasses and cancellation errors that bubbles out
+   * of the Workflow always fail the Workflow Execution, regardless of either this and the
+   * {@link WorkerOptions.workflowFailureErrorTypes} settings.
+   *
+   * @experimental
+   */
+  failureExceptionTypes?: Array<new (...args: any[]) => Error>;
 }
 
 type AsyncFunction<Args extends any[], ReturnType> = (...args: Args) => Promise<ReturnType>;

--- a/packages/core-bridge/src/helpers/try_from_js.rs
+++ b/packages/core-bridge/src/helpers/try_from_js.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, net::SocketAddr, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    net::SocketAddr,
+    time::Duration,
+};
 
 use neon::{
     handle::Handle,
@@ -158,6 +162,24 @@ impl<T: TryFromJs> TryFromJs for Vec<T> {
         for i in 0..len {
             let value = array.get_value(cx, i)?;
             result.push(T::try_from_js(cx, value)?);
+        }
+        Ok(result)
+    }
+}
+
+#[allow(clippy::implicit_hasher)]
+impl<T: TryFromJs + std::hash::Hash + Eq> TryFromJs for HashSet<T> {
+    fn try_from_js<'cx, 'b>(
+        cx: &mut impl Context<'cx>,
+        js_value: Handle<'b, JsValue>,
+    ) -> BridgeResult<Self> {
+        let array = js_value.downcast::<JsArray, _>(cx)?;
+        let len = array.len(cx);
+        let mut result = Self::with_capacity(len as usize);
+
+        for i in 0..len {
+            let value = array.get_value(cx, i)?;
+            result.insert(T::try_from_js(cx, value)?);
         }
         Ok(result)
     }

--- a/packages/core-bridge/src/worker.rs
+++ b/packages/core-bridge/src/worker.rs
@@ -493,7 +493,7 @@ impl MutableFinalize for HistoryForReplayTunnelHandle {}
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 mod config {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::{sync::Arc, time::Duration};
     use temporalio_common::protos::temporal::api::enums::v1::VersioningBehavior as CoreVersioningBehavior;
     use temporalio_common::protos::temporal::api::worker::v1::PluginInfo;
@@ -505,7 +505,8 @@ mod config {
         ActivitySlotKind, LocalActivitySlotKind, NexusSlotKind,
         PollerBehavior as CorePollerBehavior, ResourceBasedSlotsOptions, ResourceSlotOptions,
         SlotKind, SlotSupplierOptions as CoreSlotSupplierOptions, TunerHolder, TunerHolderOptions,
-        WorkerConfig, WorkerVersioningStrategy, WorkflowSlotKind,
+        WorkerConfig, WorkerVersioningStrategy, WorkflowErrorType as CoreWorkflowErrorType,
+        WorkflowSlotKind,
     };
 
     use super::custom_slot_supplier::CustomSlotSupplierOptions;
@@ -538,6 +539,8 @@ mod config {
         max_task_queue_activities_per_second: Option<f64>,
         shutdown_grace_time: Option<Duration>,
         plugins: Vec<String>,
+        workflow_failure_errors: HashSet<WorkflowErrorType>,
+        workflow_types_to_failure_errors: HashMap<String, HashSet<WorkflowErrorType>>,
     }
 
     #[derive(TryFromJs)]
@@ -635,6 +638,10 @@ mod config {
                         })
                         .collect::<HashSet<_>>(),
                 )
+                .workflow_failure_errors(into_core_workflow_error_set(self.workflow_failure_errors))
+                .workflow_types_to_failure_errors(into_core_workflow_error_map_of_sets(
+                    self.workflow_types_to_failure_errors,
+                ))
                 .build()
                 .map_err(|err| BridgeError::TypeError {
                     message: format!("Failed to convert WorkerOptions to CoreWorkerConfig: {err}"),
@@ -708,6 +715,33 @@ mod config {
                 VersioningBehavior::AutoUpgrade => Self::AutoUpgrade,
             }
         }
+    }
+
+    #[derive(TryFromJs, Hash, Eq, PartialEq)]
+    pub enum WorkflowErrorType {
+        Nondeterminism,
+    }
+
+    impl From<WorkflowErrorType> for CoreWorkflowErrorType {
+        fn from(val: WorkflowErrorType) -> Self {
+            match val {
+                WorkflowErrorType::Nondeterminism => Self::Nondeterminism,
+            }
+        }
+    }
+
+    fn into_core_workflow_error_set(
+        val: HashSet<WorkflowErrorType>,
+    ) -> HashSet<CoreWorkflowErrorType> {
+        val.into_iter().map(Into::into).collect()
+    }
+
+    fn into_core_workflow_error_map_of_sets(
+        val: HashMap<String, HashSet<WorkflowErrorType>>,
+    ) -> HashMap<String, HashSet<CoreWorkflowErrorType>> {
+        val.into_iter()
+            .map(|(k, v)| (k, into_core_workflow_error_set(v)))
+            .collect()
     }
 
     #[derive(TryFromJs)]

--- a/packages/core-bridge/ts/native.ts
+++ b/packages/core-bridge/ts/native.ts
@@ -245,6 +245,8 @@ export interface WorkerOptions {
   maxActivitiesPerSecond: Option<number>;
   shutdownGraceTime: number;
   plugins: string[];
+  workflowFailureErrors: WorkflowErrorType[];
+  workflowTypesToFailureErrors: Record<string, WorkflowErrorType[]>;
 }
 
 export type PollerBehavior =
@@ -271,6 +273,8 @@ export type WorkerDeploymentVersion = {
 };
 
 export type VersioningBehavior = { type: 'pinned' } | { type: 'auto-upgrade' };
+
+export type WorkflowErrorType = { type: 'nondeterminism' };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Worker Tuner

--- a/packages/test/src/test-bridge.ts
+++ b/packages/test/src/test-bridge.ts
@@ -314,6 +314,8 @@ const GenericConfigs = {
       maxActivitiesPerSecond: null,
       shutdownGraceTime: 1000,
       plugins: [],
+      workflowFailureErrors: [],
+      workflowTypesToFailureErrors: {},
     } satisfies native.WorkerOptions,
   },
   ephemeralServer: {

--- a/packages/test/src/test-workflow-fail-on-errors-policy.ts
+++ b/packages/test/src/test-workflow-fail-on-errors-policy.ts
@@ -1,0 +1,250 @@
+import asyncRetry from 'async-retry';
+import type { WorkflowHandle } from '@temporalio/client';
+import { WorkflowFailedError } from '@temporalio/client';
+import * as workflow from '@temporalio/workflow';
+import { ApplicationFailure } from '@temporalio/common';
+import { helpers, makeTestFunction } from './helpers-integration';
+
+const test = makeTestFunction({
+  workflowsPath: __filename,
+});
+
+////////////////////////////////////////////////////////////////////////////////
+// Test fixtures: custom error classes and workflows
+////////////////////////////////////////////////////////////////////////////////
+
+export class CustomWorkflowError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CustomWorkflowError';
+  }
+}
+
+export class CustomWorkflowSubError extends CustomWorkflowError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CustomWorkflowSubError';
+  }
+}
+
+export async function throwCustomError(): Promise<void> {
+  throw new CustomWorkflowError('custom error');
+}
+
+export async function throwCustomSubError(): Promise<void> {
+  throw new CustomWorkflowSubError('custom sub error');
+}
+
+export async function throwPlainError(): Promise<void> {
+  throw new Error('plain error');
+}
+
+export async function throwCustomErrorWithDefinitionOptions(): Promise<void> {
+  throw new CustomWorkflowError('custom error from definition options');
+}
+workflow.setWorkflowOptions({ failureExceptionTypes: [CustomWorkflowError] }, throwCustomErrorWithDefinitionOptions);
+
+export async function throwSubErrorWithParentInDefinitionOptions(): Promise<void> {
+  throw new CustomWorkflowSubError('sub error with parent in definition options');
+}
+workflow.setWorkflowOptions(
+  { failureExceptionTypes: [CustomWorkflowError] },
+  throwSubErrorWithParentInDefinitionOptions
+);
+
+/**
+ * Forces a non-determinism error by branching on `unsafe.isReplaying`. The
+ * first execution issues a `startTimer` command; on the next WFT, replay
+ * (forced via `maxCachedWorkflows: 0`) takes the no-command branch, which
+ * mismatches the recorded history.
+ */
+export async function nondeterministicWorkflow(): Promise<void> {
+  if (!workflow.workflowInfo().unsafe.isReplaying) {
+    await workflow.sleep('1ms');
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Polls workflow history until a `WorkflowTaskFailed` event referencing the
+ * given error type/message is observed, then terminates the workflow. This is
+ * how we assert "default WFT failure" behavior: the workflow remains running
+ * (retrying the task) rather than failing the execution outright.
+ */
+async function assertWftFailureAndTerminate(
+  handle: WorkflowHandle,
+  expected: { messageContains?: string; errorType?: string }
+): Promise<void> {
+  try {
+    await asyncRetry(
+      async () => {
+        const history = await handle.fetchHistory();
+        const wftFailedEvent = history.events?.findLast((ev) => ev.workflowTaskFailedEventAttributes);
+        if (wftFailedEvent === undefined) {
+          throw new Error('No WorkflowTaskFailed event found yet');
+        }
+        const { failure } = wftFailedEvent.workflowTaskFailedEventAttributes ?? {};
+        if (!failure) {
+          throw new Error('Expected `failure` in workflowTaskFailedEventAttributes');
+        }
+        if (expected.messageContains && !failure.message?.includes(expected.messageContains)) {
+          throw new Error(
+            `Expected failure message to contain ${JSON.stringify(expected.messageContains)}, got ${JSON.stringify(
+              failure.message
+            )}`
+          );
+        }
+        if (expected.errorType && failure.applicationFailureInfo?.type !== expected.errorType) {
+          throw new Error(
+            `Expected applicationFailureInfo.type=${JSON.stringify(expected.errorType)}, got ${JSON.stringify(
+              failure.applicationFailureInfo?.type
+            )}`
+          );
+        }
+      },
+      { minTimeout: 300, factor: 1, retries: 15 }
+    );
+  } finally {
+    await handle.terminate().catch(() => {
+      /* ignore */
+    });
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests for workflowFailureErrorTypes / WorkflowDefinitionOptions.failureExceptionTypes
+////////////////////////////////////////////////////////////////////////////////
+
+// Default behavior: non-TemporalFailure errors cause Workflow Task failure (not execution failure)
+test('failureExceptionTypes - default causes WFT failure', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+  const worker = await createWorker();
+  await worker.runUntil(async () => {
+    const handle = await startWorkflow(throwCustomError);
+    await assertWftFailureAndTerminate(handle, { messageContains: 'custom error' });
+    t.pass();
+  });
+});
+
+// WorkerOptions path: workflowFailureErrorTypes causes execution failure (exact class name match)
+test('failureExceptionTypes - WorkerOptions causes WF execution failure', async (t) => {
+  const { createWorker, executeWorkflow } = helpers(t);
+  const worker = await createWorker({
+    workflowFailureErrorTypes: { '*': ['CustomWorkflowError'] },
+  });
+  await worker.runUntil(async () => {
+    const err = (await t.throwsAsync(executeWorkflow(throwCustomError), {
+      instanceOf: WorkflowFailedError,
+    })) as WorkflowFailedError;
+    t.true(err.cause instanceof ApplicationFailure);
+    t.is(err.cause?.message, 'custom error');
+    t.is((err.cause as ApplicationFailure).type, 'CustomWorkflowError');
+  });
+});
+
+// WorkerOptions path: parent class name matches subclass when using string-based
+// names (lookup walks the prototype chain by `constructor.name`)
+test('failureExceptionTypes - WorkerOptions parent class name matches subclass via prototype chain', async (t) => {
+  const { createWorker, executeWorkflow } = helpers(t);
+  const worker = await createWorker({
+    workflowFailureErrorTypes: { '*': ['CustomWorkflowError'] },
+  });
+  await worker.runUntil(async () => {
+    const err = (await t.throwsAsync(executeWorkflow(throwCustomSubError), {
+      instanceOf: WorkflowFailedError,
+    })) as WorkflowFailedError;
+    t.true(err.cause instanceof ApplicationFailure);
+    t.is(err.cause?.message, 'custom sub error');
+  });
+});
+
+// WorkerOptions path: 'Error' base class matches any Error subclass
+test('failureExceptionTypes - WorkerOptions Error base class matches any error', async (t) => {
+  const { createWorker, executeWorkflow } = helpers(t);
+  const worker = await createWorker({
+    workflowFailureErrorTypes: { '*': ['Error'] },
+  });
+  await worker.runUntil(async () => {
+    const err = (await t.throwsAsync(executeWorkflow(throwPlainError), {
+      instanceOf: WorkflowFailedError,
+    })) as WorkflowFailedError;
+    t.true(err.cause instanceof ApplicationFailure);
+    t.is(err.cause?.message, 'plain error');
+  });
+});
+
+// WorkerOptions path: 'NondeterminismError' alias does NOT match an unrelated error
+test('failureExceptionTypes - WorkerOptions NondeterminismError alias does not match unrelated error', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+  const worker = await createWorker({
+    workflowFailureErrorTypes: { '*': ['NondeterminismError'] },
+  });
+  await worker.runUntil(async () => {
+    const handle = await startWorkflow(throwCustomError);
+    await assertWftFailureAndTerminate(handle, { messageContains: 'custom error' });
+    t.pass();
+  });
+});
+
+// WorkflowDefinitionOptions path: failureExceptionTypes causes execution failure
+test('failureExceptionTypes - WorkflowDefinitionOptions causes WF execution failure', async (t) => {
+  const { createWorker, executeWorkflow } = helpers(t);
+  const worker = await createWorker();
+  await worker.runUntil(async () => {
+    const err = (await t.throwsAsync(executeWorkflow(throwCustomErrorWithDefinitionOptions), {
+      instanceOf: WorkflowFailedError,
+    })) as WorkflowFailedError;
+    t.true(err.cause instanceof ApplicationFailure);
+    t.is(err.cause?.message, 'custom error from definition options');
+    t.is((err.cause as ApplicationFailure).type, 'CustomWorkflowError');
+  });
+});
+
+// WorkflowDefinitionOptions path: instanceof check matches subclasses
+test('failureExceptionTypes - WorkflowDefinitionOptions instanceof matches subclass', async (t) => {
+  const { createWorker, executeWorkflow } = helpers(t);
+  const worker = await createWorker();
+  await worker.runUntil(async () => {
+    const err = (await t.throwsAsync(executeWorkflow(throwSubErrorWithParentInDefinitionOptions), {
+      instanceOf: WorkflowFailedError,
+    })) as WorkflowFailedError;
+    t.true(err.cause instanceof ApplicationFailure);
+    t.is(err.cause?.message, 'sub error with parent in definition options');
+    t.is((err.cause as ApplicationFailure).type, 'CustomWorkflowSubError');
+  });
+});
+
+////////////////////////////////////////////////////////////////////////////////
+// Non-determinism handling
+////////////////////////////////////////////////////////////////////////////////
+
+// Default behavior: a non-determinism error causes WFT failure (workflow keeps retrying)
+test('non-determinism - default causes WFT failure', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+  const worker = await createWorker({ maxCachedWorkflows: 0 });
+  await worker.runUntil(async () => {
+    const handle = await startWorkflow(nondeterministicWorkflow);
+    await assertWftFailureAndTerminate(handle, { messageContains: 'Nondeterminism' });
+    t.pass();
+  });
+});
+
+// WorkerOptions path: 'NondeterminismError' alias causes the workflow execution
+// to fail when a non-determinism error is detected.
+test('non-determinism - WorkerOptions NondeterminismError causes WF execution failure', async (t) => {
+  const { createWorker, executeWorkflow } = helpers(t);
+  const worker = await createWorker({
+    maxCachedWorkflows: 0,
+    workflowFailureErrorTypes: { '*': ['NondeterminismError'] },
+  });
+  await worker.runUntil(async () => {
+    const err = (await t.throwsAsync(executeWorkflow(nondeterministicWorkflow), {
+      instanceOf: WorkflowFailedError,
+    })) as WorkflowFailedError;
+    t.true(err.cause instanceof ApplicationFailure);
+    t.regex(err.cause?.message ?? '', /[Nn]ondeterminism/);
+  });
+});

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -531,6 +531,37 @@ export interface WorkerOptions {
   sinks?: InjectedSinks<any>;
 
   /**
+   * The types of errors that, if thrown by a Workflow function, a signal handler, or an update
+   * handler, will cause the Workflow Execution or the Update to fail instead of failing the
+   * Workflow Task (which would result in retrying the Workflow Task until it eventually succeeds).
+   * 
+   * This property expects a record of Workflow-type names to the list of error types that will
+   * cause that type of Workflow to fail. Uses the `'*'` key to specify a list of error types that
+   * applies to all Workflow types. This is a worker-level equivalent of
+   * {@link WorkflowDefinitionOptions.failureExceptionTypes}. Both settings are evaluated; an error
+   * matching either will cause Workflow failure.
+   * 
+   * Unlike {@link WorkflowDefinitionOptions.failureExceptionTypes}, this setting requires error
+   * types to be specified as string names, not actual class references, and consequently, doesn't
+   * support subclass matching via `instanceof`. It however allows failing the workflow execution
+   * on _non-determinism errors_, by including the `NondeterminismError` type to the list of error
+   * types, either globally (via the `'*'` key) or per-Workflow-type.
+   * 
+   * Passing the `'Error'` error type string here will result in failing the Workflow on any error,
+   * including non-determinism errors.
+
+   * Note that {@link TemporalFailure} subclasses (with the exception of {@link ApplicationFailure})
+   * and cancellation errors that bubbles out of the Workflow always fail the Workflow Execution,
+   * regardless of either this and the {@link WorkflowDefinitionOptions.failureExceptionTypes} settings.
+   * 
+   * @experimental
+   */
+  workflowFailureErrorTypes?: Record<
+    '*' | (string & {}),
+    ('NondeterminismError' | 'DeterminismViolationError' | 'Error' | (string & {}))[]
+  >;
+
+  /**
    * @deprecated SDK tracing is no longer supported. This option is ignored.
    */
   enableSDKTracing?: boolean;
@@ -663,15 +694,15 @@ export type WorkerDeploymentOptions = {
    */
   defaultVersioningBehavior?: VersioningBehavior | undefined;
 } & (
-  | {
+    | {
       useWorkerVersioning: true;
       defaultVersioningBehavior: VersioningBehavior;
     }
-  | {
+    | {
       useWorkerVersioning: false;
       defaultVersioningBehavior?: never;
     }
-);
+  );
 
 // Replay Worker ///////////////////////////////////////////////////////////////////////////////////
 
@@ -972,11 +1003,11 @@ function addDefaultWorkerOptions(
       : behavior.type === 'simple-maximum'
         ? { type: 'simple-maximum', maximum: behavior.maximum ?? defaultMax }
         : {
-            type: 'autoscaling',
-            minimum: behavior.minimum ?? 1,
-            initial: behavior.initial ?? 5,
-            maximum: behavior.maximum ?? 100,
-          };
+          type: 'autoscaling',
+          minimum: behavior.minimum ?? 1,
+          initial: behavior.initial ?? 5,
+          maximum: behavior.maximum ?? 100,
+        };
 
   const wftPollerBehavior = createPollerBehavior(maxWFTPolls, workflowTaskPollerBehavior);
   const atPollerBehavior = createPollerBehavior(maxATPolls, activityTaskPollerBehavior);
@@ -1103,6 +1134,25 @@ function nexusServiceHandlersFromOptions(opts: WorkerOptions): Map<string, nexus
 export function toNativeWorkerOptions(opts: CompiledWorkerOptionsWithBuildId): native.WorkerOptions {
   const enableWorkflows = opts.workflowBundle !== undefined || opts.workflowsPath !== undefined;
   const enableLocalActivities = enableWorkflows && opts.activities.size > 0;
+
+  const workflowFailureErrors: native.WorkflowErrorType[] = [];
+  const workflowTypesToFailureErrors: Record<string, native.WorkflowErrorType[]> = {};
+
+  for (const [k, v] of Object.entries(opts.workflowFailureErrorTypes ?? {})) {
+    const errorTypes: native.WorkflowErrorType[] = [];
+
+    // Core only cares about Non-Determinism Error; other error types are handled by lang side
+    if (v.includes('NondeterminismError') || v.includes('DeterminismViolationError') || v.includes('Error')) {
+      errorTypes.push({ type: 'nondeterminism' });
+    }
+
+    if (k === '*') {
+      workflowFailureErrors.push(...errorTypes);
+    } else {
+      workflowTypesToFailureErrors[k] = errorTypes;
+    }
+  }
+
   return {
     identity: opts.identity,
     buildId: opts.buildId,
@@ -1129,6 +1179,8 @@ export function toNativeWorkerOptions(opts: CompiledWorkerOptionsWithBuildId): n
     maxActivitiesPerSecond: opts.maxActivitiesPerSecond ?? null,
     shutdownGraceTime: msToNumber(opts.shutdownGraceTime),
     plugins: opts.plugins?.map((p) => p.name) ?? [],
+    workflowFailureErrors,
+    workflowTypesToFailureErrors,
   };
 }
 

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -694,15 +694,15 @@ export type WorkerDeploymentOptions = {
    */
   defaultVersioningBehavior?: VersioningBehavior | undefined;
 } & (
-    | {
+  | {
       useWorkerVersioning: true;
       defaultVersioningBehavior: VersioningBehavior;
     }
-    | {
+  | {
       useWorkerVersioning: false;
       defaultVersioningBehavior?: never;
     }
-  );
+);
 
 // Replay Worker ///////////////////////////////////////////////////////////////////////////////////
 
@@ -1003,11 +1003,11 @@ function addDefaultWorkerOptions(
       : behavior.type === 'simple-maximum'
         ? { type: 'simple-maximum', maximum: behavior.maximum ?? defaultMax }
         : {
-          type: 'autoscaling',
-          minimum: behavior.minimum ?? 1,
-          initial: behavior.initial ?? 5,
-          maximum: behavior.maximum ?? 100,
-        };
+            type: 'autoscaling',
+            minimum: behavior.minimum ?? 1,
+            initial: behavior.initial ?? 5,
+            maximum: behavior.maximum ?? 100,
+          };
 
   const wftPollerBehavior = createPollerBehavior(maxWFTPolls, workflowTaskPollerBehavior);
   const atPollerBehavior = createPollerBehavior(maxATPolls, activityTaskPollerBehavior);

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1588,6 +1588,7 @@ export class Worker {
       randomnessSeed: randomnessSeed.toBytes(),
       now: tsToMs(activation.timestamp),
       showStackTraceSources: this.options.showStackTraceSources,
+      failureExceptionTypeNames: resolveFailureExceptionTypeNames(workflowType, this.options.workflowFailureErrorTypes),
     });
 
     this.numCachedWorkflowsSubject.next(this.numCachedWorkflowsSubject.value + 1);
@@ -2303,4 +2304,24 @@ async function timeoutPromise<R>(promise: Promise<R>, timeout: number): Promise<
  */
 async function setTimeoutUnref(timeout: number): Promise<void> {
   return new Promise((resolve) => setTimeoutCallback(resolve, timeout).unref());
+}
+
+/**
+ * Resolves the list of failure exception type names applicable to a given workflow type,
+ * combining the wildcard `'*'` entry and any entry matching the specific workflow type.
+ *
+ * `NondeterminismError` is passed through as-is (the lang-side matching treats it as an alias
+ * for `DeterminismViolationError`). All other type names are passed through unchanged.
+ */
+function resolveFailureExceptionTypeNames(
+  workflowType: string,
+  workflowFailureErrorTypes: Record<string, string[]> | undefined
+): string[] | undefined {
+  if (!workflowFailureErrorTypes) return undefined;
+
+  const typeNames = new Set<string>();
+  for (const name of workflowFailureErrorTypes['*'] ?? []) typeNames.add(name);
+  for (const name of workflowFailureErrorTypes[workflowType] ?? []) typeNames.add(name);
+
+  return typeNames.size > 0 ? [...typeNames] : undefined;
 }

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -646,6 +646,7 @@ export interface WorkflowCreateOptions {
   randomnessSeed: number[];
   now: number;
   showStackTraceSources: boolean;
+  failureExceptionTypeNames?: string[];
 }
 
 export interface WorkflowCreateOptionsInternal extends WorkflowCreateOptions {

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -272,6 +272,22 @@ export class Activator implements ActivationHandler {
   public workflowTaskError: unknown;
 
   /**
+   * Error type _names_ (from {@link WorkerOptions.workflowFailureErrorTypes}) that
+   * should cause Workflow Execution failure rather than WFT failure.
+   *
+   * Set at workflow creation time from the worker options.
+   */
+  public failureExceptionTypeNames: string[] = [];
+
+  /**
+   * Error _types_ (from {@link WorkflowDefinitionOptions.failureExceptionTypes})
+   * that should cause Workflow Execution failure rather than WFT failure.
+   *
+   * Set in `worker-interface.ts` after the workflow definition options are read.
+   */
+  public workflowDefinitionFailureExceptionTypes: Array<new (...args: any[]) => Error> | undefined = undefined;
+
+  /**
    * Set to true when running synchronous code (e.g. while processing activation jobs and when calling
    * `tryUnblockConditions()`). While this flag is set, it is safe to let errors bubble up.
    */
@@ -475,6 +491,7 @@ export class Activator implements ActivationHandler {
     randomnessSeed,
     registeredActivityNames,
     stackTracesEnabled,
+    failureExceptionTypeNames,
   }: WorkflowCreateOptionsInternal) {
     this.getTimeOfDay = getTimeOfDay;
     this.info = info;
@@ -484,6 +501,7 @@ export class Activator implements ActivationHandler {
     this.random = alea(randomnessSeed);
     this.registeredActivityNames = registeredActivityNames;
     this.stackTracesEnabled = stackTracesEnabled;
+    this.failureExceptionTypeNames = failureExceptionTypeNames ?? [];
   }
 
   /**
@@ -587,8 +605,10 @@ export class Activator implements ActivationHandler {
           ? this.failureConverter.failureToError(continuedFailure, this.payloadConverter, context)
           : undefined,
     }));
-    if (this.workflowDefinitionOptionsGetter) {
-      this.versioningBehavior = this.workflowDefinitionOptionsGetter().versioningBehavior;
+    const workflowDefinitionOpts = this.workflowDefinitionOptionsGetter?.();
+    if (workflowDefinitionOpts) {
+      this.versioningBehavior = workflowDefinitionOpts.versioningBehavior;
+      this.workflowDefinitionFailureExceptionTypes = workflowDefinitionOpts.failureExceptionTypes;
     }
   }
 
@@ -1182,7 +1202,7 @@ export class Activator implements ActivationHandler {
       this.pushCommand({ cancelWorkflowExecution: {} }, true);
     } else if (error instanceof ContinueAsNew) {
       this.pushCommand({ continueAsNewWorkflowExecution: error.command }, true);
-    } else if (error instanceof TemporalFailure) {
+    } else if (error instanceof TemporalFailure || this.isConfiguredFailureException(error)) {
       // Fail the workflow. We do not want to issue unfinishedHandlers warnings. To achieve that, we
       // mark all handlers as completed now.
       this.inProgressSignals.clear();
@@ -1190,7 +1210,7 @@ export class Activator implements ActivationHandler {
       this.pushCommand(
         {
           failWorkflowExecution: {
-            failure: this.errorToFailure(error),
+            failure: this.errorToFailure(ensureTemporalFailure(error)),
           },
         },
         true
@@ -1198,6 +1218,42 @@ export class Activator implements ActivationHandler {
     } else {
       this.recordWorkflowTaskError(error);
     }
+  }
+
+  /**
+   * Returns true if the given error matches any of the configured failure exception types
+   * (from {@link WorkerOptions.workflowFailureErrorTypes} or
+   * {@link WorkflowDefinitionOptions.failureExceptionTypes}).
+   */
+  private isConfiguredFailureException(error: unknown): boolean {
+    // Check class references from WorkflowDefinitionOptions (instanceof-based, supports subclasses)
+    if (this.workflowDefinitionFailureExceptionTypes) {
+      // We guarantee that including Error in the list will catch _any_ error.
+      if (this.workflowDefinitionFailureExceptionTypes.includes(Error)) return true;
+
+      for (const errorType of this.workflowDefinitionFailureExceptionTypes) {
+        if (error instanceof errorType) return true;
+      }
+    }
+
+    // Check class name strings from WorkerOptions (prototype-chain-based)
+    if (this.failureExceptionTypeNames.length > 0) {
+      // We guarantee that including 'Error' in the list will catch _any_ error.
+      if (this.failureExceptionTypeNames.includes('Error')) return true;
+
+      if (typeof error === 'object' && error !== null) {
+        let ctor = (error as any).constructor;
+        while (ctor != null && ctor !== Function.prototype) {
+          const name = (ctor as any).name as string | undefined;
+          if (name) {
+            if (this.failureExceptionTypeNames.includes(name)) return true;
+          }
+          ctor = Object.getPrototypeOf(ctor);
+        }
+      }
+    }
+
+    return false;
   }
 
   recordWorkflowTaskError(error: unknown): void {

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -91,6 +91,8 @@ export function initRuntime(options: WorkflowCreateOptionsInternal): void {
     if (isWorkflowFunctionWithOptions(activator.workflow)) {
       if (typeof activator.workflow.workflowDefinitionOptions === 'object') {
         activator.versioningBehavior = activator.workflow.workflowDefinitionOptions.versioningBehavior;
+        activator.workflowDefinitionFailureExceptionTypes =
+          activator.workflow.workflowDefinitionOptions.failureExceptionTypes;
       } else {
         activator.workflowDefinitionOptionsGetter = activator.workflow.workflowDefinitionOptions;
       }

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1782,7 +1782,10 @@ export function allHandlersFinished(): boolean {
  * @example
  * For example:
  * ```ts
- * setWorkflowOptions({ versioningBehavior: 'PINNED' }, myWorkflow);
+ * setWorkflowOptions({
+ *   versioningBehavior: 'PINNED',
+ *   failureExceptionTypes: [CustomWorkflowError]
+ * }, myWorkflow);
  * export async function myWorkflow(): Promise<string> {
  *   // Workflow code here
  *   return "hi";
@@ -1796,7 +1799,10 @@ export function allHandlersFinished(): boolean {
  *   // Workflow code here
  *   return "hi";
  * }
- * setWorkflowOptions({ versioningBehavior: 'PINNED' }, module.exports.default);
+ * setWorkflowOptions({
+ *   versioningBehavior: 'PINNED',
+ *   failureExceptionTypes: [CustomWorkflowError]
+ * }, module.exports.default);
  * ```
  *
  * @param options Options for the workflow defintion, or a function that returns options. If a


### PR DESCRIPTION
## What was changed

- Add support for failing workflow _execution_ (rather than workflow _task_) on some error types, notably Non-Determinism errors. Resolves #1358.