### PR TITLE
Extend serialization context to workflow client and schedule client

### DIFF
--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -228,7 +228,7 @@ export class ScheduleClient extends BaseClient {
       scheduleId: opts.scheduleId,
       schedule: {
         spec: encodeScheduleSpec(opts.spec),
-        action: await encodeScheduleAction(this.dataConverter, opts.action, headers),
+        action: await encodeScheduleAction(this.dataConverter, this.options.namespace, opts.action, headers),
         policies: encodeSchedulePolicies(opts.policies),
         state: encodeScheduleState(opts.state),
       },
@@ -292,7 +292,7 @@ export class ScheduleClient extends BaseClient {
       scheduleId,
       schedule: {
         spec: encodeScheduleSpec(opts.spec),
-        action: await encodeScheduleAction(this.dataConverter, opts.action, header),
+        action: await encodeScheduleAction(this.dataConverter, this.options.namespace, opts.action, header),
         policies: encodeSchedulePolicies(opts.policies),
         state: encodeScheduleState(opts.state),
       },
@@ -426,7 +426,11 @@ export class ScheduleClient extends BaseClient {
         return {
           scheduleId,
           spec: decodeScheduleSpec(raw.schedule.spec),
-          action: await decodeScheduleAction(this.client.dataConverter, raw.schedule.action),
+          action: await decodeScheduleAction(
+            this.client.dataConverter,
+            this.client.options.namespace,
+            raw.schedule.action
+          ),
           memo: await decodeMapFromPayloads(this.client.dataConverter, raw.memo?.fields),
           searchAttributes: decodeSearchAttributes(raw.searchAttributes?.indexedFields),
           typedSearchAttributes: decodeTypedSearchAttributes(raw.searchAttributes?.indexedFields),

--- a/packages/client/src/schedule-helpers.ts
+++ b/packages/client/src/schedule-helpers.ts
@@ -1,5 +1,5 @@
 import Long from 'long';
-import type { LoadedDataConverter } from '@temporalio/common';
+import type { LoadedDataConverter, WorkflowSerializationContext } from '@temporalio/common';
 import {
   compilePriority,
   compileRetryPolicy,
@@ -18,7 +18,7 @@ import {
   decodeArrayFromPayloads,
   decodeMapFromPayloads,
   encodeMapToPayloads,
-  encodeToPayloads,
+  encodeToPayloadsWithContext,
 } from '@temporalio/common/lib/internal-non-workflow';
 import { temporal } from '@temporalio/proto';
 import {
@@ -243,18 +243,28 @@ export function encodeScheduleSpec(spec: ScheduleSpec): temporal.api.schedule.v1
   };
 }
 
+function workflowSerializationContext(namespace: string, workflowId: string): WorkflowSerializationContext {
+  return {
+    type: 'workflow',
+    namespace,
+    workflowId,
+  };
+}
+
 export async function encodeScheduleAction(
   dataConverter: LoadedDataConverter,
+  namespace: string,
   action: CompiledScheduleAction,
   headers: Headers
 ): Promise<temporal.api.schedule.v1.IScheduleAction> {
+  const context = workflowSerializationContext(namespace, action.workflowId);
   return {
     startWorkflow: {
       workflowId: action.workflowId,
       workflowType: {
         name: action.workflowType,
       },
-      input: { payloads: await encodeToPayloads(dataConverter, ...action.args) },
+      input: { payloads: await encodeToPayloadsWithContext(dataConverter, context, action.args) },
       taskQueue: {
         kind: temporal.api.enums.v1.TaskQueueKind.TASK_QUEUE_KIND_NORMAL,
         name: action.taskQueue,
@@ -263,7 +273,7 @@ export async function encodeScheduleAction(
       workflowRunTimeout: msOptionalToTs(action.workflowRunTimeout),
       workflowTaskTimeout: msOptionalToTs(action.workflowTaskTimeout),
       retryPolicy: action.retry ? compileRetryPolicy(action.retry) : undefined,
-      memo: action.memo ? { fields: await encodeMapToPayloads(dataConverter, action.memo) } : undefined,
+      memo: action.memo ? { fields: await encodeMapToPayloads(dataConverter, action.memo, context) } : undefined,
       searchAttributes:
         action.searchAttributes || action.typedSearchAttributes // eslint-disable-line @typescript-eslint/no-deprecated
           ? {
@@ -271,7 +281,7 @@ export async function encodeScheduleAction(
             }
           : undefined,
       header: { fields: headers },
-      userMetadata: await encodeUserMetadata(dataConverter, action.staticSummary, action.staticDetails),
+      userMetadata: await encodeUserMetadata(dataConverter, action.staticSummary, action.staticDetails, context),
       priority: action.priority ? compilePriority(action.priority) : undefined,
     },
   };
@@ -319,10 +329,16 @@ export function decodeScheduleSpec(pb: temporal.api.schedule.v1.IScheduleSpec): 
 
 export async function decodeScheduleAction(
   dataConverter: LoadedDataConverter,
+  namespace: string,
   pb: temporal.api.schedule.v1.IScheduleAction
 ): Promise<ScheduleDescriptionAction> {
   if (pb.startWorkflow) {
-    const { staticSummary, staticDetails } = await decodeUserMetadata(dataConverter, pb.startWorkflow?.userMetadata);
+    const context = workflowSerializationContext(namespace, pb.startWorkflow.workflowId!);
+    const { staticSummary, staticDetails } = await decodeUserMetadata(
+      dataConverter,
+      pb.startWorkflow?.userMetadata,
+      context
+    );
     return {
       type: 'startWorkflow',
 
@@ -331,8 +347,8 @@ export async function decodeScheduleAction(
       workflowType: pb.startWorkflow.workflowType!.name!,
 
       taskQueue: pb.startWorkflow.taskQueue!.name!,
-      args: await decodeArrayFromPayloads(dataConverter, pb.startWorkflow.input?.payloads),
-      memo: await decodeMapFromPayloads(dataConverter, pb.startWorkflow.memo?.fields),
+      args: await decodeArrayFromPayloads(dataConverter, pb.startWorkflow.input?.payloads, context),
+      memo: await decodeMapFromPayloads(dataConverter, pb.startWorkflow.memo?.fields, context),
       retry: decompileRetryPolicy(pb.startWorkflow.retryPolicy),
       searchAttributes: decodeSearchAttributes(pb.startWorkflow.searchAttributes?.indexedFields),
       typedSearchAttributes: decodeTypedSearchAttributes(pb.startWorkflow.searchAttributes?.indexedFields),

--- a/packages/test/src/test-serialization-context.ts
+++ b/packages/test/src/test-serialization-context.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import asyncRetry from 'async-retry';
 import { Client, WorkflowFailedError } from '@temporalio/client';
 import { workflowInterceptorModules } from '@temporalio/testing';
 import { bundleWorkflowCode } from '@temporalio/worker';
@@ -86,6 +87,13 @@ function dec(label: string, ctx: string): string {
 // Helper to assert paired payload encode/decode operations in trace strings
 function encdec(label: string, ctx: string): string[] {
   return [enc(label, ctx), dec(label, ctx)];
+}
+
+function roundTripTrace(label: string, ctx: string) {
+  return {
+    label,
+    trace: [enc(label, ctx), dec(label, ctx)],
+  };
 }
 
 test('workflow start/result payloads carry workflow context', async (t) => {
@@ -586,4 +594,164 @@ test('local activity failure observed by workflow carries local activity decode 
     const message = await handle.result();
     t.is(message, `failure.decode.bound|${localAct}|failure.encode.bound|${localAct}|local-activity-failure`);
   });
+});
+
+test('workflow describe uses workflow serialization context', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker({ dataConverter });
+  const workflowId = `wf-id-${randomUUID()}`;
+  const wf = workflowCtx(workflowId);
+
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(currentWorkflowContext, {
+      args: [makeContextTrace('wf-input')],
+      workflowId,
+      taskQueue: h.taskQueue,
+      memo: { probe: makeContextTrace('wf-memo') },
+      staticSummary: 'wf static summary',
+      staticDetails: 'wf static details',
+    });
+
+    const desc = await handle.describe();
+    t.deepEqual(desc.memo?.probe, roundTripTrace('wf-memo', wf));
+    t.is(await desc.staticSummary(), 'wf static summary');
+    t.is(await desc.staticDetails(), 'wf static details');
+
+    await handle.result();
+  });
+});
+
+test('workflow list uses workflow serialization context', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker({ dataConverter });
+  const workflowId = `wf-id-${randomUUID()}`;
+  const wf = workflowCtx(workflowId);
+
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(messagePassingContexts, {
+      workflowId,
+      taskQueue: h.taskQueue,
+      memo: { probe: makeContextTrace('wf-list-memo') },
+    });
+
+    await asyncRetry(
+      async () => {
+        let found: { memo?: Record<string, unknown> } | undefined;
+        for await (const execution of client.workflow.list({ query: `WorkflowId = '${workflowId}'` })) {
+          found = execution;
+          break;
+        }
+
+        if (found === undefined) {
+          throw new Error('Missing list entry');
+        }
+
+        t.deepEqual(found.memo?.probe, roundTripTrace('wf-list-memo', wf));
+      },
+      {
+        retries: 10,
+        maxTimeout: 1000,
+      }
+    );
+
+    await handle.signal(unblockSignal, makeContextTrace('signal-input'));
+    await handle.result();
+  });
+});
+
+test('schedule create/describe uses target workflow serialization context', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const scheduleId = `schedule-id-${randomUUID()}`;
+  const targetWorkflowId = `scheduled-wf-id-${randomUUID()}`;
+  const wf = workflowCtx(targetWorkflowId);
+
+  const handle = await client.schedule.create({
+    scheduleId,
+    spec: {},
+    action: {
+      type: 'startWorkflow',
+      workflowType: currentWorkflowContext,
+      workflowId: targetWorkflowId,
+      taskQueue: h.taskQueue,
+      args: [makeContextTrace('schedule-action-arg')],
+      memo: { probe: makeContextTrace('schedule-action-memo') },
+      staticSummary: 'schedule action static summary',
+      staticDetails: 'schedule action static details',
+    },
+  });
+
+  try {
+    const described = await handle.describe();
+    t.is(described.action.type, 'startWorkflow');
+    if (described.action.type !== 'startWorkflow') {
+      throw new Error('Expected startWorkflow action');
+    }
+    t.truthy(described.action.args);
+    t.deepEqual(described.action.args?.[0], roundTripTrace('schedule-action-arg', wf));
+    t.deepEqual(described.action.memo?.probe, roundTripTrace('schedule-action-memo', wf));
+    t.is(described.action.staticSummary, 'schedule action static summary');
+    t.is(described.action.staticDetails, 'schedule action static details');
+  } finally {
+    await handle.delete();
+  }
+});
+
+test('schedule update/describe uses target workflow serialization context', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const scheduleId = `schedule-id-${randomUUID()}`;
+  const initialWorkflowId = `scheduled-wf-id-${randomUUID()}`;
+  const updatedWorkflowId = `scheduled-wf-id-${randomUUID()}`;
+  const updatedWf = workflowCtx(updatedWorkflowId);
+
+  const handle = await client.schedule.create({
+    scheduleId,
+    spec: {},
+    action: {
+      type: 'startWorkflow',
+      workflowType: currentWorkflowContext,
+      workflowId: initialWorkflowId,
+      taskQueue: h.taskQueue,
+      args: [makeContextTrace('schedule-action-arg-initial')],
+      memo: { probe: makeContextTrace('schedule-action-memo-initial') },
+      staticSummary: 'schedule action static summary initial',
+      staticDetails: 'schedule action static details initial',
+    },
+  });
+
+  try {
+    await handle.update((previous) => {
+      if (previous.action.type !== 'startWorkflow') {
+        throw new Error('Expected startWorkflow action');
+      }
+
+      return {
+        ...previous,
+        action: {
+          ...previous.action,
+          workflowId: updatedWorkflowId,
+          args: [makeContextTrace('schedule-action-arg-updated')],
+          memo: { probe: makeContextTrace('schedule-action-memo-updated') },
+          staticSummary: 'schedule action static summary updated',
+          staticDetails: 'schedule action static details updated',
+        },
+      };
+    });
+
+    const described = await handle.describe();
+    t.is(described.action.type, 'startWorkflow');
+    if (described.action.type !== 'startWorkflow') {
+      throw new Error('Expected startWorkflow action');
+    }
+    t.truthy(described.action.args);
+    t.deepEqual(described.action.args?.[0], roundTripTrace('schedule-action-arg-updated', updatedWf));
+    t.deepEqual(described.action.memo?.probe, roundTripTrace('schedule-action-memo-updated', updatedWf));
+    t.is(described.action.staticSummary, 'schedule action static summary updated');
+    t.is(described.action.staticDetails, 'schedule action static details updated');
+  } finally {
+    await handle.delete();
+  }
 });


### PR DESCRIPTION
## What was changed
Extended `SerializationContext` usage to the remaining workflow client usages (`describe`, `list`), and the schedule client.

Note that this PR scoped serialization context support for schedules to schedule start-workflow actions only. It does not include the top-level schedule memo and schedule list interfaces - those payloads belong to the schedule itself and therefore don't clearly map to a workflow or activity context.

## Why?
Support serialization context across all clients

1. Part of https://github.com/temporalio/sdk-typescript/issues/1661

2. How was this tested:
Integration tests

