### PR TITLE
Export WebpackConfiguration from the @temporalio/worker package root

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -65,6 +65,7 @@ export { DataConverter, defaultPayloadConverter, State, Worker, WorkerStatus } f
 export {
   CompiledWorkerOptions,
   ReplayWorkerOptions,
+  WebpackConfiguration,
   WorkerDeploymentOptions,
   WorkerOptions,
   WorkerPlugin,


### PR DESCRIPTION
`BundleOptions.webpackConfigHook` and `WorkerOptions.bundlerOptions.webpackConfigHook` are typed `(config: WebpackConfiguration) => WebpackConfiguration`, but `WebpackConfiguration` — webpack's `Configuration`, already aliased and `export type`'d in `worker-options.ts` — is only exported from that submodule, not the package root. A consumer implementing a `webpackConfigHook` (for example a plugin that appends webpack plugins to the Workflow bundle) has no way to name the parameter type without depending on `webpack` directly or reverse-deriving it from the hook signature.

This re-exports `WebpackConfiguration` from the root barrel so it can be imported as `import type { WebpackConfiguration } from '@temporalio/worker'`.