### PR TITLE
fix: single-quote paths in .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly
     cooldown:
       default-days: 14
 
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly
     cooldown:


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml` (added in #2055) uses double-quoted `"/"`, but the repo's prettier config enforces single quotes
- `lint:check` (`prettier --end-of-line auto --check .`) is failing on every open PR's merged tree as a result
- One-line fix: switch both `directory:` values to `'/'`

## Test plan
- [x] `prettier --end-of-line auto --check .github/dependabot.yml` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)