### PR TITLE
Remove OTel tags from metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
           TEMPORAL_CLOUD_MTLS_TEST_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
 
           # For Temporal Cloud + API key tests
-          TEMPORAL_CLOUD_API_KEY_TEST_TARGET_HOST: us-east-1.aws.api.temporal.io:7233
+          TEMPORAL_CLOUD_API_KEY_TEST_TARGET_HOST: ca-central-1.aws.api.temporal.io:7233
           TEMPORAL_CLOUD_API_KEY_TEST_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
           TEMPORAL_CLOUD_API_KEY_TEST_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
 

--- a/contrib/interceptors-opentelemetry/src/__tests__/activities/index.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/activities/index.ts
@@ -37,3 +37,8 @@ export async function throwMaybeBenign(): Promise<void> {
     throw ApplicationFailure.create({ message: 'benign', category: ApplicationFailureCategory.BENIGN });
   }
 }
+
+export async function emitOtelPluginMetric(): Promise<void> {
+  const counter = Context.current().metricMeter.createCounter('otel-plugin-activity-counter');
+  counter.add(1, { source: 'activity' });
+}

--- a/contrib/interceptors-opentelemetry/src/__tests__/test-otel-metric-tags.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/test-otel-metric-tags.ts
@@ -1,0 +1,116 @@
+import { randomUUID } from 'crypto';
+import * as opentelemetry from '@opentelemetry/sdk-node';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import test from 'ava';
+import { MetricsBuffer, Runtime, Worker } from '@temporalio/worker';
+import {
+  RUN_INTEGRATION_TESTS,
+  createTestWorkflowEnvironment,
+  type TestWorkflowEnvironment,
+} from '@temporalio/test-helpers';
+import { OpenTelemetryPlugin } from '..';
+import * as activities from './activities';
+import * as workflows from './workflows';
+
+class OtelSdkContext {
+  private readonly sdk: opentelemetry.NodeSDK;
+
+  constructor({
+    resource,
+    traceExporter,
+  }: {
+    resource: opentelemetry.resources.Resource;
+    traceExporter: opentelemetry.tracing.SpanExporter;
+  }) {
+    this.sdk = new opentelemetry.NodeSDK({ resource, traceExporter });
+  }
+
+  start(): void {
+    this.sdk.start();
+  }
+
+  async shutdown(): Promise<void> {
+    await this.sdk.shutdown();
+  }
+}
+
+const metricTagsTest = RUN_INTEGRATION_TESTS ? test.serial : test.skip;
+const sdkMetricAttributeKeys = new Set(['activityType', 'taskQueue', 'workflowType']);
+
+metricTagsTest('OpenTelemetryPlugin does not attach trace context to metric tags', async (t) => {
+  const buffer = new MetricsBuffer({ maxBufferSize: 1000 });
+  Runtime.install({
+    telemetryOptions: {
+      metrics: { buffer },
+    },
+  });
+
+  const traceExporter = new InMemorySpanExporter();
+  const staticResource = new opentelemetry.resources.Resource({
+    [SEMRESATTRS_SERVICE_NAME]: 'ts-test-otel-metric-tags-worker',
+  });
+  const otel = new OtelSdkContext({ resource: staticResource, traceExporter });
+  let env: TestWorkflowEnvironment | undefined;
+
+  try {
+    otel.start();
+
+    const plugin = new OpenTelemetryPlugin({
+      resource: staticResource,
+      spanProcessor: new SimpleSpanProcessor(traceExporter),
+    });
+    env = await createTestWorkflowEnvironment({ plugins: [plugin] });
+    const taskQueue = `test-otel-metric-tags-${randomUUID()}`;
+    const worker = await Worker.create({
+      connection: env.nativeConnection,
+      workflowsPath: require.resolve('./workflows'),
+      activities,
+      taskQueue,
+      plugins: [plugin],
+    });
+
+    await worker.runUntil(
+      env.client.workflow.execute(workflows.metricTraceTags, {
+        taskQueue,
+        workflowId: randomUUID(),
+      })
+    );
+
+    const metricAssertions = Array.from(buffer.retrieveUpdates())
+      .filter((update) =>
+        ['otel-plugin-workflow-counter', 'otel-plugin-activity-counter'].includes(update.metric.name)
+      )
+      .map((update) => ({
+        metricName: update.metric.name,
+        value: update.value,
+        attributes: Object.fromEntries(
+          Object.entries(update.attributes).filter(([key]) => !sdkMetricAttributeKeys.has(key))
+        ),
+      }))
+      .sort((a, b) => a.metricName.localeCompare(b.metricName));
+
+    t.deepEqual(metricAssertions, [
+      {
+        metricName: 'otel-plugin-activity-counter',
+        value: 1,
+        attributes: {
+          namespace: 'default',
+          source: 'activity',
+        },
+      },
+      {
+        metricName: 'otel-plugin-workflow-counter',
+        value: 1,
+        attributes: {
+          namespace: 'default',
+          source: 'workflow',
+        },
+      },
+    ]);
+  } finally {
+    await env?.teardown();
+    await otel.shutdown();
+    await Runtime._instance?.shutdown();
+  }
+});

--- a/contrib/interceptors-opentelemetry/src/__tests__/test-otel-metric-tags.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/test-otel-metric-tags.ts
@@ -57,9 +57,7 @@ metricTagsTest('OpenTelemetryPlugin does not attach trace context to metric tags
     );
 
     const metricAssertions = Array.from(buffer.retrieveUpdates())
-      .filter((update) =>
-        ['otel-plugin-workflow-counter', 'otel-plugin-activity-counter'].includes(update.metric.name)
-      )
+      .filter((update) => ['otel-plugin-workflow-counter', 'otel-plugin-activity-counter'].includes(update.metric.name))
       .map((update) => ({
         metricName: update.metric.name,
         value: update.value,

--- a/contrib/interceptors-opentelemetry/src/__tests__/test-otel-metric-tags.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/test-otel-metric-tags.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import * as otelApi from '@opentelemetry/api';
 import * as opentelemetry from '@opentelemetry/sdk-node';
 import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
@@ -12,28 +13,6 @@ import {
 import { OpenTelemetryPlugin } from '..';
 import * as activities from './activities';
 import * as workflows from './workflows';
-
-class OtelSdkContext {
-  private readonly sdk: opentelemetry.NodeSDK;
-
-  constructor({
-    resource,
-    traceExporter,
-  }: {
-    resource: opentelemetry.resources.Resource;
-    traceExporter: opentelemetry.tracing.SpanExporter;
-  }) {
-    this.sdk = new opentelemetry.NodeSDK({ resource, traceExporter });
-  }
-
-  start(): void {
-    this.sdk.start();
-  }
-
-  async shutdown(): Promise<void> {
-    await this.sdk.shutdown();
-  }
-}
 
 const metricTagsTest = RUN_INTEGRATION_TESTS ? test.serial : test.skip;
 const sdkMetricAttributeKeys = new Set(['activityType', 'taskQueue', 'workflowType']);
@@ -50,7 +29,7 @@ metricTagsTest('OpenTelemetryPlugin does not attach trace context to metric tags
   const staticResource = new opentelemetry.resources.Resource({
     [SEMRESATTRS_SERVICE_NAME]: 'ts-test-otel-metric-tags-worker',
   });
-  const otel = new OtelSdkContext({ resource: staticResource, traceExporter });
+  const otel = new opentelemetry.NodeSDK({ resource: staticResource, traceExporter });
   let env: TestWorkflowEnvironment | undefined;
 
   try {
@@ -111,6 +90,7 @@ metricTagsTest('OpenTelemetryPlugin does not attach trace context to metric tags
   } finally {
     await env?.teardown();
     await otel.shutdown();
+    otelApi.trace.disable();
     await Runtime._instance?.shutdown();
   }
 });

--- a/contrib/interceptors-opentelemetry/src/__tests__/test-otel.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/test-otel.ts
@@ -25,24 +25,26 @@ import type {
   NexusInboundCallsInterceptor,
   NexusOutboundCallsInterceptor,
 } from '@temporalio/worker';
-import { bundleWorkflowCode, DefaultLogger, Runtime, Worker } from '@temporalio/worker';
+import { bundleWorkflowCode, DefaultLogger, MetricsBuffer, Runtime, Worker } from '@temporalio/worker';
 import type { WorkflowInboundCallsInterceptor, WorkflowOutboundCallsInterceptor } from '@temporalio/workflow';
-import type { Info } from '@temporalio/activity';
+import type { Context as ActivityContext, Info } from '@temporalio/activity';
 import {
   RUN_INTEGRATION_TESTS,
   loadHistory as loadHistoryBase,
   createBaseBundlerOptions,
   createTestWorkflowBundle as createTestWorkflowBundleBase,
   createTestWorkflowEnvironment,
+  type TestWorkflowEnvironment,
 } from '@temporalio/test-helpers';
 import type * as workflowImportStub from '../workflow/workflow-imports';
 import type * as workflowImportImpl from '../workflow/workflow-imports-impl';
 import { instrument, instrumentSync, NEXUS_SERVICE_ATTR_KEY, NEXUS_OPERATION_ATTR_KEY } from '../instrumentation';
-import type { OpenTelemetryNexusInboundInterceptor, OpenTelemetryNexusOutboundInterceptor } from '../worker';
+import type { OpenTelemetryNexusInboundInterceptor } from '../worker';
 import {
   makeWorkflowExporter,
   OpenTelemetryActivityInboundInterceptor,
   OpenTelemetryActivityOutboundInterceptor,
+  OpenTelemetryNexusOutboundInterceptor,
 } from '../worker';
 import type {
   OpenTelemetrySinks,
@@ -51,7 +53,7 @@ import type {
 } from '../workflow';
 import { SpanName, SPAN_DELIMITER } from '../workflow';
 import { OpenTelemetryWorkflowClientInterceptor } from '../client';
-import { OpenTelemetryPlugin } from '..';
+import { OpenTelemetryPlugin, type OpenTelemetryPluginOptions } from '..';
 import * as activities from './activities';
 import { createActivities as createAsyncActivities } from './activities/async-completer';
 import * as workflows from './workflows';
@@ -943,6 +945,87 @@ if (RUN_INTEGRATION_TESTS) {
       t.is(serialized, 'vendor1=value1,vendor2=value2');
       t.is(traceState!.get('vendor1'), 'value1');
       t.is(traceState!.get('vendor2'), 'value2');
+    }
+  });
+}
+
+if (RUN_INTEGRATION_TESTS) {
+  test.serial('OpenTelemetryPlugin does not attach trace context to metric tags', async (t) => {
+    const buffer = new MetricsBuffer({ maxBufferSize: 1000 });
+    Runtime.install({
+      telemetryOptions: {
+        metrics: { buffer },
+      },
+    });
+
+    const traceExporter = new InMemorySpanExporter();
+    const staticResource = new opentelemetry.resources.Resource({
+      [SEMRESATTRS_SERVICE_NAME]: 'ts-test-otel-metric-tags-worker',
+    });
+    const otel = new OtelSdkContext({ resource: staticResource, traceExporter });
+    let env: TestWorkflowEnvironment | undefined;
+
+    try {
+      otel.start();
+
+      const plugin = new OpenTelemetryPlugin({
+        resource: staticResource,
+        spanProcessor: new SimpleSpanProcessor(traceExporter),
+      });
+      env = await createTestWorkflowEnvironment({ plugins: [plugin] });
+      const taskQueue = `test-otel-metric-tags-${randomUUID()}`;
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath: require.resolve('./workflows'),
+        activities,
+        taskQueue,
+        plugins: [plugin],
+      });
+
+      await worker.runUntil(
+        env.client.workflow.execute(workflows.metricTraceTags, {
+          taskQueue,
+          workflowId: randomUUID(),
+        })
+      );
+
+      const metricAssertions = Array.from(buffer.retrieveUpdates())
+        .filter((update) =>
+          ['otel-plugin-workflow-counter', 'otel-plugin-activity-counter'].includes(update.metric.name)
+        )
+        .map((update) => ({
+          metricName: update.metric.name,
+          value: update.value,
+          attributes: update.attributes,
+        }))
+        .sort((a, b) => a.metricName.localeCompare(b.metricName));
+
+      t.deepEqual(metricAssertions, [
+        {
+          metricName: 'otel-plugin-activity-counter',
+          value: 1,
+          attributes: {
+            activityType: 'emitOtelPluginMetric',
+            namespace: 'default',
+            source: 'activity',
+            taskQueue: 'default',
+          },
+        },
+        {
+          metricName: 'otel-plugin-workflow-counter',
+          value: 1,
+          attributes: {
+            namespace: 'default',
+            source: 'workflow',
+            taskQueue,
+            workflowType: 'metricTraceTags',
+          },
+        },
+      ]);
+    } finally {
+      await env?.teardown();
+      await otel.shutdown();
+      await Runtime._instance?.shutdown();
     }
   });
 }

--- a/contrib/interceptors-opentelemetry/src/__tests__/test-otel.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/test-otel.ts
@@ -1007,7 +1007,7 @@ if (RUN_INTEGRATION_TESTS) {
             activityType: 'emitOtelPluginMetric',
             namespace: 'default',
             source: 'activity',
-            taskQueue: 'default',
+            taskQueue,
           },
         },
         {

--- a/contrib/interceptors-opentelemetry/src/__tests__/test-otel.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/test-otel.ts
@@ -27,7 +27,7 @@ import type {
 } from '@temporalio/worker';
 import { bundleWorkflowCode, DefaultLogger, MetricsBuffer, Runtime, Worker } from '@temporalio/worker';
 import type { WorkflowInboundCallsInterceptor, WorkflowOutboundCallsInterceptor } from '@temporalio/workflow';
-import type { Context as ActivityContext, Info } from '@temporalio/activity';
+import type { Info } from '@temporalio/activity';
 import {
   RUN_INTEGRATION_TESTS,
   loadHistory as loadHistoryBase,
@@ -39,12 +39,11 @@ import {
 import type * as workflowImportStub from '../workflow/workflow-imports';
 import type * as workflowImportImpl from '../workflow/workflow-imports-impl';
 import { instrument, instrumentSync, NEXUS_SERVICE_ATTR_KEY, NEXUS_OPERATION_ATTR_KEY } from '../instrumentation';
-import type { OpenTelemetryNexusInboundInterceptor } from '../worker';
+import type { OpenTelemetryNexusInboundInterceptor, OpenTelemetryNexusOutboundInterceptor } from '../worker';
 import {
   makeWorkflowExporter,
   OpenTelemetryActivityInboundInterceptor,
   OpenTelemetryActivityOutboundInterceptor,
-  OpenTelemetryNexusOutboundInterceptor,
 } from '../worker';
 import type {
   OpenTelemetrySinks,
@@ -53,7 +52,7 @@ import type {
 } from '../workflow';
 import { SpanName, SPAN_DELIMITER } from '../workflow';
 import { OpenTelemetryWorkflowClientInterceptor } from '../client';
-import { OpenTelemetryPlugin, type OpenTelemetryPluginOptions } from '..';
+import { OpenTelemetryPlugin } from '..';
 import * as activities from './activities';
 import { createActivities as createAsyncActivities } from './activities/async-completer';
 import * as workflows from './workflows';

--- a/contrib/interceptors-opentelemetry/src/__tests__/test-otel.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/test-otel.ts
@@ -25,7 +25,7 @@ import type {
   NexusInboundCallsInterceptor,
   NexusOutboundCallsInterceptor,
 } from '@temporalio/worker';
-import { bundleWorkflowCode, DefaultLogger, MetricsBuffer, Runtime, Worker } from '@temporalio/worker';
+import { bundleWorkflowCode, DefaultLogger, Runtime, Worker } from '@temporalio/worker';
 import type { WorkflowInboundCallsInterceptor, WorkflowOutboundCallsInterceptor } from '@temporalio/workflow';
 import type { Info } from '@temporalio/activity';
 import {
@@ -34,7 +34,6 @@ import {
   createBaseBundlerOptions,
   createTestWorkflowBundle as createTestWorkflowBundleBase,
   createTestWorkflowEnvironment,
-  type TestWorkflowEnvironment,
 } from '@temporalio/test-helpers';
 import type * as workflowImportStub from '../workflow/workflow-imports';
 import type * as workflowImportImpl from '../workflow/workflow-imports-impl';
@@ -944,87 +943,6 @@ if (RUN_INTEGRATION_TESTS) {
       t.is(serialized, 'vendor1=value1,vendor2=value2');
       t.is(traceState!.get('vendor1'), 'value1');
       t.is(traceState!.get('vendor2'), 'value2');
-    }
-  });
-}
-
-if (RUN_INTEGRATION_TESTS) {
-  test.serial('OpenTelemetryPlugin does not attach trace context to metric tags', async (t) => {
-    const buffer = new MetricsBuffer({ maxBufferSize: 1000 });
-    Runtime.install({
-      telemetryOptions: {
-        metrics: { buffer },
-      },
-    });
-
-    const traceExporter = new InMemorySpanExporter();
-    const staticResource = new opentelemetry.resources.Resource({
-      [SEMRESATTRS_SERVICE_NAME]: 'ts-test-otel-metric-tags-worker',
-    });
-    const otel = new OtelSdkContext({ resource: staticResource, traceExporter });
-    let env: TestWorkflowEnvironment | undefined;
-
-    try {
-      otel.start();
-
-      const plugin = new OpenTelemetryPlugin({
-        resource: staticResource,
-        spanProcessor: new SimpleSpanProcessor(traceExporter),
-      });
-      env = await createTestWorkflowEnvironment({ plugins: [plugin] });
-      const taskQueue = `test-otel-metric-tags-${randomUUID()}`;
-      const worker = await Worker.create({
-        connection: env.nativeConnection,
-        workflowsPath: require.resolve('./workflows'),
-        activities,
-        taskQueue,
-        plugins: [plugin],
-      });
-
-      await worker.runUntil(
-        env.client.workflow.execute(workflows.metricTraceTags, {
-          taskQueue,
-          workflowId: randomUUID(),
-        })
-      );
-
-      const metricAssertions = Array.from(buffer.retrieveUpdates())
-        .filter((update) =>
-          ['otel-plugin-workflow-counter', 'otel-plugin-activity-counter'].includes(update.metric.name)
-        )
-        .map((update) => ({
-          metricName: update.metric.name,
-          value: update.value,
-          attributes: update.attributes,
-        }))
-        .sort((a, b) => a.metricName.localeCompare(b.metricName));
-
-      t.deepEqual(metricAssertions, [
-        {
-          metricName: 'otel-plugin-activity-counter',
-          value: 1,
-          attributes: {
-            activityType: 'emitOtelPluginMetric',
-            namespace: 'default',
-            source: 'activity',
-            taskQueue,
-          },
-        },
-        {
-          metricName: 'otel-plugin-workflow-counter',
-          value: 1,
-          attributes: {
-            namespace: 'default',
-            source: 'workflow',
-            taskQueue,
-            workflowType: 'metricTraceTags',
-          },
-        },
-      ]);
-    } finally {
-      await env?.teardown();
-      await otel.shutdown();
-      await Runtime._instance?.shutdown();
     }
   });
 }

--- a/contrib/interceptors-opentelemetry/src/__tests__/workflows/index.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/workflows/index.ts
@@ -1,5 +1,6 @@
 export * from './async-activity-completion-tester';
 export * from './definitions';
+export * from './metric-trace-tags';
 export * from './nexus-caller-otel';
 export * from './signal-target';
 export * from './smorgasbord';

--- a/contrib/interceptors-opentelemetry/src/__tests__/workflows/metric-trace-tags.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/workflows/metric-trace-tags.ts
@@ -1,0 +1,13 @@
+import { metricMeter, proxyActivities } from '@temporalio/workflow';
+import type * as activities from '../activities';
+
+const { emitOtelPluginMetric } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '1 minute',
+});
+
+export async function metricTraceTags(): Promise<void> {
+  const counter = metricMeter.createCounter('otel-plugin-workflow-counter');
+  counter.add(1, { source: 'workflow' });
+
+  await emitOtelPluginMetric();
+}

--- a/contrib/interceptors-opentelemetry/src/worker/index.ts
+++ b/contrib/interceptors-opentelemetry/src/worker/index.ts
@@ -79,7 +79,7 @@ export class OpenTelemetryActivityInboundInterceptor implements ActivityInboundC
 /**
  * Intercepts calls to emit logs and metrics from an Activity.
  *
- * Attach OpenTelemetry context tracing attributes to emitted log messages and metrics, if appropriate.
+ * Attach OpenTelemetry context tracing attributes to emitted log messages, if appropriate.
  */
 export class OpenTelemetryActivityOutboundInterceptor implements ActivityOutboundCallsInterceptor {
   constructor(protected readonly ctx: ActivityContext) {}
@@ -106,18 +106,7 @@ export class OpenTelemetryActivityOutboundInterceptor implements ActivityOutboun
     input: GetMetricTagsInput,
     next: Next<ActivityOutboundCallsInterceptor, 'getMetricTags'>
   ): GetMetricTagsInput {
-    const span = otel.trace.getSpan(otel.context.active());
-    const spanContext = span?.spanContext();
-    if (spanContext && otel.isSpanContextValid(spanContext)) {
-      return next({
-        trace_id: spanContext.traceId,
-        span_id: spanContext.spanId,
-        trace_flags: `0${spanContext.traceFlags.toString(16)}`,
-        ...input,
-      });
-    } else {
-      return next(input);
-    }
+    return next(input);
   }
 }
 
@@ -177,7 +166,7 @@ export class OpenTelemetryNexusInboundInterceptor implements NexusInboundCallsIn
 /**
  * Intercepts outbound calls from a Nexus Operation handler.
  *
- * Attaches OpenTelemetry context tracing attributes to emitted log messages and metrics.
+ * Attaches OpenTelemetry context tracing attributes to emitted log messages.
  */
 export class OpenTelemetryNexusOutboundInterceptor implements NexusOutboundCallsInterceptor {
   constructor(protected readonly ctx: nexus.OperationContext) {}
@@ -204,18 +193,7 @@ export class OpenTelemetryNexusOutboundInterceptor implements NexusOutboundCalls
     input: GetMetricTagsInput,
     next: Next<NexusOutboundCallsInterceptor, 'getMetricTags'>
   ): GetMetricTagsInput {
-    const span = otel.trace.getSpan(otel.context.active());
-    const spanContext = span?.spanContext();
-    if (spanContext && otel.isSpanContextValid(spanContext)) {
-      return next({
-        trace_id: spanContext.traceId,
-        span_id: spanContext.spanId,
-        trace_flags: `0${spanContext.traceFlags.toString(16)}`,
-        ...input,
-      });
-    } else {
-      return next(input);
-    }
+    return next(input);
   }
 }
 

--- a/contrib/interceptors-opentelemetry/src/workflow/index.ts
+++ b/contrib/interceptors-opentelemetry/src/workflow/index.ts
@@ -302,18 +302,7 @@ export class OpenTelemetryOutboundInterceptor implements WorkflowOutboundCallsIn
     input: GetMetricTagsInput,
     next: Next<WorkflowOutboundCallsInterceptor, 'getMetricTags'>
   ): GetMetricTagsInput {
-    const span = otel.trace.getSpan(otel.context.active());
-    const spanContext = span?.spanContext();
-    if (spanContext && otel.isSpanContextValid(spanContext)) {
-      return next({
-        trace_id: spanContext.traceId,
-        span_id: spanContext.spanId,
-        trace_flags: `0${spanContext.traceFlags.toString(16)}`,
-        ...input,
-      });
-    } else {
-      return next(input);
-    }
+    return next(input);
   }
 }
 

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -10,7 +10,7 @@
     "lib/"
   ],
   "scripts": {
-    "build": "pnpm run \"/^build:.*/\"",
+    "build": "pnpm run build:protos && pnpm run build:ts",
     "build:ts": "tsc --build",
     "build:protos": "tsx ./scripts/compile-proto.ts"
   },

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -4,7 +4,7 @@
   "version": "1.18.0",
   "description": "Temporal.io SDK Tests",
   "scripts": {
-    "build": "pnpm run \"/^build:.*/\"",
+    "build": "pnpm run build:protos && pnpm run build:ts",
     "build:ts": "tsc --build",
     "build:protos": "tsx ./scripts/compile-proto.ts",
     "test": "ava ./lib/test-*.js",


### PR DESCRIPTION
## What was changed
DWISOTT - remove otel tags from metrics (i.e. spanId, traceId)

## Why?
Blows up metrics cardinality with no benefit.

2. How was this tested:
Added integration test

3. Any docs updates needed?
Probably not
