### PR TITLE
feat(workflow): add nondeterministic random API to UnsafeWorkflowInfo

### DIFF
--- a/packages/test/src/run-activation-perf-tests.ts
+++ b/packages/test/src/run-activation-perf-tests.ts
@@ -86,7 +86,7 @@ if (!wf.inWorkflowContext()) {
         historySize: 300,
         continueAsNewSuggested: false,
         targetWorkerDeploymentVersionChanged: false,
-        unsafe: { isReplaying: false, isReplayingHistoryEvents: false, now: Date.now },
+        unsafe: { isReplaying: false, isReplayingHistoryEvents: false, now: Date.now, random: Math.random },
         startTime: new Date(),
         runStartTime: new Date(),
       };

--- a/packages/test/src/test-random-streams.ts
+++ b/packages/test/src/test-random-streams.ts
@@ -165,7 +165,7 @@ async function createWorkflow(
       historySize: 300,
       continueAsNewSuggested: false,
       targetWorkerDeploymentVersionChanged: false,
-      unsafe: { isReplaying: false, isReplayingHistoryEvents: false, now: Date.now },
+      unsafe: { isReplaying: false, isReplayingHistoryEvents: false, now: Date.now, random: Math.random },
       startTime: new Date(),
       runStartTime: new Date(),
     },

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -56,6 +56,7 @@ if (RUN_INTEGRATION_TESTS) {
 
     function fixWorkflowInfoDates(input: WorkflowInfo): WorkflowInfo {
       delete (input.unsafe as any).now;
+      delete (input.unsafe as any).random;
       return input;
     }
 

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -126,7 +126,7 @@ async function createWorkflow(
       historySize: 300,
       continueAsNewSuggested: false,
       targetWorkerDeploymentVersionChanged: false,
-      unsafe: { isReplaying: false, isReplayingHistoryEvents: false, now: Date.now },
+      unsafe: { isReplaying: false, isReplayingHistoryEvents: false, now: Date.now, random: Math.random },
       startTime: new Date(),
       runStartTime: new Date(),
     },
@@ -479,6 +479,44 @@ test('random', async (t) => {
     compareCompletion(t, req, makeSuccess());
   }
   t.deepEqual(logs, [[0.8380154962651432], ['a50eca73-ff3e-4445-a512-2330c2f4f86e'], [0.18803317612037063]]);
+});
+
+test('unsafeRandom', async (t) => {
+  const { workflowType } = t.context;
+  {
+    // Start the workflow (sets up query handlers, starts a long timer)
+    const completion = await activate(t, makeStartWorkflow(workflowType));
+    compareCompletion(
+      t,
+      completion,
+      makeSuccess([makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(100_000) })])
+    );
+  }
+  {
+    // Issue queries for both deterministic and nondeterministic random
+    const unsafeCompletion1 = await activate(t, makeQueryWorkflow('q1', 'unsafeRandom', []));
+    const unsafeResult1 = unsafeCompletion1.successful?.commands?.[0]?.respondToQuery?.succeeded?.response;
+    t.truthy(unsafeResult1, 'Expected unsafeRandom query response');
+    const unsafeValue1 = defaultPayloadConverter.fromPayload<number>(unsafeResult1!);
+    t.is(typeof unsafeValue1, 'number');
+    t.true(unsafeValue1 >= 0 && unsafeValue1 < 1, `Expected value between 0 and 1, got ${unsafeValue1}`);
+
+    const unsafeCompletion2 = await activate(t, makeQueryWorkflow('q2', 'unsafeRandom', []));
+    const unsafeResult2 = unsafeCompletion2.successful?.commands?.[0]?.respondToQuery?.succeeded?.response;
+    const unsafeValue2 = defaultPayloadConverter.fromPayload<number>(unsafeResult2!);
+
+    // Nondeterministic: successive calls must produce different values
+    t.not(unsafeValue1, unsafeValue2, 'unsafe.random() should be nondeterministic across queries');
+
+    // Deterministic Math.random() is seeded — verify it returns a known value for seed 1337
+    const detCompletion1 = await activate(t, makeQueryWorkflow('q3', 'deterministicRandom', []));
+    const detResult1 = detCompletion1.successful?.commands?.[0]?.respondToQuery?.succeeded?.response;
+    const detValue1 = defaultPayloadConverter.fromPayload<number>(detResult1!);
+    t.is(typeof detValue1, 'number');
+
+    // The two sources must be independent (different PRNG states)
+    t.not(unsafeValue1, detValue1, 'unsafe.random() and Math.random() should come from independent sources');
+  }
 });
 
 test('successString', async (t) => {

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -60,6 +60,7 @@ export * from './promise-then-promise';
 export * from './race';
 export * from './random';
 export * from './random-streams';
+export * from './unsafe-random';
 export * from './reject-promise';
 export * from './reusable-vm-disposal-bug';
 export * from './run-activity-in-different-task-queue';

--- a/packages/test/src/workflows/unsafe-random.ts
+++ b/packages/test/src/workflows/unsafe-random.ts
@@ -1,0 +1,15 @@
+import { defineQuery, setHandler, sleep, workflowInfo } from '@temporalio/workflow';
+
+const unsafeRandomQuery = defineQuery<number>('unsafeRandom');
+const deterministicRandomQuery = defineQuery<number>('deterministicRandom');
+
+export async function unsafeRandom(): Promise<void> {
+  setHandler(unsafeRandomQuery, () => {
+    return workflowInfo().unsafe.random();
+  });
+  setHandler(deterministicRandomQuery, () => {
+    return Math.random();
+  });
+  // Keep workflow alive waiting for queries
+  await sleep(100_000);
+}

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1575,6 +1575,7 @@ export class Worker {
       currentDeploymentVersion: convertDeploymentVersion(activation.deploymentVersionForCurrentTask),
       unsafe: {
         now: () => Date.now(), // re-set in initRuntime
+        random: Math.random, // re-set in initRuntime
         isReplaying: activation.isReplaying,
         isReplayingHistoryEvents: activation.isReplaying,
       },

--- a/packages/worker/src/workflow/threaded-vm.ts
+++ b/packages/worker/src/workflow/threaded-vm.ts
@@ -242,10 +242,11 @@ export class VMWorkflowThreadProxy implements Workflow {
     workerThreadClient: WorkerThreadClient,
     options: WorkflowCreateOptions
   ): Promise<VMWorkflowThreadProxy> {
-    // Delete .now because functions can't be serialized / sent to thread.
-    // Cast to any to avoid type error, since .now is a required field.
-    // Safe to cast since we immediately set it inside the thread in initRuntime.
+    // Delete .now and .random because functions can't be serialized / sent to thread.
+    // Cast to any to avoid type error, since these are required fields.
+    // Safe to cast since we immediately set them inside the thread in initRuntime.
     delete (options.info.unsafe as any).now;
+    delete (options.info.unsafe as any).random;
     await workerThreadClient.send({ type: 'create-workflow', options });
     return new this(workerThreadClient, options.info.runId);
   }
@@ -269,6 +270,7 @@ export class VMWorkflowThreadProxy implements Workflow {
 
     output.calls.forEach((call) => {
       (call.workflowInfo.unsafe.now as any) = Date.now;
+      (call.workflowInfo.unsafe.random as any) = Math.random;
     });
     return output.calls;
   }

--- a/packages/worker/src/workflow/workflow-worker-thread.ts
+++ b/packages/worker/src/workflow/workflow-worker-thread.ts
@@ -93,8 +93,9 @@ async function handleRequest({ requestId, input }: WorkerThreadRequest): Promise
       }
       const calls = await workflow.getAndResetSinkCalls();
       calls.forEach((call) => {
-        // Delete .now because functions can't be serialized / sent to thread.
+        // Delete .now and .random because functions can't be serialized / sent to thread.
         delete (call.workflowInfo.unsafe as any).now;
+        delete (call.workflowInfo.unsafe as any).random;
         // Use structuredClone when available
         // This lets us work around a bug in Bun's postMessage where
         // shared object references get corrupted during serialization.

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -269,6 +269,30 @@ export interface UnsafeWorkflowInfo {
    * callDuringReplay=false won't get processed.
    */
   readonly isReplayingHistoryEvents: boolean;
+
+  /**
+   * Returns a nondeterministic random number between 0 (inclusive) and 1 (exclusive).
+   *
+   * Unlike `Math.random()` (which is deterministic and seeded from the workflow seed in the
+   * workflow sandbox), this function uses a nondeterministic source of randomness
+   * (independent of the workflow replay seed), similar to how {@link now} provides the
+   * real system time.
+   *
+   * This is useful for generating unique IDs for observability and telemetry in query
+   * handlers and interceptors.
+   *
+   * This function is NOT cryptographically secure. Do not use it for generating tokens,
+   * secrets, or cryptographic nonces.
+   *
+   * **Safe to use in**: query handlers, update validators (for non-decision logic),
+   * interceptors, sinks.
+   *
+   * **NOT safe in**: the main workflow function, signal handlers, or update handlers —
+   * using it there will break deterministic replay.
+   *
+   * @experimental
+   */
+  readonly random: () => number;
 }
 
 /**

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -16,6 +16,7 @@ import { setActivator, getActivator, maybeGetActivator } from './global-attribut
 export { PromiseStackStore } from './internals';
 
 const OriginalDate = globalThis.Date;
+const OriginalMathRandom = Math.random;
 
 /**
  * Initialize the isolate runtime.
@@ -27,7 +28,7 @@ export function initRuntime(options: WorkflowCreateOptionsInternal): void {
     ...options,
     info: fixPrototypes({
       ...options.info,
-      unsafe: { ...options.info.unsafe, now: OriginalDate.now },
+      unsafe: { ...options.info.unsafe, now: OriginalDate.now, random: OriginalMathRandom },
     }),
   });
   // There's one activator per workflow instance, set it globally on the context.


### PR DESCRIPTION
## Summary

Adds `workflowInfo().unsafe.random()` — a nondeterministic random number generator exposed on `UnsafeWorkflowInfo`, for use in query handlers, update validators, interceptors, and sinks where deterministic replay is not required.

**Primary use case**: generating unique trace/correlation IDs for observability and telemetry in query handlers (as requested in #2110).

## Motivation

The workflow sandbox replaces `Math.random()` with a deterministic PRNG seeded from the workflow seed. This is essential for replay correctness, but makes it impossible for query handlers and interceptors to generate truly unique identifiers for observability purposes. `SideEffect()` cannot be used in query handlers since they cannot produce commands.

> **Note**: This is the first Temporal SDK to expose unsafe nondeterministic random. Go/Java SDKs rely on `SideEffect()` for nondeterminism, but `SideEffect` cannot be used in query handlers. This API fills a TypeScript-specific gap caused by the sandbox replacing `Math.random`.

## Implementation

Follows the exact same pattern as the existing `unsafe.now()`:

1. **Capture** the real `Math.random` at module load time in `worker-interface.ts` (before `overrideGlobals()` replaces it with the deterministic PRNG)
2. **Inject** it as `unsafe.random` during `initRuntime()`
3. **Delete/restore** around thread serialization boundaries (same as `unsafe.now`)

## Changes

### Core (3 files)
- `packages/workflow/src/interfaces.ts` — Added `random: () => number` to `UnsafeWorkflowInfo` with comprehensive JSDoc (`@experimental`)
- `packages/workflow/src/worker-interface.ts` — Captured `OriginalMathRandom` before sandbox overrides
- `packages/worker/src/worker.ts` — Added `random: Math.random` to initial unsafe object

### Thread serialization (2 files)
- `packages/worker/src/workflow/threaded-vm.ts` — Delete before thread send; restore after sink call deserialization
- `packages/worker/src/workflow/workflow-worker-thread.ts` — Delete before sink call serialization

### Tests (6 files)
- New test workflow (`unsafe-random.ts`) with both `unsafeRandom` and `deterministicRandom` query handlers
- Test verifies: valid range, nondeterminism across queries, independence from seeded PRNG
- Updated all existing test helpers constructing `UnsafeWorkflowInfo`

## API

```typescript
import { workflowInfo } from '@temporalio/workflow';

// In a query handler:
const traceId = workflowInfo().unsafe.random().toString(36).slice(2);
```

**Safe to use in**: query handlers, update validators, interceptors, sinks.
**NOT safe in**: main workflow function, signal handlers, update handlers (breaks replay).

## Testing

- All 73 tests in `test-workflows.js` pass
- New `unsafeRandom` test validates nondeterminism and source independence

Closes #2110
