### PR TITLE
Drop MacOS intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,6 @@ jobs:
             runner: ubuntu-24.04-arm64-2-core
             target: aarch64-unknown-linux-gnu
             out-file: libtemporal_sdk_typescript_bridge.so
-          - platform: macos-x64
-            runner: macos-15-intel
-            target: x86_64-apple-darwin
-            out-file: libtemporal_sdk_typescript_bridge.dylib
           - platform: macos-arm
             runner: macos-14
             target: aarch64-apple-darwin
@@ -119,7 +115,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20, 24, bun] # Min and max officially supported Node versions + Bun
-        platform: [linux-x64, linux-arm, macos-x64, macos-arm, windows-x64]
+        platform: [linux-x64, linux-arm, macos-arm, windows-x64]
         include:
           - platform: linux-x64
             runner: ubuntu-latest
@@ -127,9 +123,6 @@ jobs:
             reuse-v8-context: false
           - platform: linux-arm
             runner: ubuntu-24.04-arm64-2-core
-            reuse-v8-context: true
-          - platform: macos-x64
-            runner: macos-15-intel
             reuse-v8-context: true
           - platform: macos-arm
             runner: macos-14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ jobs:
             container: quay.io/pypa/manylinux_2_24_aarch64
             out-file: libtemporal_sdk_typescript_bridge.so
             protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-aarch_64.zip
+          - platform: macos-x64
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+            out-file: libtemporal_sdk_typescript_bridge.dylib
           - platform: macos-arm
             runner: macos-14
             target: aarch64-apple-darwin
@@ -193,7 +197,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20, 22, 24] # Min and max officially supported Node versions + next max
-        platform: [linux-x64, linux-arm, macos-arm, windows-x64]
+        platform: [linux-x64, linux-arm, macos-x64, macos-arm, windows-x64]
         sample: [hello-world, fetch-esm, hello-world-mtls]
         server: [cli, cloud]
         exclude:
@@ -215,6 +219,8 @@ jobs:
             runner: ubuntu-latest
           - platform: linux-arm
             runner: ubuntu-24.04-arm64-2-core
+          - platform: macos-x64
+            runner: macos-15-intel
           - platform: macos-arm
             runner: macos-14
           - platform: windows-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,6 @@ jobs:
             container: quay.io/pypa/manylinux_2_24_aarch64
             out-file: libtemporal_sdk_typescript_bridge.so
             protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-aarch_64.zip
-          - platform: macos-x64
-            runner: macos-15-intel
-            target: x86_64-apple-darwin
-            out-file: libtemporal_sdk_typescript_bridge.dylib
           - platform: macos-arm
             runner: macos-14
             target: aarch64-apple-darwin
@@ -197,7 +193,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20, 22, 24] # Min and max officially supported Node versions + next max
-        platform: [linux-x64, linux-arm, macos-x64, macos-arm, windows-x64]
+        platform: [linux-x64, linux-arm, macos-arm, windows-x64]
         sample: [hello-world, fetch-esm, hello-world-mtls]
         server: [cli, cloud]
         exclude:
@@ -219,8 +215,6 @@ jobs:
             runner: ubuntu-latest
           - platform: linux-arm
             runner: ubuntu-24.04-arm64-2-core
-          - platform: macos-x64
-            runner: macos-15-intel
           - platform: macos-arm
             runner: macos-14
           - platform: windows-x64


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Drop macos-x64 as a build matrix entry

## Why?
Little usage and a lot of CI pain

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
