### PR TITLE
fix(lint): add .npmrc that fixes issue with linter memory.

### DIFF
--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -52,8 +52,4 @@ jobs:
         run: pnpm --recursive --stream --filter '!@temporalio/core-bridge' --filter '!typescript-sdk' run build
 
       - run: pnpm run lint:check
-        env:
-          NODE_OPTIONS: --max-old-space-size=8192
       - run: pnpm run lint:prune
-        env:
-          NODE_OPTIONS: --max-old-space-size=8192

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,6 @@ jobs:
         run: pnpm run docs
         env:
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
-          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Publish production docs
         if: ${{ inputs.publish_target == 'prod' }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,10 @@ packages/*/package-lock.json
 contrib/*/package-lock.json
 /sdk-node.iml
 *~
+
+# tooling
 .claude/settings.local.json
+mise.toml
 
 # One test creates persisted SQLite DBs; they should normally be deleted automatically,
 # but may be left behind in some error scenarios.

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-options=--max-old-space-size=8192


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixes:
```
$ pnpm run lint
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

