### PR TITLE
💥 Standalone Activities support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
   IS_MAIN_OR_RELEASE: ${{ vars.IS_TEMPORALIO_SDK_TYPESCRIPT_REPO == 'true' && github.event_name != 'pull_request' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/releases')) }}
 
   # Use these variables to force specific version of CLI/Time Skipping Server for SDK tests
-  TESTS_CLI_VERSION: 'v1.6.2-server-1.31.0-151.6'
+  # TESTS_CLI_VERSION: 'v1.7.0'
   # TESTS_TIME_SKIPPING_SERVER_VERSION: 'v1.24.1'
 
 jobs:
@@ -202,7 +202,13 @@ jobs:
             --db-filename temporal.sqlite \
             --sqlite-pragma journal_mode=WAL \
             --sqlite-pragma synchronous=OFF \
-            --headless &> ./devserver.log &
+            --headless &> ./devserver.log \
+            --dynamic-config-value system.enableActivityEagerExecution=true \
+            --dynamic-config-value history.enableRequestIdRefLinks=true \
+            --dynamic-config-value frontend.activityAPIsEnabled=true \
+            --dynamic-config-value activity.enableStandalone=true \
+            --dynamic-config-value history.enableChasm=true \
+            --dynamic-config-value history.enableTransitionHistory=true &
 
       - name: Run Tests (Node)
         if: matrix.node != 'bun'

--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -267,10 +267,14 @@ export interface Info {
    * ID of the current run of this activity. Can be used to differentiate between different activity executions that
    * share the same ID. Activities started by a Workflow don't have activity run ID - instead, they can be identified by
    * workflow ID and workflow run ID; see {@link workflowExecution}
+   *
+   * @experimental Standalone Activities are experimental. APIs may be subject to change.
    */
   readonly activityRunId?: string;
   /**
    * Whether this activity was started by a workflow
+   *
+   * @experimental Standalone Activities are experimental. APIs may be subject to change.
    */
   readonly inWorkflow: boolean;
 }

--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -153,11 +153,17 @@ export const asyncLocalStorage: AsyncLocalStorage<Context> = (globalThis as any)
  * Holds information about the current Activity Execution. Retrieved inside an Activity with `Context.current().info`.
  */
 export interface Info {
+  /**
+   * Task token associated with this activity execution. Can be used for asynchronous completion
+   */
   readonly taskToken: Uint8Array;
   /**
-   * Base64 encoded `taskToken`
+   * Base64 encoded {@link taskToken}
    */
   readonly base64TaskToken: string;
+  /**
+   * ID of this activity
+   */
   readonly activityId: string;
   /**
    * Exposed Activity function name
@@ -165,6 +171,8 @@ export interface Info {
   readonly activityType: string;
   /**
    * The namespace this Activity is running in
+   *
+   * @deprecated Use {@link namespace} instead
    */
   readonly activityNamespace: string;
   /**
@@ -176,20 +184,22 @@ export interface Info {
    */
   readonly isLocal: boolean;
   /**
-   * Information about the Workflow that scheduled the Activity
+   * Information about the Workflow that scheduled the Activity. Not set if the activity was not started by a Workflow
    */
-  readonly workflowExecution: {
+  readonly workflowExecution?: {
     readonly workflowId: string;
     readonly runId: string;
   };
   /**
-   * The namespace of the Workflow that scheduled this Activity
+   * The namespace of the Workflow that scheduled this Activity. Not set if the activity was not started by a Workflow
+   *
+   * @deprecated Use {@link namespace} instead
    */
-  readonly workflowNamespace: string;
+  readonly workflowNamespace?: string;
   /**
-   * The module name of the Workflow that scheduled this Activity
+   * The module name of the Workflow that scheduled this Activity. Not set if the activity was not started by a Workflow
    */
-  readonly workflowType: string;
+  readonly workflowType?: string;
   /**
    * Timestamp for when this Activity was first scheduled.
    * For retries, this will have the timestamp of the first attempt.
@@ -249,6 +259,20 @@ export interface Info {
    * version), but it may still be defined server-side.
    */
   readonly retryPolicy?: RetryPolicy;
+  /**
+   * The namespace this Activity is running in
+   */
+  readonly namespace: string;
+  /**
+   * ID of the current run of this activity. Can be used to differentiate between different activity executions that
+   * share the same ID. Activities started by a Workflow don't have activity run ID - instead, they can be identified by
+   * workflow ID and workflow run ID; see {@link workflowExecution}
+   */
+  readonly activityRunId?: string;
+  /**
+   * Whether this activity was started by a workflow
+   */
+  readonly inWorkflow: boolean;
 }
 
 /**

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -292,7 +292,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       idReusePolicy: encodeActivityIdReusePolicy(input.options.idReusePolicy),
       idConflictPolicy: encodeActivityIdConflictPolicy(input.options.idConflictPolicy),
       searchAttributes,
-      header: input.headers,
+      header: { fields: input.headers },
       userMetadata: await encodeUserMetadata(this.dataConverter, input.options.summary, undefined),
       priority: input.options.priority ? compilePriority(input.options.priority) : undefined,
     };

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -1,0 +1,599 @@
+import { status } from '@grpc/grpc-js';
+import type {
+  LoadedDataConverter,
+  Next,
+  Priority,
+  RetryPolicy,
+  SearchAttributePair,
+  TypedSearchAttributes,
+} from '@temporalio/common';
+import { compilePriority, compileRetryPolicy, decodePriority, decompileRetryPolicy } from '@temporalio/common';
+import type { Duration } from '@temporalio/common/lib/time';
+import { msOptionalToTs, optionalTsToDate, optionalTsToMs } from '@temporalio/common/lib/time';
+import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
+import { composeInterceptors } from '@temporalio/common/lib/interceptors';
+import {
+  decodeTypedSearchAttributes,
+  encodeUnifiedSearchAttributes,
+  searchAttributePayloadConverter,
+} from '@temporalio/common/lib/converter/payload-search-attributes';
+import { convertDeploymentVersion } from '@temporalio/worker/lib/utils';
+import {
+  decodeArrayFromPayloads,
+  decodeFromPayloadsAtIndex,
+  decodeOptionalFailureToOptionalError,
+  encodeToPayloads,
+  encodeUserMetadata,
+} from '@temporalio/common/lib/internal-non-workflow';
+import { uuid4 } from '@temporalio/workflow';
+import type { temporal } from '@temporalio/proto';
+import type {
+  ActivityCancelInput,
+  ActivityClientInterceptor,
+  ActivityCountInput,
+  ActivityDescribeInput,
+  ActivityGetResultInput,
+  ActivityListInput,
+  ActivityStartInput,
+  ActivityTerminateInput,
+} from './interceptors';
+import type { AsyncCompletionClientOptions } from './async-completion-client';
+import { AsyncCompletionClient } from './async-completion-client';
+import type {
+  ActivityDescription,
+  ActivityExecutionInfo,
+  ActivityIdConflictPolicy,
+  ActivityIdReusePolicy,
+  CountActivityExecutions,
+} from './types';
+import {
+  decodeActivityExecutionStatus,
+  decodePendingActivityState,
+  encodeActivityIdConflictPolicy,
+  encodeActivityIdReusePolicy,
+} from './types';
+import { rethrowKnownErrorTypes } from './helpers';
+import { isGrpcServiceError, ServiceError } from './errors';
+
+/**
+ * Thrown when an Activity with the given ID is not known to Temporal Server.
+ */
+@SymbolBasedInstanceOfError('ActivityNotFoundError')
+export class ActivityNotFoundError extends Error {}
+
+/**
+ * Thrown by the client while waiting on Activity execution result if execution completes with failure.
+ * The failure is stored in the `cause` property.
+ */
+@SymbolBasedInstanceOfError('ActivityExecutionFailedError')
+export class ActivityExecutionFailedError extends Error {
+  constructor(
+    message: string,
+    public readonly cause: Error | undefined,
+    public readonly activityId: string,
+    public readonly runId?: string
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Options used to configure {@link ActivityClient}
+ */
+export interface ActivityClientOptions extends AsyncCompletionClientOptions {
+  interceptors?: ActivityClientInterceptor[];
+}
+
+/**
+ * Client for starting and managing Activities, and for asynchronous completion and heartbeating of Activities.
+ * Includes all functionality of {@link AsyncCompletionClient}.
+ *
+ * Typically this client should not be instantiated directly, instead create the high level {@link Client} and use
+ * {@link Client.activity} to interact with Activities.
+ */
+export class ActivityClient extends AsyncCompletionClient {
+  private readonly interceptedHandlers: {
+    [K in keyof Required<ActivityClientInterceptor>]: Next<ActivityClientInterceptor, K>;
+  };
+
+  constructor(options?: ActivityClientOptions) {
+    super(options);
+
+    const interceptors = options?.interceptors ?? [];
+    this.interceptedHandlers = {
+      start: composeInterceptors(interceptors, 'start', this.startHandler.bind(this)),
+      getResult: composeInterceptors(interceptors, 'getResult', this.getResultHandler.bind(this)),
+      describe: composeInterceptors(interceptors, 'describe', this.describeHandler.bind(this)),
+      cancel: composeInterceptors(interceptors, 'cancel', this.cancelHandler.bind(this)),
+      terminate: composeInterceptors(interceptors, 'terminate', this.terminateHandler.bind(this)),
+      list: composeInterceptors(interceptors, 'list', this.listHandler.bind(this)),
+      count: composeInterceptors(interceptors, 'count', this.countHandler.bind(this)),
+    };
+  }
+
+  /**
+   * Starts new Standalone Activity execution.
+   *
+   * @param activity Name of the activity to start.
+   * @param options Options controlling the start and execution of the activity.
+   * @returns Handle to the started activity. The handle's `runId` property will be set to the started run.
+   */
+  async start<O = any>(activity: string, options: ActivityOptions): Promise<ActivityHandle<O>> {
+    return this.interceptedHandlers.start({
+      activityType: activity,
+      options,
+      headers: {},
+    });
+  }
+
+  /**
+   * Executes a Standalone Activity until completion and returns the result.
+   * @param activity Name of the activity to start.
+   * @param options Options controlling the activity execution.
+   * @returns Result of the activity.
+   */
+  async execute<O = any>(activity: string, options: ActivityOptions): Promise<O> {
+    const handle = await this.start(activity, options);
+    return handle.result();
+  }
+
+  /**
+   * Creates an Activity handle from ID and optionally from run ID. If `runId` is not set, the handle will refer to the
+   * newest Activity run with the given Activity ID.
+   *
+   * Note 1: this function always succeeds. If the provided ID is invalid, the error will only be thrown when calling
+   * the handle's methods.
+   *
+   * Note 2: if `runID` is not set when calling `getHandle`, then `runId` property of the returned handle will always
+   * remain unset, even after method calls are performed. To get the run ID of the targeted activity execution, call
+   * {@link ActivityHandle.describe} and read the `activityRunId` field of the returned {@link ActivityDescription}.
+   *
+   * @param activityId ID of the Activity.
+   * @param runId Optional run ID of the specific Activity execution.
+   * @returns Handle to the specified activity execution.
+   */
+  getHandle<O = any>(activityId: string, runId?: string): ActivityHandle<O> {
+    return this.createHandle(activityId, runId);
+  }
+
+  /**
+   * Return a list of Activity executions matching the given `query`.
+   *
+   * Note that the list of Activity executions returned is approximate and eventually consistent.
+   *
+   * More info on the concept of "visibility" and the query syntax on the Temporal documentation site:
+   * https://docs.temporal.io/visibility
+   */
+  list(query: string): AsyncIterable<ActivityExecutionInfo> {
+    return this.interceptedHandlers.list({
+      query,
+      headers: {},
+    });
+  }
+
+  /**
+   * Return the number of Activity executions matching the given `query`.
+   *
+   * Note that the number of Activity executions returned is approximate and eventually consistent.
+   *
+   * More info on the concept of "visibility" and the query syntax on the Temporal documentation site:
+   * https://docs.temporal.io/visibility
+   */
+  async count(query: string): Promise<CountActivityExecutions> {
+    return await this.interceptedHandlers.count({
+      query,
+      headers: {},
+    });
+  }
+
+  protected createHandle<O>(activityId: string, runId?: string): ActivityHandle<O> {
+    if (!activityId) {
+      throw new TypeError('activityId is required');
+    }
+
+    const handle = {
+      client: this,
+      activityId,
+      runId,
+
+      async result(): Promise<O> {
+        return await this.client.interceptedHandlers.getResult({
+          activityId: this.activityId,
+          activityRunId: this.runId ?? '',
+          headers: {},
+        });
+      },
+
+      async describe(): Promise<ActivityDescription> {
+        return await this.client.interceptedHandlers.describe({
+          activityId: this.activityId,
+          activityRunId: this.runId ?? '',
+          headers: {},
+        });
+      },
+
+      async cancel(reason: string): Promise<void> {
+        return await this.client.interceptedHandlers.cancel({
+          activityId: this.activityId,
+          activityRunId: this.runId ?? '',
+          reason,
+          headers: {},
+        });
+      },
+
+      async terminate(reason: string): Promise<void> {
+        return await this.client.interceptedHandlers.terminate({
+          activityId: this.activityId,
+          activityRunId: this.runId ?? '',
+          reason,
+          headers: {},
+        });
+      },
+    };
+
+    return handle;
+  }
+
+  protected async startHandler(input: ActivityStartInput): Promise<ActivityHandle> {
+    if (!input.activityType) {
+      throw new TypeError('activityType is required');
+    }
+    validateActivityOptions(input.options);
+
+    try {
+      const resp = await this.workflowService.startActivityExecution(
+        await this.buildStartActivityExecutionRequest(input)
+      );
+      return this.createHandle(input.options.id, resp.runId);
+    } catch (err) {
+      this.rethrowGrpcError(err, 'Failed to start activity');
+    }
+  }
+
+  protected async buildStartActivityExecutionRequest(
+    input: ActivityStartInput
+  ): Promise<temporal.api.workflowservice.v1.IStartActivityExecutionRequest> {
+    const searchAttributes = input.options.typedSearchAttributes
+      ? encodeUnifiedSearchAttributes(undefined, input.options.typedSearchAttributes)
+      : undefined;
+
+    return {
+      namespace: this.options.namespace,
+      identity: this.options.identity,
+      requestId: uuid4(),
+      activityId: input.options.id,
+      activityType: { name: input.activityType },
+      taskQueue: { name: input.options.taskQueue },
+      scheduleToCloseTimeout: msOptionalToTs(input.options.scheduleToCloseTimeout),
+      scheduleToStartTimeout: msOptionalToTs(input.options.scheduleToStartTimeout),
+      startToCloseTimeout: msOptionalToTs(input.options.startToCloseTimeout),
+      heartbeatTimeout: msOptionalToTs(input.options.heartbeatTimeout),
+      retryPolicy: input.options.retry ? compileRetryPolicy(input.options.retry) : undefined,
+      input: { payloads: await encodeToPayloads(this.dataConverter, ...(input.options.args || [])) },
+      idReusePolicy: encodeActivityIdReusePolicy(input.options.idReusePolicy),
+      idConflictPolicy: encodeActivityIdConflictPolicy(input.options.idConflictPolicy),
+      searchAttributes: { indexedFields: searchAttributes },
+      header: input.headers,
+      userMetadata: await encodeUserMetadata(this.dataConverter, input.options.summary, undefined),
+      priority: input.options.priority ? compilePriority(input.options.priority) : undefined,
+    };
+  }
+
+  protected async getResultHandler(input: ActivityGetResultInput): Promise<any> {
+    if (!input.activityId) {
+      throw new TypeError('activityId is required');
+    }
+
+    const req: temporal.api.workflowservice.v1.IPollActivityExecutionRequest = {
+      namespace: this.options.namespace,
+      activityId: input.activityId,
+      runId: input.activityRunId || undefined,
+    };
+    for (;;) {
+      let failedErr;
+
+      try {
+        const resp = await this.workflowService.pollActivityExecution(req);
+        if (resp.outcome?.result) {
+          const [result] = await decodeArrayFromPayloads(this.dataConverter, resp.outcome.result.payloads ?? []);
+          return result;
+        } else if (resp.outcome?.failure) {
+          // If error conversion throws an exception, we want it to be caught and handled by rethrowGrpcError().
+          // If it succeeds, we want to throw the ActivityExecutionFailedError directly, so outside of try/catch.
+          failedErr = new ActivityExecutionFailedError(
+            'Activity execution failed',
+            await decodeOptionalFailureToOptionalError(this.dataConverter, resp.outcome.failure),
+            input.activityId,
+            resp.runId || input.activityRunId || undefined
+          );
+        }
+      } catch (err) {
+        this.rethrowGrpcError(err, 'Failed to get activity result');
+      }
+
+      if (failedErr) {
+        throw failedErr;
+      }
+    }
+  }
+
+  protected async describeHandler(input: ActivityDescribeInput): Promise<ActivityDescription> {
+    if (!input.activityId) {
+      throw new TypeError('activityId is required');
+    }
+
+    try {
+      const resp = await this.workflowService.describeActivityExecution({
+        namespace: this.options.namespace,
+        activityId: input.activityId,
+        runId: input.activityRunId || undefined,
+      });
+      return buildActivityDescription(resp.info!, this.dataConverter);
+    } catch (err) {
+      this.rethrowGrpcError(err, 'Failed to describe activity');
+    }
+  }
+
+  protected async cancelHandler(input: ActivityCancelInput): Promise<void> {
+    if (!input.activityId) {
+      throw new TypeError('activityId is required');
+    }
+
+    try {
+      await this.workflowService.requestCancelActivityExecution({
+        namespace: this.options.namespace,
+        activityId: input.activityId,
+        runId: input.activityRunId || undefined,
+        identity: this.options.identity,
+        requestId: uuid4(),
+        reason: input.reason || undefined,
+      });
+    } catch (err) {
+      this.rethrowGrpcError(err, 'Failed to request activity cancellation');
+    }
+  }
+
+  protected async terminateHandler(input: ActivityTerminateInput): Promise<void> {
+    if (!input.activityId) {
+      throw new TypeError('activityId is required');
+    }
+
+    try {
+      await this.workflowService.terminateActivityExecution({
+        namespace: this.options.namespace,
+        activityId: input.activityId,
+        runId: input.activityRunId || undefined,
+        identity: this.options.identity,
+        requestId: uuid4(),
+        reason: input.reason || undefined,
+      });
+    } catch (err) {
+      this.rethrowGrpcError(err, 'Failed to terminate activity');
+    }
+  }
+
+  protected async *listHandler(input: ActivityListInput): AsyncIterable<ActivityExecutionInfo> {
+    let nextPageToken: Uint8Array | null | undefined = undefined;
+    do {
+      try {
+        const resp: temporal.api.workflowservice.v1.IListActivityExecutionsResponse =
+          await this.workflowService.listActivityExecutions({
+            namespace: this.options.namespace,
+            query: input.query,
+            nextPageToken,
+          });
+
+        for (const info of resp.executions ?? []) {
+          yield buildActivityExecutionInfo(info);
+        }
+        nextPageToken = resp.nextPageToken;
+      } catch (e) {
+        this.rethrowGrpcError(e, 'Failed to list activities');
+      }
+    } while (nextPageToken && nextPageToken.length > 0);
+  }
+
+  protected async countHandler(input: ActivityCountInput): Promise<CountActivityExecutions> {
+    try {
+      const resp = await this.workflowService.countActivityExecutions({
+        namespace: this.options.namespace,
+        query: input.query,
+      });
+
+      return {
+        count: resp.count?.toNumber() ?? 0,
+        groups: resp.groups?.map((g) => ({
+          count: g.count?.toNumber() ?? 0,
+          groupValues: g.groupValues?.map((v) => searchAttributePayloadConverter.fromPayload(v)),
+        })),
+      };
+    } catch (err) {
+      this.rethrowGrpcError(err, 'Failed to request activity cancellation');
+    }
+  }
+
+  protected rethrowGrpcError(err: unknown, fallbackMessage: string): never {
+    if (isGrpcServiceError(err)) {
+      rethrowKnownErrorTypes(err);
+      if (err.code === status.NOT_FOUND) {
+        throw new ActivityNotFoundError(err.details ?? 'Activity not found');
+      }
+      throw new ServiceError(fallbackMessage, { cause: err });
+    }
+    throw new ServiceError('Unexpected error while making gRPC request');
+  }
+}
+
+/**
+ * Handle that can be used to perform operations on the associated Activity.
+ * Can be obtained by calling {@link ActivityClient.start} or {@link ActivityClient.getHandle}.
+ */
+export interface ActivityHandle<O = any> {
+  /**
+   * ID of the Activity this handle refers to.
+   */
+  readonly activityId: string;
+  /**
+   * Run ID of the specific Activity execution this handle refers to. If empty, this handle refers to the latest
+   * execution of the Activity with given ID.
+   */
+  readonly runId?: string;
+  /**
+   * Waits until the activity completes. If the activity is successful, returns the result of the activity.
+   * If the activity was not successful, throws {@link ActivityExecutionFailedError}. The activity failure is stored in
+   * the `cause` field.
+   */
+  result(): Promise<O>;
+  /**
+   * Returns information about the Activity execution.
+   */
+  describe(): Promise<ActivityDescription>;
+  /**
+   * Requests cancellation of the Activity execution. Note that cancellations are cooperative and not guaranteed to happen.
+   */
+  cancel(reason: string): Promise<void>;
+  /**
+   * Terminates the Activity execution. Note that the worker is not immediately notified of termination and may continue running the activity.
+   */
+  terminate(reason: string): Promise<void>;
+}
+
+/**
+ * Options used by {@link ActivityClient.start}.
+ */
+export interface ActivityOptions {
+  /**
+   * Activity ID of the started activity. It's recommended to use a meaningful business ID.
+   */
+  id: string;
+  /**
+   * Task queue to run this activity on.
+   */
+  taskQueue: string;
+  /**
+   * Input arguments to pass to the activity.
+   */
+  args?: any[];
+  /**
+   * If set, specifies maximum time between successful heartbeats.
+   */
+  heartbeatTimeout?: Duration;
+  retry?: RetryPolicy;
+  /**
+   * Is set, specifies total time the activity is allowed to run, including retries.
+   *
+   * Note: it is required to set at least one of {@link startToCloseTimeout} and {@link scheduleToCloseTimeout}.
+   */
+  startToCloseTimeout?: Duration;
+  /**
+   * If set, specifies maximum time the activity can wait in the task queue before being picked up by a worker.
+   * This timeout is non-retryable.
+   */
+  scheduleToStartTimeout?: Duration;
+  /**
+   * If set, specifies maximum time for a single execution attempt. This timeout is retryable.
+   *
+   * Note: it is required to set at least one of {@link startToCloseTimeout} and {@link scheduleToCloseTimeout}.
+   */
+  scheduleToCloseTimeout?: Duration;
+  /**
+   * A single-line fixed summary for this activity execution that may appear in UI/CLI.
+   * This can be in single-line Temporal markdown format.
+   */
+  summary?: string;
+  /**
+   * Priority to use when starting this activity.
+   */
+  priority?: Priority;
+  /**
+   * Specifies behavior if there's a *closed* activity with the same ID.
+   */
+  idReusePolicy?: ActivityIdReusePolicy;
+  /**
+   * Specifies behavior if there's a *running* activity with the same ID. Note that there can only be one running
+   * Activity for each Activity ID.
+   */
+  idConflictPolicy?: ActivityIdConflictPolicy;
+  /**
+   * Search attributes for the activity.
+   */
+  typedSearchAttributes?: SearchAttributePair[] | TypedSearchAttributes;
+}
+
+function validateActivityOptions(options: ActivityOptions): void {
+  if (!options.id) {
+    throw new TypeError('id is required');
+  }
+  if (!options.taskQueue) {
+    throw new TypeError('taskQueue is required');
+  }
+  if (!options.scheduleToCloseTimeout && !options.startToCloseTimeout) {
+    throw new TypeError('Either scheduleToCloseTimeout or startToCloseTimeout is required');
+  }
+}
+
+function buildActivityExecutionInfoCommonPart(
+  info: temporal.api.activity.v1.IActivityExecutionListInfo | temporal.api.activity.v1.IActivityExecutionInfo
+): ActivityExecutionInfo {
+  return {
+    activityId: info.activityId!,
+    activityRunId: info.runId!,
+    activityType: info.activityType!.name!,
+    scheduleTime: optionalTsToDate(info.scheduleTime),
+    closeTime: optionalTsToDate(info.closeTime),
+    status: decodeActivityExecutionStatus(info.status)!,
+    typedSearchAttributes: decodeTypedSearchAttributes(info.searchAttributes?.indexedFields),
+    taskQueue: info.taskQueue!,
+    executionDurationMs: optionalTsToMs(info.executionDuration),
+  };
+}
+
+function buildActivityExecutionInfo(info: temporal.api.activity.v1.IActivityExecutionListInfo): ActivityExecutionInfo {
+  return {
+    ...buildActivityExecutionInfoCommonPart(info),
+    rawListInfo: info,
+  };
+}
+
+function buildActivityDescription(
+  info: temporal.api.activity.v1.IActivityExecutionInfo,
+  dataConverter: LoadedDataConverter
+): ActivityDescription {
+  const getHeartbeatDetails: <T>() => Promise<T | undefined> = async <T>() => {
+    const payloads = info.heartbeatDetails?.payloads;
+    if (payloads && payloads.length > 0) {
+      return await decodeFromPayloadsAtIndex<T>(dataConverter, 0, info.heartbeatDetails?.payloads);
+    } else {
+      return undefined;
+    }
+  };
+
+  const getLastFailure: () => Promise<Error | undefined> = async () => {
+    return await decodeOptionalFailureToOptionalError(dataConverter, info.lastFailure);
+  };
+
+  return {
+    ...buildActivityExecutionInfoCommonPart(info),
+    rawInfo: info,
+    runState: decodePendingActivityState(info.runState),
+    scheduleToCloseTimeoutMs: optionalTsToMs(info.scheduleToCloseTimeout),
+    scheduleToStartTimeoutMs: optionalTsToMs(info.scheduleToStartTimeout),
+    startToCloseTimeoutMs: optionalTsToMs(info.startToCloseTimeout),
+    heartbeatTimeoutMs: optionalTsToMs(info.heartbeatTimeout),
+    retryPolicy: decompileRetryPolicy(info.retryPolicy)!,
+    lastHeartbeatTime: optionalTsToDate(info.lastHeartbeatTime),
+    lastStartedTime: optionalTsToDate(info.scheduleTime),
+    attempt: info.attempt!,
+    expirationTime: optionalTsToDate(info.expirationTime),
+    lastWorkerIdentity: info.lastWorkerIdentity || undefined,
+    currentRetryIntervalMs: optionalTsToMs(info.currentRetryInterval),
+    lastAttemptCompleteTime: optionalTsToDate(info.lastAttemptCompleteTime),
+    nextAttemptScheduleTime: optionalTsToDate(info.nextAttemptScheduleTime),
+    lastDeploymentVersion: convertDeploymentVersion(info.lastDeploymentVersion),
+    priority: decodePriority(info.priority),
+    canceledReason: info.canceledReason || undefined,
+
+    getHeartbeatDetails,
+    getLastFailure,
+  };
+}

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -1,4 +1,5 @@
 import { status } from '@grpc/grpc-js';
+import { v4 as uuid4 } from 'uuid';
 import type {
   LoadedDataConverter,
   Next,
@@ -7,7 +8,13 @@ import type {
   SearchAttributePair,
   TypedSearchAttributes,
 } from '@temporalio/common';
-import { compilePriority, compileRetryPolicy, decodePriority, decompileRetryPolicy } from '@temporalio/common';
+import {
+  compilePriority,
+  compileRetryPolicy,
+  convertDeploymentVersion,
+  decodePriority,
+  decompileRetryPolicy,
+} from '@temporalio/common';
 import type { Duration } from '@temporalio/common/lib/time';
 import { msOptionalToTs, optionalTsToDate, optionalTsToMs } from '@temporalio/common/lib/time';
 import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
@@ -17,7 +24,6 @@ import {
   encodeUnifiedSearchAttributes,
   searchAttributePayloadConverter,
 } from '@temporalio/common/lib/converter/payload-search-attributes';
-import { convertDeploymentVersion } from '@temporalio/worker/lib/utils';
 import {
   decodeArrayFromPayloads,
   decodeFromPayloadsAtIndex,
@@ -25,7 +31,6 @@ import {
   encodeToPayloads,
   encodeUserMetadata,
 } from '@temporalio/common/lib/internal-non-workflow';
-import { uuid4 } from '@temporalio/workflow';
 import type { temporal } from '@temporalio/proto';
 import type {
   ActivityCancelInput,

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -1,6 +1,7 @@
 import { status } from '@grpc/grpc-js';
 import { v4 as uuid4 } from 'uuid';
 import type {
+  ActivityFunction,
   LoadedDataConverter,
   Next,
   Priority,
@@ -31,6 +32,7 @@ import {
   encodeUserMetadata,
 } from '@temporalio/common/lib/internal-non-workflow';
 import type { temporal } from '@temporalio/proto';
+import type { Replace } from '@temporalio/common/lib/type-helpers';
 import type {
   ActivityCancelInput,
   ActivityClientInterceptor,
@@ -73,7 +75,7 @@ export interface ActivityClientOptions extends AsyncCompletionClientOptions {
  * Typically this client should not be instantiated directly, instead create the high level {@link Client} and use
  * {@link Client.activity} to interact with Activities.
  */
-export class ActivityClient extends AsyncCompletionClient {
+export class ActivityClient extends AsyncCompletionClient implements TypedActivityClient<any> {
   private readonly interceptedHandlers: {
     [K in keyof Required<ActivityClientInterceptor>]: Next<ActivityClientInterceptor, K>;
   };
@@ -94,13 +96,24 @@ export class ActivityClient extends AsyncCompletionClient {
   }
 
   /**
+   * Returns this client as a {@link TypedActivityClient}. It enables strong type checking of Activity name, arguments
+   * and result based on the provided Activity interface. Note that no new client object is created - this method only
+   * affects type annotations.
+   * @template T Activity interface to use for type checking. The returned client can only start activities present in
+   * this interface.
+   */
+  typedClient<T>(): TypedActivityClient<T> {
+    return this;
+  }
+
+  /**
    * Starts new Standalone Activity execution.
    *
    * @param activity Name of the activity to start.
    * @param options Options controlling the start and execution of the activity.
    * @returns Handle to the started activity. The handle's `runId` property will be set to the started run.
    */
-  async start<O = any>(activity: string, options: ActivityOptions): Promise<ActivityHandle<O>> {
+  async start<R = any>(activity: string, options: ActivityOptions): Promise<ActivityHandle<R>> {
     return this.interceptedHandlers.start({
       activityType: activity,
       options,
@@ -114,7 +127,7 @@ export class ActivityClient extends AsyncCompletionClient {
    * @param options Options controlling the activity execution.
    * @returns Result of the activity.
    */
-  async execute<O = any>(activity: string, options: ActivityOptions): Promise<O> {
+  async execute<R = any>(activity: string, options: ActivityOptions): Promise<R> {
     const handle = await this.start(activity, options);
     return handle.result();
   }
@@ -134,7 +147,7 @@ export class ActivityClient extends AsyncCompletionClient {
    * @param runId Optional run ID of the specific Activity execution.
    * @returns Handle to the specified activity execution.
    */
-  getHandle<O = any>(activityId: string, runId?: string): ActivityHandle<O> {
+  getHandle<R = any>(activityId: string, runId?: string): ActivityHandle<R> {
     return this.createHandle(activityId, runId);
   }
 
@@ -168,7 +181,7 @@ export class ActivityClient extends AsyncCompletionClient {
     });
   }
 
-  protected createHandle<O>(activityId: string, runId?: string): ActivityHandle<O> {
+  protected createHandle<R>(activityId: string, runId?: string): ActivityHandle<R> {
     if (!activityId) {
       throw new TypeError('activityId is required');
     }
@@ -178,7 +191,7 @@ export class ActivityClient extends AsyncCompletionClient {
       activityId,
       runId,
 
-      async result(): Promise<O> {
+      async result(): Promise<R> {
         return await this.client.interceptedHandlers.getResult({
           activityId: this.activityId,
           activityRunId: this.runId ?? '',
@@ -409,8 +422,9 @@ export class ActivityClient extends AsyncCompletionClient {
 /**
  * Handle that can be used to perform operations on the associated Activity.
  * Can be obtained by calling {@link ActivityClient.start} or {@link ActivityClient.getHandle}.
+ * @template R Result type of the activity. Use {@link ActivityClient.typedClient} to start activities in a type-safe way.
  */
-export interface ActivityHandle<O = any> {
+export interface ActivityHandle<R = any> {
   /**
    * ID of the Activity this handle refers to.
    */
@@ -425,7 +439,7 @@ export interface ActivityHandle<O = any> {
    * If the activity was not successful, throws {@link ActivityExecutionFailedError}. The activity failure is stored in
    * the `cause` field.
    */
-  result(): Promise<O>;
+  result(): Promise<R>;
   /**
    * Returns information about the Activity execution.
    */
@@ -455,7 +469,7 @@ export interface ActivityOptions {
   /**
    * Input arguments to pass to the activity.
    */
-  args?: any[];
+  args?: any[] | Readonly<any[]>;
   /**
    * If set, specifies maximum time between successful heartbeats.
    */
@@ -579,3 +593,76 @@ function buildActivityDescription(
     getLastFailure,
   };
 }
+
+/**
+ * Sub-interface of {@link ActivityClient} that provides a strongly-typed interface for executing Activities.
+ * Argument types in the provided options must match the argument types of the specified Activity as defined in provided
+ * interface
+ * @template T Activity interface
+ */
+export interface TypedActivityClient<T> {
+  start<N extends ActivityName<T>>(
+    activity: N,
+    options: ActivityOptionsFor<T, N>
+  ): Promise<ActivityHandle<ActivityResult<T, N>>>;
+
+  execute<N extends ActivityName<T>>(activity: N, options: ActivityOptionsFor<T, N>): Promise<ActivityResult<T, N>>;
+}
+
+/**
+ * Utility type to support strong typing in {@link TypedActivityClient}.
+ * Contains names of activities extracted from the specified activity interface.
+ * @template T Activity interface
+ */
+export type ActivityName<T> = {
+  [N in keyof T & string]: T[N] extends ActivityFunction<any, any> ? N : never;
+}[keyof T & string];
+
+/**
+ * Utility type to support strong typing in {@link TypedActivityClient}.
+ * Extracts argument types of an activity.
+ * @template T Activity interface
+ * @template N Activity name
+ */
+export type ActivityArgs<T, N extends ActivityName<T>> = T[N] extends ActivityFunction<infer P, any> ? P : never;
+
+/**
+ * Utility type to support strong typing in {@link TypedActivityClient}.
+ * Extracts result type of an activity.
+ * @template T Activity interface
+ * @template N Activity name
+ */
+export type ActivityResult<T, N extends ActivityName<T>> = T[N] extends ActivityFunction<any, infer R> ? R : never;
+
+/**
+ * Utility type to support strong typing in {@link TypedActivityClient}.
+ * Represents {@link ActivityOptions} with strongly typed arguments.
+ * @template Args Types of activity arguments as an array type.
+ */
+export type ActivityOptionsWithArgs<Args extends any[]> = Args extends [any, ...any]
+  ? Replace<
+      ActivityOptions,
+      {
+        /**
+         * Arguments to pass to the Activity
+         */
+        args: Args | Readonly<Args>;
+      }
+    >
+  : Replace<
+      ActivityOptions,
+      {
+        /**
+         * Arguments to pass to the Activity
+         */
+        args?: Args | Readonly<Args>;
+      }
+    >;
+
+/**
+ * Utility type to support strong typing in {@link TypedActivityClient}.
+ * Represents {@link ActivityOptions} with strongly typed arguments matching specified Activity in specified interface.
+ * @template T Activity interface
+ * @template N Activity name
+ */
+export type ActivityOptionsFor<T, N extends ActivityName<T>> = ActivityOptionsWithArgs<ActivityArgs<T, N>>;

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -109,7 +109,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
    * @template T Activity interface to use for type checking. The returned client can only start activities present in
    * this interface.
    */
-  typedClient<T>(): TypedActivityClient<T> {
+  typed<T>(): TypedActivityClient<T> {
     return this;
   }
 
@@ -446,7 +446,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
 /**
  * Handle that can be used to perform operations on the associated Activity.
  * Can be obtained by calling {@link ActivityClient.start} or {@link ActivityClient.getHandle}.
- * @template R Result type of the activity. Use {@link ActivityClient.typedClient} to start activities in a type-safe way.
+ * @template R Result type of the activity. Use {@link ActivityClient.typed} to start activities in a type-safe way.
  */
 export interface ActivityHandle<R = any> {
   /**

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -1,4 +1,4 @@
-import { status } from '@grpc/grpc-js';
+import { status as grpcStatus } from '@grpc/grpc-js';
 import { v4 as uuid4 } from 'uuid';
 import type {
   ActivityFunction,
@@ -31,7 +31,7 @@ import {
   encodeToPayloads,
   encodeUserMetadata,
 } from '@temporalio/common/lib/internal-non-workflow';
-import type { temporal } from '@temporalio/proto';
+import { temporal } from '@temporalio/proto';
 import type { Replace } from '@temporalio/common/lib/type-helpers';
 import type {
   ActivityCancelInput,
@@ -58,8 +58,15 @@ import {
   encodeActivityIdConflictPolicy,
   encodeActivityIdReusePolicy,
 } from './types';
-import { rethrowKnownErrorTypes } from './helpers';
-import { isGrpcServiceError, ServiceError, ActivityNotFoundError, ActivityExecutionFailedError } from './errors';
+import type { ErrorDetailsName } from './helpers';
+import { rethrowKnownErrorTypes, trimGrpcTypeUrl, getGrpcStatusDetails } from './helpers';
+import {
+  isGrpcServiceError,
+  ServiceError,
+  ActivityNotFoundError,
+  ActivityExecutionFailedError,
+  ActivityExecutionAlreadyStartedError,
+} from './errors';
 
 /**
  * Options used to configure {@link ActivityClient}
@@ -241,6 +248,23 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       );
       return this.createHandle(input.options.id, resp.runId);
     } catch (err) {
+      if (isGrpcServiceError(err) && err.code === grpcStatus.ALREADY_EXISTS) {
+        for (const entry of getGrpcStatusDetails(err) ?? []) {
+          if (!entry.type_url || !entry.value) continue;
+          if (
+            (trimGrpcTypeUrl(entry.type_url) as ErrorDetailsName) ===
+            'temporal.api.errordetails.v1.ActivityExecutionAlreadyStartedFailure'
+          ) {
+            const details = temporal.api.errordetails.v1.ActivityExecutionAlreadyStartedFailure.decode(entry.value);
+            throw new ActivityExecutionAlreadyStartedError(
+              'Activity execution already started',
+              input.options.id,
+              details.runId
+            );
+          }
+        }
+      }
+
       this.rethrowGrpcError(err, 'Failed to start activity');
     }
   }
@@ -410,7 +434,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
   protected rethrowGrpcError(err: unknown, fallbackMessage: string): never {
     if (isGrpcServiceError(err)) {
       rethrowKnownErrorTypes(err);
-      if (err.code === status.NOT_FOUND) {
+      if (err.code === grpcStatus.NOT_FOUND) {
         throw new ActivityNotFoundError(err.details ?? 'Activity not found');
       }
       throw new ServiceError(fallbackMessage, { cause: err });

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -70,6 +70,8 @@ import {
 
 /**
  * Options used to configure {@link ActivityClient}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityClientOptions extends AsyncCompletionClientOptions {
   interceptors?: ActivityClientInterceptor[];
@@ -108,6 +110,8 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
    * affects type annotations.
    * @template T Activity interface to use for type checking. The returned client can only start activities present in
    * this interface.
+   *
+   * @experimental Standalone Activities are experimental. APIs may be subject to change.
    */
   typed<T>(): TypedActivityClient<T> {
     return this;
@@ -119,6 +123,8 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
    * @param activity Name of the activity to start.
    * @param options Options controlling the start and execution of the activity.
    * @returns Handle to the started activity. The handle's `runId` property will be set to the started run.
+   *
+   * @experimental Standalone Activities are experimental. APIs may be subject to change.
    */
   async start<R = any>(activity: string, options: ActivityOptions): Promise<ActivityHandle<R>> {
     return this.interceptedHandlers.start({
@@ -133,6 +139,8 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
    * @param activity Name of the activity to start.
    * @param options Options controlling the activity execution.
    * @returns Result of the activity.
+   *
+   * @experimental Standalone Activities are experimental. APIs may be subject to change.
    */
   async execute<R = any>(activity: string, options: ActivityOptions): Promise<R> {
     const handle = await this.start(activity, options);
@@ -153,6 +161,8 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
    * @param activityId ID of the Activity.
    * @param runId Optional run ID of the specific Activity execution.
    * @returns Handle to the specified activity execution.
+   *
+   * @experimental Standalone Activities are experimental. APIs may be subject to change.
    */
   getHandle<R = any>(activityId: string, runId?: string): ActivityHandle<R> {
     return this.createHandle(activityId, runId);
@@ -165,6 +175,8 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
    *
    * More info on the concept of "visibility" and the query syntax on the Temporal documentation site:
    * https://docs.temporal.io/visibility
+   *
+   * @experimental Standalone Activities are experimental. APIs may be subject to change.
    */
   list(query: string): AsyncIterable<ActivityExecutionInfo> {
     return this.interceptedHandlers.list({
@@ -180,6 +192,8 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
    *
    * More info on the concept of "visibility" and the query syntax on the Temporal documentation site:
    * https://docs.temporal.io/visibility
+   *
+   * @experimental Standalone Activities are experimental. APIs may be subject to change.
    */
   async count(query: string): Promise<CountActivityExecutions> {
     return await this.interceptedHandlers.count({
@@ -447,6 +461,8 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
  * Handle that can be used to perform operations on the associated Activity.
  * Can be obtained by calling {@link ActivityClient.start} or {@link ActivityClient.getHandle}.
  * @template R Result type of the activity. Use {@link ActivityClient.typed} to start activities in a type-safe way.
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityHandle<R = any> {
   /**
@@ -480,6 +496,8 @@ export interface ActivityHandle<R = any> {
 
 /**
  * Options used by {@link ActivityClient.start}.
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityOptions {
   /**
@@ -626,6 +644,8 @@ function buildActivityDescription(
  * Argument types in the provided options must match the argument types of the specified Activity as defined in provided
  * interface
  * @template T Activity interface
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface TypedActivityClient<T> {
   start<N extends ActivityName<T>>(
@@ -640,6 +660,8 @@ export interface TypedActivityClient<T> {
  * Utility type to support strong typing in {@link TypedActivityClient}.
  * Contains names of activities extracted from the specified activity interface.
  * @template T Activity interface
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export type ActivityName<T> = {
   [N in keyof T & string]: T[N] extends ActivityFunction<any, any> ? N : never;
@@ -650,6 +672,8 @@ export type ActivityName<T> = {
  * Extracts argument types of an activity.
  * @template T Activity interface
  * @template N Activity name
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export type ActivityArgs<T, N extends ActivityName<T>> = T[N] extends ActivityFunction<infer P, any> ? P : never;
 
@@ -658,6 +682,8 @@ export type ActivityArgs<T, N extends ActivityName<T>> = T[N] extends ActivityFu
  * Extracts result type of an activity.
  * @template T Activity interface
  * @template N Activity name
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export type ActivityResult<T, N extends ActivityName<T>> = T[N] extends ActivityFunction<any, infer R> ? R : never;
 
@@ -665,6 +691,8 @@ export type ActivityResult<T, N extends ActivityName<T>> = T[N] extends Activity
  * Utility type to support strong typing in {@link TypedActivityClient}.
  * Represents {@link ActivityOptions} with strongly typed arguments.
  * @template Args Types of activity arguments as an array type.
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export type ActivityOptionsWithArgs<Args extends any[]> = Args extends [any, ...any]
   ? Replace<
@@ -691,5 +719,7 @@ export type ActivityOptionsWithArgs<Args extends any[]> = Args extends [any, ...
  * Represents {@link ActivityOptions} with strongly typed arguments matching specified Activity in specified interface.
  * @template T Activity interface
  * @template N Activity name
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export type ActivityOptionsFor<T, N extends ActivityName<T>> = ActivityOptionsWithArgs<ActivityArgs<T, N>>;

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -17,7 +17,6 @@ import {
 } from '@temporalio/common';
 import type { Duration } from '@temporalio/common/lib/time';
 import { msOptionalToTs, optionalTsToDate, optionalTsToMs } from '@temporalio/common/lib/time';
-import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import {
   decodeTypedSearchAttributes,
@@ -45,7 +44,7 @@ import type {
 import type { AsyncCompletionClientOptions } from './async-completion-client';
 import { AsyncCompletionClient } from './async-completion-client';
 import type {
-  ActivityDescription,
+  ActivityExecutionDescription,
   ActivityExecutionInfo,
   ActivityIdConflictPolicy,
   ActivityIdReusePolicy,
@@ -58,29 +57,7 @@ import {
   encodeActivityIdReusePolicy,
 } from './types';
 import { rethrowKnownErrorTypes } from './helpers';
-import { isGrpcServiceError, ServiceError } from './errors';
-
-/**
- * Thrown when an Activity with the given ID is not known to Temporal Server.
- */
-@SymbolBasedInstanceOfError('ActivityNotFoundError')
-export class ActivityNotFoundError extends Error {}
-
-/**
- * Thrown by the client while waiting on Activity execution result if execution completes with failure.
- * The failure is stored in the `cause` property.
- */
-@SymbolBasedInstanceOfError('ActivityExecutionFailedError')
-export class ActivityExecutionFailedError extends Error {
-  constructor(
-    message: string,
-    public readonly cause: Error | undefined,
-    public readonly activityId: string,
-    public readonly runId?: string
-  ) {
-    super(message);
-  }
-}
+import { isGrpcServiceError, ServiceError, ActivityNotFoundError, ActivityExecutionFailedError } from './errors';
 
 /**
  * Options used to configure {@link ActivityClient}
@@ -151,7 +128,7 @@ export class ActivityClient extends AsyncCompletionClient {
    *
    * Note 2: if `runID` is not set when calling `getHandle`, then `runId` property of the returned handle will always
    * remain unset, even after method calls are performed. To get the run ID of the targeted activity execution, call
-   * {@link ActivityHandle.describe} and read the `activityRunId` field of the returned {@link ActivityDescription}.
+   * {@link ActivityHandle.describe} and read the `activityRunId` field of the returned {@link ActivityExecutionDescription}.
    *
    * @param activityId ID of the Activity.
    * @param runId Optional run ID of the specific Activity execution.
@@ -209,7 +186,7 @@ export class ActivityClient extends AsyncCompletionClient {
         });
       },
 
-      async describe(): Promise<ActivityDescription> {
+      async describe(): Promise<ActivityExecutionDescription> {
         return await this.client.interceptedHandlers.describe({
           activityId: this.activityId,
           activityRunId: this.runId ?? '',
@@ -322,7 +299,7 @@ export class ActivityClient extends AsyncCompletionClient {
     }
   }
 
-  protected async describeHandler(input: ActivityDescribeInput): Promise<ActivityDescription> {
+  protected async describeHandler(input: ActivityDescribeInput): Promise<ActivityExecutionDescription> {
     if (!input.activityId) {
       throw new TypeError('activityId is required');
     }
@@ -452,7 +429,7 @@ export interface ActivityHandle<O = any> {
   /**
    * Returns information about the Activity execution.
    */
-  describe(): Promise<ActivityDescription>;
+  describe(): Promise<ActivityExecutionDescription>;
   /**
    * Requests cancellation of the Activity execution. Note that cancellations are cooperative and not guaranteed to happen.
    */
@@ -563,7 +540,7 @@ function buildActivityExecutionInfo(info: temporal.api.activity.v1.IActivityExec
 function buildActivityDescription(
   info: temporal.api.activity.v1.IActivityExecutionInfo,
   dataConverter: LoadedDataConverter
-): ActivityDescription {
+): ActivityExecutionDescription {
   const getHeartbeatDetails: <T>() => Promise<T | undefined> = async <T>() => {
     const payloads = info.heartbeatDetails?.payloads;
     if (payloads && payloads.length > 0) {
@@ -587,7 +564,7 @@ function buildActivityDescription(
     heartbeatTimeoutMs: optionalTsToMs(info.heartbeatTimeout),
     retryPolicy: decompileRetryPolicy(info.retryPolicy)!,
     lastHeartbeatTime: optionalTsToDate(info.lastHeartbeatTime),
-    lastStartedTime: optionalTsToDate(info.scheduleTime),
+    lastStartedTime: optionalTsToDate(info.lastStartedTime),
     attempt: info.attempt!,
     expirationTime: optionalTsToDate(info.expirationTime),
     lastWorkerIdentity: info.lastWorkerIdentity || undefined,

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -143,7 +143,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
    * Creates an Activity handle from ID and optionally from run ID. If `runId` is not set, the handle will refer to the
    * newest Activity run with the given Activity ID.
    *
-   * Note 1: this function always succeeds. If the provided ID is invalid, the error will only be thrown when calling
+   * Note 1: this function always succeeds. If the provided ID is invalid, an error will only be thrown when calling
    * the handle's methods.
    *
    * Note 2: if `runID` is not set when calling `getHandle`, then `runId` property of the returned handle will always
@@ -273,7 +273,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
     input: ActivityStartInput
   ): Promise<temporal.api.workflowservice.v1.IStartActivityExecutionRequest> {
     const searchAttributes = input.options.typedSearchAttributes
-      ? encodeUnifiedSearchAttributes(undefined, input.options.typedSearchAttributes)
+      ? { indexedFields: encodeUnifiedSearchAttributes(undefined, input.options.typedSearchAttributes) }
       : undefined;
 
     return {
@@ -291,7 +291,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       input: { payloads: await encodeToPayloads(this.dataConverter, ...(input.options.args || [])) },
       idReusePolicy: encodeActivityIdReusePolicy(input.options.idReusePolicy),
       idConflictPolicy: encodeActivityIdConflictPolicy(input.options.idConflictPolicy),
-      searchAttributes: { indexedFields: searchAttributes },
+      searchAttributes,
       header: input.headers,
       userMetadata: await encodeUserMetadata(this.dataConverter, input.options.summary, undefined),
       priority: input.options.priority ? compilePriority(input.options.priority) : undefined,
@@ -427,7 +427,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
         })),
       };
     } catch (err) {
-      this.rethrowGrpcError(err, 'Failed to request activity cancellation');
+      this.rethrowGrpcError(err, 'Failed to count activities');
     }
   }
 
@@ -498,6 +498,9 @@ export interface ActivityOptions {
    * If set, specifies maximum time between successful heartbeats.
    */
   heartbeatTimeout?: Duration;
+  /**
+   * Controls how Activity is retried. If not set, the server will assign default retry policy.
+   */
   retry?: RetryPolicy;
   /**
    * Is set, specifies total time the activity is allowed to run, including retries.

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -2,47 +2,14 @@ import { status as grpcStatus } from '@grpc/grpc-js';
 import { ensureTemporalFailure } from '@temporalio/common';
 import { encodeErrorToFailure, encodeToPayloads } from '@temporalio/common/lib/internal-non-workflow';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
-import { SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
 import type { BaseClientOptions, LoadedWithDefaults, WithDefaults } from './base-client';
 import { BaseClient, defaultBaseClientOptions } from './base-client';
-import { isGrpcServiceError } from './errors';
+import {
+  isGrpcServiceError, ActivityNotFoundError, ActivityCompletionError, ActivityCancelledError,
+  ActivityResetError, ActivityPausedError,
+} from './errors';
 import type { WorkflowService } from './types';
 import { rethrowKnownErrorTypes } from './helpers';
-
-/**
- * Thrown by {@link AsyncCompletionClient} when trying to complete or heartbeat an Activity that does not exist in the
- * system.
- */
-@SymbolBasedInstanceOfError('ActivityNotFoundError')
-export class ActivityNotFoundError extends Error {}
-
-/**
- * Thrown by {@link AsyncCompletionClient} when trying to complete or heartbeat
- * an Activity for any reason apart from {@link ActivityNotFoundError}.
- */
-@SymbolBasedInstanceOfError('ActivityCompletionError')
-export class ActivityCompletionError extends Error {}
-
-/**
- * Thrown by {@link AsyncCompletionClient.heartbeat} when the Workflow has
- * requested to cancel the reporting Activity.
- */
-@SymbolBasedInstanceOfError('ActivityCancelledError')
-export class ActivityCancelledError extends Error {}
-
-/**
- * Thrown by {@link AsyncCompletionClient.heartbeat} when the reporting Activity
- * has been paused.
- */
-@SymbolBasedInstanceOfError('ActivityPausedError')
-export class ActivityPausedError extends Error {}
-
-/**
- * Thrown by {@link AsyncCompletionClient.heartbeat} when the reporting Activity
- * has been reset.
- */
-@SymbolBasedInstanceOfError('ActivityResetError')
-export class ActivityResetError extends Error {}
 
 /**
  * Options used to configure {@link AsyncCompletionClient}

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -5,8 +5,12 @@ import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow
 import type { BaseClientOptions, LoadedWithDefaults, WithDefaults } from './base-client';
 import { BaseClient, defaultBaseClientOptions } from './base-client';
 import {
-  isGrpcServiceError, ActivityNotFoundError, ActivityCompletionError, ActivityCancelledError,
-  ActivityResetError, ActivityPausedError,
+  isGrpcServiceError,
+  ActivityNotFoundError,
+  ActivityCompletionError,
+  ActivityCancelledError,
+  ActivityResetError,
+  ActivityPausedError,
 } from './errors';
 import type { WorkflowService } from './types';
 import { rethrowKnownErrorTypes } from './helpers';

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -56,15 +56,31 @@ function defaultAsyncCompletionClientOptions(): WithDefaults<AsyncCompletionClie
 }
 
 /**
- * A mostly unique Activity identifier including its scheduling workflow's ID
- * and an optional runId.
+ * A mostly unique Activity identifier. If {@link workflowId} is set, it refers to a Workflow Activity.
+ * If {@link workflowId} is unset, it refers to a Standalone Activity. In both cases, it can optionally contain
+ * {@link runId}.
  *
- * Activity IDs may be reused in a single Workflow run as long as a previous
- * Activity with the same ID has completed already.
+ * Activity IDs may be reused in a single Workflow run as long as a previous Activity with the same ID has completed
+ * already. Standalone Activity IDs may be reused if `idReusePolicy` is set in Activity options when starting a new
+ * Activity, but a combination of Activity ID and Activity run ID is unique.
  */
 export interface FullActivityId {
-  workflowId: string;
+  /**
+   * ID of the Workflow that started the Activity. Unset for Standalone Activities.
+   */
+  workflowId?: string;
+  /**
+   * If {@link workflowId} is set, this optionally specifies the Workflow run ID in order to differentiate between
+   * Workflow runs with the same Workflow ID. If {@link workflowId} is unset, this optionally specifies the
+   * Activity run ID in order to differentiate between Standalone Activity runs with the same Activity ID.
+   *
+   * If {@link runId} is unset, then the {@link FullActivityId} object refers to the latest run of the Workflow or
+   * the Standalone Activity with the specified ID.
+   */
   runId?: string;
+  /**
+   * ID of the Activity.
+   */
   activityId: string;
 }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,5 +1,4 @@
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
-import { AsyncCompletionClient } from './async-completion-client';
 import type { BaseClientOptions, LoadedWithDefaults } from './base-client';
 import { BaseClient, defaultBaseClientOptions } from './base-client';
 import type { ClientInterceptors } from './interceptors';
@@ -7,6 +6,7 @@ import { ScheduleClient } from './schedule-client';
 import type { QueryRejectCondition, WorkflowService } from './types';
 import { WorkflowClient } from './workflow-client';
 import { TaskQueueClient } from './task-queue-client';
+import { ActivityClient } from './activity-client';
 
 export interface ClientOptions extends BaseClientOptions {
   /**
@@ -49,9 +49,9 @@ export class Client extends BaseClient {
    */
   public readonly workflow: WorkflowClient;
   /**
-   * (Async) Activity completion sub-client - use to manually manage Activities
+   * Activity sub-client - use to start and interact with Activities and to perform asynchronous Activity completion
    */
-  public readonly activity: AsyncCompletionClient;
+  public readonly activity: ActivityClient;
   /**
    * Schedule sub-client - use to start and interact with Schedules
    */
@@ -89,10 +89,11 @@ export class Client extends BaseClient {
       queryRejectCondition: workflow?.queryRejectCondition,
     });
 
-    this.activity = new AsyncCompletionClient({
+    this.activity = new ActivityClient({
       ...commonOptions,
       connection: this.connection,
       dataConverter: this.dataConverter,
+      interceptors: interceptors?.activity,
     });
 
     this.schedule = new ScheduleClient({

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -117,6 +117,8 @@ export class ActivityResetError extends Error {}
 /**
  * Thrown by the {@link ActivityClient} while waiting on Activity execution result if execution completes with failure.
  * The failure is stored in the `cause` property.
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 @SymbolBasedInstanceOfError('ActivityExecutionFailedError')
 export class ActivityExecutionFailedError extends Error {
@@ -134,6 +136,8 @@ export class ActivityExecutionFailedError extends Error {
  * Thrown when starting an Activity failed because another Activity with the same ID already exists and reusing the ID
  * is not allowed under chosen ID reuse policy and ID conflict policy. See {@link ActivityOptions.idReusePolicy} and
  * {@link ActivityOptions.idConflictPolicy}.
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 @SymbolBasedInstanceOfError('ActivityExecutionAlreadyStartedError')
 export class ActivityExecutionAlreadyStartedError extends Error {

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -2,8 +2,6 @@ import type { ServiceError as GrpcServiceError } from '@grpc/grpc-js';
 import { status } from '@grpc/grpc-js';
 import type { RetryState } from '@temporalio/common';
 import { isError, isRecord, SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
-import { AsyncCompletionClient, AsyncCompletionClientOptions } from './async-completion-client';
-import type { ActivityClientInterceptor } from './interceptors';
 
 /**
  * Generic Error class for errors coming from the service

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -2,6 +2,8 @@ import type { ServiceError as GrpcServiceError } from '@grpc/grpc-js';
 import { status } from '@grpc/grpc-js';
 import type { RetryState } from '@temporalio/common';
 import { isError, isRecord, SymbolBasedInstanceOfError } from '@temporalio/common/lib/type-helpers';
+import { AsyncCompletionClient, AsyncCompletionClientOptions } from './async-completion-client';
+import type { ActivityClientInterceptor } from './interceptors';
 
 /**
  * Generic Error class for errors coming from the service
@@ -75,6 +77,56 @@ export class WorkflowContinuedAsNewError extends Error {
   public constructor(
     message: string,
     public readonly newExecutionRunId: string
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Thrown when the requested Activity could not be found.
+ */
+@SymbolBasedInstanceOfError('ActivityNotFoundError')
+export class ActivityNotFoundError extends Error {}
+
+/**
+ * Thrown by {@link AsyncCompletionClient} when trying to complete or heartbeat
+ * an Activity for any reason apart from {@link ActivityNotFoundError}.
+ */
+@SymbolBasedInstanceOfError('ActivityCompletionError')
+export class ActivityCompletionError extends Error {}
+
+/**
+ * Thrown by {@link AsyncCompletionClient.heartbeat} when the Workflow has
+ * requested to cancel the reporting Activity.
+ */
+@SymbolBasedInstanceOfError('ActivityCancelledError')
+export class ActivityCancelledError extends Error {}
+
+/**
+ * Thrown by {@link AsyncCompletionClient.heartbeat} when the reporting Activity
+ * has been paused.
+ */
+@SymbolBasedInstanceOfError('ActivityPausedError')
+export class ActivityPausedError extends Error {}
+
+/**
+ * Thrown by {@link AsyncCompletionClient.heartbeat} when the reporting Activity
+ * has been reset.
+ */
+@SymbolBasedInstanceOfError('ActivityResetError')
+export class ActivityResetError extends Error {}
+
+/**
+ * Thrown by the {@link ActivityClient} while waiting on Activity execution result if execution completes with failure.
+ * The failure is stored in the `cause` property.
+ */
+@SymbolBasedInstanceOfError('ActivityExecutionFailedError')
+export class ActivityExecutionFailedError extends Error {
+  constructor(
+    message: string,
+    public readonly cause: Error | undefined,
+    public readonly activityId: string,
+    public readonly runId?: string
   ) {
     super(message);
   }

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -131,6 +131,28 @@ export class ActivityExecutionFailedError extends Error {
 }
 
 /**
+ * Thrown when starting an Activity failed because another Activity with the same ID already exists and reusing the ID
+ * is not allowed under chosen ID reuse policy and ID conflict policy. See {@link ActivityOptions.idReusePolicy} and
+ * {@link ActivityOptions.idConflictPolicy}.
+ */
+@SymbolBasedInstanceOfError('ActivityExecutionAlreadyStartedError')
+export class ActivityExecutionAlreadyStartedError extends Error {
+  constructor(
+    message: string,
+    /**
+     * ID of the Activity that failed to start.
+     */
+    public readonly activityId: string,
+    /**
+     * Run ID of the existing Activity execution with the same Activity ID.
+     */
+    public readonly runId: string
+  ) {
+    super(message);
+  }
+}
+
+/**
  * Returns true if the provided error is a {@link GrpcServiceError}.
  */
 export function isGrpcServiceError(err: unknown): err is GrpcServiceError {

--- a/packages/client/src/helpers.ts
+++ b/packages/client/src/helpers.ts
@@ -108,8 +108,8 @@ export function decodeCountWorkflowExecutionsResponse(
   };
 }
 
-type ErrorDetailsName = `temporal.api.errordetails.v1.${keyof typeof temporal.api.errordetails.v1}`;
-type FailureName = `temporal.api.failure.v1.${keyof typeof temporal.api.failure.v1}`;
+export type ErrorDetailsName = `temporal.api.errordetails.v1.${keyof typeof temporal.api.errordetails.v1}`;
+export type FailureName = `temporal.api.failure.v1.${keyof typeof temporal.api.failure.v1}`;
 
 /**
  * If the error type can be determined based on embedded grpc error details,
@@ -123,7 +123,7 @@ export function rethrowKnownErrorTypes(err: GrpcServiceError): void {
   // We really don't expect multiple error details, but this really is an array, so just in case...
   for (const entry of getGrpcStatusDetails(err) ?? []) {
     if (!entry.type_url || !entry.value) continue;
-    const type = entry.type_url.replace(/^type.googleapis.com\//, '') as ErrorDetailsName;
+    const type = trimGrpcTypeUrl(entry.type_url) as ErrorDetailsName;
 
     switch (type) {
       case 'temporal.api.errordetails.v1.NamespaceNotFoundFailure': {
@@ -139,7 +139,7 @@ export function rethrowKnownErrorTypes(err: GrpcServiceError): void {
         const { statuses } = temporal.api.errordetails.v1.MultiOperationExecutionFailure.decode(entry.value);
         for (const status of statuses) {
           const detail = status.details?.[0];
-          const statusType = detail?.type_url?.replace(/^type.googleapis.com\//, '') as FailureName | undefined;
+          const statusType = trimGrpcTypeUrl(detail?.type_url) as FailureName | '';
           if (
             statusType === 'temporal.api.failure.v1.MultiOperationExecutionAborted' ||
             status.code === grpcStatus.OK
@@ -156,10 +156,14 @@ export function rethrowKnownErrorTypes(err: GrpcServiceError): void {
   }
 }
 
-function getGrpcStatusDetails(err: GrpcServiceError): google.rpc.Status['details'] | undefined {
+export function getGrpcStatusDetails(err: GrpcServiceError): google.rpc.Status['details'] | undefined {
   const statusBuffer = err.metadata.get('grpc-status-details-bin')?.[0];
   if (!statusBuffer || typeof statusBuffer === 'string') {
     return undefined;
   }
   return google.rpc.Status.decode(statusBuffer).details;
+}
+
+export function trimGrpcTypeUrl(type_url: string | null | undefined): string {
+  return type_url?.replace(/^type.googleapis.com\//, '') || '';
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -54,6 +54,7 @@ export * from '@temporalio/common/lib/errors';
 export * from '@temporalio/common/lib/interfaces';
 export * from '@temporalio/common/lib/workflow-handle';
 export * from './async-completion-client';
+export * from './activity-client';
 export * from './client';
 export {
   Connection,

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -121,6 +121,8 @@ export interface WorkflowDescribeInput {
 
 /**
  * Implement any of these methods to intercept {@link WorkflowClient} outbound calls
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface WorkflowClientInterceptor {
   /**
@@ -253,6 +255,8 @@ export interface ClientInterceptors {
 
 /**
  * Implement any of these methods to intercept {@link ActivityClient} outbound calls
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityClientInterceptor {
   /**
@@ -287,6 +291,8 @@ export interface ActivityClientInterceptor {
 
 /**
  * Input for {@link ActivityClientInterceptor.start}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityStartInput {
   readonly activityType: string;
@@ -296,6 +302,8 @@ export interface ActivityStartInput {
 
 /**
  * Input for {@link ActivityClientInterceptor.getResult}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityGetResultInput {
   readonly activityId: string;
@@ -305,6 +313,8 @@ export interface ActivityGetResultInput {
 
 /**
  * Input for {@link ActivityClientInterceptor.describe}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityDescribeInput {
   readonly activityId: string;
@@ -314,6 +324,8 @@ export interface ActivityDescribeInput {
 
 /**
  * Input for {@link ActivityClientInterceptor.cancel}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityCancelInput {
   readonly activityId: string;
@@ -324,6 +336,8 @@ export interface ActivityCancelInput {
 
 /**
  * Input for {@link ActivityClientInterceptor.terminate}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityTerminateInput {
   readonly activityId: string;
@@ -334,6 +348,8 @@ export interface ActivityTerminateInput {
 
 /**
  * Input for {@link ActivityClientInterceptor.list}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityListInput {
   readonly query: string;
@@ -342,6 +358,8 @@ export interface ActivityListInput {
 
 /**
  * Input for {@link ActivityClientInterceptor.count}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityCountInput {
   readonly query: string;

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -8,7 +8,7 @@ import { Headers, Next } from '@temporalio/common';
 import type { temporal } from '@temporalio/proto';
 import type { CompiledScheduleOptions } from './schedule-types';
 import type {
-  ActivityDescription,
+  ActivityExecutionDescription,
   ActivityExecutionInfo,
   CountActivityExecutions,
   DescribeWorkflowExecutionResponse,
@@ -266,7 +266,7 @@ export interface ActivityClientInterceptor {
   /**
    * Intercept a service call to describeActivityExecution
    */
-  describe?: (input: ActivityDescribeInput, next: Next<this, 'describe'>) => Promise<ActivityDescription>;
+  describe?: (input: ActivityDescribeInput, next: Next<this, 'describe'>) => Promise<ActivityExecutionDescription>;
   /**
    * Intercept a service call to requestCancelActivityExecution
    */

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -8,12 +8,16 @@ import { Headers, Next } from '@temporalio/common';
 import type { temporal } from '@temporalio/proto';
 import type { CompiledScheduleOptions } from './schedule-types';
 import type {
+  ActivityDescription,
+  ActivityExecutionInfo,
+  CountActivityExecutions,
   DescribeWorkflowExecutionResponse,
   RequestCancelWorkflowExecutionResponse,
   TerminateWorkflowExecutionResponse,
   WorkflowExecution,
 } from './types';
 import type { CompiledWorkflowOptions, WorkflowUpdateOptions } from './workflow-options';
+import type { ActivityHandle, ActivityOptions } from './activity-client';
 
 export { Headers, Next };
 
@@ -116,7 +120,7 @@ export interface WorkflowDescribeInput {
 }
 
 /**
- * Implement any of these methods to intercept WorkflowClient outbound calls
+ * Implement any of these methods to intercept {@link WorkflowClient} outbound calls
  */
 export interface WorkflowClientInterceptor {
   /**
@@ -185,7 +189,7 @@ export interface WorkflowClientInterceptor {
   describe?: (input: WorkflowDescribeInput, next: Next<this, 'describe'>) => Promise<DescribeWorkflowExecutionResponse>;
 }
 
-/** @deprecated: Use WorkflowClientInterceptor instead */
+/** @deprecated: Use {@link WorkflowClientInterceptor} instead */
 export type WorkflowClientCallsInterceptor = WorkflowClientInterceptor;
 
 /** @deprecated */
@@ -216,7 +220,7 @@ export interface WorkflowClientInterceptors {
 }
 
 /**
- * Implement any of these methods to intercept ScheduleClient outbound calls
+ * Implement any of these methods to intercept {@link ScheduleClient} outbound calls
  */
 export interface ScheduleClientInterceptor {
   /**
@@ -239,12 +243,107 @@ export type CreateScheduleOutput = {
 
 /**
  * Interceptors for any high-level SDK client.
- *
- * NOTE: Currently only for {@link WorkflowClient} and {@link ScheduleClient}. More will be added later as needed.
  */
 export interface ClientInterceptors {
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   workflow?: WorkflowClientInterceptors | WorkflowClientInterceptor[];
-
   schedule?: ScheduleClientInterceptor[];
+  activity?: ActivityClientInterceptor[];
+}
+
+/**
+ * Implement any of these methods to intercept {@link ActivityClient} outbound calls
+ */
+export interface ActivityClientInterceptor {
+  /**
+   * Intercept a service call to startActivityExecution
+   */
+  start?: (input: ActivityStartInput, next: Next<this, 'start'>) => Promise<ActivityHandle>;
+  /**
+   * Intercept a service call to pollActivityExecution
+   */
+  getResult?: (input: ActivityGetResultInput, next: Next<this, 'getResult'>) => Promise<any>;
+  /**
+   * Intercept a service call to describeActivityExecution
+   */
+  describe?: (input: ActivityDescribeInput, next: Next<this, 'describe'>) => Promise<ActivityDescription>;
+  /**
+   * Intercept a service call to requestCancelActivityExecution
+   */
+  cancel?: (input: ActivityCancelInput, next: Next<this, 'cancel'>) => Promise<void>;
+  /**
+   * Intercept a service call to terminateActivityExecution
+   */
+  terminate?: (input: ActivityTerminateInput, next: Next<this, 'terminate'>) => Promise<void>;
+  /**
+   * Intercept a service call to listActivityExecutions
+   */
+  list?: (input: ActivityListInput, next: Next<this, 'list'>) => AsyncIterable<ActivityExecutionInfo>;
+  /**
+   * Intercept a service call to countActivityExecutions
+   */
+  count?: (input: ActivityCountInput, next: Next<this, 'count'>) => Promise<CountActivityExecutions>;
+}
+
+/**
+ * Input for {@link ActivityClientInterceptor.start}
+ */
+export interface ActivityStartInput {
+  readonly activityType: string;
+  readonly options: ActivityOptions;
+  readonly headers: Headers;
+}
+
+/**
+ * Input for {@link ActivityClientInterceptor.getResult}
+ */
+export interface ActivityGetResultInput {
+  readonly activityId: string;
+  readonly activityRunId: string;
+  readonly headers: Headers;
+}
+
+/**
+ * Input for {@link ActivityClientInterceptor.describe}
+ */
+export interface ActivityDescribeInput {
+  readonly activityId: string;
+  readonly activityRunId: string;
+  readonly headers: Headers;
+}
+
+/**
+ * Input for {@link ActivityClientInterceptor.cancel}
+ */
+export interface ActivityCancelInput {
+  readonly activityId: string;
+  readonly activityRunId: string;
+  readonly reason: string;
+  readonly headers: Headers;
+}
+
+/**
+ * Input for {@link ActivityClientInterceptor.terminate}
+ */
+export interface ActivityTerminateInput {
+  readonly activityId: string;
+  readonly activityRunId: string;
+  readonly reason: string;
+  readonly headers: Headers;
+}
+
+/**
+ * Input for {@link ActivityClientInterceptor.list}
+ */
+export interface ActivityListInput {
+  readonly query: string;
+  readonly headers: Headers;
+}
+
+/**
+ * Input for {@link ActivityClientInterceptor.count}
+ */
+export interface ActivityCountInput {
+  readonly query: string;
+  readonly headers: Headers;
 }

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,5 +1,12 @@
 import type * as grpc from '@grpc/grpc-js';
-import type { TypedSearchAttributes, SearchAttributes, SearchAttributeValue, Priority } from '@temporalio/common';
+import type {
+  TypedSearchAttributes,
+  SearchAttributes,
+  SearchAttributeValue,
+  Priority,
+  RetryPolicy,
+  WorkerDeploymentVersion,
+} from '@temporalio/common';
 import { makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow';
 import * as proto from '@temporalio/proto';
 import type { Replace } from '@temporalio/common/lib/type-helpers';
@@ -212,4 +219,160 @@ export const [encodeQueryRejectCondition, decodeQueryRejectCondition] = makeProt
     UNSPECIFIED: 0,
   } as const,
   'QUERY_REJECT_CONDITION_'
+);
+
+/**
+ * Return type of {@link ActivityClient.count}
+ */
+export interface CountActivityExecutions {
+  readonly count: number;
+  readonly groups?: {
+    readonly count: number;
+    readonly groupValues?: any[];
+  }[];
+}
+
+export type RawActivityExecutionInfo = proto.temporal.api.activity.v1.IActivityExecutionInfo;
+export type RawActivityExecutionListInfo = proto.temporal.api.activity.v1.IActivityExecutionListInfo;
+
+/**
+ * Type of elements returned by {@link ActivityClient.list}
+ */
+export interface ActivityExecutionInfo {
+  rawListInfo?: RawActivityExecutionListInfo;
+  activityId: string;
+  activityRunId: string;
+  activityType: string;
+  scheduleTime?: Date;
+  closeTime?: Date;
+  status: ActivityExecutionStatus;
+  typedSearchAttributes: TypedSearchAttributes;
+  taskQueue: string;
+  executionDurationMs?: number;
+}
+
+/**
+ * Return type of {@link ActivityClient.describe}
+ */
+export interface ActivityDescription extends ActivityExecutionInfo {
+  rawInfo: RawActivityExecutionInfo;
+  runState?: PendingActivityState;
+  scheduleToCloseTimeoutMs?: number;
+  scheduleToStartTimeoutMs?: number;
+  startToCloseTimeoutMs?: number;
+  heartbeatTimeoutMs?: number;
+  retryPolicy: RetryPolicy;
+  lastHeartbeatTime?: Date;
+  lastStartedTime?: Date;
+  attempt: number;
+  expirationTime?: Date;
+  lastWorkerIdentity?: string;
+  currentRetryIntervalMs?: number;
+  lastAttemptCompleteTime?: Date;
+  nextAttemptScheduleTime?: Date;
+  lastDeploymentVersion?: WorkerDeploymentVersion;
+  priority: Priority;
+  canceledReason?: string;
+
+  getHeartbeatDetails<T = any>(): Promise<T | undefined>;
+  getLastFailure(): Promise<Error | undefined>;
+}
+
+export const ActivityIdReusePolicy = {
+  ALLOW_DUPLICATE: 'ALLOW_DUPLICATE',
+  ALLOW_DUPLICATE_FAILED_ONLY: 'ALLOW_DUPLICATE_FAILED_ONLY',
+  REJECT_DUPLICATE: 'REJECT_DUPLICATE',
+} as const;
+export type ActivityIdReusePolicy = (typeof ActivityIdReusePolicy)[keyof typeof ActivityIdReusePolicy];
+export const [encodeActivityIdReusePolicy, decodeActivityIdReusePolicy] = makeProtoEnumConverters<
+  proto.temporal.api.enums.v1.ActivityIdReusePolicy,
+  typeof proto.temporal.api.enums.v1.ActivityIdReusePolicy,
+  keyof typeof proto.temporal.api.enums.v1.ActivityIdReusePolicy,
+  typeof ActivityIdReusePolicy,
+  'ACTIVITY_ID_REUSE_POLICY_'
+>(
+  {
+    [ActivityIdReusePolicy.ALLOW_DUPLICATE]: 1,
+    [ActivityIdReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY]: 2,
+    [ActivityIdReusePolicy.REJECT_DUPLICATE]: 3,
+    UNSPECIFIED: 0,
+  } as const,
+  'ACTIVITY_ID_REUSE_POLICY_'
+);
+
+export const ActivityIdConflictPolicy = {
+  FAIL: 'FAIL',
+  USE_EXISTING: 'USE_EXISTING',
+} as const;
+export type ActivityIdConflictPolicy = (typeof ActivityIdConflictPolicy)[keyof typeof ActivityIdConflictPolicy];
+
+export const [encodeActivityIdConflictPolicy, decodeActivityIdConflictPolicy] = makeProtoEnumConverters<
+  proto.temporal.api.enums.v1.ActivityIdConflictPolicy,
+  typeof proto.temporal.api.enums.v1.ActivityIdConflictPolicy,
+  keyof typeof proto.temporal.api.enums.v1.ActivityIdConflictPolicy,
+  typeof ActivityIdConflictPolicy,
+  'ACTIVITY_ID_CONFLICT_POLICY_'
+>(
+  {
+    [ActivityIdConflictPolicy.FAIL]: 1,
+    [ActivityIdConflictPolicy.USE_EXISTING]: 2,
+    UNSPECIFIED: 0,
+  } as const,
+  'ACTIVITY_ID_CONFLICT_POLICY_'
+);
+
+export const ActivityExecutionStatus = {
+  RUNNING: 'RUNNING',
+  COMPLETED: 'COMPLETED',
+  FAILED: 'FAILED',
+  CANCELED: 'CANCELED',
+  TERMINATED: 'TERMINATED',
+  TIMED_OUT: 'TIMED_OUT',
+} as const;
+export type ActivityExecutionStatus = (typeof ActivityExecutionStatus)[keyof typeof ActivityExecutionStatus];
+
+export const [encodeActivityExecutionStatus, decodeActivityExecutionStatus] = makeProtoEnumConverters<
+  proto.temporal.api.enums.v1.ActivityExecutionStatus,
+  typeof proto.temporal.api.enums.v1.ActivityExecutionStatus,
+  keyof typeof proto.temporal.api.enums.v1.ActivityExecutionStatus,
+  typeof ActivityExecutionStatus,
+  'ACTIVITY_EXECUTION_STATUS_'
+>(
+  {
+    [ActivityExecutionStatus.RUNNING]: 1,
+    [ActivityExecutionStatus.COMPLETED]: 2,
+    [ActivityExecutionStatus.FAILED]: 3,
+    [ActivityExecutionStatus.CANCELED]: 4,
+    [ActivityExecutionStatus.TERMINATED]: 5,
+    [ActivityExecutionStatus.TIMED_OUT]: 6,
+    UNSPECIFIED: 0,
+  } as const,
+  'ACTIVITY_EXECUTION_STATUS_'
+);
+
+export const PendingActivityState = {
+  SCHEDULED: 'SCHEDULED',
+  STARTED: 'STARTED',
+  CANCEL_REQUESTED: 'CANCEL_REQUESTED',
+  PAUSED: 'PAUSED',
+  PAUSE_REQUESTED: 'PAUSE_REQUESTED',
+} as const;
+export type PendingActivityState = (typeof PendingActivityState)[keyof typeof PendingActivityState];
+
+export const [encodePendingActivityState, decodePendingActivityState] = makeProtoEnumConverters<
+  proto.temporal.api.enums.v1.PendingActivityState,
+  typeof proto.temporal.api.enums.v1.PendingActivityState,
+  keyof typeof proto.temporal.api.enums.v1.PendingActivityState,
+  typeof PendingActivityState,
+  'PENDING_ACTIVITY_STATE_'
+>(
+  {
+    [PendingActivityState.SCHEDULED]: 1,
+    [PendingActivityState.STARTED]: 2,
+    [PendingActivityState.CANCEL_REQUESTED]: 3,
+    [PendingActivityState.PAUSED]: 4,
+    [PendingActivityState.PAUSE_REQUESTED]: 5,
+    UNSPECIFIED: 0,
+  } as const,
+  'PENDING_ACTIVITY_STATE_'
 );

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -254,7 +254,7 @@ export interface ActivityExecutionInfo {
 /**
  * Return type of {@link ActivityClient.describe}
  */
-export interface ActivityDescription extends ActivityExecutionInfo {
+export interface ActivityExecutionDescription extends ActivityExecutionInfo {
   rawInfo: RawActivityExecutionInfo;
   runState?: PendingActivityState;
   scheduleToCloseTimeoutMs?: number;

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -223,6 +223,8 @@ export const [encodeQueryRejectCondition, decodeQueryRejectCondition] = makeProt
 
 /**
  * Return type of {@link ActivityClient.count}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface CountActivityExecutions {
   readonly count: number;
@@ -232,11 +234,20 @@ export interface CountActivityExecutions {
   }[];
 }
 
+/**
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
 export type RawActivityExecutionInfo = proto.temporal.api.activity.v1.IActivityExecutionInfo;
+
+/**
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
 export type RawActivityExecutionListInfo = proto.temporal.api.activity.v1.IActivityExecutionListInfo;
 
 /**
  * Type of elements returned by {@link ActivityClient.list}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityExecutionInfo {
   rawListInfo?: RawActivityExecutionListInfo;
@@ -253,6 +264,8 @@ export interface ActivityExecutionInfo {
 
 /**
  * Return type of {@link ActivityClient.describe}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityExecutionDescription extends ActivityExecutionInfo {
   rawInfo: RawActivityExecutionInfo;
@@ -278,12 +291,21 @@ export interface ActivityExecutionDescription extends ActivityExecutionInfo {
   getLastFailure(): Promise<Error | undefined>;
 }
 
+/**
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
 export const ActivityIdReusePolicy = {
   ALLOW_DUPLICATE: 'ALLOW_DUPLICATE',
   ALLOW_DUPLICATE_FAILED_ONLY: 'ALLOW_DUPLICATE_FAILED_ONLY',
   REJECT_DUPLICATE: 'REJECT_DUPLICATE',
 } as const;
+/**
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
 export type ActivityIdReusePolicy = (typeof ActivityIdReusePolicy)[keyof typeof ActivityIdReusePolicy];
+/**
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
 export const [encodeActivityIdReusePolicy, decodeActivityIdReusePolicy] = makeProtoEnumConverters<
   proto.temporal.api.enums.v1.ActivityIdReusePolicy,
   typeof proto.temporal.api.enums.v1.ActivityIdReusePolicy,
@@ -300,12 +322,20 @@ export const [encodeActivityIdReusePolicy, decodeActivityIdReusePolicy] = makePr
   'ACTIVITY_ID_REUSE_POLICY_'
 );
 
+/**
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
 export const ActivityIdConflictPolicy = {
   FAIL: 'FAIL',
   USE_EXISTING: 'USE_EXISTING',
 } as const;
+/**
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
 export type ActivityIdConflictPolicy = (typeof ActivityIdConflictPolicy)[keyof typeof ActivityIdConflictPolicy];
-
+/**
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
 export const [encodeActivityIdConflictPolicy, decodeActivityIdConflictPolicy] = makeProtoEnumConverters<
   proto.temporal.api.enums.v1.ActivityIdConflictPolicy,
   typeof proto.temporal.api.enums.v1.ActivityIdConflictPolicy,
@@ -321,6 +351,9 @@ export const [encodeActivityIdConflictPolicy, decodeActivityIdConflictPolicy] = 
   'ACTIVITY_ID_CONFLICT_POLICY_'
 );
 
+/**
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
 export const ActivityExecutionStatus = {
   RUNNING: 'RUNNING',
   COMPLETED: 'COMPLETED',
@@ -329,8 +362,13 @@ export const ActivityExecutionStatus = {
   TERMINATED: 'TERMINATED',
   TIMED_OUT: 'TIMED_OUT',
 } as const;
+/**
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
 export type ActivityExecutionStatus = (typeof ActivityExecutionStatus)[keyof typeof ActivityExecutionStatus];
-
+/**
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
 export const [encodeActivityExecutionStatus, decodeActivityExecutionStatus] = makeProtoEnumConverters<
   proto.temporal.api.enums.v1.ActivityExecutionStatus,
   typeof proto.temporal.api.enums.v1.ActivityExecutionStatus,
@@ -350,6 +388,9 @@ export const [encodeActivityExecutionStatus, decodeActivityExecutionStatus] = ma
   'ACTIVITY_EXECUTION_STATUS_'
 );
 
+/**
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
 export const PendingActivityState = {
   SCHEDULED: 'SCHEDULED',
   STARTED: 'STARTED',
@@ -357,8 +398,13 @@ export const PendingActivityState = {
   PAUSED: 'PAUSED',
   PAUSE_REQUESTED: 'PAUSE_REQUESTED',
 } as const;
+/**
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
 export type PendingActivityState = (typeof PendingActivityState)[keyof typeof PendingActivityState];
-
+/**
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
 export const [encodePendingActivityState, decodePendingActivityState] = makeProtoEnumConverters<
   proto.temporal.api.enums.v1.PendingActivityState,
   typeof proto.temporal.api.enums.v1.PendingActivityState,

--- a/packages/common/src/activity-options.ts
+++ b/packages/common/src/activity-options.ts
@@ -77,7 +77,7 @@ export const [encodeActivityCancellationType, decodeActivityCancellationType] = 
 );
 
 /**
- * Options for remote activity invocation
+ * Options for non-local activity invocation inside a workflow
  */
 export interface ActivityOptions {
   /**

--- a/packages/common/src/worker-deployments.ts
+++ b/packages/common/src/worker-deployments.ts
@@ -1,4 +1,4 @@
-import type { temporal } from '@temporalio/proto';
+import type { coresdk, temporal } from '@temporalio/proto';
 import { makeProtoEnumConverters } from './internal-workflow';
 
 /**
@@ -98,3 +98,19 @@ export const [encodeInitialVersioningBehavior, decodeInitialVersioningBehavior] 
   } as const,
   'CONTINUE_AS_NEW_VERSIONING_BEHAVIOR_'
 );
+
+/**
+ * @internal
+ */
+export function convertDeploymentVersion(
+  v: coresdk.common.IWorkerDeploymentVersion | null | undefined
+): WorkerDeploymentVersion | undefined {
+  if (!v || !v.buildId) {
+    return undefined;
+  }
+
+  return {
+    buildId: v.buildId,
+    deploymentName: v.deploymentName ?? '',
+  };
+}

--- a/packages/core-bridge/src/metrics.rs
+++ b/packages/core-bridge/src/metrics.rs
@@ -48,7 +48,10 @@ pub fn init(cx: &mut neon::prelude::ModuleContext) -> neon::prelude::NeonResult<
     )?;
     cx.export_function("setMetricGaugeValue", set_metric_gauge_value)?;
     cx.export_function("setMetricGaugeF64Value", set_metric_gauge_f64_value)?;
-    cx.export_function("addMetricUpDownCounterValue", add_metric_up_down_counter_value)?;
+    cx.export_function(
+        "addMetricUpDownCounterValue",
+        add_metric_up_down_counter_value,
+    )?;
 
     Ok(())
 }

--- a/packages/interceptors-opentelemetry/src/worker/index.ts
+++ b/packages/interceptors-opentelemetry/src/worker/index.ts
@@ -63,9 +63,11 @@ export class OpenTelemetryActivityInboundInterceptor implements ActivityInboundC
       tracer: this.tracer,
       spanName,
       fn: (span) => {
-        span.setAttribute(WORKFLOW_ID_ATTR_KEY, this.ctx.info.workflowExecution.workflowId);
-        span.setAttribute(RUN_ID_ATTR_KEY, this.ctx.info.workflowExecution.runId);
         span.setAttribute(ACTIVITY_ID_ATTR_KEY, this.ctx.info.activityId);
+        if (this.ctx.info.inWorkflow) {
+          span.setAttribute(WORKFLOW_ID_ATTR_KEY, this.ctx.info.workflowExecution!.workflowId);
+          span.setAttribute(RUN_ID_ATTR_KEY, this.ctx.info.workflowExecution!.runId);
+        }
         return next(input);
       },
       context,

--- a/packages/test/src/activities/heartbeat-cancellation-details.ts
+++ b/packages/test/src/activities/heartbeat-cancellation-details.ts
@@ -12,18 +12,20 @@ export async function heartbeatCancellationDetailsActivity(
   state: ActivityState
 ): Promise<ActivityCancellationDetails | undefined> {
   const info = activity.activityInfo();
+  if (!info.inWorkflow && (state.pause || state.unpause || state.reset)) {
+    throw activity.ApplicationFailure.nonRetryable('Standalone activity pause and reset are not supported', 'Error');
+  }
   // Exit early if we've already run this activity.
   if (info.attempt > 1) {
     return activity.cancellationDetails();
   }
-
   // Otherwise, either pause or reset this activity (or both).
   const client = activity.getClient();
   const req = {
     namespace: client.options.namespace,
     execution: {
-      workflowId: info.workflowExecution.workflowId,
-      runId: info.workflowExecution.runId,
+      workflowId: info.workflowExecution?.workflowId,
+      runId: info.workflowExecution?.runId,
     },
     id: info.activityId,
   };

--- a/packages/test/src/activities/helpers.ts
+++ b/packages/test/src/activities/helpers.ts
@@ -4,8 +4,11 @@ import { Context } from '@temporalio/activity';
 
 function getSchedulingWorkflowHandle(): WorkflowHandle {
   const { info, client } = Context.current();
+  if (!info.inWorkflow) {
+    throw new Error('Not in workflow');
+  }
   const { workflowExecution } = info;
-  return client.workflow.getHandle(workflowExecution.workflowId, workflowExecution.runId);
+  return client.workflow.getHandle(workflowExecution!.workflowId, workflowExecution!.runId);
 }
 
 export async function signalSchedulingWorkflow(signalName: string): Promise<void> {

--- a/packages/test/src/helpers-integration.ts
+++ b/packages/test/src/helpers-integration.ts
@@ -36,6 +36,10 @@ export interface Context {
 const defaultDynamicConfigOptions = [
   'system.enableActivityEagerExecution=true',
   'history.enableRequestIdRefLinks=true',
+  'frontend.activityAPIsEnabled=true',
+  'activity.enableStandalone=true',
+  'history.enableChasm=true',
+  'history.enableTransitionHistory=true',
 ];
 
 function setupRuntime(recordedLogs?: { [workflowId: string]: LogEntry[] }, runtimeOpts?: Partial<RuntimeOptions>) {

--- a/packages/test/src/test-async-completion.ts
+++ b/packages/test/src/test-async-completion.ts
@@ -62,9 +62,9 @@ async function makeNotFoundTaskToken(conn: Connection, namespace: string): Promi
 const taskQueue = 'async-activity-completion';
 const test = anyTest as TestFn<Context>;
 
-async function activityStarted(t: ExecutionContext<Context>, workflowId: string): Promise<Info> {
+async function activityStarted(t: ExecutionContext<Context>, id: string): Promise<Info> {
   return await firstValueFrom(
-    t.context.activityStarted$.pipe(filter((info) => info.workflowExecution.workflowId === workflowId))
+    t.context.activityStarted$.pipe(filter((info) => (info.workflowExecution?.workflowId || info.activityId) === id))
   );
 }
 
@@ -284,5 +284,41 @@ if (RUN_INTEGRATION_TESTS) {
         instanceOf: ActivityNotFoundError,
       }
     );
+  });
+
+  test('Standalone activity can complete asynchronously', async (t) => {
+    const { client } = t.context;
+    const activityId = uuid4();
+    const handle = await client.activity.start('completeAsync', {
+      args: [false],
+      id: activityId,
+      taskQueue,
+      scheduleToCloseTimeout: '1 minute',
+      retry: {
+        maximumAttempts: 1,
+      },
+    });
+
+    const info = await activityStarted(t, activityId);
+    await client.activity.complete(info.taskToken, 'success');
+    t.is(await handle.result(), 'success');
+  });
+
+  test('Standalone activity can complete asynchronously by ID', async (t) => {
+    const { client } = t.context;
+    const activityId = uuid4();
+    const handle = await client.activity.start('completeAsync', {
+      args: [false],
+      id: activityId,
+      taskQueue,
+      scheduleToCloseTimeout: '1 minutes',
+      retry: {
+        maximumAttempts: 1,
+      },
+    });
+
+    const info = await activityStarted(t, activityId);
+    await client.activity.complete({ activityId, runId: info.activityRunId }, 'success');
+    t.is(await handle.result(), 'success');
   });
 }

--- a/packages/test/src/test-otel.ts
+++ b/packages/test/src/test-otel.ts
@@ -601,7 +601,9 @@ if (RUN_INTEGRATION_TESTS) {
         taskQueue,
         workflowId,
       });
-      const info = await firstValueFrom(infoSubject.pipe(filter((i) => i.workflowExecution.workflowId === workflowId)));
+      const info = await firstValueFrom(
+        infoSubject.pipe(filter((i) => i.workflowExecution?.workflowId === workflowId))
+      );
       await client.activity.complete(info.taskToken, 'async-result');
       t.is(await handle.result(), 'async-result');
     });

--- a/packages/test/src/test-standalone-activities.ts
+++ b/packages/test/src/test-standalone-activities.ts
@@ -1,11 +1,11 @@
 import { v4 as uuid4 } from 'uuid';
 import type { TestFn } from 'ava';
 import anyTest from 'ava';
-import { Client, Connection, TerminatedFailure } from '@temporalio/client';
+import type { ActivityHandle, TypedActivityClient } from '@temporalio/client';
+import { ActivityExecutionFailedError, Client, Connection, TerminatedFailure } from '@temporalio/client';
 import type { Duration } from '@temporalio/common';
 import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
 import type { ActivityOptions } from '@temporalio/client/lib/activity-client';
-import { ActivityExecutionFailedError } from '@temporalio/client/lib/activity-client';
 import { activityInfo } from '@temporalio/activity';
 import { RUN_INTEGRATION_TESTS, waitUntil, Worker } from './helpers';
 import { echo, throwAnError } from './activities';
@@ -41,6 +41,14 @@ const activities = {
     }
   },
 };
+
+interface ActivityInterface {
+  noArgsReturnsVoid: () => Promise<void>;
+  numberArgReturnsVoid: (a: number) => Promise<void>;
+  stringAndNumberArgsReturnsVoid: (a: string, b: number) => Promise<void>;
+  noArgsReturnsNumber: () => Promise<number>;
+  numberArgReturnsNumber: (a: number) => Promise<number>;
+}
 
 const taskQueue = 'standalone-activities';
 const defaultOptions: Omit<ActivityOptions, 'id' | 'args'> = {
@@ -319,5 +327,235 @@ if (RUN_INTEGRATION_TESTS) {
         id: uuid4(),
       })
     );
+  });
+
+  test('Typed client - start activity', async (t) => {
+    const client = t.context.client.activity.typedClient<typeof activities>();
+    const activityId = uuid4();
+    const handle = await client.start('echo', {
+      ...defaultOptions,
+      id: activityId,
+      args: ['hello'],
+    });
+    t.is(await handle.result(), 'hello');
+  });
+
+  test('Typed client - execute activity', async (t) => {
+    const client = t.context.client.activity.typedClient<typeof activities>();
+    const activityId = uuid4();
+    const result = await client.execute('echo', {
+      ...defaultOptions,
+      id: activityId,
+      args: ['hello'],
+    });
+    t.is(result, 'hello');
+  });
+
+  test('Typed client - type safety', async (t) => {
+    const options = {
+      ...defaultOptions,
+      id: 'ACTIVITY_ID',
+    };
+
+    const _ = async (client: TypedActivityClient<ActivityInterface>) => {
+      // eslint-disable @typescript-eslint/no-unused-vars
+      {
+        // OK
+        let handle: ActivityHandle<void> = await client.start('noArgsReturnsVoid', { ...options });
+        let result: void = await handle.result();
+        handle = await client.start('noArgsReturnsVoid', { ...options });
+        handle = await client.start('noArgsReturnsVoid', { ...options, args: undefined });
+        handle = await client.start('noArgsReturnsVoid', { ...options, args: [] });
+        result = await client.execute('noArgsReturnsVoid', { ...options });
+        result = await client.execute('noArgsReturnsVoid', { ...options, args: undefined });
+        result = await client.execute('noArgsReturnsVoid', { ...options, args: [] });
+      }
+      {
+        const handle: ActivityHandle<void> = await client.start('noArgsReturnsVoid', {
+          ...options,
+          args: [
+            // @ts-expect-error TS2322
+            1,
+          ],
+        });
+        const result: void = await client.execute('noArgsReturnsVoid', {
+          ...options,
+          args: [
+            // @ts-expect-error TS2322
+            1,
+          ],
+        });
+      }
+      {
+        const // @ts-expect-error TS2322
+          handle // end error
+          : ActivityHandle<number> = await client.start('noArgsReturnsVoid', { ...options });
+
+        const // @ts-expect-error TS2322
+          result // end error
+          : number = await client.execute('noArgsReturnsVoid', { ...options });
+      }
+      {
+        // OK
+        let handle: ActivityHandle<number> = await client.start('noArgsReturnsNumber', { ...options });
+        let result: number = await handle.result();
+        handle = await client.start('noArgsReturnsNumber', { ...options });
+        handle = await client.start('noArgsReturnsNumber', { ...options, args: undefined });
+        handle = await client.start('noArgsReturnsNumber', { ...options, args: [] });
+        result = await client.execute('noArgsReturnsNumber', { ...options });
+        result = await client.execute('noArgsReturnsNumber', { ...options, args: undefined });
+        result = await client.execute('noArgsReturnsNumber', { ...options, args: [] });
+      }
+      {
+        const // @ts-expect-error TS2322
+          handle // end error
+          : ActivityHandle<void> = await client.start('noArgsReturnsNumber', { ...options });
+
+        const // @ts-expect-error TS2322
+          result // end error
+          : void = await client.execute('noArgsReturnsNumber', { ...options });
+      }
+      {
+        const // @ts-expect-error TS2322
+          handle // end error
+          : ActivityHandle<string> = await client.start('noArgsReturnsNumber', { ...options });
+
+        const // @ts-expect-error TS2322
+          result // end error
+          : string = await client.execute('noArgsReturnsNumber', { ...options });
+      }
+      {
+        // OK
+        const handle: ActivityHandle<number> = await client.start('numberArgReturnsNumber', { ...options, args: [1] });
+        let result: number = await handle.result();
+        result = await client.execute('numberArgReturnsNumber', { ...options, args: [1] });
+      }
+      {
+        let handle: ActivityHandle<number> = await client.start('numberArgReturnsNumber', {
+          ...options,
+          args: [
+            // @ts-expect-error TS2322
+            'a',
+          ],
+        });
+        handle = await client.start('numberArgReturnsNumber', {
+          ...options,
+          // @ts-expect-error TS2322
+          args: [1, 2],
+        });
+        handle = await client.start('numberArgReturnsNumber', {
+          ...options,
+          // @ts-expect-error TS2322
+          args: [],
+        });
+        handle = await client.start('numberArgReturnsNumber', {
+          ...options,
+          // @ts-expect-error TS2322
+          args: undefined,
+        });
+        handle = await client.start(
+          'numberArgReturnsNumber',
+          // @ts-expect-error TS2322
+          {
+            ...options,
+          }
+        );
+        let result: number = await client.execute('numberArgReturnsNumber', {
+          ...options,
+          args: [
+            // @ts-expect-error TS2322
+            'a',
+          ],
+        });
+        result = await client.execute('numberArgReturnsNumber', {
+          ...options,
+          // @ts-expect-error TS2322
+          args: [1, 2],
+        });
+        result = await client.execute('numberArgReturnsNumber', {
+          ...options,
+          // @ts-expect-error TS2322
+          args: [],
+        });
+        result = await client.execute('numberArgReturnsNumber', {
+          ...options,
+          // @ts-expect-error TS2322
+          args: undefined,
+        });
+        result = await client.execute(
+          'numberArgReturnsNumber',
+          // @ts-expect-error TS2322
+          {
+            ...options,
+          }
+        );
+      }
+      {
+        // OK
+        const handle: ActivityHandle<void> = await client.start('stringAndNumberArgsReturnsVoid', {
+          ...options,
+          args: ['a', 1],
+        });
+        let result: void = await handle.result();
+        result = await client.execute('stringAndNumberArgsReturnsVoid', { ...options, args: ['a', 1] });
+      }
+      {
+        let handle: ActivityHandle<void> = await client.start('stringAndNumberArgsReturnsVoid', {
+          ...options,
+          args: [
+            'a',
+            // @ts-expect-error TS2322
+            'b',
+          ],
+        });
+        handle = await client.start('stringAndNumberArgsReturnsVoid', {
+          ...options,
+          args: [
+            // @ts-expect-error TS2322
+            1,
+            // end error
+            2,
+          ],
+        });
+        handle = await client.start('stringAndNumberArgsReturnsVoid', {
+          ...options,
+          args: [
+            // @ts-expect-error TS2322
+            1,
+            // @ts-expect-error TS2322
+            'a',
+          ],
+        });
+        let result: void = await client.execute('stringAndNumberArgsReturnsVoid', {
+          ...options,
+          args: [
+            'a',
+            // @ts-expect-error TS2322
+            'b',
+          ],
+        });
+        result = await client.execute('stringAndNumberArgsReturnsVoid', {
+          ...options,
+          args: [
+            // @ts-expect-error TS2322
+            1,
+            // end error
+            2,
+          ],
+        });
+        result = await client.execute('stringAndNumberArgsReturnsVoid', {
+          ...options,
+          args: [
+            // @ts-expect-error TS2322
+            1,
+            // @ts-expect-error TS2322
+            'a',
+          ],
+        });
+      }
+      // eslint-enable @typescript-eslint/no-unused-vars
+    };
+
+    t.pass();
   });
 }

--- a/packages/test/src/test-standalone-activities.ts
+++ b/packages/test/src/test-standalone-activities.ts
@@ -118,6 +118,7 @@ if (RUN_INTEGRATION_TESTS) {
 
   test.after.always(async (t) => {
     t.context.worker.shutdown();
+    await t.context.env.teardown();
     await t.context.runPromise;
   });
 

--- a/packages/test/src/test-standalone-activities.ts
+++ b/packages/test/src/test-standalone-activities.ts
@@ -2,17 +2,13 @@ import { v4 as uuid4 } from 'uuid';
 import type { TestFn } from 'ava';
 import anyTest from 'ava';
 import * as rxjs from 'rxjs';
-import {
-  ActivityHandle,
-  TypedActivityClient,
-  ActivityOptions,
-  ServiceError,
-  isGrpcCancelledError,
-} from '@temporalio/client';
+import type { ActivityHandle, TypedActivityClient, ActivityOptions } from '@temporalio/client';
 import {
   ActivityExecutionAlreadyStartedError,
   ActivityExecutionFailedError,
+  ServiceError,
   TerminatedFailure,
+  isGrpcCancelledError,
 } from '@temporalio/client';
 import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
 import { activityInfo, heartbeat } from '@temporalio/activity';

--- a/packages/test/src/test-standalone-activities.ts
+++ b/packages/test/src/test-standalone-activities.ts
@@ -1,0 +1,323 @@
+import { v4 as uuid4 } from 'uuid';
+import type { TestFn } from 'ava';
+import anyTest from 'ava';
+import { Client, Connection, TerminatedFailure } from '@temporalio/client';
+import type { Duration } from '@temporalio/common';
+import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
+import type { ActivityOptions } from '@temporalio/client/lib/activity-client';
+import { ActivityExecutionFailedError } from '@temporalio/client/lib/activity-client';
+import { activityInfo } from '@temporalio/activity';
+import { RUN_INTEGRATION_TESTS, waitUntil, Worker } from './helpers';
+import { echo, throwAnError } from './activities';
+import { heartbeatCancellationDetailsActivity } from './activities/heartbeat-cancellation-details';
+
+export interface Context {
+  worker: Worker;
+  client: Client;
+  runPromise: Promise<void>;
+}
+
+const activities = {
+  echo,
+  throwAnError,
+  heartbeatCancellationDetailsActivity,
+  verifyStandaloneActivityInfo: async () => {
+    const info = activityInfo();
+    if (info.inWorkflow) {
+      throw ApplicationFailure.nonRetryable('Expected inWorkflow to be false');
+    }
+    if (!info.activityRunId || info.activityRunId.length === 0) {
+      throw ApplicationFailure.nonRetryable('Expected non-empty activityRunId');
+    }
+    if (info.workflowExecution !== undefined) {
+      throw ApplicationFailure.nonRetryable('Expected workflowExecution to be unset');
+    }
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    if (info.workflowNamespace !== undefined) {
+      throw ApplicationFailure.nonRetryable('Expected workflowNamespace to be unset');
+    }
+    if (info.workflowType !== undefined) {
+      throw ApplicationFailure.nonRetryable('Expected workflowNamespace to be unset');
+    }
+  },
+};
+
+const taskQueue = 'standalone-activities';
+const defaultOptions: Omit<ActivityOptions, 'id' | 'args'> = {
+  taskQueue,
+  scheduleToCloseTimeout: '1 minute' as Duration,
+  idReusePolicy: 'ALLOW_DUPLICATE',
+};
+
+const test = anyTest as TestFn<Context>;
+
+if (RUN_INTEGRATION_TESTS) {
+  test.before(async (t) => {
+    const worker = await Worker.create({
+      activities,
+      taskQueue,
+    });
+    const runPromise = worker.run();
+    // Catch the error here to avoid unhandled rejection
+    runPromise.catch((err) => {
+      console.error('Caught error while worker was running', err);
+    });
+    const connection = await Connection.connect();
+    t.context = {
+      worker,
+      runPromise,
+      client: new Client({ connection }),
+    };
+  });
+
+  test.after.always(async (t) => {
+    t.context.worker.shutdown();
+    await t.context.runPromise;
+  });
+
+  test('Get activity result - success', async (t) => {
+    const { client } = t.context;
+    const activityId = uuid4();
+    const handle = await client.activity.start('echo', {
+      ...defaultOptions,
+      id: activityId,
+      args: ['hello'],
+    });
+    t.is(await handle.result(), 'hello');
+  });
+
+  test('Get activity result - failure', async (t) => {
+    const { client } = t.context;
+    const activityId = uuid4();
+    const handle = await client.activity.start('throwAnError', {
+      ...defaultOptions,
+      id: activityId,
+      args: [true, 'failure'],
+    });
+    const err = await t.throwsAsync(() => handle.result(), { instanceOf: ActivityExecutionFailedError });
+    t.truthy(err);
+    t.assert(err!.cause instanceof ApplicationFailure);
+    t.is(err!.cause!.message, 'failure');
+  });
+
+  test('Execute activity - success', async (t) => {
+    const { client } = t.context;
+    const activityId = uuid4();
+    const result = await client.activity.execute('echo', {
+      ...defaultOptions,
+      id: activityId,
+      args: ['hello'],
+    });
+    t.is(result, 'hello');
+  });
+
+  test('Execute activity - failure', async (t) => {
+    const { client } = t.context;
+    const activityId = uuid4();
+    const err = await t.throwsAsync(
+      () =>
+        client.activity.execute('throwAnError', {
+          ...defaultOptions,
+          id: activityId,
+          args: [true, 'failure'],
+        }),
+      { instanceOf: ActivityExecutionFailedError }
+    );
+    t.assert(err?.cause instanceof ApplicationFailure);
+    t.is(err?.cause?.message, 'failure');
+  });
+
+  test('Describe activity from start handle', async (t) => {
+    const { client } = t.context;
+    const activityId = uuid4();
+    const handle = await client.activity.start('echo', {
+      ...defaultOptions,
+      id: activityId,
+      args: ['hello'],
+    });
+    t.truthy(handle.runId);
+    await handle.result();
+
+    t.like(await handle.describe(), {
+      activityId,
+      activityRunId: handle.runId,
+      activityType: 'echo',
+      attempt: 1,
+      status: 'COMPLETED',
+      taskQueue,
+    });
+  });
+
+  test('Describe activity from ID handle', async (t) => {
+    const { client } = t.context;
+    const activityId = uuid4();
+
+    const firstHandle = await client.activity.start('echo', {
+      ...defaultOptions,
+      id: activityId,
+      args: ['hello'],
+    });
+    t.truthy(firstHandle.runId);
+    await firstHandle.result();
+
+    const secondHandle = await client.activity.start('echo', {
+      ...defaultOptions,
+      id: activityId,
+      args: ['hello'],
+    });
+    t.truthy(firstHandle.runId);
+    t.assert(firstHandle.runId !== secondHandle.runId);
+    await secondHandle.result();
+
+    t.like(await client.activity.getHandle(activityId).describe(), {
+      activityId,
+      activityRunId: secondHandle.runId,
+      activityType: 'echo',
+      attempt: 1,
+      status: 'COMPLETED',
+      taskQueue,
+    });
+  });
+
+  test('Describe activity from ID and run ID handle', async (t) => {
+    const { client } = t.context;
+    const activityId = uuid4();
+
+    const firstHandle = await client.activity.start('echo', {
+      ...defaultOptions,
+      id: activityId,
+      args: ['hello'],
+    });
+    t.truthy(firstHandle.runId);
+    await firstHandle.result();
+
+    const secondHandle = await client.activity.start('echo', {
+      ...defaultOptions,
+      id: activityId,
+      args: ['hello'],
+    });
+    t.truthy(firstHandle.runId);
+    t.assert(firstHandle.runId !== secondHandle.runId);
+    await secondHandle.result();
+
+    t.like(await client.activity.getHandle(activityId, firstHandle.runId).describe(), {
+      activityId,
+      activityRunId: firstHandle.runId,
+      activityType: 'echo',
+      attempt: 1,
+      status: 'COMPLETED',
+      taskQueue,
+    });
+  });
+
+  test('Cancel activity', async (t) => {
+    const { client } = t.context;
+    const activityId = uuid4();
+    const handle = await client.activity.start('heartbeatCancellationDetailsActivity', {
+      ...defaultOptions,
+      id: activityId,
+      args: [{ shouldRetry: true }],
+    });
+    await handle.cancel('test cancellation');
+
+    const err: any = await t.throwsAsync(() => handle.result(), { instanceOf: ActivityExecutionFailedError });
+    t.assert(err?.cause instanceof CancelledFailure);
+
+    const description = await handle.describe();
+    t.is(description.status, 'CANCELED');
+    t.is(description.canceledReason, 'test cancellation');
+  });
+
+  test('Terminate activity', async (t) => {
+    const { client } = t.context;
+    const activityId = uuid4();
+    const handle = await client.activity.start('heartbeatCancellationDetailsActivity', {
+      ...defaultOptions,
+      id: activityId,
+      args: [{ shouldRetry: true }],
+    });
+    await handle.terminate('test termination');
+
+    const err: any = await t.throwsAsync(() => handle.result(), { instanceOf: ActivityExecutionFailedError });
+    t.assert(err?.cause instanceof TerminatedFailure);
+    t.is(err?.cause?.message, 'test termination');
+
+    const description = await handle.describe();
+    t.is(description.status, 'TERMINATED');
+  });
+
+  async function runThreeActivities(client: Client) {
+    const firstAndSecondActivityId = uuid4();
+    const firstHandle = await client.activity.start('echo', {
+      ...defaultOptions,
+      id: firstAndSecondActivityId,
+      args: ['hello'],
+    });
+    await firstHandle.result();
+
+    const secondHandle = await client.activity.start('echo', {
+      ...defaultOptions,
+      id: firstAndSecondActivityId,
+      args: ['hello'],
+    });
+    await secondHandle.result();
+
+    const thirdActivityId = uuid4();
+    const thirdHandle = await client.activity.start('echo', {
+      ...defaultOptions,
+      id: thirdActivityId,
+      args: ['hello'],
+    });
+    await thirdHandle.result();
+
+    return {
+      firstAndSecondActivityId,
+      thirdActivityId,
+      firstRunId: firstHandle.runId,
+      secondRunId: secondHandle.runId,
+      thirdRunId: thirdHandle.runId,
+    };
+  }
+
+  test('Count and list activities', async (t) => {
+    const { client } = t.context;
+
+    const ids = await runThreeActivities(client);
+    const query = `ActivityId='${ids.firstAndSecondActivityId}' OR ActivityId='${ids.thirdActivityId}'`;
+
+    // Visibility has update delay, repeating query until the activity count is as expected
+    await waitUntil(async () => {
+      const count = await client.activity.count(query);
+      return count.count === 3;
+    }, 10000);
+
+    const isListed = {
+      [ids.firstAndSecondActivityId + ids.firstRunId]: false,
+      [ids.firstAndSecondActivityId + ids.secondRunId]: false,
+      [ids.thirdActivityId + ids.thirdRunId]: false,
+    };
+
+    for await (const info of client.activity.list(query)) {
+      t.is(info.activityType, 'echo');
+      t.is(info.taskQueue, taskQueue);
+
+      const id = info.activityId + info.activityRunId;
+      t.false(isListed[id]);
+      isListed[id] = true;
+    }
+
+    for (const id in isListed) {
+      t.true(isListed[id]);
+    }
+  });
+
+  test('Verify standalone activity info', async (t) => {
+    const { client } = t.context;
+    await t.notThrowsAsync(() =>
+      client.activity.execute('verifyStandaloneActivityInfo', {
+        ...defaultOptions,
+        id: uuid4(),
+      })
+    );
+  });
+}

--- a/packages/test/src/test-standalone-activities.ts
+++ b/packages/test/src/test-standalone-activities.ts
@@ -1,26 +1,37 @@
 import { v4 as uuid4 } from 'uuid';
 import type { TestFn } from 'ava';
 import anyTest from 'ava';
-import type { ActivityHandle, TypedActivityClient } from '@temporalio/client';
+import * as rxjs from 'rxjs';
+import {
+  ActivityHandle,
+  TypedActivityClient,
+  ActivityOptions,
+  ServiceError,
+  isGrpcCancelledError,
+} from '@temporalio/client';
 import {
   ActivityExecutionAlreadyStartedError,
   ActivityExecutionFailedError,
-  Client,
-  Connection,
   TerminatedFailure,
 } from '@temporalio/client';
-import type { Duration } from '@temporalio/common';
 import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
-import type { ActivityOptions } from '@temporalio/client/lib/activity-client';
-import { activityInfo } from '@temporalio/activity';
+import { activityInfo, heartbeat } from '@temporalio/activity';
+import type { TestWorkflowEnvironment } from './helpers';
 import { RUN_INTEGRATION_TESTS, waitUntil, Worker } from './helpers';
 import { echo, throwAnError } from './activities';
 import { heartbeatCancellationDetailsActivity } from './activities/heartbeat-cancellation-details';
+import { createLocalTestEnvironment } from './helpers-integration';
+
+// Use a reduced server long-poll expiration timeout, in order to confirm that client
+// polling/retry strategies result in the expected behavior
+const LONG_POLL_TIMEOUT_MS = 5000;
 
 export interface Context {
+  env: TestWorkflowEnvironment;
   worker: Worker;
-  client: Client;
   runPromise: Promise<void>;
+  activityStartedSubject: rxjs.Subject<string>;
+  activitySignalSubject: rxjs.Subject<string>;
 }
 
 const activities = {
@@ -59,28 +70,53 @@ interface ActivityInterface {
 const taskQueue = 'standalone-activities';
 const defaultOptions: Omit<ActivityOptions, 'id' | 'args'> = {
   taskQueue,
-  scheduleToCloseTimeout: '1 minute' as Duration,
+  scheduleToCloseTimeout: '1 minute',
   idReusePolicy: 'ALLOW_DUPLICATE',
 };
 
 const test = anyTest as TestFn<Context>;
 
+async function waitForValue<T>(subject: rxjs.Subject<T>, value: T) {
+  await rxjs.firstValueFrom(subject.pipe(rxjs.first((v) => v === value)));
+}
+
 if (RUN_INTEGRATION_TESTS) {
   test.before(async (t) => {
-    const worker = await Worker.create({
-      activities,
-      taskQueue,
+    const env = await createLocalTestEnvironment({
+      server: {
+        extraArgs: ['--dynamic-config-value', `activity.longPollTimeout="${LONG_POLL_TIMEOUT_MS}ms"`],
+      },
     });
+
+    const activityStartedSubject = new rxjs.Subject<string>();
+    const activitySignalSubject = new rxjs.Subject<string>();
+
+    const worker = await Worker.create({
+      activities: {
+        ...activities,
+        waitForSignal: async () => {
+          const activityId = activityInfo().activityId;
+          const wait = waitForValue(activitySignalSubject, activityId);
+          activityStartedSubject.next(activityId);
+          await wait;
+        },
+      },
+      taskQueue,
+      connection: env.nativeConnection,
+    });
+
     const runPromise = worker.run();
     // Catch the error here to avoid unhandled rejection
     runPromise.catch((err) => {
       console.error('Caught error while worker was running', err);
     });
-    const connection = await Connection.connect();
+
     t.context = {
+      env,
       worker,
       runPromise,
-      client: new Client({ connection }),
+      activityStartedSubject,
+      activitySignalSubject,
     };
   });
 
@@ -90,20 +126,22 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Get activity result - success', async (t) => {
-    const { client } = t.context;
+    const client = t.context.env.client.activity;
     const activityId = uuid4();
-    const handle = await client.activity.start('echo', {
+    const handle = await client.start('echo', {
       ...defaultOptions,
       id: activityId,
       args: ['hello'],
     });
     t.is(await handle.result(), 'hello');
+    t.is(await client.getHandle(activityId).result(), 'hello');
+    t.is(await client.getHandle(activityId, handle.runId).result(), 'hello');
   });
 
   test('Get activity result - failure', async (t) => {
-    const { client } = t.context;
+    const client = t.context.env.client.activity;
     const activityId = uuid4();
-    const handle = await client.activity.start('throwAnError', {
+    const handle = await client.start('throwAnError', {
       ...defaultOptions,
       id: activityId,
       args: [true, 'failure'],
@@ -114,9 +152,9 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Execute activity - success', async (t) => {
-    const { client } = t.context;
+    const client = t.context.env.client.activity;
     const activityId = uuid4();
-    const result = await client.activity.execute('echo', {
+    const result = await client.execute('echo', {
       ...defaultOptions,
       id: activityId,
       args: ['hello'],
@@ -125,11 +163,11 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Execute activity - failure', async (t) => {
-    const { client } = t.context;
+    const client = t.context.env.client.activity;
     const activityId = uuid4();
     const err = await t.throwsAsync(
       () =>
-        client.activity.execute('throwAnError', {
+        client.execute('throwAnError', {
           ...defaultOptions,
           id: activityId,
           args: [true, 'failure'],
@@ -141,9 +179,9 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Describe activity from start handle', async (t) => {
-    const { client } = t.context;
+    const client = t.context.env.client.activity;
     const activityId = uuid4();
-    const handle = await client.activity.start('echo', {
+    const handle = await client.start('echo', {
       ...defaultOptions,
       id: activityId,
       args: ['hello'],
@@ -162,10 +200,10 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Describe activity from ID handle', async (t) => {
-    const { client } = t.context;
+    const client = t.context.env.client.activity;
     const activityId = uuid4();
 
-    const firstHandle = await client.activity.start('echo', {
+    const firstHandle = await client.start('echo', {
       ...defaultOptions,
       id: activityId,
       args: ['hello'],
@@ -173,7 +211,7 @@ if (RUN_INTEGRATION_TESTS) {
     t.truthy(firstHandle.runId);
     await firstHandle.result();
 
-    const secondHandle = await client.activity.start('echo', {
+    const secondHandle = await client.start('echo', {
       ...defaultOptions,
       id: activityId,
       args: ['hello'],
@@ -182,7 +220,7 @@ if (RUN_INTEGRATION_TESTS) {
     t.assert(firstHandle.runId !== secondHandle.runId);
     await secondHandle.result();
 
-    t.like(await client.activity.getHandle(activityId).describe(), {
+    t.like(await client.getHandle(activityId).describe(), {
       activityId,
       activityRunId: secondHandle.runId,
       activityType: 'echo',
@@ -193,10 +231,10 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Describe activity from ID and run ID handle', async (t) => {
-    const { client } = t.context;
+    const client = t.context.env.client.activity;
     const activityId = uuid4();
 
-    const firstHandle = await client.activity.start('echo', {
+    const firstHandle = await client.start('echo', {
       ...defaultOptions,
       id: activityId,
       args: ['hello'],
@@ -204,7 +242,7 @@ if (RUN_INTEGRATION_TESTS) {
     t.truthy(firstHandle.runId);
     await firstHandle.result();
 
-    const secondHandle = await client.activity.start('echo', {
+    const secondHandle = await client.start('echo', {
       ...defaultOptions,
       id: activityId,
       args: ['hello'],
@@ -213,7 +251,7 @@ if (RUN_INTEGRATION_TESTS) {
     t.assert(firstHandle.runId !== secondHandle.runId);
     await secondHandle.result();
 
-    t.like(await client.activity.getHandle(activityId, firstHandle.runId).describe(), {
+    t.like(await client.getHandle(activityId, firstHandle.runId).describe(), {
       activityId,
       activityRunId: firstHandle.runId,
       activityType: 'echo',
@@ -224,9 +262,9 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Cancel activity', async (t) => {
-    const { client } = t.context;
+    const client = t.context.env.client.activity;
     const activityId = uuid4();
-    const handle = await client.activity.start('heartbeatCancellationDetailsActivity', {
+    const handle = await client.start('heartbeatCancellationDetailsActivity', {
       ...defaultOptions,
       id: activityId,
       args: [{ shouldRetry: true }],
@@ -242,9 +280,9 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Terminate activity', async (t) => {
-    const { client } = t.context;
+    const client = t.context.env.client.activity;
     const activityId = uuid4();
-    const handle = await client.activity.start('heartbeatCancellationDetailsActivity', {
+    const handle = await client.start('heartbeatCancellationDetailsActivity', {
       ...defaultOptions,
       id: activityId,
       args: [{ shouldRetry: true }],
@@ -260,17 +298,17 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Count and list activities', async (t) => {
-    const { client } = t.context;
+    const client = t.context.env.client.activity;
 
     const firstAndSecondActivityId = uuid4();
-    const firstHandle = await client.activity.start('echo', {
+    const firstHandle = await client.start('echo', {
       ...defaultOptions,
       id: firstAndSecondActivityId,
       args: ['hello'],
     });
     await firstHandle.result();
 
-    const secondHandle = await client.activity.start('echo', {
+    const secondHandle = await client.start('echo', {
       ...defaultOptions,
       id: firstAndSecondActivityId,
       args: ['hello'],
@@ -278,7 +316,7 @@ if (RUN_INTEGRATION_TESTS) {
     await secondHandle.result();
 
     const thirdActivityId = uuid4();
-    const thirdHandle = await client.activity.start('echo', {
+    const thirdHandle = await client.start('echo', {
       ...defaultOptions,
       id: thirdActivityId,
       args: ['hello'],
@@ -289,7 +327,7 @@ if (RUN_INTEGRATION_TESTS) {
 
     // Visibility has update delay, repeating query until the activity count is as expected
     await waitUntil(async () => {
-      const count = await client.activity.count(query);
+      const count = await client.count(query);
       return count.count === 3;
     }, 10000);
 
@@ -299,7 +337,7 @@ if (RUN_INTEGRATION_TESTS) {
       [thirdActivityId + thirdHandle.runId]: false,
     };
 
-    for await (const info of client.activity.list(query)) {
+    for await (const info of client.list(query)) {
       t.is(info.activityType, 'echo');
       t.is(info.taskQueue, taskQueue);
 
@@ -314,9 +352,9 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Verify standalone activity info', async (t) => {
-    const { client } = t.context;
+    const client = t.context.env.client.activity;
     await t.notThrowsAsync(() =>
-      client.activity.execute('verifyStandaloneActivityInfo', {
+      client.execute('verifyStandaloneActivityInfo', {
         ...defaultOptions,
         id: uuid4(),
       })
@@ -324,47 +362,78 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Throws ActivityExecutionAlreadyExistsError on ID conflict', async (t) => {
-    const { client } = t.context;
+    const client = t.context.env.client.activity;
     const activityId = uuid4();
     const options: ActivityOptions = {
       ...defaultOptions,
       id: activityId,
-      args: [{}],
       idConflictPolicy: 'FAIL',
     };
 
-    const handle = await client.activity.start('heartbeatCancellationDetailsActivity', options);
-    const err = await t.throwsAsync(() => client.activity.start('heartbeatCancellationDetailsActivity', options), {
+    const activityStarted = waitForValue(t.context.activityStartedSubject, activityId);
+    const handle = await client.start('waitForSignal', options);
+    await activityStarted;
+
+    const err = await t.throwsAsync(() => client.start('waitForSignal', options), {
       instanceOf: ActivityExecutionAlreadyStartedError,
     });
     t.is(err?.activityId, activityId);
     t.is(err?.runId, handle.runId);
 
-    // stop the activity
-    await handle.cancel('test cleanup');
+    t.context.activitySignalSubject.next(activityId);
+    await handle.result();
   });
 
   test('Throws ActivityExecutionAlreadyExistsError on ID reuse', async (t) => {
-    const { client } = t.context;
+    const client = t.context.env.client.activity;
     const activityId = uuid4();
     const options: ActivityOptions = {
       ...defaultOptions,
       id: activityId,
-      args: [{}],
+      args: ['hello'],
       idReusePolicy: 'REJECT_DUPLICATE',
     };
 
-    const handle = await client.activity.start('echo', options);
+    const handle = await client.start('echo', options);
     await handle.result();
-    const err = await t.throwsAsync(() => client.activity.start('echo', options), {
+    const err = await t.throwsAsync(() => client.start('echo', options), {
       instanceOf: ActivityExecutionAlreadyStartedError,
     });
     t.is(err?.activityId, activityId);
     t.is(err?.runId, handle.runId);
   });
 
+  test('Wait for result longer than server long poll timeout', async (t) => {
+    const client = t.context.env.client.activity;
+    const activityId = uuid4();
+    const handle = await client.start('waitForSignal', {
+      ...defaultOptions,
+      id: activityId,
+    });
+    const resultPromise = handle.result();
+    setTimeout(() => t.context.activitySignalSubject.next(activityId), LONG_POLL_TIMEOUT_MS * 1.5);
+    await resultPromise;
+    t.pass();
+  });
+
+  test('Cancel waiting for result', async (t) => {
+    const client = t.context.env.client.activity;
+    const activityId = uuid4();
+    const handle = await client.start('waitForSignal', {
+      ...defaultOptions,
+      id: activityId,
+      scheduleToCloseTimeout: '5s'
+    });
+    const abortController = new AbortController();
+    const resultPromise = client.withAbortSignal(abortController.signal, () => handle.result());
+    setTimeout(() => abortController.abort(), LONG_POLL_TIMEOUT_MS * 0.25);
+    const err = await t.throwsAsync(() => resultPromise, { instanceOf: ServiceError, });
+    t.assert(isGrpcCancelledError(err));
+    t.context.activitySignalSubject.next(activityId);
+  });
+
   test('Typed client - start activity', async (t) => {
-    const client = t.context.client.activity.typedClient<typeof activities>();
+    const client = t.context.env.client.activity.typed<typeof activities>();
     const activityId = uuid4();
     const handle = await client.start('echo', {
       ...defaultOptions,
@@ -375,7 +444,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Typed client - execute activity', async (t) => {
-    const client = t.context.client.activity.typedClient<typeof activities>();
+    const client = t.context.env.client.activity.typed<typeof activities>();
     const activityId = uuid4();
     const result = await client.execute('echo', {
       ...defaultOptions,

--- a/packages/test/src/test-standalone-activities.ts
+++ b/packages/test/src/test-standalone-activities.ts
@@ -422,12 +422,12 @@ if (RUN_INTEGRATION_TESTS) {
     const handle = await client.start('waitForSignal', {
       ...defaultOptions,
       id: activityId,
-      scheduleToCloseTimeout: '5s'
+      scheduleToCloseTimeout: '5s',
     });
     const abortController = new AbortController();
     const resultPromise = client.withAbortSignal(abortController.signal, () => handle.result());
     setTimeout(() => abortController.abort(), LONG_POLL_TIMEOUT_MS * 0.25);
-    const err = await t.throwsAsync(() => resultPromise, { instanceOf: ServiceError, });
+    const err = await t.throwsAsync(() => resultPromise, { instanceOf: ServiceError });
     t.assert(isGrpcCancelledError(err));
     t.context.activitySignalSubject.next(activityId);
   });

--- a/packages/test/src/test-standalone-activities.ts
+++ b/packages/test/src/test-standalone-activities.ts
@@ -2,7 +2,13 @@ import { v4 as uuid4 } from 'uuid';
 import type { TestFn } from 'ava';
 import anyTest from 'ava';
 import type { ActivityHandle, TypedActivityClient } from '@temporalio/client';
-import { ActivityExecutionFailedError, Client, Connection, TerminatedFailure } from '@temporalio/client';
+import {
+  ActivityExecutionAlreadyStartedError,
+  ActivityExecutionFailedError,
+  Client,
+  Connection,
+  TerminatedFailure,
+} from '@temporalio/client';
 import type { Duration } from '@temporalio/common';
 import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
 import type { ActivityOptions } from '@temporalio/client/lib/activity-client';
@@ -103,9 +109,8 @@ if (RUN_INTEGRATION_TESTS) {
       args: [true, 'failure'],
     });
     const err = await t.throwsAsync(() => handle.result(), { instanceOf: ActivityExecutionFailedError });
-    t.truthy(err);
-    t.assert(err!.cause instanceof ApplicationFailure);
-    t.is(err!.cause!.message, 'failure');
+    t.assert(err?.cause instanceof ApplicationFailure);
+    t.is(err?.cause?.message, 'failure');
   });
 
   test('Execute activity - success', async (t) => {
@@ -254,7 +259,9 @@ if (RUN_INTEGRATION_TESTS) {
     t.is(description.status, 'TERMINATED');
   });
 
-  async function runThreeActivities(client: Client) {
+  test('Count and list activities', async (t) => {
+    const { client } = t.context;
+
     const firstAndSecondActivityId = uuid4();
     const firstHandle = await client.activity.start('echo', {
       ...defaultOptions,
@@ -278,20 +285,7 @@ if (RUN_INTEGRATION_TESTS) {
     });
     await thirdHandle.result();
 
-    return {
-      firstAndSecondActivityId,
-      thirdActivityId,
-      firstRunId: firstHandle.runId,
-      secondRunId: secondHandle.runId,
-      thirdRunId: thirdHandle.runId,
-    };
-  }
-
-  test('Count and list activities', async (t) => {
-    const { client } = t.context;
-
-    const ids = await runThreeActivities(client);
-    const query = `ActivityId='${ids.firstAndSecondActivityId}' OR ActivityId='${ids.thirdActivityId}'`;
+    const query = `ActivityId='${firstAndSecondActivityId}' OR ActivityId='${thirdActivityId}'`;
 
     // Visibility has update delay, repeating query until the activity count is as expected
     await waitUntil(async () => {
@@ -300,9 +294,9 @@ if (RUN_INTEGRATION_TESTS) {
     }, 10000);
 
     const isListed = {
-      [ids.firstAndSecondActivityId + ids.firstRunId]: false,
-      [ids.firstAndSecondActivityId + ids.secondRunId]: false,
-      [ids.thirdActivityId + ids.thirdRunId]: false,
+      [firstAndSecondActivityId + firstHandle.runId]: false,
+      [firstAndSecondActivityId + secondHandle.runId]: false,
+      [thirdActivityId + thirdHandle.runId]: false,
     };
 
     for await (const info of client.activity.list(query)) {
@@ -327,6 +321,46 @@ if (RUN_INTEGRATION_TESTS) {
         id: uuid4(),
       })
     );
+  });
+
+  test('Throws ActivityExecutionAlreadyExistsError on ID conflict', async (t) => {
+    const { client } = t.context;
+    const activityId = uuid4();
+    const options: ActivityOptions = {
+      ...defaultOptions,
+      id: activityId,
+      args: [{}],
+      idConflictPolicy: 'FAIL',
+    };
+
+    const handle = await client.activity.start('heartbeatCancellationDetailsActivity', options);
+    const err = await t.throwsAsync(() => client.activity.start('heartbeatCancellationDetailsActivity', options), {
+      instanceOf: ActivityExecutionAlreadyStartedError,
+    });
+    t.is(err?.activityId, activityId);
+    t.is(err?.runId, handle.runId);
+
+    // stop the activity
+    await handle.cancel('test cleanup');
+  });
+
+  test('Throws ActivityExecutionAlreadyExistsError on ID reuse', async (t) => {
+    const { client } = t.context;
+    const activityId = uuid4();
+    const options: ActivityOptions = {
+      ...defaultOptions,
+      id: activityId,
+      args: [{}],
+      idReusePolicy: 'REJECT_DUPLICATE',
+    };
+
+    const handle = await client.activity.start('echo', options);
+    await handle.result();
+    const err = await t.throwsAsync(() => client.activity.start('echo', options), {
+      instanceOf: ActivityExecutionAlreadyStartedError,
+    });
+    t.is(err?.activityId, activityId);
+    t.is(err?.runId, handle.runId);
   });
 
   test('Typed client - start activity', async (t) => {
@@ -358,27 +392,26 @@ if (RUN_INTEGRATION_TESTS) {
     };
 
     const _ = async (client: TypedActivityClient<ActivityInterface>) => {
-      // eslint-disable @typescript-eslint/no-unused-vars
       {
         // OK
-        let handle: ActivityHandle<void> = await client.start('noArgsReturnsVoid', { ...options });
-        let result: void = await handle.result();
-        handle = await client.start('noArgsReturnsVoid', { ...options });
-        handle = await client.start('noArgsReturnsVoid', { ...options, args: undefined });
-        handle = await client.start('noArgsReturnsVoid', { ...options, args: [] });
-        result = await client.execute('noArgsReturnsVoid', { ...options });
-        result = await client.execute('noArgsReturnsVoid', { ...options, args: undefined });
-        result = await client.execute('noArgsReturnsVoid', { ...options, args: [] });
+        let _handle: ActivityHandle<void> = await client.start('noArgsReturnsVoid', { ...options });
+        let _result: void = await _handle.result();
+        _handle = await client.start('noArgsReturnsVoid', { ...options });
+        _handle = await client.start('noArgsReturnsVoid', { ...options, args: undefined });
+        _handle = await client.start('noArgsReturnsVoid', { ...options, args: [] });
+        _result = await client.execute('noArgsReturnsVoid', { ...options });
+        _result = await client.execute('noArgsReturnsVoid', { ...options, args: undefined });
+        _result = await client.execute('noArgsReturnsVoid', { ...options, args: [] });
       }
       {
-        const handle: ActivityHandle<void> = await client.start('noArgsReturnsVoid', {
+        const _handle: ActivityHandle<void> = await client.start('noArgsReturnsVoid', {
           ...options,
           args: [
             // @ts-expect-error TS2322
             1,
           ],
         });
-        const result: void = await client.execute('noArgsReturnsVoid', {
+        const _result: void = await client.execute('noArgsReturnsVoid', {
           ...options,
           args: [
             // @ts-expect-error TS2322
@@ -388,101 +421,101 @@ if (RUN_INTEGRATION_TESTS) {
       }
       {
         const // @ts-expect-error TS2322
-          handle // end error
+          _handle // end error
           : ActivityHandle<number> = await client.start('noArgsReturnsVoid', { ...options });
 
         const // @ts-expect-error TS2322
-          result // end error
+          _result // end error
           : number = await client.execute('noArgsReturnsVoid', { ...options });
       }
       {
         // OK
-        let handle: ActivityHandle<number> = await client.start('noArgsReturnsNumber', { ...options });
-        let result: number = await handle.result();
-        handle = await client.start('noArgsReturnsNumber', { ...options });
-        handle = await client.start('noArgsReturnsNumber', { ...options, args: undefined });
-        handle = await client.start('noArgsReturnsNumber', { ...options, args: [] });
-        result = await client.execute('noArgsReturnsNumber', { ...options });
-        result = await client.execute('noArgsReturnsNumber', { ...options, args: undefined });
-        result = await client.execute('noArgsReturnsNumber', { ...options, args: [] });
+        let _handle: ActivityHandle<number> = await client.start('noArgsReturnsNumber', { ...options });
+        let _result: number = await _handle.result();
+        _handle = await client.start('noArgsReturnsNumber', { ...options });
+        _handle = await client.start('noArgsReturnsNumber', { ...options, args: undefined });
+        _handle = await client.start('noArgsReturnsNumber', { ...options, args: [] });
+        _result = await client.execute('noArgsReturnsNumber', { ...options });
+        _result = await client.execute('noArgsReturnsNumber', { ...options, args: undefined });
+        _result = await client.execute('noArgsReturnsNumber', { ...options, args: [] });
       }
       {
         const // @ts-expect-error TS2322
-          handle // end error
+          _handle // end error
           : ActivityHandle<void> = await client.start('noArgsReturnsNumber', { ...options });
 
         const // @ts-expect-error TS2322
-          result // end error
+          _result // end error
           : void = await client.execute('noArgsReturnsNumber', { ...options });
       }
       {
         const // @ts-expect-error TS2322
-          handle // end error
+          _handle // end error
           : ActivityHandle<string> = await client.start('noArgsReturnsNumber', { ...options });
 
         const // @ts-expect-error TS2322
-          result // end error
+          _result // end error
           : string = await client.execute('noArgsReturnsNumber', { ...options });
       }
       {
         // OK
-        const handle: ActivityHandle<number> = await client.start('numberArgReturnsNumber', { ...options, args: [1] });
-        let result: number = await handle.result();
-        result = await client.execute('numberArgReturnsNumber', { ...options, args: [1] });
+        const _handle: ActivityHandle<number> = await client.start('numberArgReturnsNumber', { ...options, args: [1] });
+        let _result: number = await _handle.result();
+        _result = await client.execute('numberArgReturnsNumber', { ...options, args: [1] });
       }
       {
-        let handle: ActivityHandle<number> = await client.start('numberArgReturnsNumber', {
+        let _handle: ActivityHandle<number> = await client.start('numberArgReturnsNumber', {
           ...options,
           args: [
             // @ts-expect-error TS2322
             'a',
           ],
         });
-        handle = await client.start('numberArgReturnsNumber', {
+        _handle = await client.start('numberArgReturnsNumber', {
           ...options,
           // @ts-expect-error TS2322
           args: [1, 2],
         });
-        handle = await client.start('numberArgReturnsNumber', {
+        _handle = await client.start('numberArgReturnsNumber', {
           ...options,
           // @ts-expect-error TS2322
           args: [],
         });
-        handle = await client.start('numberArgReturnsNumber', {
+        _handle = await client.start('numberArgReturnsNumber', {
           ...options,
           // @ts-expect-error TS2322
           args: undefined,
         });
-        handle = await client.start(
+        _handle = await client.start(
           'numberArgReturnsNumber',
           // @ts-expect-error TS2322
           {
             ...options,
           }
         );
-        let result: number = await client.execute('numberArgReturnsNumber', {
+        let _result: number = await client.execute('numberArgReturnsNumber', {
           ...options,
           args: [
             // @ts-expect-error TS2322
             'a',
           ],
         });
-        result = await client.execute('numberArgReturnsNumber', {
+        _result = await client.execute('numberArgReturnsNumber', {
           ...options,
           // @ts-expect-error TS2322
           args: [1, 2],
         });
-        result = await client.execute('numberArgReturnsNumber', {
+        _result = await client.execute('numberArgReturnsNumber', {
           ...options,
           // @ts-expect-error TS2322
           args: [],
         });
-        result = await client.execute('numberArgReturnsNumber', {
+        _result = await client.execute('numberArgReturnsNumber', {
           ...options,
           // @ts-expect-error TS2322
           args: undefined,
         });
-        result = await client.execute(
+        _result = await client.execute(
           'numberArgReturnsNumber',
           // @ts-expect-error TS2322
           {
@@ -492,15 +525,15 @@ if (RUN_INTEGRATION_TESTS) {
       }
       {
         // OK
-        const handle: ActivityHandle<void> = await client.start('stringAndNumberArgsReturnsVoid', {
+        const _handle: ActivityHandle<void> = await client.start('stringAndNumberArgsReturnsVoid', {
           ...options,
           args: ['a', 1],
         });
-        let result: void = await handle.result();
-        result = await client.execute('stringAndNumberArgsReturnsVoid', { ...options, args: ['a', 1] });
+        let _result: void = await _handle.result();
+        _result = await client.execute('stringAndNumberArgsReturnsVoid', { ...options, args: ['a', 1] });
       }
       {
-        let handle: ActivityHandle<void> = await client.start('stringAndNumberArgsReturnsVoid', {
+        let _handle: ActivityHandle<void> = await client.start('stringAndNumberArgsReturnsVoid', {
           ...options,
           args: [
             'a',
@@ -508,7 +541,7 @@ if (RUN_INTEGRATION_TESTS) {
             'b',
           ],
         });
-        handle = await client.start('stringAndNumberArgsReturnsVoid', {
+        _handle = await client.start('stringAndNumberArgsReturnsVoid', {
           ...options,
           args: [
             // @ts-expect-error TS2322
@@ -517,7 +550,7 @@ if (RUN_INTEGRATION_TESTS) {
             2,
           ],
         });
-        handle = await client.start('stringAndNumberArgsReturnsVoid', {
+        _handle = await client.start('stringAndNumberArgsReturnsVoid', {
           ...options,
           args: [
             // @ts-expect-error TS2322
@@ -526,7 +559,7 @@ if (RUN_INTEGRATION_TESTS) {
             'a',
           ],
         });
-        let result: void = await client.execute('stringAndNumberArgsReturnsVoid', {
+        let _result: void = await client.execute('stringAndNumberArgsReturnsVoid', {
           ...options,
           args: [
             'a',
@@ -534,7 +567,7 @@ if (RUN_INTEGRATION_TESTS) {
             'b',
           ],
         });
-        result = await client.execute('stringAndNumberArgsReturnsVoid', {
+        _result = await client.execute('stringAndNumberArgsReturnsVoid', {
           ...options,
           args: [
             // @ts-expect-error TS2322
@@ -543,7 +576,7 @@ if (RUN_INTEGRATION_TESTS) {
             2,
           ],
         });
-        result = await client.execute('stringAndNumberArgsReturnsVoid', {
+        _result = await client.execute('stringAndNumberArgsReturnsVoid', {
           ...options,
           args: [
             // @ts-expect-error TS2322
@@ -553,7 +586,6 @@ if (RUN_INTEGRATION_TESTS) {
           ],
         });
       }
-      // eslint-enable @typescript-eslint/no-unused-vars
     };
 
     t.pass();

--- a/packages/testing/src/mocking-activity-environment.ts
+++ b/packages/testing/src/mocking-activity-environment.ts
@@ -97,4 +97,7 @@ export const defaultActivityInfo: activity.Info = {
   currentAttemptScheduledTimestampMs: 1,
   priority: undefined,
   retryPolicy: undefined,
+  namespace: 'test',
+  activityRunId: undefined,
+  inWorkflow: true,
 };

--- a/packages/worker/src/activity.ts
+++ b/packages/worker/src/activity.ts
@@ -118,7 +118,7 @@ export class Activity {
 
   protected getMetricTags(): MetricTags {
     const baseTags = {
-      namespace: this.info.workflowNamespace,
+      namespace: this.info.namespace,
       taskQueue: this.info.taskQueue,
       activityType: this.info.activityType,
     };
@@ -260,16 +260,23 @@ export class Activity {
  * Returns a map of attributes to be set on log messages for a given Activity
  */
 export function activityLogAttributes(info: Info): Record<string, unknown> {
-  return {
+  const attrs: Record<string, any> = {
     isLocal: info.isLocal,
     attempt: info.attempt,
-    namespace: info.workflowNamespace,
+    namespace: info.namespace,
     taskToken: info.base64TaskToken,
-    workflowId: info.workflowExecution.workflowId,
-    workflowRunId: info.workflowExecution.runId,
-    workflowType: info.workflowType,
     activityId: info.activityId,
     activityType: info.activityType,
     taskQueue: info.taskQueue,
   };
+
+  if (info.inWorkflow) {
+    attrs.workflowId = info.workflowExecution!.workflowId;
+    attrs.workflowRunId = info.workflowExecution!.runId;
+    attrs.workflowType = info.workflowType;
+  } else {
+    attrs.activityRunId = info.activityRunId;
+  }
+
+  return attrs;
 }

--- a/packages/worker/src/utils.ts
+++ b/packages/worker/src/utils.ts
@@ -1,4 +1,3 @@
-import type { WorkerDeploymentVersion } from '@temporalio/common';
 import type { coresdk, temporal } from '@temporalio/proto';
 import type { ParentWorkflowInfo, RootWorkflowInfo } from '@temporalio/workflow';
 
@@ -23,19 +22,6 @@ export function convertToParentWorkflowType(
     workflowId: parent.workflowId,
     runId: parent.runId,
     namespace: parent.namespace,
-  };
-}
-
-export function convertDeploymentVersion(
-  v: coresdk.common.IWorkerDeploymentVersion | null | undefined
-): WorkerDeploymentVersion | undefined {
-  if (!v || !v.buildId) {
-    return undefined;
-  }
-
-  return {
-    buildId: v.buildId,
-    deploymentName: v.deploymentName ?? '',
   };
 }
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1059,12 +1059,7 @@ export class Worker {
                         `Got start event for an already running activity: ${base64TaskToken}`
                       );
                     }
-                    info = await extractActivityInfo(
-                      task,
-                      this.options.loadedDataConverter,
-                      this.options.namespace,
-                      this.options.taskQueue
-                    );
+                    info = await extractActivityInfo(task, this.options.loadedDataConverter, this.options.taskQueue);
 
                     const { activityType } = info;
                     // Use the corresponding activity if it exists, otherwise, fallback to default activity function (if exists)
@@ -2187,7 +2182,6 @@ function extractSourceMap(code: string): [string, string] {
 async function extractActivityInfo(
   task: coresdk.activity_task.ActivityTask,
   dataConverter: LoadedDataConverter,
-  activityNamespace: string,
   taskQueue: string
 ): Promise<ActivityInfo> {
   // NOTE: We trust core to supply all of these fields instead of checking for null and undefined everywhere
@@ -2202,20 +2196,23 @@ async function extractActivityInfo(
       message: `Failed to parse heartbeat details for activity ${activityId}: ${errorMessage(e)}`,
     });
   }
+  const inWorkflow = !!start.workflowExecution?.workflowId;
   return {
     taskToken,
     taskQueue,
     base64TaskToken: formatTaskToken(taskToken),
     activityId,
-    workflowExecution: start.workflowExecution as NonNullableObject<temporal.api.common.v1.WorkflowExecution>,
+    workflowExecution: inWorkflow
+      ? (start.workflowExecution as NonNullableObject<temporal.api.common.v1.WorkflowExecution>)
+      : undefined,
     attempt: start.attempt,
     isLocal: start.isLocal,
     activityType: start.activityType,
-    workflowType: start.workflowType,
+    workflowType: inWorkflow ? start.workflowType : undefined,
     heartbeatTimeoutMs: optionalTsToMs(start.heartbeatTimeout),
     heartbeatDetails,
-    activityNamespace,
-    workflowNamespace: start.workflowNamespace,
+    activityNamespace: start.workflowNamespace,
+    workflowNamespace: inWorkflow ? start.workflowNamespace : undefined,
     scheduledTimestampMs: requiredTsToMs(start.scheduledTime, 'scheduledTime'),
     startToCloseTimeoutMs: requiredTsToMs(start.startToCloseTimeout, 'startToCloseTimeout'),
     scheduleToCloseTimeoutMs: requiredTsToMs(start.scheduleToCloseTimeout, 'scheduleToCloseTimeout'),
@@ -2225,6 +2222,9 @@ async function extractActivityInfo(
     ),
     priority: decodePriority(start.priority),
     retryPolicy: decompileRetryPolicy(start.retryPolicy),
+    namespace: start.workflowNamespace,
+    activityRunId: !inWorkflow ? start.activityId : undefined,
+    inWorkflow,
   };
 }
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -2219,7 +2219,7 @@ async function extractActivityInfo(
     priority: decodePriority(start.priority),
     retryPolicy: decompileRetryPolicy(start.retryPolicy),
     namespace: start.workflowNamespace,
-    activityRunId: !inWorkflow ? start.activityId : undefined,
+    activityRunId: !inWorkflow ? start.runId : undefined,
     inWorkflow,
   };
 }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -23,6 +23,7 @@ import {
   decodePriority,
   CancelledFailure,
   ActivityCancellationDetails,
+  convertDeploymentVersion,
 } from '@temporalio/common';
 import type { Decoded } from '@temporalio/common/lib/internal-non-workflow';
 import {
@@ -65,12 +66,7 @@ import type { History } from './runtime';
 import { Runtime } from './runtime';
 import type { CloseableGroupedObservable } from './rxutils';
 import { closeableGroupBy, mapWithState, mergeMapWithState } from './rxutils';
-import {
-  byteArrayToBuffer,
-  convertDeploymentVersion,
-  convertToParentWorkflowType,
-  convertToRootWorkflowType,
-} from './utils';
+import { byteArrayToBuffer, convertToParentWorkflowType, convertToRootWorkflowType } from './utils';
 import type {
   CompiledWorkerOptions,
   CompiledWorkerOptionsWithBuildId,

--- a/packages/worker/src/workflow/vm-shared.ts
+++ b/packages/worker/src/workflow/vm-shared.ts
@@ -5,7 +5,7 @@ import assert from 'node:assert';
 import { URL, URLSearchParams } from 'node:url';
 import { TextDecoder, TextEncoder } from 'node:util';
 import { SourceMapConsumer } from 'source-map';
-import { cutoffStackTrace, IllegalStateError } from '@temporalio/common';
+import { cutoffStackTrace, IllegalStateError, convertDeploymentVersion } from '@temporalio/common';
 import { suggestContinueAsNewReasonsFromProto } from '@temporalio/common/lib/continue-as-new';
 import { tsToMs } from '@temporalio/common/lib/time';
 import { coresdk } from '@temporalio/proto';
@@ -15,7 +15,6 @@ import type * as internals from '@temporalio/workflow/lib/worker-interface';
 import type { Activator } from '@temporalio/workflow/lib/internals';
 import { SdkFlags } from '@temporalio/workflow/lib/flags';
 import { UnhandledRejectionError } from '../errors';
-import { convertDeploymentVersion } from '../utils';
 import type { Workflow } from './interface';
 import type { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
 


### PR DESCRIPTION
## 💥 Breaking change

This PR alters Activity Info interface in backward-incompatible way by making `workflowExecution`, `workflowNamespace` and `workflowType` properties optional. As long as Standalone Activities are not being used, it is safe to use `!` to remove type errors, however the recommended migration path is to check the `inWorkflow` property and handle both cases - this way the activity can be run in standalone context.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Implemented support for Standalone Activities.

Telemetry support will be done separately, see #2031

## Why?
<!-- Tell your future self why have you made these changes -->
Feature request: https://github.com/temporalio/features/issues/706

## Checklist
<!--- add/delete as needed --->

1. Closes #1851 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- New test file `test-standalone-activities.ts`
- New tests added to `test-async-completion.ts`

