### PR TITLE
Expose continue-as-new backoff start interval

### DIFF
--- a/packages/core-bridge/Cargo.lock
+++ b/packages/core-bridge/Cargo.lock
@@ -774,6 +774,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1240,11 +1246,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2132,9 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "ringbuf"
-version = "0.4.8"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe47b720588c8702e34b5979cb3271a8b1842c7cb6f57408efa70c779363488c"
+checksum = "2d3ecbcab081b935fb9c618b07654924f27686b4aac8818e700580a83eedcb7f"
 dependencies = [
  "crossbeam-utils",
  "portable-atomic",
@@ -2565,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "temporalio-client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2586,6 +2592,7 @@ dependencies = [
  "temporalio-common",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tonic",
  "tower",
  "tracing",
@@ -2595,11 +2602,10 @@ dependencies = [
 
 [[package]]
 name = "temporalio-common"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
  "bon",
  "crc32fast",
  "derive_more",
@@ -2614,23 +2620,19 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
- "pbjson",
- "pbjson-build",
  "prometheus",
  "prost",
  "prost-types",
- "prost-wkt",
- "prost-wkt-types",
- "rand 0.10.1",
+ "reqwest 0.12.28",
  "ringbuf",
  "serde",
  "serde_json",
+ "temporalio-common-wasm",
+ "temporalio-protos",
  "thiserror 2.0.18",
  "tokio",
  "toml",
  "tonic",
- "tonic-prost",
- "tonic-prost-build",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -2639,8 +2641,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "temporalio-common-wasm"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bon",
+ "crc32fast",
+ "derive_more",
+ "erased-serde",
+ "futures",
+ "parking_lot",
+ "prost",
+ "serde",
+ "serde_json",
+ "temporalio-protos",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "temporalio-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2648,8 +2673,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "temporalio-protos"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "derive_more",
+ "http",
+ "pbjson",
+ "pbjson-build",
+ "prost",
+ "prost-types",
+ "prost-wkt-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+]
+
+[[package]]
 name = "temporalio-sdk-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2667,6 +2713,7 @@ dependencies = [
  "itertools",
  "lru",
  "mockall",
+ "opentelemetry-otlp",
  "parking_lot",
  "pid",
  "pin-project",
@@ -2877,14 +2924,15 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
  "base64",
  "bytes",
+ "flate2",
  "h2",
  "http",
  "http-body",
@@ -2908,9 +2956,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27aac809edf60b741e2d7db6367214d078856b8a5bff0087e94ff330fb97b6fc"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2920,9 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -2931,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4556786613791cfef4ed134aa670b61a85cfcacf71543ef33e8d801abae988f"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/packages/core-bridge/src/client.rs
+++ b/packages/core-bridge/src/client.rs
@@ -342,6 +342,7 @@ async fn client_invoke_workflow_service(
         "ListWorkflowRules" => rpc_call!(connection, call, list_workflow_rules),
         "PatchSchedule" => rpc_call!(connection, call, patch_schedule),
         "PauseActivity" => rpc_call!(connection, call, pause_activity),
+        "PauseActivityExecution" => rpc_call!(connection, call, pause_activity_execution),
         "PauseWorkflowExecution" => rpc_call!(connection, call, pause_workflow_execution),
         "PollActivityExecution" => rpc_call!(connection, call, poll_activity_execution),
         "PollActivityTaskQueue" => rpc_call!(connection, call, poll_activity_task_queue),
@@ -372,6 +373,7 @@ async fn client_invoke_workflow_service(
             rpc_call!(connection, call, request_cancel_workflow_execution)
         }
         "ResetActivity" => rpc_call!(connection, call, reset_activity),
+        "ResetActivityExecution" => rpc_call!(connection, call, reset_activity_execution),
         "ResetStickyTaskQueue" => rpc_call!(connection, call, reset_sticky_task_queue),
         "ResetWorkflowExecution" => rpc_call!(connection, call, reset_workflow_execution),
         "RespondActivityTaskCanceled" => {
@@ -425,7 +427,11 @@ async fn client_invoke_workflow_service(
         "TerminateWorkflowExecution" => rpc_call!(connection, call, terminate_workflow_execution),
         "TriggerWorkflowRule" => rpc_call!(connection, call, trigger_workflow_rule),
         "UnpauseActivity" => rpc_call!(connection, call, unpause_activity),
+        "UnpauseActivityExecution" => rpc_call!(connection, call, unpause_activity_execution),
         "UnpauseWorkflowExecution" => rpc_call!(connection, call, unpause_workflow_execution),
+        "UpdateActivityExecutionOptions" => {
+            rpc_call!(connection, call, update_activity_execution_options)
+        }
         "UpdateActivityOptions" => rpc_call!(connection, call, update_activity_options),
         "UpdateNamespace" => rpc_call!(connection, call, update_namespace),
         "UpdateSchedule" => rpc_call!(connection, call, update_schedule),
@@ -718,6 +724,7 @@ mod config {
                     client_cert: pair.client_cert,
                     client_private_key: pair.client_private_key,
                 }),
+                server_cert_verifier: None,
             }
         }
     }

--- a/packages/proto/scripts/compile-proto.ts
+++ b/packages/proto/scripts/compile-proto.ts
@@ -10,7 +10,7 @@ const outputDir = resolve(__dirname, '../protos');
 const jsOutputFile = resolve(outputDir, 'json-module.js');
 const tempFile = resolve(outputDir, 'temp.js');
 
-const protoBaseDir = resolve(__dirname, '../../core-bridge/sdk-core/crates/common/protos');
+const protoBaseDir = resolve(__dirname, '../../core-bridge/sdk-core/crates/protos/protos');
 
 function mtime(path: string) {
   try {

--- a/packages/test/src/test-client-connection.ts
+++ b/packages/test/src/test-client-connection.ts
@@ -24,14 +24,14 @@ import { grpc as grpcProto } from '@temporalio/proto';
 const workflowServicePackageDefinition = protoLoader.loadSync(
   path.resolve(
     __dirname,
-    '../../core-bridge/sdk-core/crates/common/protos/api_upstream/temporal/api/workflowservice/v1/service.proto'
+    '../../core-bridge/sdk-core/crates/protos/protos/api_upstream/temporal/api/workflowservice/v1/service.proto'
   ),
-  { includeDirs: [path.resolve(__dirname, '../../core-bridge/sdk-core/crates/common/protos/api_upstream')] }
+  { includeDirs: [path.resolve(__dirname, '../../core-bridge/sdk-core/crates/protos/protos/api_upstream')] }
 );
 const workflowServiceProtoDescriptor = grpc.loadPackageDefinition(workflowServicePackageDefinition) as any;
 
 const healthServicePackageDefinition = protoLoader.loadSync(
-  path.resolve(__dirname, '../../core-bridge/sdk-core/crates/common/protos/grpc/health/v1/health.proto')
+  path.resolve(__dirname, '../../core-bridge/sdk-core/crates/protos/protos/grpc/health/v1/health.proto')
 );
 const healthServicePackageDescriptor = grpc.loadPackageDefinition(healthServicePackageDefinition) as any;
 

--- a/packages/test/src/test-native-connection-headers.ts
+++ b/packages/test/src/test-native-connection-headers.ts
@@ -12,9 +12,9 @@ import { Worker } from './helpers';
 const workflowServicePackageDefinition = protoLoader.loadSync(
   path.resolve(
     __dirname,
-    '../../core-bridge/sdk-core/crates/common/protos/api_upstream/temporal/api/workflowservice/v1/service.proto'
+    '../../core-bridge/sdk-core/crates/protos/protos/api_upstream/temporal/api/workflowservice/v1/service.proto'
   ),
-  { includeDirs: [path.resolve(__dirname, '../../core-bridge/sdk-core/crates/common/protos/api_upstream')] }
+  { includeDirs: [path.resolve(__dirname, '../../core-bridge/sdk-core/crates/protos/protos/api_upstream')] }
 );
 const workflowServiceProtoDescriptor = grpc.loadPackageDefinition(workflowServicePackageDefinition) as any;
 
@@ -26,9 +26,9 @@ test('NativeConnection passes headers provided in options', async (t) => {
   const packageDefinition = protoLoader.loadSync(
     path.resolve(
       __dirname,
-      '../../core-bridge/sdk-core/crates/common/protos/api_upstream/temporal/api/workflowservice/v1/service.proto'
+      '../../core-bridge/sdk-core/crates/protos/protos/api_upstream/temporal/api/workflowservice/v1/service.proto'
     ),
-    { includeDirs: [path.resolve(__dirname, '../../core-bridge/sdk-core/crates/common/protos/api_upstream')] }
+    { includeDirs: [path.resolve(__dirname, '../../core-bridge/sdk-core/crates/protos/protos/api_upstream')] }
   );
   const protoDescriptor = grpc.loadPackageDefinition(packageDefinition) as any;
 

--- a/packages/test/src/test-native-connection.ts
+++ b/packages/test/src/test-native-connection.ts
@@ -18,23 +18,23 @@ import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
 const workflowServicePackageDefinition = protoLoader.loadSync(
   path.resolve(
     __dirname,
-    '../../core-bridge/sdk-core/crates/common/protos/api_upstream/temporal/api/workflowservice/v1/service.proto'
+    '../../core-bridge/sdk-core/crates/protos/protos/api_upstream/temporal/api/workflowservice/v1/service.proto'
   ),
-  { includeDirs: [path.resolve(__dirname, '../../core-bridge/sdk-core/crates/common/protos/api_upstream')] }
+  { includeDirs: [path.resolve(__dirname, '../../core-bridge/sdk-core/crates/protos/protos/api_upstream')] }
 );
 const workflowServiceProtoDescriptor = grpc.loadPackageDefinition(workflowServicePackageDefinition) as any;
 
 const operatorServicePackageDefinition = protoLoader.loadSync(
   path.resolve(
     __dirname,
-    '../../core-bridge/sdk-core/crates/common/protos/api_upstream/temporal/api/operatorservice/v1/service.proto'
+    '../../core-bridge/sdk-core/crates/protos/protos/api_upstream/temporal/api/operatorservice/v1/service.proto'
   ),
-  { includeDirs: [path.resolve(__dirname, '../../core-bridge/sdk-core/crates/common/protos/api_upstream')] }
+  { includeDirs: [path.resolve(__dirname, '../../core-bridge/sdk-core/crates/protos/protos/api_upstream')] }
 );
 const operatorServiceProtoDescriptor = grpc.loadPackageDefinition(operatorServicePackageDefinition) as any;
 
 const healthServicePackageDefinition = protoLoader.loadSync(
-  path.resolve(__dirname, '../../core-bridge/sdk-core/crates/common/protos/grpc/health/v1/health.proto'),
+  path.resolve(__dirname, '../../core-bridge/sdk-core/crates/protos/protos/grpc/health/v1/health.proto'),
   { includeDirs: [] }
 );
 const healthServiceProtoDescriptor = grpc.loadPackageDefinition(healthServicePackageDefinition) as any;
@@ -42,9 +42,9 @@ const healthServiceProtoDescriptor = grpc.loadPackageDefinition(healthServicePac
 const testServicePackageDefinition = protoLoader.loadSync(
   path.resolve(
     __dirname,
-    '../../core-bridge/sdk-core/crates/common/protos/testsrv_upstream/temporal/api/testservice/v1/service.proto'
+    '../../core-bridge/sdk-core/crates/protos/protos/testsrv_upstream/temporal/api/testservice/v1/service.proto'
   ),
-  { includeDirs: [path.resolve(__dirname, '../../core-bridge/sdk-core/crates/common/protos/testsrv_upstream')] }
+  { includeDirs: [path.resolve(__dirname, '../../core-bridge/sdk-core/crates/protos/protos/testsrv_upstream')] }
 );
 const testServiceProtoDescriptor = grpc.loadPackageDefinition(testServicePackageDefinition) as any;
 

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -1837,6 +1837,7 @@ test('continueAsNewSameWorkflow', async (t) => {
             workflowType,
             taskQueue: 'test',
             arguments: toPayloads(defaultPayloadConverter, 'signal'),
+            backoffStartInterval: msToTs('1ms'),
             versioningIntent: coresdk.common.VersioningIntent.UNSPECIFIED,
           },
         },

--- a/packages/test/src/workflows/continue-as-new-same-workflow.ts
+++ b/packages/test/src/workflows/continue-as-new-same-workflow.ts
@@ -2,7 +2,13 @@
  * Tests continueAsNew for the same Workflow from execute and signal handler
  * @module
  */
-import { continueAsNew, CancellationScope, defineSignal, setHandler } from '@temporalio/workflow';
+import {
+  continueAsNew,
+  CancellationScope,
+  defineSignal,
+  makeContinueAsNewFunc,
+  setHandler,
+} from '@temporalio/workflow';
 
 export const continueAsNewSignal = defineSignal('continueAsNew');
 
@@ -17,7 +23,7 @@ export async function continueAsNewSameWorkflow(
     return;
   }
   if (continueFrom === 'execute') {
-    await continueAsNew<typeof continueAsNewSameWorkflow>(continueTo);
+    await makeContinueAsNewFunc<typeof continueAsNewSameWorkflow>({ backoffStartInterval: '1ms' })(continueTo);
   }
   await CancellationScope.current().cancelRequested;
 }

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -330,6 +330,11 @@ export interface ContinueAsNewOptions {
    */
   workflowTaskTimeout?: Duration;
   /**
+   * Delay before the first Workflow Task of the continued run is scheduled
+   * @format {@link https://www.npmjs.com/package/ms | ms-formatted string}
+   */
+  backoffStartInterval?: Duration;
+  /**
    * Non-searchable attributes to attach to next Workflow run
    */
   memo?: Record<string, unknown>;

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1083,6 +1083,7 @@ export function makeContinueAsNewFunc<F extends Workflow>(
             : undefined,
         workflowRunTimeout: msOptionalToTs(options.workflowRunTimeout),
         workflowTaskTimeout: msOptionalToTs(options.workflowTaskTimeout),
+        backoffStartInterval: msOptionalToTs(options.backoffStartInterval),
         versioningIntent: versioningIntentToProto(options.versioningIntent),
         initialVersioningBehavior: encodeInitialVersioningBehavior(options.initialVersioningBehavior),
       });


### PR DESCRIPTION
Expose the continue-as-new `backoffStartInterval` option and pass it through to the Core bridge command.

Also updates the Core submodule and adjusts the proto/Core bridge plumbing needed for the current Core layout and TLS options shape.

Validation:
- `pnpm --filter @temporalio/core-bridge build`
- `pnpm --filter @temporalio/test build:ts`
- `pnpm --filter @temporalio/test exec ava ./lib/test-workflows.js --match='continueAsNewSameWorkflow'`