### PR TITLE
fix: Fix multiple lint warnings

### DIFF
--- a/contrib/ai-sdk/src/__tests__/test-ai-sdk.ts
+++ b/contrib/ai-sdk/src/__tests__/test-ai-sdk.ts
@@ -454,7 +454,7 @@ test('Telemetry', async (t) => {
     });
     await otel.start();
     const sinks: InjectedSinks<OpenTelemetrySinks> = {
-      exporter: makeWorkflowExporter(traceExporter, staticResource),
+      exporter: makeWorkflowExporter(traceExporter, staticResource), // eslint-disable-line @typescript-eslint/no-deprecated
     };
 
     const worker = await Worker.create({

--- a/contrib/interceptors-opentelemetry/src/__tests__/test-otel.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/test-otel.ts
@@ -728,7 +728,7 @@ if (RUN_INTEGRATION_TESTS) {
       const sinks: InjectedSinks<OpenTelemetrySinks> = {
         exporter: useSpanProcessor
           ? makeWorkflowExporter(new TestSpanProcessor(traceExporter), resource)
-          : makeWorkflowExporter(traceExporter, resource),
+          : makeWorkflowExporter(traceExporter, resource), // eslint-disable-line @typescript-eslint/no-deprecated
       };
 
       const worker = await Worker.create({
@@ -879,7 +879,7 @@ if (RUN_INTEGRATION_TESTS) {
       otel.start();
 
       const sinks: InjectedSinks<OpenTelemetrySinks> = {
-        exporter: makeWorkflowExporter(workflowSpanExporter, staticResource),
+        exporter: makeWorkflowExporter(workflowSpanExporter, staticResource), // eslint-disable-line @typescript-eslint/no-deprecated
       };
 
       const worker = await Worker.create({

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,8 +28,86 @@ export default tseslint.config(
       'no-duplicate-imports': ['error', { allowSeparateTypeImports: true }],
       'object-shorthand': ['error', 'always'],
       'no-restricted-imports': ['error', { patterns: ['@temporalio/*/src/*'] }],
-      // TypeScript rules
-      '@typescript-eslint/no-deprecated': 'warn',
+      '@typescript-eslint/no-deprecated': [
+        'warn',
+        {
+          allow: [
+            // Untyped Search Attributes
+            {
+              from: 'file',
+              name: [
+                'SearchAttributes',
+                'searchAttributes',
+                'searchAttributeValue',
+                'SearchAttributeValue',
+                'SearchAttributeValueOrReadonly',
+              ],
+            },
+
+            // Worker Versioning v2
+            {
+              from: 'file',
+              name: [
+                'AddNewCompatibleVersion',
+                'AddNewIdInNewDefaultSet',
+                'BaseReachabilityOptions',
+                'buildId',
+                'BuildIdNotFoundError',
+                'BuildIdOperation',
+                'BuildIdReachability',
+                'BuildIdVersionSet',
+                'currentBuildId',
+                'getBuildIdCompatability',
+                'getReachability',
+                'LoadedTaskQueueClientOptions',
+                'MergeSets',
+                'PromoteBuildIdWithinSet',
+                'PromoteSetByBuildId',
+                'ReachabilityOptions',
+                'ReachabilityResponse',
+                'ReachabilityType',
+                'ReachabilityTypeResponse',
+                'TaskQueueClient',
+                'TaskQueueClientOptions',
+                'UnversionedBuildId',
+                'updateBuildIdCompatibility',
+                'useVersioning',
+                'versioningIntent',
+                'VersioningIntent',
+                'versioningIntentToProto',
+                'VersioningIntentString',
+                'workerBuildId',
+                'WorkerBuildIdVersionSets',
+              ],
+            },
+
+            // Activity Inbound Calls Interceptors and Workflow Client Calls Interceptor
+            {
+              from: 'file',
+              name: [
+                'activityInbound',
+                'ActivityInboundCallsInterceptorFactory',
+                'WorkflowClientInterceptors',
+                'WorkflowClientCallsInterceptor',
+                'WorkflowClientCallsInterceptorFactory',
+                'WorkflowClientCallsInterceptorFactoryInput',
+              ],
+            },
+
+            // Legacy Log Interceptors / Sinks
+            {
+              from: 'file',
+              name: [
+                'ActivityInboundLogInterceptor',
+                'defaultSinks',
+                'defaultWorkerLogger',
+                'LoggerSinks',
+                'WorkflowLogInterceptor',
+              ],
+            },
+          ],
+        },
+      ],
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/explicit-module-boundary-types': 'error',

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -206,7 +206,6 @@ export interface WorkflowClientCallsInterceptorFactoryInput {
  * @deprecated: Please define interceptors directly, without factory
  */
 export interface WorkflowClientCallsInterceptorFactory {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   (input: WorkflowClientCallsInterceptorFactoryInput): WorkflowClientCallsInterceptor;
 }
 
@@ -217,7 +216,6 @@ export interface WorkflowClientCallsInterceptorFactory {
  */
 export interface WorkflowClientInterceptors {
   /** @deprecated */
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   calls?: WorkflowClientCallsInterceptorFactory[];
 }
 
@@ -247,7 +245,6 @@ export type CreateScheduleOutput = {
  * Interceptors for any high-level SDK client.
  */
 export interface ClientInterceptors {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   workflow?: WorkflowClientInterceptors | WorkflowClientInterceptor[];
   schedule?: ScheduleClientInterceptor[];
   activity?: ActivityClientInterceptor[];

--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -234,9 +234,9 @@ export class ScheduleClient extends BaseClient {
       },
       memo: opts.memo ? { fields: await encodeMapToPayloads(this.dataConverter, opts.memo) } : undefined,
       searchAttributes:
-        opts.searchAttributes || opts.typedSearchAttributes // eslint-disable-line @typescript-eslint/no-deprecated
+        opts.searchAttributes || opts.typedSearchAttributes
           ? {
-              indexedFields: encodeUnifiedSearchAttributes(opts.searchAttributes, opts.typedSearchAttributes), // eslint-disable-line @typescript-eslint/no-deprecated
+              indexedFields: encodeUnifiedSearchAttributes(opts.searchAttributes, opts.typedSearchAttributes),
             }
           : undefined,
       initialPatch: {
@@ -299,9 +299,9 @@ export class ScheduleClient extends BaseClient {
       identity: this.options.identity,
       requestId: uuid4(),
       searchAttributes:
-        opts.searchAttributes || opts.typedSearchAttributes // eslint-disable-line @typescript-eslint/no-deprecated
+        opts.searchAttributes || opts.typedSearchAttributes
           ? {
-              indexedFields: encodeUnifiedSearchAttributes(opts.searchAttributes, opts.typedSearchAttributes), // eslint-disable-line @typescript-eslint/no-deprecated
+              indexedFields: encodeUnifiedSearchAttributes(opts.searchAttributes, opts.typedSearchAttributes),
             }
           : undefined,
     };

--- a/packages/client/src/schedule-helpers.ts
+++ b/packages/client/src/schedule-helpers.ts
@@ -275,9 +275,9 @@ export async function encodeScheduleAction(
       retryPolicy: action.retry ? compileRetryPolicy(action.retry) : undefined,
       memo: action.memo ? { fields: await encodeMapToPayloads(dataConverter, action.memo, context) } : undefined,
       searchAttributes:
-        action.searchAttributes || action.typedSearchAttributes // eslint-disable-line @typescript-eslint/no-deprecated
+        action.searchAttributes || action.typedSearchAttributes
           ? {
-              indexedFields: encodeUnifiedSearchAttributes(action.searchAttributes, action.typedSearchAttributes), // eslint-disable-line @typescript-eslint/no-deprecated
+              indexedFields: encodeUnifiedSearchAttributes(action.searchAttributes, action.typedSearchAttributes),
             }
           : undefined,
       header: { fields: headers },

--- a/packages/client/src/schedule-types.ts
+++ b/packages/client/src/schedule-types.ts
@@ -80,7 +80,7 @@ export interface ScheduleOptions<A extends ScheduleOptionsAction = ScheduleOptio
    *
    * @deprecated Use {@link typedSearchAttributes} instead.
    */
-  searchAttributes?: SearchAttributes; // eslint-disable-line @typescript-eslint/no-deprecated
+  searchAttributes?: SearchAttributes;
 
   /**
    * Additional indexed information attached to the Schedule. More info:
@@ -199,7 +199,7 @@ export interface ScheduleSummary {
    *
    * @deprecated Use {@link typedSearchAttributes} instead.
    */
-  searchAttributes?: SearchAttributes; // eslint-disable-line @typescript-eslint/no-deprecated
+  searchAttributes?: SearchAttributes;
 
   /**
    * Additional indexed information attached to the Schedule. More info:
@@ -321,7 +321,7 @@ export type ScheduleDescription = {
    *
    * @deprecated Use {@link typedSearchAttributes} instead.
    */
-  searchAttributes: SearchAttributes; // eslint-disable-line @typescript-eslint/no-deprecated
+  searchAttributes: SearchAttributes;
 
   /**
    * Additional indexed information attached to the Schedule. More info:

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -57,7 +57,7 @@ export interface WorkflowExecutionInfo {
   closeTime?: Date;
   memo?: Record<string, unknown>;
   /** @deprecated Use {@link typedSearchAttributes} instead. */
-  searchAttributes: SearchAttributes; // eslint-disable-line @typescript-eslint/no-deprecated
+  searchAttributes: SearchAttributes;
   typedSearchAttributes: TypedSearchAttributes;
   parentExecution?: Required<proto.temporal.api.common.v1.IWorkflowExecution>;
   rootExecution?: Required<proto.temporal.api.common.v1.IWorkflowExecution>;
@@ -69,7 +69,7 @@ export interface CountWorkflowExecution {
   count: number;
   groups: {
     count: number;
-    groupValues: SearchAttributeValue[]; // eslint-disable-line @typescript-eslint/no-deprecated
+    groupValues: SearchAttributeValue[];
   }[];
 }
 

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -294,7 +294,6 @@ export interface WorkflowClientOptions extends BaseClientOptions {
    *
    * Useful for injecting auth headers and tracing Workflow executions
    */
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   interceptors?: WorkflowClientInterceptors | WorkflowClientInterceptor[];
 
   /**
@@ -1261,9 +1260,9 @@ export class WorkflowClient extends BaseClient {
       retryPolicy: options.retry ? compileRetryPolicy(options.retry) : undefined,
       memo: options.memo ? { fields: await encodeMapToPayloads(dataConverter, options.memo, context) } : undefined,
       searchAttributes:
-        options.searchAttributes || options.typedSearchAttributes // eslint-disable-line @typescript-eslint/no-deprecated
+        options.searchAttributes || options.typedSearchAttributes
           ? {
-              indexedFields: encodeUnifiedSearchAttributes(options.searchAttributes, options.typedSearchAttributes), // eslint-disable-line @typescript-eslint/no-deprecated
+              indexedFields: encodeUnifiedSearchAttributes(options.searchAttributes, options.typedSearchAttributes),
             }
           : undefined,
       cronSchedule: options.cronSchedule,
@@ -1352,9 +1351,9 @@ export class WorkflowClient extends BaseClient {
       retryPolicy: opts.retry ? compileRetryPolicy(opts.retry) : undefined,
       memo: opts.memo ? { fields: await encodeMapToPayloads(dataConverter, opts.memo, context) } : undefined,
       searchAttributes:
-        opts.searchAttributes || opts.typedSearchAttributes // eslint-disable-line @typescript-eslint/no-deprecated
+        opts.searchAttributes || opts.typedSearchAttributes
           ? {
-              indexedFields: encodeUnifiedSearchAttributes(opts.searchAttributes, opts.typedSearchAttributes), // eslint-disable-line @typescript-eslint/no-deprecated
+              indexedFields: encodeUnifiedSearchAttributes(opts.searchAttributes, opts.typedSearchAttributes),
             }
           : undefined,
       cronSchedule: opts.cronSchedule,

--- a/packages/common/src/activity-options.ts
+++ b/packages/common/src/activity-options.ts
@@ -178,7 +178,7 @@ export interface ActivityOptions {
    *
    * @deprecated Worker Versioning is now deprecated. Please use the Worker Deployment API instead: https://docs.temporal.io/worker-deployments
    */
-  versioningIntent?: VersioningIntent; // eslint-disable-line @typescript-eslint/no-deprecated
+  versioningIntent?: VersioningIntent;
 
   /**
    * A fixed, single-line summary for this workflow execution that may appear in the UI/CLI.

--- a/packages/common/src/converter/payload-search-attributes.ts
+++ b/packages/common/src/converter/payload-search-attributes.ts
@@ -163,7 +163,7 @@ export const typedSearchAttributePayloadConverter = new TypedSearchAttributePayl
 
 // If both params are provided, conflicting keys will be overwritten by typedSearchAttributes.
 export function encodeUnifiedSearchAttributes(
-  searchAttributes?: SearchAttributes, // eslint-disable-line @typescript-eslint/no-deprecated
+  searchAttributes?: SearchAttributes,
   typedSearchAttributes?: TypedSearchAttributes | SearchAttributeUpdatePair[]
 ): Record<string, Payload> {
   return {
@@ -183,11 +183,9 @@ export function encodeUnifiedSearchAttributes(
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 export function decodeSearchAttributes(indexedFields: Record<string, Payload> | undefined | null): SearchAttributes {
   if (!indexedFields) return {};
   return Object.fromEntries(
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
     Object.entries(mapFromPayloads(searchAttributePayloadConverter, indexedFields) as SearchAttributes).filter(
       ([_, v]) => v && v.length > 0
     ) // Filter out empty arrays returned by pre 1.18 servers

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -36,8 +36,8 @@ export * from './workflow-handle';
 export * from './workflow-options';
 export * from './versioning-intent';
 export {
-  SearchAttributes, // eslint-disable-line @typescript-eslint/no-deprecated
-  SearchAttributeValue, // eslint-disable-line @typescript-eslint/no-deprecated
+  SearchAttributes,
+  SearchAttributeValue,
   SearchAttributeType,
   SearchAttributePair,
   SearchAttributeUpdatePair,

--- a/packages/common/src/search-attributes.ts
+++ b/packages/common/src/search-attributes.ts
@@ -2,9 +2,9 @@ import type { temporal } from '@temporalio/proto';
 import { makeProtoEnumConverters } from './internal-workflow';
 
 /** @deprecated: Use {@link TypedSearchAttributes} instead */
-export type SearchAttributeValueOrReadonly = SearchAttributeValue | Readonly<SearchAttributeValue> | undefined; // eslint-disable-line @typescript-eslint/no-deprecated
+export type SearchAttributeValueOrReadonly = SearchAttributeValue | Readonly<SearchAttributeValue> | undefined;
 /** @deprecated: Use {@link TypedSearchAttributes} instead */
-export type SearchAttributes = Record<string, SearchAttributeValueOrReadonly>; // eslint-disable-line @typescript-eslint/no-deprecated
+export type SearchAttributes = Record<string, SearchAttributeValueOrReadonly>;
 /** @deprecated: Use {@link TypedSearchAttributes} instead */
 export type SearchAttributeValue = string[] | number[] | boolean[] | Date[];
 
@@ -212,7 +212,7 @@ export class TypedSearchAttributes {
 
   static getKeyFromUntyped(
     key: string,
-    value: SearchAttributeValueOrReadonly // eslint-disable-line @typescript-eslint/no-deprecated
+    value: SearchAttributeValueOrReadonly
   ): SearchAttributeKey<SearchAttributeType> | undefined {
     if (value == null) {
       return;

--- a/packages/common/src/versioning-intent-enum.ts
+++ b/packages/common/src/versioning-intent-enum.ts
@@ -2,8 +2,6 @@ import type { coresdk } from '@temporalio/proto';
 import type { VersioningIntent as VersioningIntentString } from './versioning-intent';
 import { assertNever, checkExtends } from './type-helpers';
 
-/* eslint-disable @typescript-eslint/no-deprecated */
-
 // Avoid importing the proto implementation to reduce workflow bundle size
 // Copied from coresdk.common.VersioningIntent
 /**

--- a/packages/common/src/workflow-options.ts
+++ b/packages/common/src/workflow-options.ts
@@ -179,7 +179,7 @@ export interface BaseWorkflowOptions {
    *
    * @deprecated Use {@link typedSearchAttributes} instead.
    */
-  searchAttributes?: SearchAttributes; // eslint-disable-line @typescript-eslint/no-deprecated
+  searchAttributes?: SearchAttributes;
 
   /**
    * Specifies additional indexed information to attach to the Workflow Execution. More info:

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -267,7 +267,6 @@ function resolveWorkerInterceptors(
 }
 
 function modernWorkflowInterceptors(
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   interceptors: WorkflowClientInterceptors | WorkflowClientInterceptor[] | undefined
 ): WorkflowClientInterceptor[] | undefined {
   if (interceptors === undefined || Array.isArray(interceptors)) {

--- a/packages/test/src/mock-native-worker.ts
+++ b/packages/test/src/mock-native-worker.ts
@@ -63,7 +63,7 @@ export class MockNativeWorker implements NativeWorkerLike {
   }
 
   public initiateShutdown(): void {
-    const shutdownErrorPromise = Promise.reject(new ShutdownError('Core is shut down'));
+    const shutdownErrorPromise = Promise.reject(new ShutdownError('Core is shut down')); // eslint-disable-line @typescript-eslint/no-deprecated
     shutdownErrorPromise.catch(() => {
       /* avoid unhandled rejection */
     });

--- a/packages/test/src/test-activity-log-interceptor.ts
+++ b/packages/test/src/test-activity-log-interceptor.ts
@@ -128,7 +128,6 @@ test('(Legacy) ActivityInboundLogInterceptor does not override Context.log by de
   const env = new MockActivityEnvironment(
     {},
     {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
       interceptors: [(ctx) => ({ inbound: new ActivityInboundLogInterceptor(ctx) })],
       logger: mockLogger,
     }
@@ -150,7 +149,6 @@ test('(Legacy) ActivityInboundLogInterceptor overrides Context.log if a logger i
   const env = new MockActivityEnvironment(
     {},
     {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
       interceptors: [(ctx) => ({ inbound: new ActivityInboundLogInterceptor(ctx, logger) })],
       logger: mockLogger,
     }
@@ -163,7 +161,6 @@ test('(Legacy) ActivityInboundLogInterceptor overrides Context.log if a logger i
 });
 
 test('(Legacy) ActivityInboundLogInterceptor overrides Context.log if class is extended', async (t) => {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   class CustomActivityInboundLogInterceptor extends ActivityInboundLogInterceptor {
     protected logAttributes(): Record<string, unknown> {
       const { namespace: _, ...rest } = super.logAttributes();

--- a/packages/test/src/test-integration-split-one.ts
+++ b/packages/test/src/test-integration-split-one.ts
@@ -632,20 +632,19 @@ test.serial('WorkflowHandle.describe result is wrapped', configMacro, async (t, 
   t.deepEqual(execution.type, 'argsAndReturn');
   t.deepEqual(execution.memo, { note: 'foo' });
   t.true(execution.startTime instanceof Date);
-  t.deepEqual(execution.searchAttributes!.CustomKeywordField, ['test-value']); // eslint-disable-line @typescript-eslint/no-deprecated
-  t.deepEqual(execution.searchAttributes!.CustomIntField, [1]); // eslint-disable-line @typescript-eslint/no-deprecated
-  t.deepEqual(execution.searchAttributes!.CustomDatetimeField, [date]); // eslint-disable-line @typescript-eslint/no-deprecated
-  const binSum = execution.searchAttributes!.BinaryChecksums as string[]; // eslint-disable-line @typescript-eslint/no-deprecated
+  t.deepEqual(execution.searchAttributes!.CustomKeywordField, ['test-value']);
+  t.deepEqual(execution.searchAttributes!.CustomIntField, [1]);
+  t.deepEqual(execution.searchAttributes!.CustomDatetimeField, [date]);
+  const binSum = execution.searchAttributes!.BinaryChecksums as string[];
   if (binSum != null) {
     t.regex(binSum[0], /@temporalio\/worker@/);
   } else {
-    t.deepEqual(execution.searchAttributes!.BuildIds, ['unversioned', `unversioned:${worker.options.buildId}`]); // eslint-disable-line @typescript-eslint/no-deprecated
+    t.deepEqual(execution.searchAttributes!.BuildIds, ['unversioned', `unversioned:${worker.options.buildId}`]);
   }
 });
 
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 export async function returnSearchAttributes(): Promise<SearchAttributes | undefined> {
-  const sa = workflowInfo().searchAttributes!; // eslint-disable-line @typescript-eslint/no-deprecated
+  const sa = workflowInfo().searchAttributes!;
   const datetime = (sa.CustomDatetimeField as Array<Date>)[0];
   return {
     ...sa,
@@ -705,7 +704,7 @@ test.serial('Workflow can upsert Search Attributes', configMacro, async (t, conf
     CustomDatetimeField: [date.toISOString()],
     CustomDoubleField: [3.14],
   });
-  const { searchAttributes } = await handle.describe(); // eslint-disable-line @typescript-eslint/no-deprecated
+  const { searchAttributes } = await handle.describe();
   const { BinaryChecksums, BuildIds, ...rest } = searchAttributes;
   t.deepEqual(rest, {
     CustomBoolField: [true],
@@ -767,7 +766,7 @@ test.serial('Workflow can read WorkflowInfo', configMacro, async (t, config) => 
     historySize: res.historySize,
     startTime: res.startTime,
     runStartTime: res.runStartTime,
-    currentBuildId: res.currentBuildId, // eslint-disable-line @typescript-eslint/no-deprecated
+    currentBuildId: res.currentBuildId,
     currentDeploymentVersion: res.currentDeploymentVersion,
     // unsafe.now is a function, so doesn't make it through serialization, but .now is required, so we need to cast
     unsafe: { isReplaying: false, isReplayingHistoryEvents: false } as UnsafeWorkflowInfo,

--- a/packages/test/src/test-integration-split-two.ts
+++ b/packages/test/src/test-integration-split-two.ts
@@ -118,7 +118,7 @@ test.serial('WorkflowOptions are passed correctly', configMacro, async (t, confi
     ),
     [3]
   );
-  t.deepEqual(execution.searchAttributes!.CustomIntField, [3]); // eslint-disable-line @typescript-eslint/no-deprecated
+  t.deepEqual(execution.searchAttributes!.CustomIntField, [3]);
   t.is(execution.raw.executionConfig?.taskQueue?.name, 'diff-task-queue');
   t.is(
     execution.raw.executionConfig?.taskQueue?.kind,
@@ -246,8 +246,8 @@ test.serial('continue-as-new-to-same-workflow keeps memo and search attributes',
     const execution = await handle.describe();
     t.not(execution.runId, handle.firstExecutionRunId);
     t.deepEqual(execution.memo, { note: 'foo' });
-    t.deepEqual(execution.searchAttributes!.CustomKeywordField, ['test-value']); // eslint-disable-line @typescript-eslint/no-deprecated
-    t.deepEqual(execution.searchAttributes!.CustomIntField, [1]); // eslint-disable-line @typescript-eslint/no-deprecated
+    t.deepEqual(execution.searchAttributes!.CustomKeywordField, ['test-value']);
+    t.deepEqual(execution.searchAttributes!.CustomIntField, [1]);
   });
 });
 
@@ -275,8 +275,8 @@ test.serial(
       t.is(info.type, 'sleeper');
       t.not(info.runId, handle.firstExecutionRunId);
       t.deepEqual(info.memo, { note: 'foo' });
-      t.deepEqual(info.searchAttributes!.CustomKeywordField, ['test-value']); // eslint-disable-line @typescript-eslint/no-deprecated
-      t.deepEqual(info.searchAttributes!.CustomIntField, [1]); // eslint-disable-line @typescript-eslint/no-deprecated
+      t.deepEqual(info.searchAttributes!.CustomKeywordField, ['test-value']);
+      t.deepEqual(info.searchAttributes!.CustomIntField, [1]);
     });
   }
 );
@@ -316,8 +316,8 @@ test.serial(
       t.is(info.type, 'sleeper');
       t.not(info.runId, handle.firstExecutionRunId);
       t.deepEqual(info.memo, { note: 'bar' });
-      t.deepEqual(info.searchAttributes!.CustomKeywordField, ['test-value-2']); // eslint-disable-line @typescript-eslint/no-deprecated
-      t.deepEqual(info.searchAttributes!.CustomIntField, [3]); // eslint-disable-line @typescript-eslint/no-deprecated
+      t.deepEqual(info.searchAttributes!.CustomKeywordField, ['test-value-2']);
+      t.deepEqual(info.searchAttributes!.CustomIntField, [3]);
     });
   }
 );

--- a/packages/test/src/test-integration-workflows.ts
+++ b/packages/test/src/test-integration-workflows.ts
@@ -525,7 +525,7 @@ export async function buildIdTester(): Promise<void> {
   });
 
   workflow.setHandler(getBuildIdQuery, () => {
-    return workflow.workflowInfo().currentBuildId ?? ''; // eslint-disable-line @typescript-eslint/no-deprecated
+    return workflow.workflowInfo().currentBuildId ?? '';
   });
 
   // The unblock signal will only be sent once we are in Worker 1.1.
@@ -1321,7 +1321,7 @@ test.serial('can register search attributes to dev server', async (t) => {
   // Expect workflow description to have search attribute.
   const desc = await handle.describe();
   t.deepEqual(desc.typedSearchAttributes, new TypedSearchAttributes([newSearchAttribute]));
-  t.deepEqual(desc.searchAttributes, { 'new-search-attr': [12] }); // eslint-disable-line @typescript-eslint/no-deprecated
+  t.deepEqual(desc.searchAttributes, { 'new-search-attr': [12] });
   await env.teardown();
 });
 

--- a/packages/test/src/test-lambda-worker.ts
+++ b/packages/test/src/test-lambda-worker.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import type { WorkerOptions, NativeConnectionOptions } from '@temporalio/worker';
-import { runWorker, type LambdaWorkerConfig } from '@temporalio/lambda-worker';
+import type { LambdaWorkerConfig } from '@temporalio/lambda-worker';
 import { type WorkerDeps, _runWorkerInternal } from '@temporalio/lambda-worker/lib/lambda-worker';
 import { LAMBDA_WORKER_DEFAULTS } from '@temporalio/lambda-worker/lib/defaults';
 

--- a/packages/test/src/test-native-connection.ts
+++ b/packages/test/src/test-native-connection.ts
@@ -86,7 +86,7 @@ test('NativeConnection.connect() throws meaningful error when passed invalid cli
 if (RUN_INTEGRATION_TESTS) {
   test('NativeConnection errors have detail', async (t) => {
     await t.throwsAsync(() => NativeConnection.connect({ address: '127.0.0.1:1' }), {
-      instanceOf: TransportError,
+      instanceOf: TransportError, // eslint-disable-line @typescript-eslint/no-deprecated
       message: /.*Connection[ ]?refused.*/i,
     });
   });

--- a/packages/test/src/test-nexus-workflow-caller.ts
+++ b/packages/test/src/test-nexus-workflow-caller.ts
@@ -936,7 +936,7 @@ test('inbound cancelOperation interceptor can modify input', async (t) => {
             return input;
           },
           asyncOp: {
-            async start(_ctx, input) {
+            async start(_ctx, _input) {
               return nexus.HandlerStartOperationResult.async('original-token');
             },
             async cancel(_ctx, token) {

--- a/packages/test/src/test-schedules.ts
+++ b/packages/test/src/test-schedules.ts
@@ -180,7 +180,6 @@ if (RUN_INTEGRATION_TESTS) {
       t.is(describedSchedule.action.type, 'startWorkflow');
       t.is(describedSchedule.action.workflowType, 'dummyWorkflow');
       t.deepEqual(describedSchedule.action.memo, { 'my-memo': 'foo' });
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
       t.deepEqual(describedSchedule.action.searchAttributes, {
         CustomKeywordField: ['test-value2'],
         CustomIntField: [42],
@@ -227,7 +226,6 @@ if (RUN_INTEGRATION_TESTS) {
       t.is(describedSchedule.action.workflowType, 'dummyWorkflowWith2Args');
       t.deepEqual(describedSchedule.action.args, [3, 4]);
       t.deepEqual(describedSchedule.action.memo, { 'my-memo': 'foo' });
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
       t.deepEqual(describedSchedule.action.searchAttributes, {
         CustomKeywordField: ['test-value2'],
         CustomIntField: [42],
@@ -577,7 +575,7 @@ if (RUN_INTEGRATION_TESTS) {
     const expectedIds: string[] = [];
     for (let i = 0; i < 4; i++) {
       const scheduleId = `test-query-${groupId}-${i + 1}`;
-      const searchAttributes: SearchAttributes = {}; // eslint-disable-line @typescript-eslint/no-deprecated
+      const searchAttributes: SearchAttributes = {};
       if (i < 2) {
         searchAttributes['CustomKeywordField'] = ['some-value'];
         expectedIds.push(scheduleId);
@@ -791,7 +789,6 @@ if (RUN_INTEGRATION_TESTS) {
 
     // Check the search attributes are part of the schedule description.
     const desc = await handle.describe();
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
     t.deepEqual(desc.searchAttributes, {
       CustomKeywordField: ['keyword-one'],
       CustomIntField: [1],
@@ -822,7 +819,6 @@ if (RUN_INTEGRATION_TESTS) {
       }));
 
       let desc = await waitForAttributeChange(handle, 'CustomTextField', true);
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
       t.deepEqual(desc.searchAttributes, {
         CustomKeywordField: ['keyword-two'],
         CustomIntField: [2],
@@ -849,7 +845,6 @@ if (RUN_INTEGRATION_TESTS) {
       }));
 
       desc = await waitForAttributeChange(handle, 'CustomTextField', false);
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
       t.deepEqual(desc.searchAttributes, {
         CustomKeywordField: ['keyword-three'],
         CustomIntField: [3],
@@ -870,7 +865,7 @@ if (RUN_INTEGRATION_TESTS) {
       }));
 
       desc = await waitForAttributeChange(handle, 'CustomIntField', false);
-      t.deepEqual(desc.searchAttributes, {}); // eslint-disable-line @typescript-eslint/no-deprecated
+      t.deepEqual(desc.searchAttributes, {});
       t.deepEqual(desc.typedSearchAttributes, new TypedSearchAttributes([]));
     } finally {
       await handle.delete();

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -108,7 +108,7 @@ if (RUN_INTEGRATION_TESTS) {
     });
 
     // Capture volatile values that are hard to predict
-    const { historySize, startTime, runStartTime, currentBuildId, currentDeploymentVersion } = recordedCalls[0].info; // eslint-disable-line @typescript-eslint/no-deprecated
+    const { historySize, startTime, runStartTime, currentBuildId, currentDeploymentVersion } = recordedCalls[0].info;
     t.true(historySize > 300);
 
     const info: WorkflowInfo = {
@@ -394,14 +394,14 @@ if (RUN_INTEGRATION_TESTS) {
   test('Sink functions contains upserted search attributes', async (t) => {
     const taskQueue = `${__filename}-${t.title}`;
 
-    const recordedMessages = Array<{ message: string; searchAttributes: SearchAttributes }>(); // eslint-disable-line @typescript-eslint/no-deprecated
+    const recordedMessages = Array<{ message: string; searchAttributes: SearchAttributes }>();
     const sinks: InjectedSinks<workflows.CustomLoggerSinks> = {
       customLogger: {
         info: {
           fn: async (info, message) => {
             recordedMessages.push({
               message,
-              searchAttributes: info.searchAttributes, // eslint-disable-line @typescript-eslint/no-deprecated
+              searchAttributes: info.searchAttributes,
             });
           },
           callDuringReplay: false,

--- a/packages/test/src/test-standalone-activities.ts
+++ b/packages/test/src/test-standalone-activities.ts
@@ -11,7 +11,7 @@ import {
   isGrpcCancelledError,
 } from '@temporalio/client';
 import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
-import { activityInfo, heartbeat } from '@temporalio/activity';
+import { activityInfo } from '@temporalio/activity';
 import type { TestWorkflowEnvironment } from './helpers';
 import { RUN_INTEGRATION_TESTS, waitUntil, Worker } from './helpers';
 import { echo, throwAnError } from './activities';

--- a/packages/test/src/test-typed-search-attributes.ts
+++ b/packages/test/src/test-typed-search-attributes.ts
@@ -31,7 +31,6 @@ const test = makeTestFunction({
 const date = new Date();
 const secondDate = new Date(date.getTime() + 1000);
 
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 const untypedAttrsInput: SearchAttributes = {
   untyped_single_string: ['one'],
   untyped_single_int: [1],
@@ -67,7 +66,6 @@ const typedAttrsListInput: SearchAttributePair[] = [
 const typedAttrsObjInput = new TypedSearchAttributes(typedAttrsListInput);
 
 // The corresponding untyped search attributes from typedSearchAttributesList.
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 const untypedFromTypedInput: SearchAttributes = {
   typed_text: ['typed_text'],
   typed_keyword: ['typed_keyword'],
@@ -168,11 +166,11 @@ test('does not allow non-integer values for integer search attributes', async (t
 interface TestInputSearchAttributes {
   name: string;
   input: {
-    searchAttributes?: SearchAttributes; // eslint-disable-line @typescript-eslint/no-deprecated
+    searchAttributes?: SearchAttributes;
     typedSearchAttributes?: TypedSearchAttributes | SearchAttributePair[];
   };
   expected: {
-    searchAttributes?: SearchAttributes; // eslint-disable-line @typescript-eslint/no-deprecated
+    searchAttributes?: SearchAttributes;
     typedSearchAttributes?: TypedSearchAttributes;
   };
 }
@@ -252,7 +250,7 @@ test('creating schedules with various input search attributes', async (t) => {
         ...input,
       });
       const desc = await handle.describe();
-      t.deepEqual(desc.searchAttributes, expected.searchAttributes, name); // eslint-disable-line @typescript-eslint/no-deprecated
+      t.deepEqual(desc.searchAttributes, expected.searchAttributes, name);
       t.deepEqual(desc.typedSearchAttributes, expected.typedSearchAttributes, name);
     })
   );
@@ -260,7 +258,7 @@ test('creating schedules with various input search attributes', async (t) => {
 
 export const getWorkflowInfo = defineQuery<WorkflowInfo>('getWorkflowInfo');
 export const mutateSearchAttributes =
-  defineSignal<[SearchAttributes | SearchAttributeUpdatePair[]]>('mutateSearchAttributes'); // eslint-disable-line @typescript-eslint/no-deprecated
+  defineSignal<[SearchAttributes | SearchAttributeUpdatePair[]]>('mutateSearchAttributes');
 export const complete = defineSignal('complete');
 
 export async function changeSearchAttributes(): Promise<void> {
@@ -291,7 +289,6 @@ test('upsert works with various search attribute mutations', async (t) => {
     assertWorkflowDescSearchAttributes(t, desc, untypedFromTypedInput, typedAttrsListInput);
 
     // Update search attributes with untyped input.
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const untypedUpdateAttrs: SearchAttributes = {
       typed_text: ['new_value'],
       typed_keyword: ['new_keyword'],
@@ -399,12 +396,12 @@ test('upsert works with various search attribute mutations', async (t) => {
 function assertWorkflowInfoSearchAttributes(
   t: ExecutionContext<Context>,
   res: WorkflowInfo,
-  searchAttributes: SearchAttributes, // eslint-disable-line @typescript-eslint/no-deprecated
+  searchAttributes: SearchAttributes,
   searchAttrPairs: SearchAttributePair[]
 ) {
   // Check initial search attributes are present.
   // Response from query serializes datetime attributes to strings so we serialize our expected responses.
-  t.deepEqual(res.searchAttributes, normalizeSearchAttrs(searchAttributes)); // eslint-disable-line @typescript-eslint/no-deprecated
+  t.deepEqual(res.searchAttributes, normalizeSearchAttrs(searchAttributes));
   // This casting is necessary because res.typedSearchAttributes has actually been serialized by its toJSON method
   // (returning an array of SearchAttributePair), but is not reflected in its type definition.
   assertMatchingSearchAttributePairs(t, res.typedSearchAttributes as unknown as SearchAttributePair[], searchAttrPairs);
@@ -413,20 +410,19 @@ function assertWorkflowInfoSearchAttributes(
 function assertWorkflowDescSearchAttributes(
   t: ExecutionContext<Context>,
   desc: WorkflowExecutionDescription,
-  searchAttributes: SearchAttributes, // eslint-disable-line @typescript-eslint/no-deprecated
+  searchAttributes: SearchAttributes,
   searchAttrPairs: SearchAttributePair[]
 ) {
   // Check that all search attributes are present in the workflow description's search attributes.
-  t.like(desc.searchAttributes, searchAttributes); // eslint-disable-line @typescript-eslint/no-deprecated
+  t.like(desc.searchAttributes, searchAttributes);
   const descOmittingBuildIds = desc.typedSearchAttributes
     .updateCopy([{ key: defineSearchAttributeKey('BuildIds', SearchAttributeType.KEYWORD_LIST), value: null }])
     .getAll();
   assertMatchingSearchAttributePairs(t, descOmittingBuildIds, searchAttrPairs);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 function normalizeSearchAttrs(attrs: SearchAttributes): SearchAttributes {
-  const res: SearchAttributes = {}; // eslint-disable-line @typescript-eslint/no-deprecated
+  const res: SearchAttributes = {};
   for (const [key, value] of Object.entries(attrs)) {
     if (Array.isArray(value) && value.length === 1 && value[0] instanceof Date) {
       res[key] = [value[0].toISOString()];

--- a/packages/test/src/test-worker-deployment-versioning.ts
+++ b/packages/test/src/test-worker-deployment-versioning.ts
@@ -712,20 +712,20 @@ test('Worker with deployment options and useWorkerVersioning false can run workf
 });
 
 test('WorkerDeploymentOptions with useWorkerVersioning true requires defaultVersioningBehavior', (t) => {
-  const valid: WorkerDeploymentOptions = {
+  const _valid: WorkerDeploymentOptions = {
     version: { buildId: '1.0', deploymentName: 'my-deployment' },
     useWorkerVersioning: true,
     defaultVersioningBehavior: 'AUTO_UPGRADE',
   };
 
-  const validPinned: WorkerDeploymentOptions = {
+  const _validPinned: WorkerDeploymentOptions = {
     version: { buildId: '1.0', deploymentName: 'my-deployment' },
     useWorkerVersioning: true,
     defaultVersioningBehavior: 'PINNED',
   };
 
   // @ts-expect-error defaultVersioningBehavior is required when useWorkerVersioning is true
-  const missingBehavior: WorkerDeploymentOptions = {
+  const _missingBehavior: WorkerDeploymentOptions = {
     version: { buildId: '1.0', deploymentName: 'my-deployment' },
     useWorkerVersioning: true,
   };
@@ -739,7 +739,7 @@ test('WorkerDeploymentOptions with useWorkerVersioning false does not allow defa
     useWorkerVersioning: false,
   };
 
-  const invalidWithBehavior: WorkerDeploymentOptions = {
+  const _invalidWithBehavior: WorkerDeploymentOptions = {
     version: { buildId: '1.0', deploymentName: 'my-deployment' },
     useWorkerVersioning: false,
     // @ts-expect-error defaultVersioningBehavior must not be specified when useWorkerVersioning is false

--- a/packages/test/src/test-worker-tuner.ts
+++ b/packages/test/src/test-worker-tuner.ts
@@ -220,7 +220,7 @@ class MySS<SI extends SlotInfo> implements CustomSlotSupplier<SI> {
     this.seenSlotTypes.add(ctx.slotType);
     this.t.truthy(ctx.taskQueue);
     this.t.truthy(ctx.workerIdentity);
-    this.t.truthy(ctx.workerBuildId); // eslint-disable-line @typescript-eslint/no-deprecated
+    this.t.truthy(ctx.workerBuildId);
     this.t.not(ctx.isSticky, undefined);
     this.seenStickyFlags.add(ctx.isSticky);
     this.reserved++;

--- a/packages/test/src/test-workflow-log-interceptor.ts
+++ b/packages/test/src/test-workflow-log-interceptor.ts
@@ -121,7 +121,6 @@ test('(Legacy) defaultSinks(logger) can be used to customize where logs are sent
     connection: nativeConnection,
     taskQueue: t.context.taskQueue,
     workflowsPath: require.resolve('./workflows'),
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
     sinks: defaultSinks(logger),
   });
   await worker.runUntil(
@@ -153,7 +152,6 @@ test('(Legacy) Can register defaultWorkerLogger sink to customize where logs are
     connection: nativeConnection,
     taskQueue: t.context.taskQueue,
     workflowsPath: require.resolve('./workflows'),
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
     sinks: <InjectedSinks<LoggerSinks>>{
       defaultWorkerLogger: {
         trace: { fn: fn.bind(undefined, 'TRACE') },

--- a/packages/test/src/test-workflow-unhandled-rejection-crash.ts
+++ b/packages/test/src/test-workflow-unhandled-rejection-crash.ts
@@ -19,7 +19,7 @@ if (RUN_INTEGRATION_TESTS) {
     });
     try {
       await t.throwsAsync(worker.run(), {
-        instanceOf: UnexpectedError,
+        instanceOf: UnexpectedError, // eslint-disable-line @typescript-eslint/no-deprecated
         message:
           `Workflow Worker Thread exited prematurely: ${isBun ? 'Error' : 'UnhandledRejectionError'}: ` +
           "Unhandled Promise rejection for unknown Workflow Run id='undefined': " +

--- a/packages/test/src/workflows/log-sink-tester.ts
+++ b/packages/test/src/workflows/log-sink-tester.ts
@@ -35,7 +35,6 @@ export async function logSinkTester(): Promise<void> {
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 const { defaultWorkerLogger } = wf.proxySinks<wf.LoggerSinks>();
 
 export async function useDepreatedLoggerSinkWorkflow(): Promise<void> {

--- a/packages/test/src/workflows/upsert-and-read-search-attributes.ts
+++ b/packages/test/src/workflows/upsert-and-read-search-attributes.ts
@@ -4,7 +4,6 @@ import type { CustomLoggerSinks } from './log-sink-tester';
 
 const { customLogger } = proxySinks<CustomLoggerSinks>();
 
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 export async function upsertAndReadSearchAttributes(msSinceEpoch: number): Promise<SearchAttributes | undefined> {
   customLogger.info('Before upsert');
   upsertSearchAttributes({
@@ -19,5 +18,5 @@ export async function upsertAndReadSearchAttributes(msSinceEpoch: number): Promi
     CustomDoubleField: [3.14],
   });
   customLogger.info('After upsert');
-  return workflowInfo().searchAttributes; // eslint-disable-line @typescript-eslint/no-deprecated
+  return workflowInfo().searchAttributes;
 }

--- a/packages/testing/src/mocking-activity-environment.ts
+++ b/packages/testing/src/mocking-activity-environment.ts
@@ -52,7 +52,7 @@ export class MockActivityEnvironment extends events.EventEmitter {
       loadedDataConverter,
       {
         type: 'activity',
-        namespace: activityInfo.activityNamespace,
+        namespace: activityInfo.activityNamespace, // eslint-disable-line @typescript-eslint/no-deprecated
         activityId: activityInfo.activityId,
         workflowId: activityInfo.workflowExecution?.workflowId,
         isLocal: activityInfo.isLocal,

--- a/packages/worker/src/activity-log-interceptor.ts
+++ b/packages/worker/src/activity-log-interceptor.ts
@@ -29,10 +29,7 @@ export class ActivityInboundLogInterceptor implements ActivityInboundCallsInterc
     // extending it (ie. to inject custom log attributes), then just be a noop. This is just to avoid bothering users
     // that followed something that used to be a recommended pattern. The "default" behavior that used to be provided by
     // this class is now handled elsewhere.
-    if (
-      this.logger === runtimeLogger &&
-      Object.getPrototypeOf(this) === ActivityInboundLogInterceptor.prototype // eslint-disable-line @typescript-eslint/no-deprecated
-    )
+    if (this.logger === runtimeLogger && Object.getPrototypeOf(this) === ActivityInboundLogInterceptor.prototype)
       return;
 
     this.ctx.log = Object.fromEntries(

--- a/packages/worker/src/interceptors.ts
+++ b/packages/worker/src/interceptors.ts
@@ -214,7 +214,7 @@ export interface WorkerInterceptors {
    *
    * @deprecated Use {@link WorkerInterceptors.activity} instead.
    */
-  activityInbound?: ActivityInboundCallsInterceptorFactory[]; // eslint-disable-line @typescript-eslint/no-deprecated
+  activityInbound?: ActivityInboundCallsInterceptorFactory[];
 
   /**
    * List of factory functions that instanciate {@link NexusInterceptors}s.

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -765,7 +765,6 @@ export function isPathBundleOption(bundleOpt: WorkflowBundleOption): bundleOpt i
  * @deprecated Calling `defaultSink()` is no longer required. To configure a custom logger, set the
  *             {@link Runtime.logger} property instead.
  */
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 export function defaultSinks(logger?: Logger): InjectedSinks<LoggerSinks> {
   // initLoggerSink() returns a sink that complies to the new LoggerSinksInternal API (ie. named __temporal_logger), but
   // code that is still calling defaultSinks() expects return type to match the deprecated LoggerSinks API. Silently
@@ -775,12 +774,11 @@ export function defaultSinks(logger?: Logger): InjectedSinks<LoggerSinks> {
   // If no logger was provided, the legacy behavior was to _lazily_ set the sink's logger to the Runtime's logger.
   // This was required because we may call defaultSinks() before the Runtime is initialized. We preserve that behavior
   // here by silently not initializing the sink if no logger is provided.
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   if (!logger) return {} as InjectedSinks<LoggerSinks>;
 
   // Register the logger sink with its historical name
   const { __temporal_logger: defaultWorkerLogger } = initLoggerSink(logger);
-  return { defaultWorkerLogger } satisfies InjectedSinks<LoggerSinks>; // eslint-disable-line @typescript-eslint/no-deprecated
+  return { defaultWorkerLogger } satisfies InjectedSinks<LoggerSinks>;
 }
 
 /**
@@ -798,12 +796,7 @@ export function appendDefaultInterceptors(
   if (!logger || logger === Runtime.instance().logger) return interceptors;
 
   return {
-    activityInbound: [
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      (ctx) => new ActivityInboundLogInterceptor(ctx, logger),
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      ...(interceptors.activityInbound ?? []),
-    ],
+    activityInbound: [(ctx) => new ActivityInboundLogInterceptor(ctx, logger), ...(interceptors.activityInbound ?? [])],
     activity: interceptors.activity,
     workflowModules: interceptors.workflowModules,
   };
@@ -812,7 +805,7 @@ export function appendDefaultInterceptors(
 function compileWorkerInterceptors({
   client,
   activity,
-  activityInbound, // eslint-disable-line @typescript-eslint/no-deprecated
+  activityInbound,
   nexus,
   workflowModules,
 }: Required<WorkerInterceptors>): CompiledWorkerInterceptors {
@@ -899,8 +892,8 @@ function addDefaultWorkerOptions(
   metricMeter: MetricMeter
 ): WorkerOptionsWithDefaults {
   const {
-    buildId, // eslint-disable-line @typescript-eslint/no-deprecated
-    useVersioning, // eslint-disable-line @typescript-eslint/no-deprecated
+    buildId,
+    useVersioning,
     maxCachedWorkflows,
     showStackTraceSources,
     namespace,
@@ -1015,7 +1008,6 @@ function addDefaultWorkerOptions(
       },
       activity: interceptors?.activity ?? [],
       nexus: interceptors?.nexus ?? [],
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
       activityInbound: interceptors?.activityInbound ?? [],
       workflowModules: interceptors?.workflowModules ?? [],
     },
@@ -1113,8 +1105,8 @@ export function toNativeWorkerOptions(opts: CompiledWorkerOptionsWithBuildId): n
   const enableLocalActivities = enableWorkflows && opts.activities.size > 0;
   return {
     identity: opts.identity,
-    buildId: opts.buildId, // eslint-disable-line @typescript-eslint/no-deprecated
-    useVersioning: opts.useVersioning, // eslint-disable-line @typescript-eslint/no-deprecated
+    buildId: opts.buildId,
+    useVersioning: opts.useVersioning,
     workerDeploymentOptions: toNativeDeploymentOptions(opts.workerDeploymentOptions),
     taskQueue: opts.taskQueue,
     namespace: opts.namespace,

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -168,7 +168,7 @@ interface WorkflowWithLogAttributes {
 }
 
 function addBuildIdIfMissing(options: CompiledWorkerOptions, bundleCode?: string): CompiledWorkerOptionsWithBuildId {
-  const bid = options.buildId; // eslint-disable-line @typescript-eslint/no-deprecated
+  const bid = options.buildId;
   if (bid != null) {
     return options as CompiledWorkerOptionsWithBuildId;
   }
@@ -2255,7 +2255,7 @@ async function extractActivityInfo(
 function activitySerializationContextFromInfo(info: ActivityInfo): ActivitySerializationContext {
   return {
     type: 'activity',
-    namespace: info.activityNamespace,
+    namespace: info.activityNamespace, // eslint-disable-line @typescript-eslint/no-deprecated
     activityId: info.activityId,
     workflowId: info.workflowExecution?.workflowId,
     isLocal: info.isLocal,

--- a/packages/worker/src/workflow-log-interceptor.ts
+++ b/packages/worker/src/workflow-log-interceptor.ts
@@ -35,12 +35,10 @@ export class WorkflowLogInterceptor implements WorkflowInboundCallsInterceptor, 
  *             by the SDK. To customize workflow log attributes, simply register a custom `WorkflowInterceptors` that
  *             intercepts the `outbound.getLogAttributes()` method.
  */
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 export const WorkflowInboundLogInterceptor = WorkflowLogInterceptor;
 
 // ts-prune-ignore-next
 export const interceptors: WorkflowInterceptorsFactory = () => {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const interceptor = new WorkflowLogInterceptor();
   return { inbound: [interceptor], outbound: [interceptor] };
 };

--- a/packages/workflow/src/flags.ts
+++ b/packages/workflow/src/flags.ts
@@ -114,7 +114,7 @@ type AltConditionFn = (ctx: { info: WorkflowInfo; sdkVersion?: string }) => bool
 
 function buildIdSdkVersionMatches(version: RegExp): AltConditionFn {
   const regex = new RegExp(`^@temporalio/worker@(${version.source})[+]`);
-  return ({ info }) => info.currentBuildId != null && regex.test(info.currentBuildId); // eslint-disable-line @typescript-eslint/no-deprecated
+  return ({ info }) => info.currentBuildId != null && regex.test(info.currentBuildId);
 }
 
 type SemVer = {

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -93,8 +93,8 @@ export {
   PayloadConverter,
   RetryPolicy,
   rootCause,
-  SearchAttributes, // eslint-disable-line @typescript-eslint/no-deprecated
-  SearchAttributeValue, // eslint-disable-line @typescript-eslint/no-deprecated
+  SearchAttributes,
+  SearchAttributeValue,
   ServerFailure,
   TemporalFailure,
   TerminatedFailure,

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -47,7 +47,7 @@ export interface WorkflowInfo {
    * This value may change during the lifetime of an Execution.
    * @deprecated Use {@link typedSearchAttributes} instead.
    */
-  readonly searchAttributes: SearchAttributes; // eslint-disable-line @typescript-eslint/no-deprecated
+  readonly searchAttributes: SearchAttributes;
 
   /**
    * Indexed information attached to the Workflow Execution, exposed through an interface.
@@ -337,7 +337,7 @@ export interface ContinueAsNewOptions {
    * Searchable attributes to attach to next Workflow run
    * @deprecated Use {@link typedSearchAttributes} instead.
    */
-  searchAttributes?: SearchAttributes; // eslint-disable-line @typescript-eslint/no-deprecated
+  searchAttributes?: SearchAttributes;
   /**
    * Specifies additional indexed information to attach to the Workflow Execution. More info:
    * https://docs.temporal.io/docs/typescript/search-attributes
@@ -357,7 +357,7 @@ export interface ContinueAsNewOptions {
    *
    * @deprecated Worker Versioning is now deprecated. Please use the Worker Deployment API instead: https://docs.temporal.io/worker-deployments
    */
-  versioningIntent?: VersioningIntent; // eslint-disable-line @typescript-eslint/no-deprecated
+  versioningIntent?: VersioningIntent;
   /**
    * Defines the versioning behavior to be used by the first task of a new workflow run in a continue-as-new chain.
    *
@@ -567,7 +567,7 @@ export interface ChildWorkflowOptions extends Omit<CommonWorkflowOptions, 'workf
    *
    * @deprecated Worker Versioning is now deprecated. Please use the Worker Deployment API instead: https://docs.temporal.io/worker-deployments
    */
-  versioningIntent?: VersioningIntent; // eslint-disable-line @typescript-eslint/no-deprecated
+  versioningIntent?: VersioningIntent;
 }
 
 export type RequiredChildWorkflowOptions = Required<Pick<ChildWorkflowOptions, 'workflowId' | 'cancellationType'>> & {

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -243,7 +243,7 @@ function scheduleActivityNextHandler({ options, args, headers, seq, activityType
         headers,
         cancellationType: encodeActivityCancellationType(options.cancellationType),
         doNotEagerlyExecute: !(options.allowEagerDispatch ?? true),
-        versioningIntent: versioningIntentToProto(options.versioningIntent), // eslint-disable-line @typescript-eslint/no-deprecated
+        versioningIntent: versioningIntentToProto(options.versioningIntent),
         priority: options.priority ? compilePriority(options.priority) : undefined,
       },
       userMetadata: userMetadataToPayload(activator.payloadConverter, options.summary, undefined, context),
@@ -446,11 +446,11 @@ function startChildWorkflowExecutionNextHandler({
         parentClosePolicy: encodeParentClosePolicy(options.parentClosePolicy),
         cronSchedule: options.cronSchedule,
         searchAttributes:
-          options.searchAttributes || options.typedSearchAttributes // eslint-disable-line @typescript-eslint/no-deprecated
-            ? { indexedFields: encodeUnifiedSearchAttributes(options.searchAttributes, options.typedSearchAttributes) } // eslint-disable-line @typescript-eslint/no-deprecated
+          options.searchAttributes || options.typedSearchAttributes
+            ? { indexedFields: encodeUnifiedSearchAttributes(options.searchAttributes, options.typedSearchAttributes) }
             : undefined,
         memo: options.memo && mapToPayloads(activator.payloadConverter, options.memo, context),
-        versioningIntent: versioningIntentToProto(options.versioningIntent), // eslint-disable-line @typescript-eslint/no-deprecated
+        versioningIntent: versioningIntentToProto(options.versioningIntent),
         priority: options.priority ? compilePriority(options.priority) : undefined,
       },
       userMetadata: userMetadataToPayload(
@@ -1077,12 +1077,12 @@ export function makeContinueAsNewFunc<F extends Workflow>(
         taskQueue: options.taskQueue,
         memo: options.memo && mapToPayloads(activator.payloadConverter, options.memo, context),
         searchAttributes:
-          options.searchAttributes || options.typedSearchAttributes // eslint-disable-line @typescript-eslint/no-deprecated
-            ? { indexedFields: encodeUnifiedSearchAttributes(options.searchAttributes, options.typedSearchAttributes) } // eslint-disable-line @typescript-eslint/no-deprecated
+          options.searchAttributes || options.typedSearchAttributes
+            ? { indexedFields: encodeUnifiedSearchAttributes(options.searchAttributes, options.typedSearchAttributes) }
             : undefined,
         workflowRunTimeout: msOptionalToTs(options.workflowRunTimeout),
         workflowTaskTimeout: msOptionalToTs(options.workflowTaskTimeout),
-        versioningIntent: versioningIntentToProto(options.versioningIntent), // eslint-disable-line @typescript-eslint/no-deprecated
+        versioningIntent: versioningIntentToProto(options.versioningIntent),
         initialVersioningBehavior: encodeInitialVersioningBehavior(options.initialVersioningBehavior),
       });
     });
@@ -1569,7 +1569,6 @@ export function setDefaultQueryHandler(handler: DefaultQueryHandler | undefined)
  * If using SearchAttributeUpdatePair[] (preferred), set a value to null to remove the search attribute.
  * If using SearchAttributes (deprecated), set a value to undefined or an empty list to remove the search attribute.
  */
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 export function upsertSearchAttributes(searchAttributes: SearchAttributes | SearchAttributeUpdatePair[]): void {
   const activator = assertInWorkflowContext(
     'Workflow.upsertSearchAttributes(...) may only be used from a Workflow Execution.'
@@ -1591,7 +1590,7 @@ export function upsertSearchAttributes(searchAttributes: SearchAttributes | Sear
 
     activator.mutateWorkflowInfo((info: WorkflowInfo): WorkflowInfo => {
       // Create a copy of the current state.
-      const newSearchAttributes: SearchAttributes = { ...info.searchAttributes }; // eslint-disable-line @typescript-eslint/no-deprecated
+      const newSearchAttributes: SearchAttributes = { ...info.searchAttributes };
       for (const pair of searchAttributes) {
         if (pair.value == null) {
           // If the value is null, remove the search attribute.
@@ -1600,7 +1599,7 @@ export function upsertSearchAttributes(searchAttributes: SearchAttributes | Sear
         } else {
           newSearchAttributes[pair.key.name] = Array.isArray(pair.value)
             ? pair.value
-            : ([pair.value] as SearchAttributeValue); // eslint-disable-line @typescript-eslint/no-deprecated
+            : ([pair.value] as SearchAttributeValue);
         }
       }
       return {
@@ -1623,7 +1622,7 @@ export function upsertSearchAttributes(searchAttributes: SearchAttributes | Sear
     activator.mutateWorkflowInfo((info: WorkflowInfo): WorkflowInfo => {
       // Create a new copy of the current state.
       let typedSearchAttributes = info.typedSearchAttributes.updateCopy([]);
-      const newSearchAttributes: SearchAttributes = { ...info.searchAttributes }; // eslint-disable-line @typescript-eslint/no-deprecated
+      const newSearchAttributes: SearchAttributes = { ...info.searchAttributes };
 
       // Upsert legacy search attributes into typedSearchAttributes.
       for (const [k, v] of Object.entries(searchAttributes)) {


### PR DESCRIPTION
## What was changed

- Added explicit allow patterns on the `@typescript-eslint/no-deprecated` eslint rule to silence legitimate use of common internally-deprecated symbols.
- Fixed other miscelaneous lint warnings.
