### PR TITLE
Grant explicit actions:read to features reusable-workflow caller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,9 @@ jobs:
   # FIXME: Update this job to reuse native build artifacts from compile-native-binaries
   features-tests:
     name: Features Tests
+    permissions:
+      contents: read
+      actions: read
     uses: temporalio/features/.github/workflows/typescript.yaml@main
     with:
       typescript-repo-path: ${{github.event.pull_request.head.repo.full_name}}


### PR DESCRIPTION
## What 
Adds a job-level permissions block granting `contents: read` and `actions: read` to the job that calls the temporalio/features workflow. 

## Why
The org default GITHUB_TOKEN permissions are now restrictive (`actions: none`), so without this grant the reusable workflow fails validation at parse time and the check never starts.