### PR TITLE
Add standalone activity startDelay support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,6 @@ jobs:
         env:
           RUN_INTEGRATION_TESTS: true
           REUSE_V8_CONTEXT: ${{ matrix.reuse-v8-context }}
-          TEMPORAL_SERVICE_ADDRESS: localhost:7233
 
           # For Temporal Cloud + mTLS tests
           TEMPORAL_CLOUD_MTLS_TEST_TARGET_HOST: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}.tmprl.cloud:7233
@@ -239,7 +238,6 @@ jobs:
         env:
           RUN_INTEGRATION_TESTS: true
           REUSE_V8_CONTEXT: ${{ matrix.reuse-v8-context }}
-          TEMPORAL_SERVICE_ADDRESS: localhost:7233
 
       # FIXME: Move samples tests to a custom activity
       # Sample 1: hello-world to local server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,8 @@ jobs:
 
       - name: Install Temporal CLI
         uses: temporalio/setup-temporal@1059a504f87e7fa2f385e3fa40d1aa7e62f1c6ca # v0
+        with:
+          version: ${{ env.TESTS_CLI_VERSION }}
 
       - name: Run Temporal CLI
         working-directory: ${{ runner.temp }}
@@ -201,6 +203,8 @@ jobs:
             --dynamic-config-value history.enableRequestIdRefLinks=true \
             --dynamic-config-value frontend.activityAPIsEnabled=true \
             --dynamic-config-value activity.enableStandalone=true \
+            --dynamic-config-value activity.startDelayEnabled=true \
+            --dynamic-config-value 'activity.longPollTimeout="5000ms"' \
             --dynamic-config-value history.enableChasm=true \
             --dynamic-config-value history.enableTransitionHistory=true &
 
@@ -210,6 +214,7 @@ jobs:
         env:
           RUN_INTEGRATION_TESTS: true
           REUSE_V8_CONTEXT: ${{ matrix.reuse-v8-context }}
+          TEMPORAL_SERVICE_ADDRESS: localhost:7233
 
           # For Temporal Cloud + mTLS tests
           TEMPORAL_CLOUD_MTLS_TEST_TARGET_HOST: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}.tmprl.cloud:7233
@@ -234,6 +239,7 @@ jobs:
         env:
           RUN_INTEGRATION_TESTS: true
           REUSE_V8_CONTEXT: ${{ matrix.reuse-v8-context }}
+          TEMPORAL_SERVICE_ADDRESS: localhost:7233
 
       # FIXME: Move samples tests to a custom activity
       # Sample 1: hello-world to local server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         run: pnpm tsx scripts/publish-to-verdaccio.ts --registry-dir ${{ steps.tmp-dir.outputs.dir }}/npm-registry
 
       - name: Install Temporal CLI
-        uses: temporalio/setup-temporal@1059a504f87e7fa2f385e3fa40d1aa7e62f1c6ca # v0
+        uses: temporalio/setup-temporal@8bde337644eaaa6644b8b527d9a8406c2207de5b # v0
         with:
           version: ${{ env.TESTS_CLI_VERSION }}
 

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -17,7 +17,7 @@ import {
   decompileRetryPolicy,
 } from '@temporalio/common';
 import type { Duration } from '@temporalio/common/lib/time';
-import { msOptionalToTs, optionalTsToDate, optionalTsToMs } from '@temporalio/common/lib/time';
+import { msOptionalToTs, msToNumber, optionalTsToDate, optionalTsToMs } from '@temporalio/common/lib/time';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import {
   decodeTypedSearchAttributes,
@@ -309,6 +309,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       header: { fields: input.headers },
       userMetadata: await encodeUserMetadata(this.dataConverter, input.options.summary, undefined),
       priority: input.options.priority ? compilePriority(input.options.priority) : undefined,
+      startDelay: msOptionalToTs(input.options.startDelay),
     };
   }
 
@@ -547,6 +548,10 @@ export interface ActivityOptions {
    */
   priority?: Priority;
   /**
+   * Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
+   */
+  startDelay?: Duration;
+  /**
    * Specifies behavior if there's a *closed* activity with the same ID.
    */
   idReusePolicy?: ActivityIdReusePolicy;
@@ -570,6 +575,9 @@ function validateActivityOptions(options: ActivityOptions): void {
   }
   if (!options.scheduleToCloseTimeout && !options.startToCloseTimeout) {
     throw new TypeError('Either scheduleToCloseTimeout or startToCloseTimeout is required');
+  }
+  if (options.startDelay !== undefined && msToNumber(options.startDelay) < 0) {
+    throw new TypeError('startDelay must be non-negative');
   }
 }
 

--- a/packages/test/src/test-standalone-activities.ts
+++ b/packages/test/src/test-standalone-activities.ts
@@ -4,6 +4,7 @@ import anyTest from 'ava';
 import * as rxjs from 'rxjs';
 import type { ActivityHandle, TypedActivityClient, ActivityOptions } from '@temporalio/client';
 import {
+  ActivityExecutionStatus,
   ActivityExecutionAlreadyStartedError,
   ActivityExecutionFailedError,
   ServiceError,
@@ -64,6 +65,7 @@ interface ActivityInterface {
 }
 
 const taskQueue = 'standalone-activities';
+const startDelayTestCliVersion = 'v1.7.1-standalone-nexus-operations';
 const defaultOptions: Omit<ActivityOptions, 'id' | 'args'> = {
   taskQueue,
   scheduleToCloseTimeout: '1 minute',
@@ -118,8 +120,8 @@ if (RUN_INTEGRATION_TESTS) {
 
   test.after.always(async (t) => {
     t.context.worker.shutdown();
-    await t.context.env.teardown();
     await t.context.runPromise;
+    await t.context.env.teardown();
   });
 
   test('Get activity result - success', async (t) => {
@@ -173,6 +175,49 @@ if (RUN_INTEGRATION_TESTS) {
     );
     t.assert(err?.cause instanceof ApplicationFailure);
     t.is(err?.cause?.message, 'failure');
+  });
+
+  test('Start activity with start delay', async (t) => {
+    const env = await createLocalTestEnvironment({
+      server: {
+        executable: {
+          type: 'cached-download',
+          version: startDelayTestCliVersion,
+        },
+        extraArgs: ['--dynamic-config-value', 'activity.startDelayEnabled=true'],
+      },
+    });
+
+    try {
+      const startDelayTaskQueue = `${taskQueue}-${uuid4()}`;
+      const worker = await Worker.create({
+        activities: { echo },
+        taskQueue: startDelayTaskQueue,
+        connection: env.nativeConnection,
+      });
+
+      await worker.runUntil(async () => {
+        const activityId = uuid4();
+        const startDelayMs = 2000;
+        const handle = await env.client.activity.start('echo', {
+          ...defaultOptions,
+          id: activityId,
+          taskQueue: startDelayTaskQueue,
+          args: ['hello'],
+          startDelay: startDelayMs,
+        });
+
+        t.is(await handle.result(), 'hello');
+
+        const description = await handle.describe();
+        t.is(description.status, ActivityExecutionStatus.COMPLETED);
+        t.truthy(description.scheduleTime);
+        t.truthy(description.lastStartedTime);
+        t.true(description.lastStartedTime!.getTime() - description.scheduleTime!.getTime() >= startDelayMs - 500);
+      });
+    } finally {
+      await env.teardown();
+    }
   });
 
   test('Describe activity from start handle', async (t) => {

--- a/packages/test/src/test-standalone-activities.ts
+++ b/packages/test/src/test-standalone-activities.ts
@@ -17,7 +17,7 @@ import type { TestWorkflowEnvironment } from './helpers';
 import { RUN_INTEGRATION_TESTS, waitUntil, Worker } from './helpers';
 import { echo, throwAnError } from './activities';
 import { heartbeatCancellationDetailsActivity } from './activities/heartbeat-cancellation-details';
-import { createLocalTestEnvironment } from './helpers-integration';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 
 // Use a reduced server long-poll expiration timeout, in order to confirm that client
 // polling/retry strategies result in the expected behavior
@@ -65,7 +65,6 @@ interface ActivityInterface {
 }
 
 const taskQueue = 'standalone-activities';
-const startDelayTestCliVersion = 'v1.7.1-standalone-nexus-operations';
 const defaultOptions: Omit<ActivityOptions, 'id' | 'args'> = {
   taskQueue,
   scheduleToCloseTimeout: '1 minute',
@@ -80,9 +79,14 @@ async function waitForValue<T>(subject: rxjs.Subject<T>, value: T) {
 
 if (RUN_INTEGRATION_TESTS) {
   test.before(async (t) => {
-    const env = await createLocalTestEnvironment({
+    const env = await createTestWorkflowEnvironment({
       server: {
-        extraArgs: ['--dynamic-config-value', `activity.longPollTimeout="${LONG_POLL_TIMEOUT_MS}ms"`],
+        extraArgs: [
+          '--dynamic-config-value',
+          `activity.longPollTimeout="${LONG_POLL_TIMEOUT_MS}ms"`,
+          '--dynamic-config-value',
+          'activity.startDelayEnabled=true',
+        ],
       },
     });
 
@@ -178,46 +182,23 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Start activity with start delay', async (t) => {
-    const env = await createLocalTestEnvironment({
-      server: {
-        executable: {
-          type: 'cached-download',
-          version: startDelayTestCliVersion,
-        },
-        extraArgs: ['--dynamic-config-value', 'activity.startDelayEnabled=true'],
-      },
+    const client = t.context.env.client.activity;
+    const activityId = uuid4();
+    const startDelayMs = 2000;
+    const handle = await client.start('echo', {
+      ...defaultOptions,
+      id: activityId,
+      args: ['hello'],
+      startDelay: startDelayMs,
     });
 
-    try {
-      const startDelayTaskQueue = `${taskQueue}-${uuid4()}`;
-      const worker = await Worker.create({
-        activities: { echo },
-        taskQueue: startDelayTaskQueue,
-        connection: env.nativeConnection,
-      });
+    t.is(await handle.result(), 'hello');
 
-      await worker.runUntil(async () => {
-        const activityId = uuid4();
-        const startDelayMs = 2000;
-        const handle = await env.client.activity.start('echo', {
-          ...defaultOptions,
-          id: activityId,
-          taskQueue: startDelayTaskQueue,
-          args: ['hello'],
-          startDelay: startDelayMs,
-        });
-
-        t.is(await handle.result(), 'hello');
-
-        const description = await handle.describe();
-        t.is(description.status, ActivityExecutionStatus.COMPLETED);
-        t.truthy(description.scheduleTime);
-        t.truthy(description.lastStartedTime);
-        t.true(description.lastStartedTime!.getTime() - description.scheduleTime!.getTime() >= startDelayMs - 500);
-      });
-    } finally {
-      await env.teardown();
-    }
+    const description = await handle.describe();
+    t.is(description.status, ActivityExecutionStatus.COMPLETED);
+    t.truthy(description.scheduleTime);
+    t.truthy(description.lastStartedTime);
+    t.true(description.lastStartedTime!.getTime() - description.scheduleTime!.getTime() >= startDelayMs - 500);
   });
 
   test('Describe activity from start handle', async (t) => {

--- a/packages/test/src/test-standalone-activities.ts
+++ b/packages/test/src/test-standalone-activities.ts
@@ -183,7 +183,7 @@ if (RUN_INTEGRATION_TESTS) {
 
   test('Start activity with start delay', async (t) => {
     const client = t.context.env.client.activity;
-    const activityId = uuid4();
+    const activityId = randomUUID();
     const startDelayMs = 2000;
     const handle = await client.start('echo', {
       ...defaultOptions,


### PR DESCRIPTION
Wire ActivityOptions.startDelay into StartActivityExecutionRequest and validate that it is non-negative.

Port the standalone activity delayed-start integration coverage from Python, including the server version/config needed to assert the scheduled-to-started delay.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Delayed-start is surfaced as `ActivityOptions.startDelay`
- An integration test checks that the option has the desired effect

## Why?
Standalone activities now have a delayed-start feature. These changes expose this feature from the TS SDK

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
A new integration test was added and validated that new option has the desired effect of delaying the start of a standalone activity.

3. Any docs updates needed?
No.
