### PR TITLE
fix(worker): close replay iterator in runReplayHistory

### DIFF
--- a/packages/test/src/test-replay.ts
+++ b/packages/test/src/test-replay.ts
@@ -60,6 +60,28 @@ test('cancel-fake-progress-replay from JSON', async (t) => {
   t.pass();
 });
 
+test('runReplayHistory closes replay iterator after first result', async (t) => {
+  const hist = { events: [{ eventId: 1 }] };
+  let iteratorClosed = false;
+
+  class TestWorker extends Worker {
+    public static override async *runReplayHistories(): AsyncIterableIterator<{
+      workflowId: string;
+      runId: string;
+    }> {
+      try {
+        yield { workflowId: 'fake', runId: 'run' };
+      } finally {
+        iteratorClosed = true;
+      }
+    }
+  }
+
+  await TestWorker.runReplayHistory({ workflowBundle: t.context.bundle }, hist);
+
+  t.true(iteratorClosed);
+});
+
 test('cancel-fake-progress-replay-nondeterministic', async (t) => {
   const hist = await loadHistory('cancel_fake_progress_history.bin');
   // Manually alter the workflow type to point to different workflow code

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -600,9 +600,13 @@ export class Worker {
     workflowId?: string
   ): Promise<void> {
     const validated = this.validateHistory(history);
-    const result = await this.runReplayHistories(options, [
-      { history: validated, workflowId: workflowId ?? 'fake' },
-    ]).next();
+    const replay = this.runReplayHistories(options, [{ history: validated, workflowId: workflowId ?? 'fake' }]);
+    let result: IteratorResult<ReplayResult>;
+    try {
+      result = await replay.next();
+    } finally {
+      await replay.return?.();
+    }
     if (result.done) throw new IllegalStateError('Expected at least one replay result');
     if (result.value.error) throw result.value.error;
   }


### PR DESCRIPTION
## What changed

`Worker.runReplayHistory` now closes the async iterator returned by `runReplayHistories` after reading the single replay result.

## Why

`runReplayHistory` previously called `.next()` on the replay iterator and then discarded it. Because `runReplayHistories` is an async generator, its `finally` block does not run unless the iterator is completed or explicitly closed. That skipped the replay cleanup path that closes the history stream and shuts down the replay worker.

## Validation

- `pnpm exec prettier --check packages/worker/src/worker.ts packages/test/src/test-replay.ts`
- `pnpm -C packages/test run build:ts`
- `pnpm -C packages/test exec ava ./lib/test-replay.js`
