### PR TITLE
fix(activity): correctly populate activity info task queue and namespace

### DIFF
--- a/packages/test/src/test-worker-activities.ts
+++ b/packages/test/src/test-worker-activities.ts
@@ -107,7 +107,7 @@ test('Worker activity info does not confuse task queue and namespace', async (t)
       completed: {
         result: defaultPayloadConverter.toPayload({
           taskQueue: 'activity-task-queue',
-          namespace: 'activity-namespace',
+          namespace: 'workflow-namespace',
           activityNamespace: 'activity-namespace',
           workflowNamespace: 'workflow-namespace',
         }),

--- a/packages/test/src/test-worker-activities.ts
+++ b/packages/test/src/test-worker-activities.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import type { ExecutionContext, TestFn } from 'ava';
 import anyTest from 'ava';
 import dedent from 'dedent';
+import { activityInfo } from '@temporalio/activity';
 import { TemporalFailure, defaultPayloadConverter, toPayloads, ApplicationFailure } from '@temporalio/common';
 import { coresdk, google } from '@temporalio/proto';
 import { msToTs } from '@temporalio/common/lib/time';
@@ -67,6 +68,50 @@ test('Worker runs an activity and reports completion', async (t) => {
     });
     compareCompletion(t, completion.result, {
       completed: { result: defaultPayloadConverter.toPayload(await httpGet(url)) },
+    });
+  });
+});
+
+test('Worker activity info does not confuse task queue and namespace', async (t) => {
+  const worker = isolateFreeWorker({
+    ...defaultOptions,
+    namespace: 'activity-namespace',
+    taskQueue: 'activity-task-queue',
+    activities: {
+      async getActivityInfo() {
+        const info = activityInfo();
+        return {
+          taskQueue: info.taskQueue,
+          namespace: info.namespace,
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
+          activityNamespace: info.activityNamespace,
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
+          workflowNamespace: info.workflowNamespace,
+        };
+      },
+    },
+  });
+  t.context.worker = worker;
+
+  await runWorker(t, async () => {
+    const taskToken = Buffer.from(randomUUID());
+    const completion = await worker.native.runActivityTask({
+      taskToken,
+      start: {
+        activityType: 'getActivityInfo',
+        workflowNamespace: 'workflow-namespace',
+        workflowExecution: { workflowId: 'wfid', runId: 'runId' },
+      },
+    });
+    compareCompletion(t, completion.result, {
+      completed: {
+        result: defaultPayloadConverter.toPayload({
+          taskQueue: 'activity-task-queue',
+          namespace: 'activity-namespace',
+          activityNamespace: 'activity-namespace',
+          workflowNamespace: 'workflow-namespace',
+        }),
+      },
     });
   });
 });

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1059,13 +1059,13 @@ export class Worker {
                         `Got start event for an already running activity: ${base64TaskToken}`
                       );
                     }
-                    info = await extractActivityInfo(
+                    info = await extractActivityInfo({
                       task,
-                      loadedDataConverter,
-                      this.options.namespace,
-                      this.options.taskQueue,
-                      context
-                    );
+                      dataConverter: loadedDataConverter,
+                      taskQueue: this.options.taskQueue,
+                      activityNamespace: this.options.namespace,
+                      context,
+                    });
 
                     const { activityType } = info;
                     // Use the corresponding activity if it exists, otherwise, fallback to default activity function (if exists)
@@ -2202,13 +2202,19 @@ function extractSourceMap(code: string): [string, string] {
 /**
  * Transform an ActivityTask into ActivityInfo to pass on into an Activity
  */
-async function extractActivityInfo(
-  task: coresdk.activity_task.ActivityTask,
-  dataConverter: LoadedDataConverter,
-  taskQueue: string,
-  activityNamespace: string,
-  context: ActivitySerializationContext
-): Promise<ActivityInfo> {
+async function extractActivityInfo({
+  task,
+  dataConverter,
+  taskQueue,
+  activityNamespace,
+  context,
+}: {
+  task: coresdk.activity_task.ActivityTask;
+  dataConverter: LoadedDataConverter;
+  taskQueue: string;
+  activityNamespace: string;
+  context: ActivitySerializationContext;
+}): Promise<ActivityInfo> {
   // NOTE: We trust core to supply all of these fields instead of checking for null and undefined everywhere
   const { taskToken } = task as NonNullableObject<coresdk.activity_task.IActivityTask>;
   const start = task.start as NonNullableObject<coresdk.activity_task.IStart>;
@@ -2236,7 +2242,7 @@ async function extractActivityInfo(
     workflowType: inWorkflow ? start.workflowType : undefined,
     heartbeatTimeoutMs: optionalTsToMs(start.heartbeatTimeout),
     heartbeatDetails,
-    activityNamespace: start.workflowNamespace,
+    activityNamespace,
     workflowNamespace: inWorkflow ? start.workflowNamespace : undefined,
     scheduledTimestampMs: requiredTsToMs(start.scheduledTime, 'scheduledTime'),
     startToCloseTimeoutMs: requiredTsToMs(start.startToCloseTimeout, 'startToCloseTimeout'),
@@ -2247,7 +2253,7 @@ async function extractActivityInfo(
     ),
     priority: decodePriority(start.priority),
     retryPolicy: decompileRetryPolicy(start.retryPolicy),
-    namespace: start.workflowNamespace,
+    namespace: activityNamespace,
     activityRunId: !inWorkflow ? start.runId : undefined,
     inWorkflow,
   };

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -2253,7 +2253,7 @@ async function extractActivityInfo({
     ),
     priority: decodePriority(start.priority),
     retryPolicy: decompileRetryPolicy(start.retryPolicy),
-    namespace: activityNamespace,
+    namespace: start.workflowNamespace || activityNamespace,
     activityRunId: !inWorkflow ? start.runId : undefined,
     inWorkflow,
   };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Use `activityNamespace` over workflow namespace for populating namespace fields on `activityInfo`
- Switch to use an object instead of loose params to prevent incorrect calling of `extractActivityInfo` in the future

## Why?
In #1996 we accidentally flipped task queue and activity namespace in the call to `extractActivityInfo`

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Added test to verify task queue and activity namespace work as expected.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
