### PR TITLE
docs: add workflow-streams and openai-agents to API docs

### DIFF
--- a/packages/meta/package.json
+++ b/packages/meta/package.json
@@ -11,11 +11,13 @@
     "@temporalio/envconfig": "workspace:*",
     "@temporalio/interceptors-opentelemetry": "workspace:*",
     "@temporalio/nexus": "workspace:*",
+    "@temporalio/openai-agents": "workspace:*",
     "@temporalio/plugin": "workspace:*",
     "@temporalio/proto": "workspace:*",
     "@temporalio/testing": "workspace:*",
     "@temporalio/worker": "workspace:*",
-    "@temporalio/workflow": "workspace:*"
+    "@temporalio/workflow": "workspace:*",
+    "@temporalio/workflow-streams": "workspace:*"
   },
   "author": "Temporal Technologies Inc. <sdk@temporal.io>",
   "license": "MIT",

--- a/packages/meta/src/index.ts
+++ b/packages/meta/src/index.ts
@@ -14,3 +14,6 @@ export * as envconfig from '@temporalio/envconfig';
 export * as plugin from '@temporalio/plugin';
 export * as cloud from '@temporalio/cloud';
 export * as aisdk from '@temporalio/ai-sdk';
+export * as openaiAgents from '@temporalio/openai-agents';
+export * as workflowStreams from '@temporalio/workflow-streams/workflow';
+export * as workflowStreamsClient from '@temporalio/workflow-streams/client';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,6 +557,9 @@ importers:
       '@temporalio/nexus':
         specifier: workspace:*
         version: link:../nexus
+      '@temporalio/openai-agents':
+        specifier: workspace:*
+        version: link:../../contrib/openai-agents
       '@temporalio/plugin':
         specifier: workspace:*
         version: link:../plugin
@@ -572,6 +575,9 @@ importers:
       '@temporalio/workflow':
         specifier: workspace:*
         version: link:../workflow
+      '@temporalio/workflow-streams':
+        specifier: workspace:*
+        version: link:../../contrib/workflow-streams
 
   packages/nexus:
     dependencies:
@@ -5037,6 +5043,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-name@5.0.1:


### PR DESCRIPTION
## What

Adds the `@temporalio/openai-agents` and `@temporalio/workflow-streams` contrib packages to the published API docs at https://typescript.temporal.io/.

The docs site is generated by TypeDoc from a single entry point, `packages/meta/src/index.ts`. Only packages re-exported there appear on the site, so these two contrib packages were previously missing.

## Changes

- `packages/meta/package.json` — add `@temporalio/openai-agents` and `@temporalio/workflow-streams` as workspace dependencies.
- `packages/meta/src/index.ts` — re-export both packages.
  - `workflow-streams` has no root export (only `./workflow` and `./client` subpaths), so it's surfaced as two namespaces: `workflowStreams` (workflow side) and `workflowStreamsClient` (client side).
- `pnpm-lock.yaml` — updated for the new meta dependencies.

## Verification

- `temporalio` (meta) builds clean.
- Full CI-style package build passes.
- `pnpm run docs` generates the new namespace pages: `openaiAgents`, `workflowStreams`, `workflowStreamsClient`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)