### PR TITLE
chore: add @temporalio/ai-sdk as co-codeowner of contrib/ai-sdk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,5 @@
 # @temporalio/sdk will be requested for review when
 # someone opens a pull request.
 * @temporalio/sdk
+
+/contrib/ai-sdk/ @temporalio/sdk @temporalio/ai-sdk


### PR DESCRIPTION
Following the pattern found in https://github.com/temporalio/sdk-python/blob/main/.github/CODEOWNERS