### PR TITLE
extstore gcs driver

### DIFF
--- a/contrib/external-storage-gcs-google-sdk/README.md
+++ b/contrib/external-storage-gcs-google-sdk/README.md
@@ -1,0 +1,27 @@
+# @google-cloud/storage Client for the Temporal GCS External Storage Driver
+
+> ⚠️ **This package is experimental and may be subject to change.** ⚠️
+
+`@temporalio/external-storage-gcs-google-sdk` provides a [`@google-cloud/storage`](https://www.npmjs.com/package/@google-cloud/storage)-backed `GcsStorageDriverClient` for [`@temporalio/external-storage-gcs`](../external-storage-gcs).
+
+`@google-cloud/storage` is a peer dependency, so the driver uses the same `Storage` instance (and version) your application already configures.
+
+## Usage
+
+    npm install @temporalio/external-storage-gcs @temporalio/external-storage-gcs-google-sdk @google-cloud/storage
+
+```ts
+import { Storage } from '@google-cloud/storage';
+import { GcsStorageDriver } from '@temporalio/external-storage-gcs';
+import { GoogleCloudGcsStorageDriverClient } from '@temporalio/external-storage-gcs-google-sdk';
+
+const storage = new Storage();
+const driver = new GcsStorageDriver({
+  client: new GoogleCloudGcsStorageDriverClient(storage),
+  bucket: 'my-temporal-payloads',
+});
+```
+
+## Notes
+
+- `@google-cloud/storage` cannot cancel a request once it is in flight, so an `abortSignal` is honored only up front (via `AbortSignal.throwIfAborted()`): a signal that has already fired prevents the request from starting. An in-flight request is always awaited, so no request is left running in the background.

--- a/contrib/external-storage-gcs-google-sdk/package.json
+++ b/contrib/external-storage-gcs-google-sdk/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@temporalio/external-storage-gcs-google-sdk",
+  "version": "1.18.1",
+  "private": true,
+  "description": "@google-cloud/storage client for the Temporal GCS external storage driver",
+  "main": "lib/index.js",
+  "types": "./lib/index.d.ts",
+  "keywords": [
+    "temporal",
+    "workflow",
+    "external storage",
+    "payload",
+    "gcs",
+    "gcp"
+  ],
+  "author": "Temporal Technologies Inc. <sdk@temporal.io>",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc --build",
+    "test": "ava ./lib/__tests__/test-*.js"
+  },
+  "ava": {
+    "timeout": "60s"
+  },
+  "dependencies": {
+    "@temporalio/external-storage-gcs": "workspace:*"
+  },
+  "peerDependencies": {
+    "@google-cloud/storage": "^7.0.0"
+  },
+  "devDependencies": {
+    "@google-cloud/storage": "^7.0.0",
+    "ava": "^5.3.1"
+  },
+  "engines": {
+    "node": ">= 20.3.0"
+  },
+  "bugs": {
+    "url": "https://github.com/temporalio/sdk-typescript/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/temporalio/sdk-typescript.git",
+    "directory": "contrib/external-storage-gcs-google-sdk"
+  },
+  "homepage": "https://github.com/temporalio/sdk-typescript/tree/main/contrib/external-storage-gcs-google-sdk",
+  "files": [
+    "src",
+    "lib",
+    "!src/__tests__",
+    "!lib/__tests__"
+  ]
+}

--- a/contrib/external-storage-gcs-google-sdk/src/__tests__/test-google-cloud-client.ts
+++ b/contrib/external-storage-gcs-google-sdk/src/__tests__/test-google-cloud-client.ts
@@ -1,0 +1,85 @@
+import test from 'ava';
+import type { Storage } from '@google-cloud/storage';
+import { GoogleCloudGcsStorageDriverClient } from '../google-cloud-client';
+
+interface FakeFile {
+  save?: (data: Uint8Array, options?: unknown) => Promise<void>;
+  download?: () => Promise<[Buffer]>;
+}
+
+/** Minimal Storage stand-in: only `bucket().file()`, `save`/`download`, and `projectId` are exercised. */
+function fakeStorage(file: FakeFile, projectId?: string): Storage {
+  return { projectId, bucket: () => ({ file: () => file }) } as unknown as Storage;
+}
+
+test('save uploads with an ifGenerationMatch: 0 precondition', async (t) => {
+  let received: unknown;
+  const client = new GoogleCloudGcsStorageDriverClient(
+    fakeStorage({
+      save: async (_data, options) => {
+        received = options;
+      },
+    })
+  );
+
+  await client.save('b', 'o', new Uint8Array([1, 2, 3]));
+
+  t.deepEqual(received, { preconditionOpts: { ifGenerationMatch: 0 } });
+});
+
+test('save treats a 412 precondition failure as a successful no-op', async (t) => {
+  const client = new GoogleCloudGcsStorageDriverClient(
+    fakeStorage({
+      save: async () => {
+        throw Object.assign(new Error('precondition failed'), { code: 412 });
+      },
+    })
+  );
+
+  await t.notThrowsAsync(() => client.save('b', 'o', new Uint8Array([1])));
+});
+
+test('save rethrows non-412 errors', async (t) => {
+  const client = new GoogleCloudGcsStorageDriverClient(
+    fakeStorage({
+      save: async () => {
+        throw Object.assign(new Error('denied'), { code: 403 });
+      },
+    })
+  );
+
+  await t.throwsAsync(() => client.save('b', 'o', new Uint8Array([1])), { message: 'denied' });
+});
+
+test('download resolves the stored bytes', async (t) => {
+  const bytes = Buffer.from([1, 2, 3]);
+  const client = new GoogleCloudGcsStorageDriverClient(fakeStorage({ download: async () => [bytes] }));
+
+  t.deepEqual(await client.download('b', 'o'), bytes);
+});
+
+test('an already-aborted signal short-circuits before issuing the request', async (t) => {
+  let saveCalled = false;
+  const client = new GoogleCloudGcsStorageDriverClient(
+    fakeStorage({
+      save: async () => {
+        saveCalled = true;
+      },
+    })
+  );
+
+  await t.throwsAsync(() => client.save('b', 'o', new Uint8Array([1]), { abortSignal: AbortSignal.abort() }), {
+    name: 'AbortError',
+  });
+  t.false(saveCalled);
+});
+
+test('describe surfaces the project ID when available', (t) => {
+  const client = new GoogleCloudGcsStorageDriverClient(fakeStorage({}, 'my-project'));
+  t.deepEqual(client.describe(), { projectId: 'my-project' });
+});
+
+test('describe omits the project ID when unavailable', (t) => {
+  const client = new GoogleCloudGcsStorageDriverClient(fakeStorage({}));
+  t.deepEqual(client.describe(), {});
+});

--- a/contrib/external-storage-gcs-google-sdk/src/google-cloud-client.ts
+++ b/contrib/external-storage-gcs-google-sdk/src/google-cloud-client.ts
@@ -1,0 +1,46 @@
+import type { Storage } from '@google-cloud/storage';
+import type { GcsStorageDriverClient, GcsRequestOptions } from '@temporalio/external-storage-gcs';
+
+/**
+ * A {@link GcsStorageDriverClient} backed by a `@google-cloud/storage` `Storage`
+ * instance, for use with `GcsStorageDriver`.
+ *
+ * `@google-cloud/storage` cannot cancel a request once it is in flight, so an
+ * `abortSignal` is checked up front.
+ *
+ * @experimental
+ */
+export class GoogleCloudGcsStorageDriverClient implements GcsStorageDriverClient {
+  constructor(private readonly storage: Storage) {}
+
+  describe(): Record<string, string> {
+    const projectId = this.storage.projectId;
+    return typeof projectId === 'string' && projectId ? { projectId } : {};
+  }
+
+  async save(bucket: string, object: string, data: Uint8Array, options?: GcsRequestOptions): Promise<void> {
+    options?.abortSignal?.throwIfAborted();
+    const file = this.storage.bucket(bucket).file(object);
+    try {
+      // ifGenerationMatch: 0 is GCS's atomic create-if-absent
+      await file.save(data, { preconditionOpts: { ifGenerationMatch: 0 } });
+    } catch (err) {
+      // That 412 means the object already exists, which for content-addressed
+      // payloads is a successful no-op.
+      if (isAlreadyExistsError(err)) return;
+      throw err;
+    }
+  }
+
+  async download(bucket: string, object: string, options?: GcsRequestOptions): Promise<Uint8Array> {
+    options?.abortSignal?.throwIfAborted();
+    const file = this.storage.bucket(bucket).file(object);
+    const [contents] = await file.download();
+    return contents;
+  }
+}
+
+/** A create-if-absent upload fails with HTTP 412 when the object already exists. */
+function isAlreadyExistsError(err: unknown): boolean {
+  return (err as { code?: number })?.code === 412;
+}

--- a/contrib/external-storage-gcs-google-sdk/src/index.ts
+++ b/contrib/external-storage-gcs-google-sdk/src/index.ts
@@ -1,0 +1,4 @@
+/**
+ * @experimental The External Storage GCS driver is an experimental feature and may be subject to change.
+ */
+export { GoogleCloudGcsStorageDriverClient } from './google-cloud-client';

--- a/contrib/external-storage-gcs-google-sdk/tsconfig.json
+++ b/contrib/external-storage-gcs-google-sdk/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDir": "./src"
+  },
+  "references": [{ "path": "../external-storage-gcs" }],
+  "include": ["./src/**/*.ts"]
+}

--- a/contrib/external-storage-gcs/README.md
+++ b/contrib/external-storage-gcs/README.md
@@ -1,0 +1,142 @@
+# Google Cloud Storage External Storage Driver for the Temporal TypeScript SDK
+
+> ⚠️ **This package is experimental and may be subject to change.** ⚠️
+
+`@temporalio/external-storage-gcs` stores and retrieves Temporal payloads in Google Cloud Storage via the [External Storage](https://docs.temporal.io/external-storage) feature.
+
+This package has no Google Cloud dependency: it defines the driver and the `GcsStorageDriverClient` interface, and you supply the GCS client. Use the companion [`@temporalio/external-storage-gcs-google-sdk`](../external-storage-gcs-google-sdk) package for a [`@google-cloud/storage`](https://www.npmjs.com/package/@google-cloud/storage) `Storage`-backed client, or implement the interface yourself.
+
+## Using the Google Cloud SDK client
+
+Install the adapter package alongside this one:
+
+    npm install @temporalio/external-storage-gcs @temporalio/external-storage-gcs-google-sdk @google-cloud/storage
+
+```ts
+import { Storage } from '@google-cloud/storage';
+import { GcsStorageDriver } from '@temporalio/external-storage-gcs';
+import { GoogleCloudGcsStorageDriverClient } from '@temporalio/external-storage-gcs-google-sdk';
+
+const storage = new Storage();
+const driver = new GcsStorageDriver({
+  client: new GoogleCloudGcsStorageDriverClient(storage),
+  bucket: 'my-temporal-payloads',
+});
+```
+
+Register the resulting driver with the SDK's External Storage configuration so the
+client and worker offload eligible payloads to it.
+
+## Custom GCS client implementations
+
+To use a different GCS library, implement `GcsStorageDriverClient`.
+
+```ts
+import type { GcsStorageDriverClient } from '@temporalio/external-storage-gcs';
+
+const myClient: GcsStorageDriverClient = {
+  async save(bucket, object, data, options) {
+    /* ... */
+  },
+  async download(bucket, object, options) {
+    /* ... */
+    return new Uint8Array();
+  },
+};
+```
+
+## Dynamic bucket selection
+
+Pass a callable as `bucket` to choose the destination per payload:
+
+```ts
+const driver = new GcsStorageDriver({
+  client: new GoogleCloudGcsStorageDriverClient(storage),
+  bucket: (_context, payload) => ((payload.data?.length ?? 0) > 10 * 1024 * 1024 ? 'large-payloads' : 'small-payloads'),
+});
+```
+
+## Required IAM permissions
+
+The credentials used by your GCS client must have these permissions on the target bucket and its objects:
+
+- `storage.objects.create` — required by components that store payloads (typically the client and worker sending workflow/activity inputs). Granted by the `roles/storage.objectCreator` role.
+- `storage.objects.get` — required by components that retrieve payloads. Granted by the `roles/storage.objectViewer` role.
+
+Components that only retrieve do not need `storage.objects.create`, and vice versa.
+
+## GCS Object Name Specification
+
+All Temporal GCS drivers generate object names in a consistent manner.
+
+### Object name format
+
+Workflow object name:
+
+```text
+v0/ns/{namespace}/wt/{workflow-type}/wi/{workflow-id}/ri/{run-id}/d/{hash-algorithm}/{hex-digest}
+```
+
+Activity object name:
+
+```text
+v0/ns/{namespace}/at/{activity-type}/ai/{activity-id}/ri/{run-id}/d/{hash-algorithm}/{hex-digest}
+```
+
+Fallback object name (unknown target):
+
+```text
+v0/d/{hash-algorithm}/{hex-digest}
+```
+
+- If no namespace, workflow, or activity information is available, the fallback is used.
+- Dynamic path segments are encoded per the rules below.
+- Missing values (including a missing `run-id`) are encoded as `null`.
+- `hex-digest` is lower-case SHA-256 hex (64 characters).
+
+### Encoding rules
+
+GCS object names accept any Unicode, so the Temporal SDKs leave readable characters intact and percent-encode only what Google forbids or discourages: https://cloud.google.com/storage/docs/objects#naming
+
+Encoded characters:
+
+```text
+Carriage return, line feed, and other control characters (U+0000–U+001F, U+007F–U+009F)
+The discouraged set: # [ ] * ? : " < > |
+Forward slash (/), so a value cannot introduce extra path segments
+Percent (%), so the encoding stays reversible
+```
+
+A segment that is exactly `.` or `..` (both reserved by GCS) is encoded as `%2E` and `%2E%2E` respectively.
+
+### Examples
+
+Workflow object name example:
+
+```text
+input:
+  namespace=payments prod
+  workflow-type=ChargeWorkflow
+  workflow-id=order+123=abc
+  run-id=3f1d6c7a-8b2e-4f7a-9d0a-87a6f95e4d31
+  hash-algorithm=sha256
+  hex-digest=9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+
+output:
+  v0/ns/payments prod/wt/ChargeWorkflow/wi/order+123=abc/ri/3f1d6c7a-8b2e-4f7a-9d0a-87a6f95e4d31/d/sha256/9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+```
+
+Activity object name example:
+
+```text
+input:
+  namespace=payments prod
+  activity-type=Capture/Charge
+  activity-id=activity id+42
+  run-id=9e1d1fd9-2f8a-4c40-93e2-731f31b9268b
+  hash-algorithm=sha256
+  hex-digest=2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+
+output:
+  v0/ns/payments prod/at/Capture%2FCharge/ai/activity id+42/ri/9e1d1fd9-2f8a-4c40-93e2-731f31b9268b/d/sha256/2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+```

--- a/contrib/external-storage-gcs/package.json
+++ b/contrib/external-storage-gcs/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@temporalio/external-storage-gcs",
+  "version": "1.18.1",
+  "private": true,
+  "description": "Google Cloud Storage external storage driver for the Temporal TypeScript SDK",
+  "main": "lib/index.js",
+  "types": "./lib/index.d.ts",
+  "keywords": [
+    "temporal",
+    "workflow",
+    "external storage",
+    "payload",
+    "gcs",
+    "gcp"
+  ],
+  "author": "Temporal Technologies Inc. <sdk@temporal.io>",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc --build",
+    "test": "ava ./lib/__tests__/test-*.js"
+  },
+  "ava": {
+    "timeout": "60s"
+  },
+  "dependencies": {
+    "@temporalio/common": "workspace:*",
+    "@temporalio/proto": "workspace:*"
+  },
+  "devDependencies": {
+    "ava": "^5.3.1"
+  },
+  "engines": {
+    "node": ">= 20.3.0"
+  },
+  "bugs": {
+    "url": "https://github.com/temporalio/sdk-typescript/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/temporalio/sdk-typescript.git",
+    "directory": "contrib/external-storage-gcs"
+  },
+  "homepage": "https://github.com/temporalio/sdk-typescript/tree/main/contrib/external-storage-gcs",
+  "files": [
+    "src",
+    "lib",
+    "!src/__tests__",
+    "!lib/__tests__"
+  ]
+}

--- a/contrib/external-storage-gcs/src/__tests__/test-driver.ts
+++ b/contrib/external-storage-gcs/src/__tests__/test-driver.ts
@@ -1,0 +1,234 @@
+import assert from 'node:assert';
+import { createHash } from 'node:crypto';
+import test from 'ava';
+import * as proto from '@temporalio/proto';
+import { ValueError } from '@temporalio/common';
+import type { Payload } from '@temporalio/common';
+import { StorageDriverClaim, type StorageDriverStoreContext } from '@temporalio/common/lib/converter/extstore';
+import { GcsStorageDriver } from '../driver';
+import type { GcsStorageDriverClient } from '../client';
+
+const PayloadProto = proto.temporal.api.common.v1.Payload;
+const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+function makePayload(value: string): Payload {
+  return { metadata: { encoding: enc('json/plain') }, data: enc(value) };
+}
+
+function payloadBytes(p: Payload): Uint8Array {
+  return PayloadProto.encode(p).finish();
+}
+
+class FakeGcsClient implements GcsStorageDriverClient {
+  readonly objects = new Map<string, Uint8Array>();
+  saveCount = 0;
+  describeValue: Record<string, string> = {};
+
+  async save(bucket: string, object: string, data: Uint8Array): Promise<void> {
+    this.saveCount += 1;
+    const k = `${bucket}/${object}`;
+    if (!this.objects.has(k)) this.objects.set(k, data);
+  }
+
+  async download(bucket: string, object: string): Promise<Uint8Array> {
+    const value = this.objects.get(`${bucket}/${object}`);
+    if (!value) throw new Error(`missing object ${bucket}/${object}`);
+    return value;
+  }
+
+  describe(): Record<string, string> {
+    return this.describeValue;
+  }
+}
+
+const workflowContext: StorageDriverStoreContext = {
+  target: { kind: 'workflow', namespace: 'my-ns', type: 'MyWorkflow', id: 'wf-1', runId: 'run-1' },
+};
+
+test('store then retrieve round-trips the payload bytes', async (t) => {
+  const driver = new GcsStorageDriver({ client: new FakeGcsClient(), bucket: 'b' });
+  const original = makePayload('"hello"');
+
+  const [claim] = await driver.store(workflowContext, [original]);
+  assert(claim);
+  const [retrieved] = await driver.retrieve({}, [claim]);
+  assert(retrieved);
+
+  t.deepEqual(payloadBytes(retrieved), payloadBytes(original));
+});
+
+test('object name is content-addressed and segmented by the store context', async (t) => {
+  const driver = new GcsStorageDriver({ client: new FakeGcsClient(), bucket: 'b' });
+  const payload = makePayload('"hello"');
+  const expectedHash = createHash('sha256').update(payloadBytes(payload)).digest('hex');
+
+  const [claim] = await driver.store(workflowContext, [payload]);
+  assert(claim);
+
+  t.is(claim.claimData.object, `v0/ns/my-ns/wt/MyWorkflow/wi/wf-1/ri/run-1/d/sha256/${expectedHash}`);
+  t.is(claim.claimData.hashValue, expectedHash);
+  t.is(claim.claimData.hashAlgorithm, 'sha256');
+  t.is(claim.claimData.bucket, 'b');
+});
+
+test('object name segments percent-encode only GCS-discouraged characters', async (t) => {
+  const driver = new GcsStorageDriver({ client: new FakeGcsClient(), bucket: 'b' });
+
+  const [claim] = await driver.store(
+    {
+      target: {
+        kind: 'workflow',
+        namespace: 'payments prod',
+        type: "Capture/Charge!*'()",
+        id: 'order+123=abc',
+        runId: 'r~1',
+      },
+    },
+    [makePayload('"x"')]
+  );
+  assert(claim?.claimData.object);
+
+  // Per Google's recommendations: space, + = ~ ! ' ( ) are left intact;
+  // / -> %2F and * -> %2A are escaped.
+  t.true(
+    claim.claimData.object.startsWith(
+      "v0/ns/payments prod/wt/Capture%2FCharge!%2A'()/wi/order+123=abc/ri/r~1/d/sha256/"
+    )
+  );
+});
+
+test('reserved and empty segments are encoded', async (t) => {
+  const driver = new GcsStorageDriver({ client: new FakeGcsClient(), bucket: 'b' });
+
+  // namespace '.' and type '..' are reserved object names; id is absent and runId is
+  // empty. Reserved names escape to %2E / %2E%2E; empty or absent values become 'null'.
+  const [claim] = await driver.store({ target: { kind: 'workflow', namespace: '.', type: '..', runId: '' } }, [
+    makePayload('"x"'),
+  ]);
+  assert(claim?.claimData.object);
+
+  t.true(claim.claimData.object.startsWith('v0/ns/%2E/wt/%2E%2E/wi/null/ri/null/d/sha256/'));
+});
+
+test('a target with no identity falls back to a bare digest object name', async (t) => {
+  const driver = new GcsStorageDriver({ client: new FakeGcsClient(), bucket: 'b' });
+
+  const [claim] = await driver.store({}, [makePayload('"x"')]);
+  assert(claim?.claimData.object);
+
+  t.regex(claim.claimData.object, /^v0\/d\/sha256\/[0-9a-f]{64}$/);
+});
+
+test('identical payloads in the same scope deduplicate to one stored object', async (t) => {
+  const client = new FakeGcsClient();
+  const driver = new GcsStorageDriver({ client, bucket: 'b' });
+
+  const [first] = await driver.store(workflowContext, [makePayload('"hello"')]);
+  const [second] = await driver.store(workflowContext, [makePayload('"hello"')]);
+  assert(first);
+  assert(second);
+
+  t.is(client.objects.size, 1);
+  t.deepEqual(first.claimData, second.claimData);
+});
+
+test('concurrent identical payloads in one batch upload once', async (t) => {
+  const client = new FakeGcsClient();
+  const driver = new GcsStorageDriver({ client, bucket: 'b' });
+
+  const [first, second] = await driver.store(workflowContext, [makePayload('"hello"'), makePayload('"hello"')]);
+  assert(first);
+  assert(second);
+
+  t.is(client.saveCount, 1);
+  t.is(first.claimData.object, second.claimData.object);
+});
+
+test('retrieve rejects when stored bytes fail the integrity check', async (t) => {
+  const client = new FakeGcsClient();
+  const driver = new GcsStorageDriver({ client, bucket: 'b' });
+
+  const [claim] = await driver.store(workflowContext, [makePayload('"hello"')]);
+  assert(claim);
+  client.objects.set(`${claim.claimData.bucket}/${claim.claimData.object}`, enc('tampered'));
+
+  await t.throwsAsync(() => driver.retrieve({}, [claim]), {
+    instanceOf: ValueError,
+    message: /integrity check failed/,
+  });
+});
+
+test('store rejects payloads larger than maxPayloadSize', async (t) => {
+  const driver = new GcsStorageDriver({ client: new FakeGcsClient(), bucket: 'b', maxPayloadSize: 1 });
+
+  await t.throwsAsync(() => driver.store(workflowContext, [makePayload('"hello"')]), {
+    instanceOf: ValueError,
+    message: /exceeds the configured maxPayloadSize/,
+  });
+});
+
+test('retrieve rejects a claim missing hash information', async (t) => {
+  const client = new FakeGcsClient();
+  const driver = new GcsStorageDriver({ client, bucket: 'b' });
+  client.objects.set('b/some-object', payloadBytes(makePayload('"hello"')));
+
+  const claim = new StorageDriverClaim({ bucket: 'b', object: 'some-object' });
+
+  await t.throwsAsync(() => driver.retrieve({}, [claim]), {
+    instanceOf: ValueError,
+    message: /missing required content hash information/,
+  });
+});
+
+test('bucket selector chooses the destination per payload', async (t) => {
+  const client = new FakeGcsClient();
+  const driver = new GcsStorageDriver({
+    client,
+    bucket: (_ctx, payload) => ((payload.data?.length ?? 0) > 4 ? 'large' : 'small'),
+  });
+
+  const [big] = await driver.store(workflowContext, [makePayload('"a-long-value"')]);
+  const [small] = await driver.store(workflowContext, [makePayload('"x"')]);
+  assert(big);
+  assert(small);
+
+  t.is(big.claimData.bucket, 'large');
+  t.is(small.claimData.bucket, 'small');
+});
+
+test('store aborts in-flight sibling uploads when one fails', async (t) => {
+  let siblingAborted = false;
+  const client: GcsStorageDriverClient = {
+    async save(bucket: string, _object: string, _data: Uint8Array, options) {
+      if (bucket === 'fail') {
+        throw new Error('boom');
+      }
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        const signal = options?.abortSignal;
+        if (!signal) return resolve();
+        if (signal.aborted) {
+          siblingAborted = true;
+          return resolve();
+        }
+        signal.addEventListener('abort', () => {
+          siblingAborted = true;
+          resolve();
+        });
+      });
+    },
+    async download(): Promise<Uint8Array> {
+      throw new Error('unused');
+    },
+  };
+  const driver = new GcsStorageDriver({
+    client,
+    bucket: (_ctx, payload) => ((payload.data?.length ?? 0) < 5 ? 'fail' : 'ok'),
+  });
+
+  await t.throwsAsync(
+    () => driver.store(workflowContext, [makePayload('"x"'), makePayload('"a-much-longer-sibling-value"')]),
+    { message: /store failed/ }
+  );
+  t.true(siblingAborted);
+});

--- a/contrib/external-storage-gcs/src/client.ts
+++ b/contrib/external-storage-gcs/src/client.ts
@@ -1,0 +1,33 @@
+/**
+ * Google Cloud Storage object operations used by {@link GcsStorageDriver}.
+ *
+ * @experimental
+ */
+
+/** Per-request options. */
+export interface GcsRequestOptions {
+  /**
+   * Aborts the in-flight request.
+   */
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * GCS driver client operations
+ *
+ * @experimental
+ */
+export interface GcsStorageDriverClient {
+  /**
+   * Store `data` at the given bucket and object name. Payloads are
+   * content-addressed, so an object that already exists holds identical bytes.
+   */
+  save(bucket: string, object: string, data: Uint8Array, options?: GcsRequestOptions): Promise<void>;
+  /** Download and resolve the bytes stored at the given bucket and object name. */
+  download(bucket: string, object: string, options?: GcsRequestOptions): Promise<Uint8Array>;
+  /**
+   * Optional client-specific diagnostic metadata (e.g. project ID) that the driver
+   * appends to error messages to help diagnose common misconfigurations.
+   */
+  describe?(): Record<string, string>;
+}

--- a/contrib/external-storage-gcs/src/driver.ts
+++ b/contrib/external-storage-gcs/src/driver.ts
@@ -1,0 +1,251 @@
+import { createHash } from 'node:crypto';
+import * as proto from '@temporalio/proto';
+import { ValueError } from '@temporalio/common';
+import type { Payload } from '@temporalio/common';
+import {
+  StorageDriverClaim,
+  type StorageDriver,
+  type StorageDriverStoreContext,
+  type StorageDriverRetrieveContext,
+  type StorageDriverTargetInfo,
+} from '@temporalio/common/lib/converter/extstore';
+import type { GcsStorageDriverClient } from './client';
+
+const PayloadProto = proto.temporal.api.common.v1.Payload;
+
+const DRIVER_TYPE = 'gcp.gcsdriver';
+const DEFAULT_MAX_PAYLOAD_SIZE = 50 * 1024 * 1024;
+/** Object name segment written when a context value is empty or absent. */
+const NULL_SEGMENT = 'null';
+
+/** Picks the destination bucket for a given payload. Enables dynamic per-payload routing. */
+export type BucketSelector = (context: StorageDriverStoreContext, payload: Payload) => string;
+
+/**
+ * Configuration for a {@link GcsStorageDriver}.
+ *
+ * @experimental
+ */
+export interface GcsStorageDriverOptions {
+  /**
+   * A {@link GcsStorageDriverClient} that performs the underlying requests,
+   * e.g. a `GoogleCloudGcsStorageDriverClient`.
+   */
+  client: GcsStorageDriverClient;
+  /** Static bucket name or a {@link BucketSelector}. */
+  bucket: string | BucketSelector;
+  /**
+   * Per-instance routing name written into the wire format. Defaults to
+   * `"gcp.gcsdriver"`. Override only when registering multiple GCS drivers with
+   * distinct configurations under the same `ExternalStorage.drivers` list.
+   */
+  driverName?: string;
+  /**
+   * Hard upper limit, in bytes, on the serialized size of a single payload.
+   * Defaults to 52428800 (50 MiB). Stores larger than this throw.
+   */
+  maxPayloadSize?: number;
+}
+
+/**
+ * GCS object names accept any Unicode, but Google forbids carriage-return and
+ * line-feed and the literal segments `.` and `..`, and strongly recommends
+ * avoiding `# [ ] * ? : " < > |` and control characters. This escapes only that
+ * set, plus `/` (so a value cannot introduce extra path segments) and `%` (so the
+ * encoding stays injective), leaving readable Unicode intact.
+ * See https://cloud.google.com/storage/docs/objects#naming.
+ */
+// eslint-disable-next-line no-control-regex -- intentionally matches the control characters GCS recommends avoiding
+const GCS_UNSAFE_SEGMENT = /[\u0000-\u001f\u007f-\u009f#[\]*?:"<>|/%]/g;
+
+function percentEncodeChar(char: string): string {
+  let encoded = '';
+  for (const byte of new TextEncoder().encode(char)) {
+    encoded += '%' + byte.toString(16).toUpperCase().padStart(2, '0');
+  }
+  return encoded;
+}
+
+function encodeObjectNameSegment(value: string | undefined): string {
+  if (!value) return NULL_SEGMENT;
+  const encoded = value.replace(GCS_UNSAFE_SEGMENT, percentEncodeChar);
+  if (encoded === '.') return '%2E';
+  if (encoded === '..') return '%2E%2E';
+  return encoded;
+}
+
+function buildContextSegments(target: StorageDriverTargetInfo | undefined): string {
+  if (target?.kind === 'workflow') {
+    return (
+      `/ns/${encodeObjectNameSegment(target.namespace)}` +
+      `/wt/${encodeObjectNameSegment(target.type)}` +
+      `/wi/${encodeObjectNameSegment(target.id)}` +
+      `/ri/${encodeObjectNameSegment(target.runId)}`
+    );
+  }
+  if (target?.kind === 'activity') {
+    return (
+      `/ns/${encodeObjectNameSegment(target.namespace)}` +
+      `/at/${encodeObjectNameSegment(target.type)}` +
+      `/ai/${encodeObjectNameSegment(target.id)}` +
+      `/ri/${encodeObjectNameSegment(target.runId)}`
+    );
+  }
+  return '';
+}
+
+/**
+ * Formats `describe()` output as ", k=v, k=v" for error messages. Returns an
+ * empty string when the client reports no metadata or `describe` itself throws.
+ */
+function formatClientContext(client: GcsStorageDriverClient): string {
+  let info: Record<string, string>;
+  try {
+    info = client.describe?.() ?? {};
+  } catch {
+    return '';
+  }
+  const entries = Object.entries(info);
+  return entries.map(([k, v]) => `, ${k}=${v}`).join('');
+}
+
+/**
+ * Runs the per-payload operations concurrently. On the first failure, aborts the
+ * shared signal so in-flight sibling requests are cancelled, then waits for them
+ * to settle before propagating the original error.
+ */
+async function runAllWithAbortOnError<T>(
+  external: AbortSignal | undefined,
+  makeTasks: (signal: AbortSignal) => Promise<T>[]
+): Promise<T[]> {
+  const controller = new AbortController();
+  const signal = external ? AbortSignal.any([external, controller.signal]) : controller.signal;
+  const tasks = makeTasks(signal);
+  try {
+    return await Promise.all(tasks);
+  } catch (err) {
+    controller.abort();
+    await Promise.allSettled(tasks);
+    throw err;
+  }
+}
+
+/**
+ * Stores and retrieves Temporal payloads in Google Cloud Storage.
+ *
+ * Payloads are content-addressed by a SHA-256 hash of their serialized bytes. Object
+ * names are created using the namespace, workflow/activity type, and other metadata
+ * from the store context.
+ *
+ * @experimental
+ */
+export class GcsStorageDriver implements StorageDriver {
+  readonly name: string;
+  readonly type = DRIVER_TYPE;
+  private readonly client: GcsStorageDriverClient;
+  private readonly bucket: BucketSelector;
+  private readonly maxPayloadSize: number;
+
+  constructor(options: GcsStorageDriverOptions) {
+    const { client, bucket, driverName = DRIVER_TYPE, maxPayloadSize = DEFAULT_MAX_PAYLOAD_SIZE } = options;
+    if (!Number.isFinite(maxPayloadSize) || maxPayloadSize <= 0) {
+      throw new ValueError(`maxPayloadSize must be a positive finite number, got ${String(maxPayloadSize)}`);
+    }
+    this.client = client;
+    this.bucket = typeof bucket === 'string' ? () => bucket : bucket;
+    this.name = driverName;
+    this.maxPayloadSize = maxPayloadSize;
+  }
+
+  async store(context: StorageDriverStoreContext, payloads: Payload[]): Promise<StorageDriverClaim[]> {
+    const contextSegments = buildContextSegments(context.target);
+    return runAllWithAbortOnError(context.abortSignal, (signal) => {
+      const uploads = new Map<string, Promise<void>>();
+      return payloads.map((payload) => this.storePayload(context, payload, contextSegments, signal, uploads));
+    });
+  }
+
+  async retrieve(context: StorageDriverRetrieveContext, claims: StorageDriverClaim[]): Promise<Payload[]> {
+    return runAllWithAbortOnError(context.abortSignal, (signal) =>
+      claims.map((claim) => this.retrievePayload(claim, signal))
+    );
+  }
+
+  private async storePayload(
+    context: StorageDriverStoreContext,
+    payload: Payload,
+    contextSegments: string,
+    abortSignal: AbortSignal,
+    uploads: Map<string, Promise<void>>
+  ): Promise<StorageDriverClaim> {
+    const bucket = this.bucket(context, payload);
+
+    const payloadBytes = PayloadProto.encode(payload).finish();
+    if (payloadBytes.length > this.maxPayloadSize) {
+      throw new ValueError(
+        `Payload size ${payloadBytes.length} bytes exceeds the configured maxPayloadSize of ${this.maxPayloadSize} bytes`
+      );
+    }
+
+    const hashValue = createHash('sha256').update(payloadBytes).digest('hex');
+    const object = `v0${contextSegments}/d/sha256/${hashValue}`;
+
+    try {
+      const dedupeKey = `${bucket} ${object}`;
+      let upload = uploads.get(dedupeKey);
+      if (!upload) {
+        upload = this.client.save(bucket, object, payloadBytes, { abortSignal });
+        uploads.set(dedupeKey, upload);
+      }
+      await upload;
+    } catch (err) {
+      throw new Error(
+        `GcsStorageDriver store failed [bucket=${bucket}, object=${object}${formatClientContext(this.client)}]`,
+        { cause: err }
+      );
+    }
+
+    return new StorageDriverClaim({ bucket, object, hashAlgorithm: 'sha256', hashValue });
+  }
+
+  private async retrievePayload(claim: StorageDriverClaim, abortSignal: AbortSignal): Promise<Payload> {
+    const { bucket, object, hashAlgorithm, hashValue: expectedHash } = claim.claimData;
+    if (!bucket || !object) {
+      throw new ValueError(
+        `GcsStorageDriver claim is missing required location information: ` +
+          `claimData must contain 'bucket' and 'object'`
+      );
+    }
+    if (!hashAlgorithm || !expectedHash) {
+      throw new ValueError(
+        `GcsStorageDriver claim is missing required content hash information [bucket=${bucket}, object=${object}]: ` +
+          `claimData must contain 'hashAlgorithm' and 'hashValue'`
+      );
+    }
+    if (hashAlgorithm !== 'sha256') {
+      throw new ValueError(
+        `GcsStorageDriver unsupported hash algorithm [bucket=${bucket}, object=${object}]: expected sha256, got ${hashAlgorithm}`
+      );
+    }
+
+    let payloadBytes: Uint8Array;
+    try {
+      payloadBytes = await this.client.download(bucket, object, { abortSignal });
+    } catch (err) {
+      throw new Error(
+        `GcsStorageDriver retrieve failed [bucket=${bucket}, object=${object}${formatClientContext(this.client)}]`,
+        { cause: err }
+      );
+    }
+
+    const actualHash = createHash('sha256').update(payloadBytes).digest('hex');
+    if (actualHash !== expectedHash) {
+      throw new ValueError(
+        `GcsStorageDriver integrity check failed [bucket=${bucket}, object=${object}]: ` +
+          `expected ${hashAlgorithm}:${expectedHash}, got ${hashAlgorithm}:${actualHash}`
+      );
+    }
+
+    return PayloadProto.decode(payloadBytes);
+  }
+}

--- a/contrib/external-storage-gcs/src/index.ts
+++ b/contrib/external-storage-gcs/src/index.ts
@@ -1,0 +1,6 @@
+/**
+ * @experimental The External Storage GCS driver is an experimental feature and may be subject to change.
+ */
+export { GcsStorageDriver } from './driver';
+export type { GcsStorageDriverOptions, BucketSelector } from './driver';
+export type { GcsStorageDriverClient, GcsRequestOptions } from './client';

--- a/contrib/external-storage-gcs/tsconfig.json
+++ b/contrib/external-storage-gcs/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDir": "./src"
+  },
+  "references": [{ "path": "../../packages/common" }, { "path": "../../packages/proto" }],
+  "include": ["./src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,32 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
 
+  contrib/external-storage-gcs:
+    dependencies:
+      '@temporalio/common':
+        specifier: workspace:*
+        version: link:../../packages/common
+      '@temporalio/proto':
+        specifier: workspace:*
+        version: link:../../packages/proto
+    devDependencies:
+      ava:
+        specifier: ^5.3.1
+        version: 5.3.1
+
+  contrib/external-storage-gcs-google-sdk:
+    dependencies:
+      '@temporalio/external-storage-gcs':
+        specifier: workspace:*
+        version: link:../external-storage-gcs
+    devDependencies:
+      '@google-cloud/storage':
+        specifier: ^7.0.0
+        version: 7.21.0(encoding@0.1.13)
+      ava:
+        specifier: ^5.3.1
+        version: 5.3.1
+
   contrib/external-storage-s3:
     dependencies:
       '@temporalio/common':
@@ -1588,6 +1614,22 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@google-cloud/paginator@5.0.2':
+    resolution: {integrity: sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==}
+    engines: {node: '>=14.0.0'}
+
+  '@google-cloud/projectify@4.0.0':
+    resolution: {integrity: sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==}
+    engines: {node: '>=14.0.0'}
+
+  '@google-cloud/promisify@4.0.0':
+    resolution: {integrity: sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==}
+    engines: {node: '>=14'}
+
+  '@google-cloud/storage@7.21.0':
+    resolution: {integrity: sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==}
+    engines: {node: '>=14'}
+
   '@grpc/grpc-js@1.12.4':
     resolution: {integrity: sha512-NBhrxEWnFh0FxeA0d//YP95lRFsSx2TNLEUQg4/W+5f/BMxcCjgOOIT24iD+ZB/tZw057j44DaIxja7w4XMrhg==}
     engines: {node: '>=12.10.0'}
@@ -2190,6 +2232,10 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
+  '@tootallnate/once@2.0.1':
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
+    engines: {node: '>= 10'}
+
   '@ts-morph/common@0.12.3':
     resolution: {integrity: sha512-4tUmeLyXJnJWvTFOKtcNJ1yh0a3SsTLi2MUoyj8iUNznFRN1ZquaNe7Oukqrnki2FzZkm0J9adCNLDZxUzvj+w==}
 
@@ -2204,6 +2250,9 @@ packages:
 
   '@types/babel-types@7.0.15':
     resolution: {integrity: sha512-JUgfZHUOMbtjopxiOQaaF+Uovk5wpDqpXR+XLWiOivCWSy1FccO30lvNNpCt8geFwq8VmGT2y9OMkOpA0g5O5g==}
+
+  '@types/caseless@0.12.5':
+    resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
 
   '@types/convert-source-map@2.0.3':
     resolution: {integrity: sha512-ag0BfJLZf6CQz8VIuRIEYQ5Ggwk/82uvTQf27RcpyDNbY0Vw49LIPqAxk5tqYfrCs9xDaIMvl4aj7ZopnYL8bA==}
@@ -2255,6 +2304,9 @@ packages:
 
   '@types/prompts@2.4.9':
     resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
+
+  '@types/request@2.48.13':
+    resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
 
   '@types/responselike@1.0.0':
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
@@ -2586,6 +2638,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   aggregate-error@4.0.1:
     resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
     engines: {node: '>=12'}
@@ -2697,6 +2753,10 @@ packages:
     resolution: {integrity: sha512-a4eg4yhp7mmruZDQFqVMlxNRFGi/i1r87pt8SDHy0/I8PqSXoUTlWZRdAZo0VXgvEARcujbtTk8kiZRi1uDGRw==}
     engines: {node: '>=8.0.0'}
 
+  arrify@2.0.1:
+    resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
+    engines: {node: '>=8'}
+
   arrify@3.0.0:
     resolution: {integrity: sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==}
     engines: {node: '>=12'}
@@ -2776,6 +2836,9 @@ packages:
 
   bcryptjs@2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
@@ -3201,6 +3264,9 @@ packages:
 
   duplexify@3.7.1:
     resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
+
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -3647,6 +3713,14 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -3734,6 +3808,14 @@ packages:
     resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -3751,6 +3833,10 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   gunzip-maybe@1.4.2:
     resolution: {integrity: sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==}
@@ -3798,6 +3884,9 @@ packages:
     resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
     engines: {node: '>=16.9.0'}
 
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
 
@@ -3811,6 +3900,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
 
   http-signature@1.4.0:
     resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
@@ -3826,6 +3919,10 @@ packages:
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   hyperdyperid@1.2.0:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
@@ -4036,6 +4133,10 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
@@ -4135,6 +4236,9 @@ packages:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
     hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -4523,6 +4627,15 @@ packages:
       encoding:
         optional: true
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -4879,6 +4992,10 @@ packages:
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readable-stream@4.7.0:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -4953,6 +5070,10 @@ packages:
   responselike@3.0.0:
     resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
     engines: {node: '>=14.16'}
+
+  retry-request@7.0.2:
+    resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
+    engines: {node: '>=14'}
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -5162,6 +5283,9 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
 
@@ -5217,6 +5341,9 @@ packages:
   strnum@2.3.0:
     resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
   supertap@3.0.1:
     resolution: {integrity: sha512-u1ZpIBCawJnO+0QePsEiOknOfCRq0yERxiAchT0i4li0WHNUJbf0evXXSXOcCAR4M8iMDoajXYmstm/qO81Isw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -5257,6 +5384,10 @@ packages:
   tar@7.5.11:
     resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
     engines: {node: '>=18'}
+
+  teeny-request@9.0.0:
+    resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
+    engines: {node: '>=14'}
 
   temp-dir@3.0.0:
     resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
@@ -5521,6 +5652,11 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
@@ -6387,6 +6523,35 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@google-cloud/paginator@5.0.2':
+    dependencies:
+      arrify: 2.0.1
+      extend: 3.0.2
+
+  '@google-cloud/projectify@4.0.0': {}
+
+  '@google-cloud/promisify@4.0.0': {}
+
+  '@google-cloud/storage@7.21.0(encoding@0.1.13)':
+    dependencies:
+      '@google-cloud/paginator': 5.0.2
+      '@google-cloud/projectify': 4.0.0
+      '@google-cloud/promisify': 4.0.0
+      abort-controller: 3.0.0
+      async-retry: 1.3.3
+      duplexify: 4.1.3
+      fast-xml-parser: 5.7.3
+      gaxios: 6.7.1(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      html-entities: 2.6.0
+      mime: 3.0.0
+      p-limit: 3.1.0
+      retry-request: 7.0.2(encoding@0.1.13)
+      teeny-request: 9.0.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@grpc/grpc-js@1.12.4':
     dependencies:
       '@grpc/proto-loader': 0.7.13
@@ -7108,6 +7273,8 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@tootallnate/once@2.0.1': {}
+
   '@ts-morph/common@0.12.3':
     dependencies:
       fast-glob: 3.3.2
@@ -7124,6 +7291,8 @@ snapshots:
   '@types/aws-lambda@8.10.161': {}
 
   '@types/babel-types@7.0.15': {}
+
+  '@types/caseless@0.12.5': {}
 
   '@types/convert-source-map@2.0.3': {}
 
@@ -7179,6 +7348,13 @@ snapshots:
     dependencies:
       '@types/node': 20.19.41
       kleur: 3.0.3
+
+  '@types/request@2.48.13':
+    dependencies:
+      '@types/caseless': 0.12.5
+      '@types/node': 20.19.41
+      '@types/tough-cookie': 4.0.5
+      form-data: 2.5.5
 
   '@types/responselike@1.0.0':
     dependencies:
@@ -7680,6 +7856,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   aggregate-error@4.0.1:
     dependencies:
       clean-stack: 4.2.0
@@ -7810,6 +7988,8 @@ snapshots:
 
   arrgv@1.0.2: {}
 
+  arrify@2.0.1: {}
+
   arrify@3.0.0: {}
 
   asn1@0.2.6:
@@ -7901,6 +8081,8 @@ snapshots:
       tweetnacl: 0.14.5
 
   bcryptjs@2.4.3: {}
+
+  bignumber.js@9.3.1: {}
 
   binary-extensions@2.2.0: {}
 
@@ -8335,6 +8517,13 @@ snapshots:
       end-of-stream: 1.4.5
       inherits: 2.0.4
       readable-stream: 2.3.8
+      stream-shift: 1.0.3
+
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
       stream-shift: 1.0.3
 
   eastasianwidth@0.2.0: {}
@@ -8953,6 +9142,26 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  gaxios@6.7.1(encoding@0.1.13):
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0(encoding@0.1.13)
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  gcp-metadata@6.1.1(encoding@0.1.13):
+    dependencies:
+      gaxios: 6.7.1(encoding@0.1.13)
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
@@ -9057,6 +9266,20 @@ snapshots:
       merge2: 1.4.1
       slash: 4.0.0
 
+  google-auth-library@9.15.1(encoding@0.1.13):
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1(encoding@0.1.13)
+      gcp-metadata: 6.1.1(encoding@0.1.13)
+      gtoken: 7.1.0(encoding@0.1.13)
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-logging-utils@0.0.2: {}
+
   gopd@1.2.0: {}
 
   got-cjs@12.5.4:
@@ -9091,6 +9314,14 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  gtoken@7.1.0(encoding@0.1.13):
+    dependencies:
+      gaxios: 6.7.1(encoding@0.1.13)
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   gunzip-maybe@1.4.2:
     dependencies:
@@ -9138,6 +9369,8 @@ snapshots:
 
   hono@4.12.5: {}
 
+  html-entities@2.6.0: {}
+
   http-cache-semantics@4.1.1: {}
 
   http-cache-semantics@4.2.0: {}
@@ -9158,6 +9391,14 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.1
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-signature@1.4.0:
     dependencies:
       assert-plus: 1.0.0
@@ -9174,6 +9415,13 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -9364,6 +9612,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-stream@2.0.1: {}
+
   is-string@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -9472,6 +9722,10 @@ snapshots:
       underscore: 1.13.8
 
   jsesc@2.5.2: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
 
   json-buffer@3.0.1: {}
 
@@ -9783,6 +10037,12 @@ snapshots:
   nexus-rpc@0.0.2: {}
 
   node-fetch@2.6.7(encoding@0.1.13):
+    dependencies:
+      whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
+
+  node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
     optionalDependencies:
@@ -10165,6 +10425,12 @@ snapshots:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readable-stream@4.7.0:
     dependencies:
       abort-controller: 3.0.0
@@ -10256,6 +10522,15 @@ snapshots:
   responselike@3.0.0:
     dependencies:
       lowercase-keys: 3.0.0
+
+  retry-request@7.0.2(encoding@0.1.13):
+    dependencies:
+      '@types/request': 2.48.13
+      extend: 3.0.2
+      teeny-request: 9.0.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   retry@0.13.1: {}
 
@@ -10510,6 +10785,10 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+
   stream-shift@1.0.3: {}
 
   streamx@2.23.0:
@@ -10580,6 +10859,8 @@ snapshots:
 
   strnum@2.3.0: {}
 
+  stubs@3.0.0: {}
+
   supertap@3.0.1:
     dependencies:
       indent-string: 5.0.0
@@ -10624,6 +10905,17 @@ snapshots:
       minipass: 7.1.2
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  teeny-request@9.0.0(encoding@0.1.13):
+    dependencies:
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0(encoding@0.1.13)
+      stream-events: 1.0.5
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   temp-dir@3.0.0: {}
 
@@ -10874,6 +11166,8 @@ snapshots:
   uuid@11.1.0: {}
 
   uuid@8.3.2: {}
+
+  uuid@9.0.1: {}
 
   validate-npm-package-name@5.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,8 @@ packages:
   - contrib/openai-agents
   - contrib/external-storage-s3
   - contrib/external-storage-s3-aws-sdk
+  - contrib/external-storage-gcs
+  - contrib/external-storage-gcs-google-sdk
   - contrib/workflow-streams
   - scripts
 

--- a/tsconfig.prune.json
+++ b/tsconfig.prune.json
@@ -11,6 +11,8 @@
       "@temporalio/openai-agents/*": ["contrib/openai-agents/src/*"],
       "@temporalio/external-storage-s3": ["contrib/external-storage-s3"],
       "@temporalio/external-storage-s3-aws-sdk": ["contrib/external-storage-s3-aws-sdk"],
+      "@temporalio/external-storage-gcs": ["contrib/external-storage-gcs"],
+      "@temporalio/external-storage-gcs-google-sdk": ["contrib/external-storage-gcs-google-sdk"],
       "@temporalio/*": ["packages/*"]
     }
   },
@@ -30,6 +32,8 @@
     "./contrib/interceptors-opentelemetry/src/index.ts",
     "./contrib/external-storage-s3/src/index.ts",
     "./contrib/external-storage-s3-aws-sdk/src/index.ts",
+    "./contrib/external-storage-gcs/src/index.ts",
+    "./contrib/external-storage-gcs-google-sdk/src/index.ts",
     "./packages/nyc-test-coverage/src/index.ts",
     "./packages/meta/src/index.ts",
     "./packages/plugin/src/index.ts",


### PR DESCRIPTION
## What changed?

  - Adds the built-in GCS driver for External Storage.
  - `@temporalio/external-storage-gcs`: `GcsStorageDriver` + `GcsStorageDriverClient` interface, no Google SDK
  dependency.
  - `@temporalio/external-storage-gcs-google-sdk`: `GoogleCloudGcsStorageDriverClient`, backed by
  `@google-cloud/storage` (peer dep).
  - `@experimental` and both packages `private` (unpublished)

  ## Why?

- extstore GA

## Checklist

- New tests for both packages.