### PR TITLE
[backport 1.16.2] Update core to pickup shutdown fix

### DIFF
--- a/packages/core-bridge/src/worker.rs
+++ b/packages/core-bridge/src/worker.rs
@@ -339,6 +339,12 @@ pub fn worker_complete_nexus_task(
 #[js_function]
 pub fn worker_initiate_shutdown(worker: OpaqueInboundHandle<Worker>) -> BridgeResult<()> {
     let worker_ref = worker.borrow()?;
+
+    // Core worker shutdown now spawns a Tokio task, so this sync Neon binding must
+    // enter Core's Tokio runtime before initiating shutdown.
+    let runtime = worker_ref.core_runtime.clone();
+    enter_sync!(runtime);
+
     worker_ref.core_worker.initiate_shutdown();
     Ok(())
 }


### PR DESCRIPTION


## What was changed
Pick up shutdown fix cherry-pick for v1.13.1 patch release, https://github.com/temporalio/sdk-rust/pull/1260

## Why?
<!-- Tell your future self why have you made these changes -->
bugfix

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches worker shutdown plumbing; incorrect runtime entry could still cause shutdown to hang or behave differently in production, though the change is small and localized.
> 
> **Overview**
> Fixes `workerInitiateShutdown` to **enter Core's Tokio runtime** before calling `core_worker.initiate_shutdown()`, aligning the synchronous Neon binding with Core's updated shutdown behavior (now spawning a Tokio task) to avoid missed/ineffective shutdown initiation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 453a67c8f02db7e1bcff9b3dfbe822f32e534f41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->