### PR TITLE
Add Temporal Operation Handler

### DIFF
--- a/packages/nexus/src/__tests__/test-nexus-token-helpers.ts
+++ b/packages/nexus/src/__tests__/test-nexus-token-helpers.ts
@@ -1,5 +1,10 @@
 import test from 'ava';
-import { base64URLEncodeNoPadding, generateWorkflowRunOperationToken, loadWorkflowRunOperationToken } from '../token';
+import {
+  base64URLEncodeNoPadding,
+  generateWorkflowRunOperationToken,
+  loadOperationToken,
+  loadWorkflowRunOperationToken,
+} from '../token';
 
 test('encode and decode workflow run Operation token', (t) => {
   const expected = {
@@ -12,28 +17,30 @@ test('encode and decode workflow run Operation token', (t) => {
   t.deepEqual(decoded, expected);
 });
 
-test('decode workflow run Operation token errors', (t) => {
-  t.throws(() => loadWorkflowRunOperationToken(''), { message: /invalid workflow run token: token is empty/ });
+test('decode Operation token errors', (t) => {
+  t.throws(() => loadOperationToken(''), { message: /invalid operation token: token is empty/ });
 
-  t.throws(() => loadWorkflowRunOperationToken('not-base64!@#$'), { message: /failed to decode token/ });
+  t.throws(() => loadOperationToken('not-base64!@#$'), { message: /failed to decode token/ });
 
   const invalidJSONToken = base64URLEncodeNoPadding('invalid json');
-  t.throws(() => loadWorkflowRunOperationToken(invalidJSONToken), {
-    message: /failed to unmarshal workflow run Operation token/,
-  });
-
-  const invalidTypeToken = base64URLEncodeNoPadding('{"t":2}');
-  t.throws(() => loadWorkflowRunOperationToken(invalidTypeToken), {
-    message: /invalid workflow token type: 2, expected: 1/,
-  });
-
-  const missingWIDToken = base64URLEncodeNoPadding('{"t":1}');
-  t.throws(() => loadWorkflowRunOperationToken(missingWIDToken), {
-    message: /invalid workflow run token: missing workflow ID \(wid\)/,
+  t.throws(() => loadOperationToken(invalidJSONToken), {
+    message: /failed to unmarshal Operation token/,
   });
 
   const versionedToken = base64URLEncodeNoPadding('{"v":1, "t":1,"wid": "workflow-id"}');
-  t.throws(() => loadWorkflowRunOperationToken(versionedToken), {
-    message: /invalid workflow run token: "v" field should not be present/,
+  t.throws(() => loadOperationToken(versionedToken), {
+    message: /invalid operation token: "v" field should not be present/,
+  });
+});
+
+test('decode workflow run Operation token errors', (t) => {
+  const invalidTypeToken = base64URLEncodeNoPadding('{"t":2,"ns":"ns"}');
+  t.throws(() => loadOperationToken(invalidTypeToken), {
+    message: /invalid operation token: unknown token type: 2/,
+  });
+
+  const missingWIDToken = base64URLEncodeNoPadding('{"t":1,"ns":"ns"}');
+  t.throws(() => loadWorkflowRunOperationToken(missingWIDToken), {
+    message: /invalid workflow run token: missing workflow ID \(wid\)/,
   });
 });

--- a/packages/nexus/src/__tests__/test-nexus-token-helpers.ts
+++ b/packages/nexus/src/__tests__/test-nexus-token-helpers.ts
@@ -35,7 +35,10 @@ test('decode Operation token errors', (t) => {
 
 test('decode workflow run Operation token errors', (t) => {
   const invalidTypeToken = base64URLEncodeNoPadding('{"t":2,"ns":"ns"}');
-  t.throws(() => loadOperationToken(invalidTypeToken), {
+  t.throws(() => loadWorkflowRunOperationToken(invalidTypeToken), {
+    // This currently fails on unknown token type as there are no other existing token types.
+    // When new token types are added this regex will need to be updated to
+    //  /invalid workflow token type: 2/
     message: /invalid operation token: unknown token type: 2/,
   });
 

--- a/packages/nexus/src/context.ts
+++ b/packages/nexus/src/context.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import type * as nexus from 'nexus-rpc';
 import type { Logger, LogLevel, LogMetadata, MetricMeter } from '@temporalio/common';
 import type { Client } from '@temporalio/client';
 
@@ -56,6 +57,24 @@ export interface OperationInfo {
    */
   readonly endpoint: string;
 }
+
+/**
+ * Context received by a {@link TemporalOperationHandler}'s start handler when a Nexus Operation is
+ * started.
+ *
+ * @experimental Nexus support in Temporal SDK is experimental.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface TemporalNexusStartOperationContext extends nexus.StartOperationContext {}
+
+/**
+ * Context received by a {@link TemporalOperationHandler}'s cancel handler when a Nexus Operation is
+ * canceled.
+ *
+ * @experimental Nexus support in Temporal SDK is experimental.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface TemporalNexusCancelOperationContext extends nexus.CancelOperationContext {}
 
 // Basic APIs //////////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/nexus/src/context.ts
+++ b/packages/nexus/src/context.ts
@@ -65,7 +65,7 @@ export interface OperationInfo {
  * @experimental Nexus support in Temporal SDK is experimental.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface TemporalNexusStartOperationContext extends nexus.StartOperationContext {}
+export interface TemporalStartOperationContext extends nexus.StartOperationContext {}
 
 /**
  * Context received by a {@link TemporalOperationHandler}'s cancel handler when a Nexus Operation is
@@ -74,7 +74,7 @@ export interface TemporalNexusStartOperationContext extends nexus.StartOperation
  * @experimental Nexus support in Temporal SDK is experimental.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface TemporalNexusCancelOperationContext extends nexus.CancelOperationContext {}
+export interface TemporalCancelOperationContext extends nexus.CancelOperationContext {}
 
 // Basic APIs //////////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/nexus/src/index.ts
+++ b/packages/nexus/src/index.ts
@@ -11,10 +11,13 @@ export {
   metricMeter,
   operationInfo,
   type OperationInfo,
+  type TemporalNexusCancelOperationContext,
+  type TemporalNexusStartOperationContext,
 } from './context';
 
 export {
   startWorkflow,
+  type CancelWorkflowRunOptions,
   type TemporalOperationHandlerOptions,
   TemporalOperationHandler,
   TemporalOperationResult,

--- a/packages/nexus/src/index.ts
+++ b/packages/nexus/src/index.ts
@@ -15,6 +15,7 @@ export {
 
 export {
   startWorkflow,
+  type TemporalOperationHandlerOptions,
   TemporalOperationHandler,
   TemporalOperationResult,
   type TemporalNexusClient,

--- a/packages/nexus/src/index.ts
+++ b/packages/nexus/src/index.ts
@@ -15,6 +15,10 @@ export {
 
 export {
   startWorkflow,
+  TemporalOperationHandler,
+  TemporalOperationResult,
+  type TemporalNexusClient,
+  type TemporalOperationStartHandler,
   WorkflowHandle,
   WorkflowRunOperationHandler,
   WorkflowRunOperationStartHandler,

--- a/packages/nexus/src/index.ts
+++ b/packages/nexus/src/index.ts
@@ -11,8 +11,8 @@ export {
   metricMeter,
   operationInfo,
   type OperationInfo,
-  type TemporalNexusCancelOperationContext,
-  type TemporalNexusStartOperationContext,
+  type TemporalCancelOperationContext,
+  type TemporalStartOperationContext,
 } from './context';
 
 export {

--- a/packages/nexus/src/token.ts
+++ b/packages/nexus/src/token.ts
@@ -5,35 +5,45 @@
  * @internal
  * @hidden
  */
-export interface WorkflowRunOperationToken {
+export interface OperationToken {
   /**
-   * Version of the token, by default we assume we're on version 1, this field is not emitted as part of the output,
+   * Version of the token, by default we assume we're on version 0, this field is not emitted as part of the output,
    * it's only used to reject newer token versions on load.
    */
   v?: number;
 
   /**
-   * Type of the Operation. Must be OPERATION_TOKEN_TYPE_WORKFLOW_RUN.
+   * Type of the Operation.
    */
   t: OperationTokenType;
 
   /**
-   * Namespace of the workflow.
+   * Namespace of the operation.
    */
   ns: string;
 
   /**
    * ID of the workflow.
    */
-  wid: string;
+  wid?: string;
 }
-type OperationTokenType = (typeof OperationTokenType)[keyof typeof OperationTokenType];
 
 /**
  * @internal
  * @hidden
  */
-const OperationTokenType = {
+export interface WorkflowRunOperationToken extends OperationToken {
+  t: typeof OperationTokenType.WORKFLOW_RUN;
+  wid: string;
+}
+
+export type OperationTokenType = (typeof OperationTokenType)[keyof typeof OperationTokenType];
+
+/**
+ * @internal
+ * @hidden
+ */
+export const OperationTokenType = {
   WORKFLOW_RUN: 1,
 } as const;
 
@@ -50,11 +60,11 @@ export function generateWorkflowRunOperationToken(namespace: string, workflowId:
 }
 
 /**
- * Load and validate a workflow run Operation token.
+ * Load and validate the common fields of an Operation token.
  */
-export function loadWorkflowRunOperationToken(data: string): WorkflowRunOperationToken {
+export function loadOperationToken(data: string): OperationToken {
   if (!data) {
-    throw new TypeError('invalid workflow run token: token is empty');
+    throw new TypeError('invalid operation token: token is empty');
   }
 
   let decoded: string;
@@ -64,24 +74,55 @@ export function loadWorkflowRunOperationToken(data: string): WorkflowRunOperatio
     throw new TypeError('failed to decode token', { cause: err });
   }
 
-  let token: WorkflowRunOperationToken;
+  let token: OperationToken;
   try {
     token = JSON.parse(decoded);
   } catch (err) {
-    throw new TypeError('failed to unmarshal workflow run Operation token', { cause: err });
+    throw new TypeError('failed to unmarshal Operation token', { cause: err });
   }
 
-  if (token.t !== OperationTokenType.WORKFLOW_RUN) {
-    throw new TypeError(`invalid workflow token type: ${token.t}, expected: ${OperationTokenType.WORKFLOW_RUN}`);
+  if (typeof token !== 'object' || token == null) {
+    throw new TypeError(`invalid operation token: expected object, got ${typeof token}`);
   }
   if (token.v !== undefined && token.v !== 0) {
-    throw new TypeError('invalid workflow run token: "v" field should not be present');
+    throw new TypeError('invalid operation token: "v" field should not be present');
   }
-  if (!token.wid) {
-    throw new TypeError('invalid workflow run token: missing workflow ID (wid)');
+  if (typeof token.t !== 'number') {
+    throw new TypeError(`invalid operation token: expected token type to be a number, got ${typeof token.t}`);
+  }
+  if (!isOperationTokenType(token.t)) {
+    throw new TypeError(`invalid operation token: unknown token type: ${token.t}`);
+  }
+  if (typeof token.ns !== 'string') {
+    throw new TypeError(`invalid operation token: expected namespace to be a string, got ${typeof token.ns}`);
   }
 
   return token;
+}
+
+/**
+ * Load and validate a workflow run Operation token.
+ */
+export function loadWorkflowRunOperationToken(data: string): WorkflowRunOperationToken {
+  const token = loadOperationToken(data);
+  assertWorkflowRunOperationToken(token);
+  return token;
+}
+
+/**
+ * Assert that an OperationToken identifies a workflow run.
+ */
+export function assertWorkflowRunOperationToken(token: OperationToken): asserts token is WorkflowRunOperationToken {
+  if (token.t !== OperationTokenType.WORKFLOW_RUN) {
+    throw new TypeError(`invalid workflow token type: ${token.t}, expected: ${OperationTokenType.WORKFLOW_RUN}`);
+  }
+  if (!token.wid || typeof token.wid !== 'string') {
+    throw new TypeError('invalid workflow run token: missing workflow ID (wid)');
+  }
+}
+
+function isOperationTokenType(value: number): value is OperationTokenType {
+  return Object.values(OperationTokenType).includes(value as OperationTokenType);
 }
 
 // Exported for use in tests.

--- a/packages/nexus/src/token.ts
+++ b/packages/nexus/src/token.ts
@@ -28,10 +28,6 @@ export interface OperationToken {
   wid?: string;
 }
 
-/**
- * @internal
- * @hidden
- */
 export interface WorkflowRunOperationToken extends OperationToken {
   t: typeof OperationTokenType.WORKFLOW_RUN;
   wid: string;

--- a/packages/nexus/src/token.ts
+++ b/packages/nexus/src/token.ts
@@ -1,6 +1,5 @@
 /**
- * OperationTokenType is used to identify the type of Operation token.
- * Currently, we only have one type of Operation token: WorkflowRun.
+ * Serializable token identifying a Nexus operation target.
  *
  * @internal
  * @hidden
@@ -28,11 +27,24 @@ export interface OperationToken {
   wid?: string;
 }
 
+/**
+ * An OperationToken that identifies a WorkflowRun operation.
+ *
+ * @internal
+ * @hidden
+ */
 export interface WorkflowRunOperationToken extends OperationToken {
   t: typeof OperationTokenType.WORKFLOW_RUN;
   wid: string;
 }
 
+/**
+ * OperationTokenType is used to identify the type of Operation token.
+ * Currently, we only have one type of Operation token: WorkflowRun.
+ *
+ * @internal
+ * @hidden
+ */
 export type OperationTokenType = (typeof OperationTokenType)[keyof typeof OperationTokenType];
 
 /**

--- a/packages/nexus/src/workflow-helpers.ts
+++ b/packages/nexus/src/workflow-helpers.ts
@@ -280,15 +280,30 @@ export type TemporalOperationStartHandler<I, O> = (
 ) => Promise<TemporalOperationResult<O>>;
 
 /**
+ * Options for customizing a {@link TemporalOperationHandler}.
+ *
+ * @experimental Nexus support in Temporal SDK is experimental.
+ */
+export interface TemporalOperationHandlerOptions {
+  cancelWorkflowRun?: (ctx: nexus.CancelOperationContext, client: Client, workflowId: string) => Promise<void>;
+}
+
+/**
  * A Nexus Operation implementation for operations that interact with Temporal.
  *
  * @experimental Nexus support in Temporal SDK is experimental.
  */
 export class TemporalOperationHandler<I, O> implements nexus.OperationHandler<I, O> {
-  constructor(readonly handler: TemporalOperationStartHandler<I, O>) {}
+  private readonly startHandler: TemporalOperationStartHandler<I, O>;
+  private readonly cancelWorkflowRunHandler: NonNullable<TemporalOperationHandlerOptions['cancelWorkflowRun']>;
+
+  constructor(options: { start: TemporalOperationStartHandler<I, O> } & TemporalOperationHandlerOptions) {
+    this.startHandler = options.start;
+    this.cancelWorkflowRunHandler = options.cancelWorkflowRun ?? defaultCancelWorkflowRun;
+  }
 
   async start(ctx: nexus.StartOperationContext, input: I): Promise<nexus.HandlerStartOperationResult<O>> {
-    const result = await this.handler(ctx, new TemporalNexusClientImpl(ctx), input);
+    const result = await this.startHandler(ctx, new TemporalNexusClientImpl(ctx), input);
     return result[toHandlerResult]();
   }
 
@@ -309,8 +324,14 @@ export class TemporalOperationHandler<I, O> implements nexus.OperationHandler<I,
     }
     switch (opToken.t) {
       case OperationTokenType.WORKFLOW_RUN:
-        assertWorkflowRunOperationToken(opToken);
-        await this.cancelWorkflowRun(ctx, opToken.wid);
+        try {
+          assertWorkflowRunOperationToken(opToken);
+        } catch (err) {
+          throw new nexus.HandlerError(nexus.HandlerErrorType.BAD_REQUEST, 'invalid workflow run operation token', {
+            cause: err,
+          });
+        }
+        await this.cancelWorkflowRunHandler(ctx, getClient(), opToken.wid);
         return;
       default:
         throw new nexus.HandlerError(
@@ -319,15 +340,8 @@ export class TemporalOperationHandler<I, O> implements nexus.OperationHandler<I,
         );
     }
   }
+}
 
-  /**
-   * Cancel the workflow backing this Nexus Operation.
-   *
-   * Override this method to customize workflow cancellation behavior.
-   *
-   * @experimental Nexus support in Temporal SDK is experimental.
-   */
-  protected async cancelWorkflowRun(_ctx: nexus.CancelOperationContext, workflowId: string): Promise<void> {
-    await getClient().workflow.getHandle(workflowId).cancel();
-  }
+async function defaultCancelWorkflowRun(_ctx: nexus.CancelOperationContext, client: Client, workflowId: string) {
+  await client.workflow.getHandle(workflowId).cancel();
 }

--- a/packages/nexus/src/workflow-helpers.ts
+++ b/packages/nexus/src/workflow-helpers.ts
@@ -187,9 +187,9 @@ export const TemporalOperationResult = {
     };
   },
 
-  async(token: string): TemporalOperationResult<never> {
+  async<T = unknown>(token: string): TemporalOperationResult<T> {
     return {
-      [toHandlerResult](): nexus.HandlerStartOperationResult<never> {
+      [toHandlerResult](): nexus.HandlerStartOperationResult<T> {
         return nexus.HandlerStartOperationResult.async(token);
       },
     };
@@ -292,7 +292,7 @@ export class TemporalOperationHandler<I, O> implements nexus.OperationHandler<I,
     return result[toHandlerResult]();
   }
 
-  async cancel(_ctx: nexus.CancelOperationContext, token: string): Promise<void> {
+  async cancel(ctx: nexus.CancelOperationContext, token: string): Promise<void> {
     const { namespace } = getHandlerContext();
     let opToken;
     try {
@@ -310,7 +310,7 @@ export class TemporalOperationHandler<I, O> implements nexus.OperationHandler<I,
     switch (opToken.t) {
       case OperationTokenType.WORKFLOW_RUN:
         assertWorkflowRunOperationToken(opToken);
-        await this.cancelWorkflowRun(_ctx, opToken.wid);
+        await this.cancelWorkflowRun(ctx, opToken.wid);
         return;
       default:
         throw new nexus.HandlerError(

--- a/packages/nexus/src/workflow-helpers.ts
+++ b/packages/nexus/src/workflow-helpers.ts
@@ -1,17 +1,18 @@
 import * as nexus from 'nexus-rpc';
 import type { Workflow, WorkflowResultType } from '@temporalio/common';
 import type { Replace } from '@temporalio/common/lib/type-helpers';
-import type { WorkflowStartOptions as ClientWorkflowStartOptions } from '@temporalio/client';
+import type { Client, WorkflowStartOptions as ClientWorkflowStartOptions } from '@temporalio/client';
 import { type temporal } from '@temporalio/proto';
 import type { InternalWorkflowStartOptions } from '@temporalio/client/lib/internal';
 import { InternalWorkflowStartOptionsSymbol } from '@temporalio/client/lib/internal';
-import { generateWorkflowRunOperationToken, loadWorkflowRunOperationToken } from './token';
+import { convertNexusLinkToTemporalLink, convertTemporalLinkToNexusLink } from './link-converter';
 import {
-  convertNexusLinkToTemporalLink,
-  convertNexusLinkToWorkflowEventLink,
-  convertTemporalLinkToNexusLink,
-  convertWorkflowEventLinkToNexusLink,
-} from './link-converter';
+  assertWorkflowRunOperationToken,
+  generateWorkflowRunOperationToken,
+  loadOperationToken,
+  loadWorkflowRunOperationToken,
+  OperationTokenType,
+} from './token';
 import { getClient, getHandlerContext, log } from './context';
 
 declare const isNexusWorkflowHandle: unique symbol;
@@ -157,5 +158,176 @@ export class WorkflowRunOperationHandler<I, O> implements nexus.OperationHandler
   async cancel(_ctx: nexus.CancelOperationContext, token: string): Promise<void> {
     const decoded = loadWorkflowRunOperationToken(token);
     await getClient().workflow.getHandle(decoded.wid).cancel();
+  }
+}
+
+/**
+ * Module-private brand and conversion key for {@link TemporalOperationResult}. Doubles as the
+ * type-level brand (so external code can't satisfy the interface) and the runtime accessor
+ * (since the symbol is in scope inside this module).
+ */
+const toHandlerResult: unique symbol = Symbol.for('__temporal_nexus_TemporalOperationResult_toHandlerResult__');
+
+/**
+ * A result produced by a {@link TemporalOperationHandler}. Construct via
+ * {@link TemporalOperationResult.sync} or {@link TemporalOperationResult.async}.
+
+ * @experimental Nexus support in Temporal SDK is experimental.
+ */
+export interface TemporalOperationResult<T> {
+  readonly [toHandlerResult]: () => nexus.HandlerStartOperationResult<T>;
+}
+
+export const TemporalOperationResult = {
+  sync<T>(value: T): TemporalOperationResult<T> {
+    return {
+      [toHandlerResult](): nexus.HandlerStartOperationResult<T> {
+        return nexus.HandlerStartOperationResult.sync(value);
+      },
+    };
+  },
+
+  async(token: string): TemporalOperationResult<never> {
+    return {
+      [toHandlerResult](): nexus.HandlerStartOperationResult<never> {
+        return nexus.HandlerStartOperationResult.async(token);
+      },
+    };
+  },
+};
+
+/**
+ * A Nexus-aware Temporal Client for use inside {@link TemporalOperationHandler} implementations.
+ *
+ * @experimental Nexus support in Temporal SDK is experimental.
+ */
+export interface TemporalNexusClient {
+  /**
+   * The Temporal Client for the active Nexus Operation.
+   *
+   * @experimental Nexus support in Temporal SDK is experimental.
+   */
+  readonly client: Client;
+
+  /**
+   * Starts a workflow run as the asynchronous backing operation for the current Nexus Operation.
+   *
+   * @experimental Nexus support in Temporal SDK is experimental.
+   */
+  startWorkflow<T extends Workflow>(
+    workflowTypeOrFunc: string | T,
+    workflowOptions: WorkflowStartOptions<T>
+  ): Promise<TemporalOperationResult<WorkflowResultType<T>>>;
+}
+
+class TemporalNexusClientImpl implements TemporalNexusClient {
+  private asyncOperationStarted = false;
+
+  constructor(private readonly startOperationContext: nexus.StartOperationContext) {}
+
+  /**
+   * The Temporal Client for the active Nexus Operation.
+   *
+   * @experimental Nexus support in Temporal SDK is experimental.
+   */
+  public get client(): Client {
+    return getClient();
+  }
+
+  /**
+   * Starts a workflow run as the asynchronous backing operation for the current Nexus Operation.
+   *
+   * @experimental Nexus support in Temporal SDK is experimental.
+   */
+  public async startWorkflow<T extends Workflow>(
+    workflowTypeOrFunc: string | T,
+    workflowOptions: WorkflowStartOptions<T>
+  ): Promise<TemporalOperationResult<WorkflowResultType<T>>> {
+    return await this.withAsyncOperationStartReservation(async () => {
+      const handle = await startWorkflow(this.startOperationContext, workflowTypeOrFunc, workflowOptions);
+      const { namespace } = getHandlerContext();
+      return TemporalOperationResult.async(generateWorkflowRunOperationToken(namespace, handle.workflowId));
+    });
+  }
+
+  private async withAsyncOperationStartReservation<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.asyncOperationStarted) {
+      throw new nexus.HandlerError(
+        'BAD_REQUEST',
+        'Only one async operation can be started per operation handler invocation. Use TemporalNexusClient.client for additional workflow interactions'
+      );
+    }
+
+    this.asyncOperationStarted = true;
+    try {
+      return await fn();
+    } catch (err) {
+      this.asyncOperationStarted = false;
+      throw err;
+    }
+  }
+}
+
+/**
+ * A handler function for the {@link TemporalOperationHandler} constructor.
+ *
+ * @experimental Nexus support in Temporal SDK is experimental.
+ */
+export type TemporalOperationStartHandler<I, O> = (
+  ctx: nexus.StartOperationContext,
+  client: TemporalNexusClient,
+  input: I
+) => Promise<TemporalOperationResult<O>>;
+
+/**
+ * A Nexus Operation implementation for operations that interact with Temporal.
+ *
+ * @experimental Nexus support in Temporal SDK is experimental.
+ */
+export class TemporalOperationHandler<I, O> implements nexus.OperationHandler<I, O> {
+  constructor(readonly handler: TemporalOperationStartHandler<I, O>) {}
+
+  async start(ctx: nexus.StartOperationContext, input: I): Promise<nexus.HandlerStartOperationResult<O>> {
+    const result = await this.handler(ctx, new TemporalNexusClientImpl(ctx), input);
+    return result[toHandlerResult]();
+  }
+
+  async cancel(_ctx: nexus.CancelOperationContext, token: string): Promise<void> {
+    const { namespace } = getHandlerContext();
+    let opToken;
+    try {
+      opToken = loadOperationToken(token);
+    } catch (err) {
+      throw new nexus.HandlerError(nexus.HandlerErrorType.BAD_REQUEST, 'invalid operation token', { cause: err });
+    }
+
+    if (opToken.ns !== namespace) {
+      throw new nexus.HandlerError(
+        nexus.HandlerErrorType.BAD_REQUEST,
+        `Client namespace ${namespace} does not match operation token namespace ${opToken.ns}`
+      );
+    }
+    switch (opToken.t) {
+      case OperationTokenType.WORKFLOW_RUN:
+        assertWorkflowRunOperationToken(opToken);
+        await this.cancelWorkflowRun(_ctx, opToken.wid);
+        return;
+      default:
+        throw new nexus.HandlerError(
+          nexus.HandlerErrorType.BAD_REQUEST,
+          `Unsupported operation token type: ${opToken.t}`
+        );
+    }
+  }
+
+  /**
+   * Cancel the workflow backing this Nexus Operation.
+   *
+   * Override this method to customize workflow cancellation behavior.
+   *
+   * @experimental Nexus support in Temporal SDK is experimental.
+   */
+  protected async cancelWorkflowRun(_ctx: nexus.CancelOperationContext, workflowId: string): Promise<void> {
+    await getClient().workflow.getHandle(workflowId).cancel();
   }
 }

--- a/packages/nexus/src/workflow-helpers.ts
+++ b/packages/nexus/src/workflow-helpers.ts
@@ -106,10 +106,17 @@ export async function startWorkflow<T extends Workflow>(
     attachRequestId: true,
   };
 
+  // Add nexus-operation-token header to solve for race between Workflow completion
+  // and Nexus Operation start recording
+  const callbackHeaders = {
+    ...ctx.callbackHeaders,
+    'nexus-operation-token': generateWorkflowRunOperationToken(client.options.namespace, workflowOptions.workflowId),
+  };
+
   if (ctx.callbackUrl) {
     internalOptions.completionCallbacks = [
       {
-        nexus: { url: ctx.callbackUrl, header: ctx.callbackHeaders },
+        nexus: { url: ctx.callbackUrl, header: callbackHeaders },
         links, // pass in links here as well for older servers, newer servers dedupe them.
       },
     ];

--- a/packages/nexus/src/workflow-helpers.ts
+++ b/packages/nexus/src/workflow-helpers.ts
@@ -168,11 +168,9 @@ export class WorkflowRunOperationHandler<I, O> implements nexus.OperationHandler
 }
 
 /**
- * Module-private brand and conversion key for {@link TemporalOperationResult}. Doubles as the
- * type-level brand (so external code can't satisfy the interface) and the runtime accessor
- * (since the symbol is in scope inside this module).
+ * Module-private brand and payload key for {@link TemporalOperationResult}.
  */
-const toHandlerResult: unique symbol = Symbol.for('__temporal_nexus_TemporalOperationResult_toHandlerResult__');
+const operationResult: unique symbol = Symbol('temporal_nexus_TemporalOperationResult');
 
 /**
  * A result produced by a {@link TemporalOperationHandler}. Construct via
@@ -181,23 +179,19 @@ const toHandlerResult: unique symbol = Symbol.for('__temporal_nexus_TemporalOper
  * @experimental Nexus support in Temporal SDK is experimental.
  */
 export interface TemporalOperationResult<T> {
-  readonly [toHandlerResult]: () => nexus.HandlerStartOperationResult<T>;
+  readonly [operationResult]: nexus.HandlerStartOperationResult<T>;
 }
 
 export const TemporalOperationResult = {
   sync<T>(value: T): TemporalOperationResult<T> {
     return {
-      [toHandlerResult](): nexus.HandlerStartOperationResult<T> {
-        return nexus.HandlerStartOperationResult.sync(value);
-      },
+      [operationResult]: nexus.HandlerStartOperationResult.sync(value),
     };
   },
 
   async<T = unknown>(token: string): TemporalOperationResult<T> {
     return {
-      [toHandlerResult](): nexus.HandlerStartOperationResult<T> {
-        return nexus.HandlerStartOperationResult.async(token);
-      },
+      [operationResult]: nexus.HandlerStartOperationResult.async(token),
     };
   },
 };
@@ -229,7 +223,7 @@ export interface TemporalNexusClient {
 class TemporalNexusClientImpl implements TemporalNexusClient {
   private asyncOperationStarted = false;
 
-  constructor(private readonly startOperationContext: nexus.StartOperationContext) {}
+  constructor(private readonly startOperationContext: TemporalNexusStartOperationContext) {}
 
   /**
    * The Temporal Client for the active Nexus Operation.
@@ -323,11 +317,10 @@ export class TemporalOperationHandler<I, O> implements nexus.OperationHandler<I,
 
   async start(ctx: nexus.StartOperationContext, input: I): Promise<nexus.HandlerStartOperationResult<O>> {
     const result = await this.startHandler(ctx, new TemporalNexusClientImpl(ctx), input);
-    return result[toHandlerResult]();
+    return result[operationResult];
   }
 
   async cancel(ctx: nexus.CancelOperationContext, token: string): Promise<void> {
-    const { namespace } = getHandlerContext();
     let opToken;
     try {
       opToken = loadOperationToken(token);
@@ -335,12 +328,6 @@ export class TemporalOperationHandler<I, O> implements nexus.OperationHandler<I,
       throw new nexus.HandlerError(nexus.HandlerErrorType.BAD_REQUEST, 'invalid operation token', { cause: err });
     }
 
-    if (opToken.ns !== namespace) {
-      throw new nexus.HandlerError(
-        nexus.HandlerErrorType.BAD_REQUEST,
-        `Client namespace ${namespace} does not match operation token namespace ${opToken.ns}`
-      );
-    }
     switch (opToken.t) {
       case OperationTokenType.WORKFLOW_RUN:
         try {

--- a/packages/nexus/src/workflow-helpers.ts
+++ b/packages/nexus/src/workflow-helpers.ts
@@ -17,8 +17,8 @@ import {
   getClient,
   getHandlerContext,
   log,
-  type TemporalNexusCancelOperationContext,
-  type TemporalNexusStartOperationContext,
+  type TemporalCancelOperationContext,
+  type TemporalStartOperationContext,
 } from './context';
 
 declare const isNexusWorkflowHandle: unique symbol;
@@ -223,7 +223,7 @@ export interface TemporalNexusClient {
 class TemporalNexusClientImpl implements TemporalNexusClient {
   private asyncOperationStarted = false;
 
-  constructor(private readonly startOperationContext: TemporalNexusStartOperationContext) {}
+  constructor(private readonly startOperationContext: TemporalStartOperationContext) {}
 
   /**
    * The Temporal Client for the active Nexus Operation.
@@ -274,7 +274,7 @@ class TemporalNexusClientImpl implements TemporalNexusClient {
  * @experimental Nexus support in Temporal SDK is experimental.
  */
 export type TemporalOperationStartHandler<I, O> = (
-  ctx: TemporalNexusStartOperationContext,
+  ctx: TemporalStartOperationContext,
   client: TemporalNexusClient,
   input: I
 ) => Promise<TemporalOperationResult<O>>;
@@ -298,7 +298,7 @@ export interface CancelWorkflowRunOptions {
  * @experimental Nexus support in Temporal SDK is experimental.
  */
 export interface TemporalOperationHandlerOptions {
-  cancelWorkflowRun?: (ctx: TemporalNexusCancelOperationContext, options: CancelWorkflowRunOptions) => Promise<void>;
+  cancelWorkflowRun?: (ctx: TemporalCancelOperationContext, options: CancelWorkflowRunOptions) => Promise<void>;
 }
 
 /**
@@ -348,6 +348,6 @@ export class TemporalOperationHandler<I, O> implements nexus.OperationHandler<I,
   }
 }
 
-async function defaultCancelWorkflowRun(_ctx: TemporalNexusCancelOperationContext, options: CancelWorkflowRunOptions) {
+async function defaultCancelWorkflowRun(_ctx: TemporalCancelOperationContext, options: CancelWorkflowRunOptions) {
   await getClient().workflow.getHandle(options.workflowId).cancel();
 }

--- a/packages/nexus/src/workflow-helpers.ts
+++ b/packages/nexus/src/workflow-helpers.ts
@@ -13,7 +13,13 @@ import {
   loadWorkflowRunOperationToken,
   OperationTokenType,
 } from './token';
-import { getClient, getHandlerContext, log } from './context';
+import {
+  getClient,
+  getHandlerContext,
+  log,
+  type TemporalNexusCancelOperationContext,
+  type TemporalNexusStartOperationContext,
+} from './context';
 
 declare const isNexusWorkflowHandle: unique symbol;
 declare const workflowResultType: unique symbol;
@@ -274,10 +280,23 @@ class TemporalNexusClientImpl implements TemporalNexusClient {
  * @experimental Nexus support in Temporal SDK is experimental.
  */
 export type TemporalOperationStartHandler<I, O> = (
-  ctx: nexus.StartOperationContext,
+  ctx: TemporalNexusStartOperationContext,
   client: TemporalNexusClient,
   input: I
 ) => Promise<TemporalOperationResult<O>>;
+
+/**
+ * Options passed to a {@link TemporalOperationHandlerOptions.cancelWorkflowRun} handler describing
+ * the workflow run to cancel.
+ *
+ * @experimental Nexus support in Temporal SDK is experimental.
+ */
+export interface CancelWorkflowRunOptions {
+  /**
+   * The ID of the workflow backing the Nexus Operation that is being canceled.
+   */
+  readonly workflowId: string;
+}
 
 /**
  * Options for customizing a {@link TemporalOperationHandler}.
@@ -285,7 +304,7 @@ export type TemporalOperationStartHandler<I, O> = (
  * @experimental Nexus support in Temporal SDK is experimental.
  */
 export interface TemporalOperationHandlerOptions {
-  cancelWorkflowRun?: (ctx: nexus.CancelOperationContext, client: Client, workflowId: string) => Promise<void>;
+  cancelWorkflowRun?: (ctx: TemporalNexusCancelOperationContext, options: CancelWorkflowRunOptions) => Promise<void>;
 }
 
 /**
@@ -331,7 +350,7 @@ export class TemporalOperationHandler<I, O> implements nexus.OperationHandler<I,
             cause: err,
           });
         }
-        await this.cancelWorkflowRunHandler(ctx, getClient(), opToken.wid);
+        await this.cancelWorkflowRunHandler(ctx, { workflowId: opToken.wid });
         return;
       default:
         throw new nexus.HandlerError(
@@ -342,6 +361,6 @@ export class TemporalOperationHandler<I, O> implements nexus.OperationHandler<I,
   }
 }
 
-async function defaultCancelWorkflowRun(_ctx: nexus.CancelOperationContext, client: Client, workflowId: string) {
-  await client.workflow.getHandle(workflowId).cancel();
+async function defaultCancelWorkflowRun(_ctx: TemporalNexusCancelOperationContext, options: CancelWorkflowRunOptions) {
+  await getClient().workflow.getHandle(options.workflowId).cancel();
 }

--- a/packages/test/src/test-nexus-standalone.ts
+++ b/packages/test/src/test-nexus-standalone.ts
@@ -19,9 +19,9 @@ import {
 import * as temporalnexus from '@temporalio/nexus';
 import * as workflow from '@temporalio/workflow';
 import { CancelledFailure, TerminatedFailure, ApplicationFailure, SearchAttributeType } from '@temporalio/common';
+import { generateWorkflowRunOperationToken } from '@temporalio/nexus/lib/token';
 import { helpers, makeTestFunction } from './helpers-integration';
 import { waitUntil } from './helpers';
-import { generateWorkflowRunOperationToken } from '@temporalio/nexus/lib/token';
 
 const test = makeTestFunction({
   workflowsPath: __filename,

--- a/packages/test/src/test-nexus-standalone.ts
+++ b/packages/test/src/test-nexus-standalone.ts
@@ -21,6 +21,7 @@ import * as workflow from '@temporalio/workflow';
 import { CancelledFailure, TerminatedFailure, ApplicationFailure, SearchAttributeType } from '@temporalio/common';
 import { helpers, makeTestFunction } from './helpers-integration';
 import { waitUntil } from './helpers';
+import { generateWorkflowRunOperationToken } from '@temporalio/nexus/lib/token';
 
 const test = makeTestFunction({
   workflowsPath: __filename,
@@ -491,5 +492,40 @@ test('interceptor integration', async (t) => {
     t.true(calls.includes('terminate'), 'terminate called');
     t.true(calls.includes('list'), 'list called');
     t.true(calls.includes('count'), 'count called');
+  });
+});
+
+test('WorkflorRunOperation workflow run has Nexus-Operation-Token Header', async (t) => {
+  const { createWorker, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+  const { handler, workflowStarted } = makeTestHandler();
+  const worker = await createWorker({ nexusServices: [handler] });
+  const { client } = t.context.env;
+
+  await worker.runUntil(async () => {
+    const svc = client.nexus.createServiceClient({ endpoint: endpointName, service: testService });
+    const id = randomUUID();
+    const handle = await svc.startOperation(
+      testService.operations.blockingAsync,
+      { echo: 'async-hello', wfId: id },
+      {
+        id: `op-${id}`,
+        scheduleToCloseTimeout: '10s',
+      }
+    );
+
+    // wait for workflow to start
+    await workflowStarted;
+
+    // unblock workflow
+    const wfHandle = client.workflow.getHandle(id);
+    await wfHandle.executeUpdate(unblockEcho);
+
+    const result = await handle.result();
+    t.is(result, 'async-hello');
+
+    const desc = await wfHandle.describe();
+    const opToken = desc.raw.callbacks?.[0].callback?.nexus?.header?.['nexus-operation-token'];
+    t.is(opToken, generateWorkflowRunOperationToken(client.options.namespace, wfHandle.workflowId));
   });
 });

--- a/packages/test/src/test-nexus-temporal-operation.ts
+++ b/packages/test/src/test-nexus-temporal-operation.ts
@@ -1,0 +1,410 @@
+import assert from 'assert';
+import { randomUUID } from 'crypto';
+import * as nexus from 'nexus-rpc';
+import { NexusOperationFailure } from '@temporalio/common';
+import {
+  NexusOperationExecutionStatus,
+  WorkflowExecutionAlreadyStartedError,
+  WorkflowFailedError,
+} from '@temporalio/client';
+import * as temporalnexus from '@temporalio/nexus';
+import { asyncLocalStorage } from '@temporalio/nexus/lib/context';
+import { base64URLEncodeNoPadding } from '@temporalio/nexus/lib/token';
+import * as workflow from '@temporalio/workflow';
+import { helpers, makeTestFunction } from './helpers-integration';
+import { innermostHandlerError } from './helpers-nexus';
+import { waitUntil } from './helpers';
+
+const test = makeTestFunction({
+  workflowsPath: __filename,
+  workflowEnvironmentOpts: {
+    server: {
+      extraArgs: [
+        '--dynamic-config-value',
+        'nexusoperation.enableStandalone=true',
+        '--dynamic-config-value',
+        'system.refreshNexusEndpointsMinWait="0s"',
+        '--dynamic-config-value',
+        'history.enableChasmCallbacks=true',
+      ],
+    },
+  },
+});
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Service definitions
+
+const temporalOpService = nexus.service('temporalOperationService', {
+  asyncOp: nexus.operation<string, string>(),
+  syncOp: nexus.operation<string, string>(),
+  doubleStartOp: nexus.operation<string, void>(),
+  retryAfterFailedStartOp: nexus.operation<string, string>(),
+});
+
+const temporalCancelOpService = nexus.service('temporalCancelOperationService', {
+  blockingOp: nexus.operation<string, void>(),
+});
+
+type TemporalOpServiceHandlers = nexus.ServiceHandlerFor<typeof temporalOpService.operations>;
+type TemporalCancelOpServiceHandlers = nexus.ServiceHandlerFor<typeof temporalCancelOpService.operations>;
+
+function unusedTemporalOperationHandler<I, O>(): nexus.OperationHandler<I, O> {
+  return new temporalnexus.TemporalOperationHandler<I, O>(async () => {
+    throw new nexus.HandlerError('NOT_IMPLEMENTED', 'not used by this test');
+  });
+}
+
+function makeTemporalOpServiceHandler(overrides: Partial<TemporalOpServiceHandlers>) {
+  const handlers: TemporalOpServiceHandlers = {
+    asyncOp: unusedTemporalOperationHandler(),
+    syncOp: unusedTemporalOperationHandler(),
+    doubleStartOp: unusedTemporalOperationHandler(),
+    retryAfterFailedStartOp: unusedTemporalOperationHandler(),
+    ...overrides,
+  };
+  return nexus.serviceHandler(temporalOpService, handlers);
+}
+
+function makeTemporalCancelOpServiceHandler(handlers: TemporalCancelOpServiceHandlers) {
+  return nexus.serviceHandler(temporalCancelOpService, handlers);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Caller workflows
+
+export async function temporalAsyncOpCaller(endpoint: string): Promise<string> {
+  const client = workflow.createNexusServiceClient({ endpoint, service: temporalOpService });
+  return await client.executeOperation('asyncOp', 'hello');
+}
+
+export async function temporalSyncOpCaller(endpoint: string): Promise<string> {
+  const client = workflow.createNexusServiceClient({ endpoint, service: temporalOpService });
+  return await client.executeOperation('syncOp', 'hello');
+}
+
+export async function temporalDoubleStartOpCaller(endpoint: string): Promise<void> {
+  const client = workflow.createNexusServiceClient({ endpoint, service: temporalOpService });
+  return await client.executeOperation('doubleStartOp', 'hello');
+}
+
+export async function temporalRetryAfterFailedStartOpCaller(endpoint: string, workflowId: string): Promise<string> {
+  const client = workflow.createNexusServiceClient({ endpoint, service: temporalOpService });
+  return await client.executeOperation('retryAfterFailedStartOp', workflowId);
+}
+
+export async function temporalDefaultCancelWorkflowCaller(endpoint: string, targetWorkflowId: string): Promise<void> {
+  const client = workflow.createNexusServiceClient({ endpoint, service: temporalCancelOpService });
+  try {
+    await client.executeOperation('blockingOp', targetWorkflowId, {
+      cancellationType: 'WAIT_CANCELLATION_COMPLETED',
+    });
+  } catch (err) {
+    if (workflow.isCancellation(err)) return;
+    throw err;
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Target workflows
+
+export async function echoWorkflow(input: string): Promise<string> {
+  return input;
+}
+
+export async function blockingTargetWorkflow(): Promise<void> {
+  await workflow.condition(() => false);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Tests
+
+test('TemporalOperationHandler infers correct output type from typed workflow function', async (t) => {
+  const _stringOp: nexus.OperationHandler<string, string> = new temporalnexus.TemporalOperationHandler(
+    async (_ctx, client, input: string) => {
+      return await client.startWorkflow(echoWorkflow, {
+        args: [input],
+        workflowId: 'test',
+      });
+    }
+  );
+
+  // @ts-expect-error - Output type should be string, not number
+  const _mismatchedOp: nexus.OperationHandler<string, number> = new temporalnexus.TemporalOperationHandler(
+    async (_ctx, client, input: string) => {
+      return await client.startWorkflow(echoWorkflow, {
+        args: [input],
+        workflowId: 'test',
+      });
+    }
+  );
+
+  const _syncOp: nexus.OperationHandler<string, string> = new temporalnexus.TemporalOperationHandler(
+    async (_ctx, _client, input: string) => {
+      return temporalnexus.TemporalOperationResult.sync(input);
+    }
+  );
+
+  const _explicitStringOp: nexus.OperationHandler<string, string> = new temporalnexus.TemporalOperationHandler<
+    string,
+    string
+  >(async (_ctx, client, input) => {
+    return await client.startWorkflow(echoWorkflow, {
+      args: [input],
+      workflowId: 'test',
+    });
+  });
+
+  // This test only checks for compile-time errors.
+  t.pass();
+});
+
+test('TemporalOperationHandler cancel delegates to overridable cancelWorkflow', async (t) => {
+  const { createWorker, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+  const workflowId = randomUUID();
+
+  let customCancelCalled = false;
+
+  class CustomCancelHandler extends temporalnexus.TemporalOperationHandler<string, void> {
+    async cancelWorkflowRun(_ctx: nexus.CancelOperationContext, workflowId: string): Promise<void> {
+      const handle = temporalnexus.getClient().workflow.getHandle(workflowId);
+      await handle.cancel();
+      customCancelCalled = true;
+    }
+  }
+
+  const worker = await createWorker({
+    nexusServices: [
+      makeTemporalCancelOpServiceHandler({
+        blockingOp: new CustomCancelHandler(async (_ctx, client, workflowId) => {
+          return await client.startWorkflow(blockingTargetWorkflow, {
+            workflowId,
+          });
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const serviceClient = t.context.env.client.nexus.createServiceClient({
+      endpoint: endpointName,
+      service: temporalCancelOpService,
+    });
+    const operation = await serviceClient.startOperation(temporalCancelOpService.operations.blockingOp, workflowId, {
+      id: 'op-' + randomUUID(),
+      scheduleToCloseTimeout: '60s',
+    });
+    const workflowHandle = t.context.env.client.workflow.getHandle(workflowId);
+
+    await waitUntil(async () => {
+      try {
+        return (await workflowHandle.describe()).status.name === 'RUNNING';
+      } catch {
+        return false;
+      }
+    }, 4000);
+
+    await operation.cancel('test cancellation');
+
+    await waitUntil(async () => (await operation.describe()).status === NexusOperationExecutionStatus.CANCELED, 4000);
+    await waitUntil(async () => (await workflowHandle.describe()).status.name === 'CANCELLED', 4000);
+
+    t.is((await operation.describe()).status, NexusOperationExecutionStatus.CANCELED);
+    t.is((await workflowHandle.describe()).status.name, 'CANCELLED');
+    t.true(customCancelCalled);
+  });
+});
+
+test('TemporalOperationHandler cancel rejects invalid operation token type', async (t) => {
+  class CustomCancelHandler extends temporalnexus.TemporalOperationHandler<void, void> {
+    async cancelWorkflowRun(_ctx: nexus.CancelOperationContext, _workflowId: string): Promise<void> {
+      throw new Error('cancelWorkflow should not be called');
+    }
+  }
+
+  const handler = new CustomCancelHandler(async () => temporalnexus.TemporalOperationResult.sync(undefined));
+  const token = base64URLEncodeNoPadding(JSON.stringify({ t: 2, ns: 'test-namespace' }));
+
+  const err = await asyncLocalStorage.run(
+    {
+      client: undefined as any,
+      endpoint: 'test-endpoint',
+      namespace: 'test-namespace',
+      taskQueue: 'test-task-queue',
+      log: undefined as any,
+      metrics: undefined as any,
+    },
+    async () => {
+      return await t.throwsAsync(
+        handler.cancel(
+          {
+            abortSignal: new AbortController().signal,
+            headers: {},
+            operation: 'operation',
+            service: 'service',
+          },
+          token
+        )
+      );
+    }
+  );
+
+  t.regex(err?.message ?? '', /invalid operation token/);
+});
+
+test('TemporalOperationHandler async and sync happy paths - caller workflow', async (t) => {
+  const { createWorker, executeWorkflow, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+
+  const worker = await createWorker({
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        asyncOp: new temporalnexus.TemporalOperationHandler<string, string>(async (_ctx, client, input) => {
+          return await client.startWorkflow(echoWorkflow, {
+            workflowId: randomUUID(),
+            args: [input],
+          });
+        }),
+        syncOp: new temporalnexus.TemporalOperationHandler<string, string>(async (_ctx, _client, input) => {
+          return temporalnexus.TemporalOperationResult.sync(input);
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    let result = await executeWorkflow(temporalAsyncOpCaller, {
+      args: [endpointName],
+    });
+    t.is(result, 'hello');
+
+    result = await executeWorkflow(temporalSyncOpCaller, {
+      args: [endpointName],
+    });
+    t.is(result, 'hello');
+  });
+});
+
+test('TemporalOperationHandler rejects multiple async starts', async (t) => {
+  const { createWorker, executeWorkflow, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+
+  const worker = await createWorker({
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        doubleStartOp: new temporalnexus.TemporalOperationHandler<string, void>(async (_ctx, client, input) => {
+          await client.startWorkflow(echoWorkflow, {
+            workflowId: randomUUID(),
+            args: [input],
+          });
+          await client.startWorkflow(echoWorkflow, {
+            workflowId: randomUUID(),
+            args: [input],
+          });
+          throw new nexus.HandlerError('INTERNAL', 'expected previous error to be thrown');
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const err = await t.throwsAsync(
+      () =>
+        executeWorkflow(temporalDoubleStartOpCaller, {
+          args: [endpointName],
+        }),
+      {
+        instanceOf: WorkflowFailedError,
+      }
+    );
+    assert(err?.cause instanceof NexusOperationFailure);
+    assert(err.cause.cause instanceof nexus.HandlerError);
+    const inner = innermostHandlerError(err.cause.cause);
+    t.is(inner.type, 'BAD_REQUEST');
+    t.regex(inner.message, /Only one async operation can be started per operation handler invocation/);
+  });
+});
+
+test('TemporalOperationHandler allows retry after failed async start', async (t) => {
+  const { createWorker, executeWorkflow, startWorkflow, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+  const conflictWorkflowId = randomUUID();
+
+  const worker = await createWorker({
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        retryAfterFailedStartOp: new temporalnexus.TemporalOperationHandler<string, string>(
+          async (_ctx, client, workflowId) => {
+            try {
+              await client.startWorkflow(blockingTargetWorkflow, {
+                workflowId,
+                workflowIdConflictPolicy: 'FAIL',
+              });
+            } catch (err) {
+              if (!(err instanceof WorkflowExecutionAlreadyStartedError)) {
+                throw err;
+              }
+              return await client.startWorkflow(echoWorkflow, {
+                workflowId: randomUUID(),
+                args: [workflowId],
+              });
+            }
+            throw new nexus.HandlerError('INTERNAL', 'Expected first workflow start to fail');
+          }
+        ),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const conflictHandle = await startWorkflow(blockingTargetWorkflow, {
+      workflowId: conflictWorkflowId,
+    });
+    try {
+      const result = await executeWorkflow(temporalRetryAfterFailedStartOpCaller, {
+        args: [endpointName, conflictWorkflowId],
+      });
+      t.is(result, conflictWorkflowId);
+    } finally {
+      await conflictHandle.cancel();
+    }
+  });
+});
+
+test('TemporalOperationHandler default cancelWorkflow cancels backing workflow', async (t) => {
+  const { createWorker, startWorkflow, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+  const targetWorkflowId = randomUUID();
+
+  const worker = await createWorker({
+    nexusServices: [
+      makeTemporalCancelOpServiceHandler({
+        blockingOp: new temporalnexus.TemporalOperationHandler<string, void>(async (_ctx, client, workflowId) => {
+          return await client.startWorkflow(blockingTargetWorkflow, {
+            workflowId,
+          });
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const callerHandle = await startWorkflow(temporalDefaultCancelWorkflowCaller, {
+      args: [endpointName, targetWorkflowId],
+    });
+
+    await waitUntil(
+      async () => !!(await callerHandle.fetchHistory()).events?.some((ev) => ev.nexusOperationStartedEventAttributes),
+      4000
+    );
+
+    const targetHandle = t.context.env.client.workflow.getHandle(targetWorkflowId);
+    t.is((await targetHandle.describe()).status.name, 'RUNNING');
+
+    await callerHandle.cancel();
+    await callerHandle.result();
+
+    await waitUntil(async () => (await targetHandle.describe()).status.name === 'CANCELLED', 4000);
+    t.is((await targetHandle.describe()).status.name, 'CANCELLED');
+  });
+});

--- a/packages/test/src/test-nexus-temporal-operation.ts
+++ b/packages/test/src/test-nexus-temporal-operation.ts
@@ -49,8 +49,10 @@ type TemporalOpServiceHandlers = nexus.ServiceHandlerFor<typeof temporalOpServic
 type TemporalCancelOpServiceHandlers = nexus.ServiceHandlerFor<typeof temporalCancelOpService.operations>;
 
 function unusedTemporalOperationHandler<I, O>(): nexus.OperationHandler<I, O> {
-  return new temporalnexus.TemporalOperationHandler<I, O>(async () => {
-    throw new nexus.HandlerError('NOT_IMPLEMENTED', 'not used by this test');
+  return new temporalnexus.TemporalOperationHandler<I, O>({
+    async start() {
+      throw new nexus.HandlerError('NOT_IMPLEMENTED', 'not used by this test');
+    },
   });
 }
 
@@ -114,67 +116,68 @@ export async function blockingTargetWorkflow(): Promise<void> {
 // Tests
 
 test('TemporalOperationHandler infers correct output type from typed workflow function', async (t) => {
-  const _stringOp: nexus.OperationHandler<string, string> = new temporalnexus.TemporalOperationHandler(
-    async (_ctx, client, input: string) => {
+  const _stringOp: nexus.OperationHandler<string, string> = new temporalnexus.TemporalOperationHandler({
+    async start(_ctx, client, input: string) {
       return await client.startWorkflow(echoWorkflow, {
         args: [input],
         workflowId: 'test',
       });
-    }
-  );
+    },
+  });
 
   // @ts-expect-error - Output type should be string, not number
-  const _mismatchedOp: nexus.OperationHandler<string, number> = new temporalnexus.TemporalOperationHandler(
-    async (_ctx, client, input: string) => {
+  const _mismatchedOp: nexus.OperationHandler<string, number> = new temporalnexus.TemporalOperationHandler({
+    async start(_ctx, client, input: string) {
       return await client.startWorkflow(echoWorkflow, {
         args: [input],
         workflowId: 'test',
       });
-    }
-  );
+    },
+  });
 
-  const _syncOp: nexus.OperationHandler<string, string> = new temporalnexus.TemporalOperationHandler(
-    async (_ctx, _client, input: string) => {
+  const _syncOp: nexus.OperationHandler<string, string> = new temporalnexus.TemporalOperationHandler({
+    async start(_ctx, _client, input: string) {
       return temporalnexus.TemporalOperationResult.sync(input);
-    }
-  );
+    },
+  });
 
   const _explicitStringOp: nexus.OperationHandler<string, string> = new temporalnexus.TemporalOperationHandler<
     string,
     string
-  >(async (_ctx, client, input) => {
-    return await client.startWorkflow(echoWorkflow, {
-      args: [input],
-      workflowId: 'test',
-    });
+  >({
+    async start(_ctx, client, input) {
+      return await client.startWorkflow(echoWorkflow, {
+        args: [input],
+        workflowId: 'test',
+      });
+    },
   });
 
   // This test only checks for compile-time errors.
   t.pass();
 });
 
-test('TemporalOperationHandler cancel delegates to overridable cancelWorkflow', async (t) => {
+test('TemporalOperationHandler cancel delegates to provided cancelWorkflowRun handler', async (t) => {
   const { createWorker, registerNexusEndpoint } = helpers(t);
   const { endpointName } = await registerNexusEndpoint();
   const workflowId = randomUUID();
 
   let customCancelCalled = false;
 
-  class CustomCancelHandler extends temporalnexus.TemporalOperationHandler<string, void> {
-    async cancelWorkflowRun(_ctx: nexus.CancelOperationContext, workflowId: string): Promise<void> {
-      const handle = temporalnexus.getClient().workflow.getHandle(workflowId);
-      await handle.cancel();
-      customCancelCalled = true;
-    }
-  }
-
   const worker = await createWorker({
     nexusServices: [
       makeTemporalCancelOpServiceHandler({
-        blockingOp: new CustomCancelHandler(async (_ctx, client, workflowId) => {
-          return await client.startWorkflow(blockingTargetWorkflow, {
-            workflowId,
-          });
+        blockingOp: new temporalnexus.TemporalOperationHandler({
+          async start(_ctx, client, workflowId) {
+            return await client.startWorkflow(blockingTargetWorkflow, {
+              workflowId,
+            });
+          },
+          async cancelWorkflowRun(_ctx, client, workflowId) {
+            const handle = client.workflow.getHandle(workflowId);
+            await handle.cancel();
+            customCancelCalled = true;
+          },
         }),
       }),
     ],
@@ -208,14 +211,16 @@ test('TemporalOperationHandler cancel delegates to overridable cancelWorkflow', 
   });
 });
 
-test('TemporalOperationHandler cancel rejects invalid operation token type', async (t) => {
-  class CustomCancelHandler extends temporalnexus.TemporalOperationHandler<void, void> {
-    async cancelWorkflowRun(_ctx: nexus.CancelOperationContext, _workflowId: string): Promise<void> {
-      throw new Error('cancelWorkflowRun should not be called');
-    }
-  }
+test('TemporalOperationHandler.cancel rejects invalid operation token type before invoking cancellation hooks', async (t) => {
+  const handler = new temporalnexus.TemporalOperationHandler({
+    async start(_ctx, _client, _input) {
+      return temporalnexus.TemporalOperationResult.sync(undefined);
+    },
 
-  const handler = new CustomCancelHandler(async () => temporalnexus.TemporalOperationResult.sync(undefined));
+    async cancelWorkflowRun(_ctx, _client, _workflowId) {
+      throw new Error('cancelWorkflowRun should not be called');
+    },
+  });
   const token = base64URLEncodeNoPadding(JSON.stringify({ t: 2, ns: 'test-namespace' }));
 
   const err = await asyncLocalStorage.run(
@@ -252,14 +257,18 @@ test('TemporalOperationHandler async and sync happy paths - caller workflow', as
   const worker = await createWorker({
     nexusServices: [
       makeTemporalOpServiceHandler({
-        asyncOp: new temporalnexus.TemporalOperationHandler<string, string>(async (_ctx, client, input) => {
-          return await client.startWorkflow(echoWorkflow, {
-            workflowId: randomUUID(),
-            args: [input],
-          });
+        asyncOp: new temporalnexus.TemporalOperationHandler<string, string>({
+          async start(_ctx, client, input) {
+            return await client.startWorkflow(echoWorkflow, {
+              workflowId: randomUUID(),
+              args: [input],
+            });
+          },
         }),
-        syncOp: new temporalnexus.TemporalOperationHandler<string, string>(async (_ctx, _client, input) => {
-          return temporalnexus.TemporalOperationResult.sync(input);
+        syncOp: new temporalnexus.TemporalOperationHandler<string, string>({
+          async start(_ctx, _client, input) {
+            return temporalnexus.TemporalOperationResult.sync(input);
+          },
         }),
       }),
     ],
@@ -285,16 +294,18 @@ test('TemporalOperationHandler rejects multiple async starts', async (t) => {
   const worker = await createWorker({
     nexusServices: [
       makeTemporalOpServiceHandler({
-        doubleStartOp: new temporalnexus.TemporalOperationHandler<string, void>(async (_ctx, client, input) => {
-          await client.startWorkflow(echoWorkflow, {
-            workflowId: randomUUID(),
-            args: [input],
-          });
-          await client.startWorkflow(echoWorkflow, {
-            workflowId: randomUUID(),
-            args: [input],
-          });
-          throw new nexus.HandlerError('INTERNAL', 'expected previous error to be thrown');
+        doubleStartOp: new temporalnexus.TemporalOperationHandler<string, void>({
+          async start(_ctx, client, input) {
+            await client.startWorkflow(echoWorkflow, {
+              workflowId: randomUUID(),
+              args: [input],
+            });
+            await client.startWorkflow(echoWorkflow, {
+              workflowId: randomUUID(),
+              args: [input],
+            });
+            throw new nexus.HandlerError('INTERNAL', 'expected previous error to be thrown');
+          },
         }),
       }),
     ],
@@ -326,8 +337,8 @@ test('TemporalOperationHandler allows retry after failed async start', async (t)
   const worker = await createWorker({
     nexusServices: [
       makeTemporalOpServiceHandler({
-        retryAfterFailedStartOp: new temporalnexus.TemporalOperationHandler<string, string>(
-          async (_ctx, client, workflowId) => {
+        retryAfterFailedStartOp: new temporalnexus.TemporalOperationHandler<string, string>({
+          async start(_ctx, client, workflowId) {
             try {
               await client.startWorkflow(blockingTargetWorkflow, {
                 workflowId,
@@ -345,8 +356,8 @@ test('TemporalOperationHandler allows retry after failed async start', async (t)
             throw new nexus.HandlerError('INTERNAL', 'Expected first workflow start to fail', {
               retryableOverride: false,
             });
-          }
-        ),
+          },
+        }),
       }),
     ],
   });
@@ -374,10 +385,12 @@ test('TemporalOperationHandler default cancelWorkflowRun cancels backing workflo
   const worker = await createWorker({
     nexusServices: [
       makeTemporalCancelOpServiceHandler({
-        blockingOp: new temporalnexus.TemporalOperationHandler<string, void>(async (_ctx, client, workflowId) => {
-          return await client.startWorkflow(blockingTargetWorkflow, {
-            workflowId,
-          });
+        blockingOp: new temporalnexus.TemporalOperationHandler<string, void>({
+          async start(_ctx, client, workflowId) {
+            return await client.startWorkflow(blockingTargetWorkflow, {
+              workflowId,
+            });
+          },
         }),
       }),
     ],

--- a/packages/test/src/test-nexus-temporal-operation.ts
+++ b/packages/test/src/test-nexus-temporal-operation.ts
@@ -94,14 +94,9 @@ export async function temporalRetryAfterFailedStartOpCaller(endpoint: string, wo
 
 export async function temporalDefaultCancelWorkflowCaller(endpoint: string, targetWorkflowId: string): Promise<void> {
   const client = workflow.createNexusServiceClient({ endpoint, service: temporalCancelOpService });
-  try {
-    await client.executeOperation('blockingOp', targetWorkflowId, {
-      cancellationType: 'WAIT_CANCELLATION_COMPLETED',
-    });
-  } catch (err) {
-    if (workflow.isCancellation(err)) return;
-    throw err;
-  }
+  await client.executeOperation('blockingOp', targetWorkflowId, {
+    cancellationType: 'WAIT_CANCELLATION_COMPLETED',
+  });
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -209,8 +204,6 @@ test('TemporalOperationHandler cancel delegates to overridable cancelWorkflow', 
     await waitUntil(async () => (await operation.describe()).status === NexusOperationExecutionStatus.CANCELED, 4000);
     await waitUntil(async () => (await workflowHandle.describe()).status.name === 'CANCELLED', 4000);
 
-    t.is((await operation.describe()).status, NexusOperationExecutionStatus.CANCELED);
-    t.is((await workflowHandle.describe()).status.name, 'CANCELLED');
     t.true(customCancelCalled);
   });
 });
@@ -218,7 +211,7 @@ test('TemporalOperationHandler cancel delegates to overridable cancelWorkflow', 
 test('TemporalOperationHandler cancel rejects invalid operation token type', async (t) => {
   class CustomCancelHandler extends temporalnexus.TemporalOperationHandler<void, void> {
     async cancelWorkflowRun(_ctx: nexus.CancelOperationContext, _workflowId: string): Promise<void> {
-      throw new Error('cancelWorkflow should not be called');
+      throw new Error('cancelWorkflowRun should not be called');
     }
   }
 
@@ -349,7 +342,9 @@ test('TemporalOperationHandler allows retry after failed async start', async (t)
                 args: [workflowId],
               });
             }
-            throw new nexus.HandlerError('INTERNAL', 'Expected first workflow start to fail');
+            throw new nexus.HandlerError('INTERNAL', 'Expected first workflow start to fail', {
+              retryableOverride: false,
+            });
           }
         ),
       }),
@@ -371,7 +366,7 @@ test('TemporalOperationHandler allows retry after failed async start', async (t)
   });
 });
 
-test('TemporalOperationHandler default cancelWorkflow cancels backing workflow', async (t) => {
+test('TemporalOperationHandler default cancelWorkflowRun cancels backing workflow', async (t) => {
   const { createWorker, startWorkflow, registerNexusEndpoint } = helpers(t);
   const { endpointName } = await registerNexusEndpoint();
   const targetWorkflowId = randomUUID();
@@ -402,9 +397,8 @@ test('TemporalOperationHandler default cancelWorkflow cancels backing workflow',
     t.is((await targetHandle.describe()).status.name, 'RUNNING');
 
     await callerHandle.cancel();
-    await callerHandle.result();
 
+    await waitUntil(async () => (await callerHandle.describe()).status.name === 'CANCELLED', 4000);
     await waitUntil(async () => (await targetHandle.describe()).status.name === 'CANCELLED', 4000);
-    t.is((await targetHandle.describe()).status.name, 'CANCELLED');
   });
 });

--- a/packages/test/src/test-nexus-temporal-operation.ts
+++ b/packages/test/src/test-nexus-temporal-operation.ts
@@ -9,7 +9,7 @@ import {
 } from '@temporalio/client';
 import * as temporalnexus from '@temporalio/nexus';
 import { asyncLocalStorage } from '@temporalio/nexus/lib/context';
-import { base64URLEncodeNoPadding } from '@temporalio/nexus/lib/token';
+import { base64URLEncodeNoPadding, generateWorkflowRunOperationToken } from '@temporalio/nexus/lib/token';
 import * as workflow from '@temporalio/workflow';
 import { helpers, makeTestFunction } from './helpers-integration';
 import { innermostHandlerError } from './helpers-nexus';
@@ -413,5 +413,43 @@ test('TemporalOperationHandler default cancelWorkflowRun cancels backing workflo
 
     await waitUntil(async () => (await callerHandle.describe()).status.name === 'CANCELLED', 4000);
     await waitUntil(async () => (await targetHandle.describe()).status.name === 'CANCELLED', 4000);
+  });
+});
+
+test('TemporalOperationHandler workflow run has Nexus-Operation-Token Header', async (t) => {
+  const { createWorker, registerNexusEndpoint } = helpers(t);
+  const { client } = t.context.env;
+  const { endpointName } = await registerNexusEndpoint();
+
+  const worker = await createWorker({
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        asyncOp: new temporalnexus.TemporalOperationHandler<string, string>({
+          async start(_ctx, client, input) {
+            return await client.startWorkflow(echoWorkflow, {
+              workflowId: input,
+              args: [input],
+            });
+          },
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const targetWorkflowId = randomUUID();
+    const nexusClient = client.nexus.createServiceClient({ endpoint: endpointName, service: temporalOpService });
+
+    const result = await nexusClient.executeOperation(temporalOpService.operations.asyncOp, targetWorkflowId, {
+      id: randomUUID(),
+      scheduleToCloseTimeout: '10s',
+    });
+    t.is(result, targetWorkflowId);
+
+    const targetHandle = client.workflow.getHandle(targetWorkflowId);
+    const desc = await targetHandle.describe();
+
+    const opToken = desc.raw.callbacks?.[0].callback?.nexus?.header?.['nexus-operation-token'];
+    t.is(opToken, generateWorkflowRunOperationToken(client.options.namespace, targetHandle.workflowId));
   });
 });

--- a/packages/test/src/test-nexus-temporal-operation.ts
+++ b/packages/test/src/test-nexus-temporal-operation.ts
@@ -173,8 +173,8 @@ test('TemporalOperationHandler cancel delegates to provided cancelWorkflowRun ha
               workflowId,
             });
           },
-          async cancelWorkflowRun(_ctx, client, workflowId) {
-            const handle = client.workflow.getHandle(workflowId);
+          async cancelWorkflowRun(_ctx, { workflowId }) {
+            const handle = temporalnexus.getClient().workflow.getHandle(workflowId);
             await handle.cancel();
             customCancelCalled = true;
           },
@@ -217,7 +217,7 @@ test('TemporalOperationHandler.cancel rejects invalid operation token type befor
       return temporalnexus.TemporalOperationResult.sync(undefined);
     },
 
-    async cancelWorkflowRun(_ctx, _client, _workflowId) {
+    async cancelWorkflowRun(_ctx, _options) {
       throw new Error('cancelWorkflowRun should not be called');
     },
   });


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

 ## What was changed
Added `TemporalOperationHandler` for Nexus operations backed by Temporal workflows, including sync/async result helpers, a Nexus-aware client wrapper, operation-token parsing, default workflow cancellation, and public exports from `@temporalio/nexus`.

Added unit and integration coverage for token validation, type inference, sync/async operation execution, cancellation behavior, invalid tokens, duplicate async starts, and retrying after a failed workflow start.

  ## Why?
This gives Nexus handlers a first-class way to return synchronous results or start a Temporal workflow as the asynchronous backing operation, while preserving correct token validation and cancellation behavior.

  ## Checklist

  1. How was this tested:
  - New tests added
  - Existing tests