### PR TITLE
Expose endpoint on OperationInfo

### DIFF
--- a/packages/nexus/src/context.ts
+++ b/packages/nexus/src/context.ts
@@ -54,7 +54,7 @@ export interface OperationInfo {
    * Nexus Endpoint this Operation was routed through.
    * Only available with server version 1.30.0 or later.
    */
-  readonly endpoint?: string;
+  readonly endpoint: string;
 }
 
 // Basic APIs //////////////////////////////////////////////////////////////////////////////////////

--- a/packages/nexus/src/context.ts
+++ b/packages/nexus/src/context.ts
@@ -31,6 +31,7 @@ export interface HandlerContext {
   client: Client;
   namespace: string;
   taskQueue: string;
+  endpoint: string;
 }
 
 /**
@@ -48,6 +49,12 @@ export interface OperationInfo {
    * Task Queue this Nexus Operation is executing on
    */
   readonly taskQueue: string;
+
+  /**
+   * Nexus Endpoint this Operation was routed through.
+   * Only available with server version 1.30.0 or later.
+   */
+  readonly endpoint?: string;
 }
 
 // Basic APIs //////////////////////////////////////////////////////////////////////////////////////
@@ -131,5 +138,6 @@ export function operationInfo(): OperationInfo {
   return {
     namespace: ctx.namespace,
     taskQueue: ctx.taskQueue,
+    endpoint: ctx.endpoint,
   };
 }

--- a/packages/test/src/test-nexus-workflow-caller.ts
+++ b/packages/test/src/test-nexus-workflow-caller.ts
@@ -42,7 +42,7 @@ const getClientService = nexus.service('getClientTestService', {
 });
 
 const operationInfoService = nexus.service('operationInfoTestService', {
-  operationInfoOp: nexus.operation<void, { namespace: string; taskQueue: string }>(),
+  operationInfoOp: nexus.operation<void, { namespace: string; taskQueue: string; endpoint: string }>(),
 });
 
 const cancelErrorService = nexus.service('cancelErrorService', {
@@ -111,7 +111,9 @@ export async function getClientCaller(endpoint: string): Promise<boolean> {
   return await client.executeOperation('getClientOp', undefined);
 }
 
-export async function operationInfoCaller(endpoint: string): Promise<{ namespace: string; taskQueue: string }> {
+export async function operationInfoCaller(
+  endpoint: string
+): Promise<{ namespace: string; taskQueue: string; endpoint: string }> {
   const client = workflow.createNexusServiceClient({ endpoint, service: operationInfoService });
   return await client.executeOperation('operationInfoOp', undefined);
 }
@@ -624,6 +626,7 @@ test('operationInfo is available in handler context - caller workflow', async (t
           return {
             namespace: info.namespace,
             taskQueue: info.taskQueue,
+            endpoint: info.endpoint,
           };
         },
       }),
@@ -636,6 +639,7 @@ test('operationInfo is available in handler context - caller workflow', async (t
     });
     t.is(result.namespace, 'default');
     t.is(result.taskQueue, h.taskQueue);
+    t.is(result.endpoint, endpointName);
   });
 });
 

--- a/packages/worker/src/nexus/index.ts
+++ b/packages/worker/src/nexus/index.ts
@@ -273,6 +273,7 @@ export class NexusHandler {
           client: this.client,
           namespace: this.namespace,
           taskQueue: this.taskQueue,
+          endpoint: task.request?.endpoint ?? '',
           log: LoggerWithComposedMetadata.compose(this.logger, { sdkComponent: SdkComponent.nexus }),
           metrics: this.metricMeter,
         },


### PR DESCRIPTION
Expose endpoint on OperationInfo like we did in all other SDKs.

closes https://github.com/temporalio/sdk-typescript/issues/2040

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive API surface that threads an `endpoint` string through the existing Nexus handler context. Main risk is minor compatibility/behavior differences on older servers where `endpoint` may be missing and now defaults to an empty string.
> 
> **Overview**
> Exposes the Nexus **endpoint name** to handlers via `operationInfo()` by adding `endpoint` to `OperationInfo`/`HandlerContext` and populating it from `PollNexusTaskQueue` responses in the worker.
> 
> Updates Nexus integration tests to return and assert the new `endpoint` field when calling `operationInfo`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0160afb40eb10051220ec628618ad728b5f27f1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->