### PR TITLE
feat(common): export SDK version

### DIFF
--- a/packages/common/src/__tests__/test-sdk-version.ts
+++ b/packages/common/src/__tests__/test-sdk-version.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import test from 'ava';
+import { sdkVersion } from '../index';
+
+const pkg = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf8')) as { version: string };
+
+test('sdkVersion exposes the package version', (t) => {
+  t.is(sdkVersion, pkg.version);
+  t.regex(sdkVersion, /^\d+\.\d+\.\d+/);
+});

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -6,6 +6,12 @@
 
 import * as encoding from './encoding';
 import * as helpers from './type-helpers';
+import { version as sdkVersion } from './pkg';
+
+/**
+ * Version of the Temporal TypeScript SDK.
+ */
+export { sdkVersion };
 
 export * from './activity-options';
 export { ActivityCancellationDetailsOptions, ActivityCancellationDetails } from './activity-cancellation-details';

--- a/packages/common/src/pkg.ts
+++ b/packages/common/src/pkg.ts
@@ -1,0 +1,7 @@
+// ../package.json is outside of the TS project rootDir which causes TS to complain about this import.
+// We do not want to change the rootDir because it messes up the output structure.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import pkg from '../package.json';
+
+export const version = pkg.version as string;


### PR DESCRIPTION
Adds a public `sdkVersion` export from `@temporalio/common`, backed by the package version so consumers do not need to import `package.json` or internal package metadata directly.

The new focused AVA test imports the public export and independently reads `packages/common/package.json`, so it verifies the runtime wiring and version value rather than comparing the export to itself.

Closes #417.

## Verification

- `pnpm install --frozen-lockfile`
- `git submodule update --init --recursive packages/core-bridge/sdk-core`
- `pnpm run build:protos`
- `pnpm -C packages/common run build`
- `pnpm -C packages/common run test`
- `pnpm exec prettier --check packages/common/src/index.ts packages/common/src/pkg.ts packages/common/src/__tests__/test-sdk-version.ts`
