### PR TITLE
docs(worker): fix broken link to production deploy guide

### DIFF
--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -125,7 +125,7 @@ export interface WorkerOptions {
    * This option is typically used for local development, for production it's preferred to pre-build the Workflow bundle
    * and pass that to {@link Worker.create} via the {@link workflowBundle} option.
    *
-   * See https://docs.temporal.io/typescript/production-deploy#pre-build-code for more information.
+   * See https://docs.temporal.io/develop/typescript/workers/run-worker-process#register-types for more information.
    */
   workflowsPath?: string;
 
@@ -136,7 +136,7 @@ export interface WorkerOptions {
    *
    * This is the recommended way to deploy Workers to production.
    *
-   * See https://docs.temporal.io/typescript/production-deploy#pre-build-code for more information.
+   * See https://docs.temporal.io/develop/typescript/workers/run-worker-process#register-types for more information.
    *
    * When using this option, {@link workflowsPath}, {@link bundlerOptions} and any Workflow interceptors modules
    * provided in * {@link interceptors} are not used. To use workflow interceptors, pass them via


### PR DESCRIPTION
### **What was changed**
Updated two broken documentation links in packages/worker/src/worker-options.ts. The docstrings for workflowsPath and workflowBundle both linked to https://docs.temporal.io/typescript/production-deploy#pre-build-code, which no longer resolves. Both now point to https://docs.temporal.io/develop/typescript/workers/run-worker-process#register-types, which covers the same content (bundling workflow code ahead of time for production, via bundleWorkflowCode and workflowBundle).

### **Why?**
The old URL structure for Temporal's docs site changed at some point, and these two docstring references were never updated to match. Anyone reading the SDK's inline docs (e.g. via IDE tooltips or generated API docs) following this link would hit a dead page, as reported in #1653.

### **Checklist**
1. Closes #1653
2. How was this tested: Verified the new URL (https://docs.temporal.io/develop/typescript/workers/run-worker-process#register-types) resolves and contains the matching workflowsPath → bundleWorkflowCode → workflowBundle guidance described in the docstrings. Confirmed via codebase search that these were the only two occurrences of the broken link in the codebase. Ran pnpm build successfully (docstring-only change, no functional impact).

3. Any docs updates needed? No additional docs.temporal.io changes needed — this PR only fixes inline SDK docstrings to point to the already-correct, existing docs page.