### PR TITLE
Expose gRPC compression options

### DIFF
--- a/packages/core-bridge/src/client.rs
+++ b/packages/core-bridge/src/client.rs
@@ -52,7 +52,7 @@ pub fn client_new(
 ) -> BridgeResult<BridgeFuture<OpaqueOutboundHandle<Client>>> {
     let runtime = runtime.borrow()?.core_runtime.clone();
     let metric_meter = runtime.telemetry().get_temporal_metric_meter();
-    let options = config.into_connection_options(metric_meter);
+    let options = config.into_connection_options(metric_meter)?;
 
     runtime.clone().future_to_promise(async move {
         let core_connection = match Connection::connect(options).await {
@@ -621,7 +621,8 @@ mod config {
 
     use temporalio_client::{
         ClientTlsOptions as CoreClientTlsOptions, ConnectionOptions, DnsLoadBalancingOptions,
-        HttpConnectProxyOptions, TlsOptions as CoreTlsOptions,
+        GrpcCompression as CoreGrpcCompression, HttpConnectProxyOptions,
+        TlsOptions as CoreTlsOptions,
     };
     use temporalio_common::telemetry::metrics::TemporalMeter;
     use temporalio_sdk_core::Url;
@@ -629,7 +630,10 @@ mod config {
 
     use bridge_macros::TryFromJs;
 
-    use crate::client::MetadataValue;
+    use crate::{
+        client::MetadataValue,
+        helpers::{BridgeError, BridgeResult},
+    };
 
     #[derive(Debug, Clone, TryFromJs)]
     pub(super) struct ClientOptions {
@@ -639,6 +643,7 @@ mod config {
         tls: Option<TlsOptions>,
         http_connect_proxy: Option<HttpConnectProxy>,
         dns_load_balancing_config: Option<DnsLoadBalancingConfig>,
+        grpc_compression: Option<GrpcCompressionConfig>,
         headers: Option<HashMap<String, MetadataValue>>,
         api_key: Option<String>,
         disable_error_code_metric_tags: bool,
@@ -675,11 +680,16 @@ mod config {
         resolution_interval_millis: u64,
     }
 
+    #[derive(Debug, Clone, TryFromJs)]
+    struct GrpcCompressionConfig {
+        codec: String,
+    }
+
     impl ClientOptions {
         pub(super) fn into_connection_options(
             self,
             metrics_meter: Option<TemporalMeter>,
-        ) -> ConnectionOptions {
+        ) -> BridgeResult<ConnectionOptions> {
             let (ascii_headers, bin_headers) = partition_headers(self.headers);
             let has_http_connect_proxy = self.http_connect_proxy.is_some();
             // Core rejects DNS load balancing alongside an HTTP CONNECT proxy, so
@@ -694,13 +704,17 @@ mod config {
                 self.dns_load_balancing_config.map(Into::into)
             };
             let http_connect_proxy = self.http_connect_proxy.map(Into::into);
+            let grpc_compression = self
+                .grpc_compression
+                .map_or(Ok(CoreGrpcCompression::Gzip), TryInto::try_into)?;
 
-            ConnectionOptions::new(self.target_url)
+            Ok(ConnectionOptions::new(self.target_url)
                 .client_name(self.client_name)
                 .client_version(self.client_version)
                 .maybe_tls_options(self.tls.map(Into::into))
                 .maybe_http_connect_proxy(http_connect_proxy)
                 .dns_load_balancing(dns_load_balancing)
+                .grpc_compression(grpc_compression)
                 .maybe_headers(ascii_headers)
                 .maybe_binary_headers(bin_headers)
                 .maybe_api_key(self.api_key)
@@ -711,7 +725,22 @@ mod config {
                 // override_origin -- skipped: will default to tls_cfg.domain
                 // keep_alive -- skipped: defaults to true; is there any reason to disable this?
                 // skip_get_system_info -- skipped: defaults to false; is there any reason to set this?
-                .build()
+                .build())
+        }
+    }
+
+    impl TryFrom<GrpcCompressionConfig> for CoreGrpcCompression {
+        type Error = BridgeError;
+
+        fn try_from(val: GrpcCompressionConfig) -> Result<Self, Self::Error> {
+            match val.codec.as_str() {
+                "gzip" => Ok(Self::Gzip),
+                "none" => Ok(Self::None),
+                codec => Err(BridgeError::InvalidVariant {
+                    enum_name: "GrpcCompressionConfig".to_string(),
+                    variant: codec.to_string(),
+                }),
+            }
         }
     }
 

--- a/packages/core-bridge/ts/native.ts
+++ b/packages/core-bridge/ts/native.ts
@@ -136,6 +136,7 @@ export interface ClientOptions {
   tls: Option<TlsOptions>;
   httpConnectProxy: Option<HttpConnectProxy>;
   dnsLoadBalancingConfig: Option<DnsLoadBalancingConfig>;
+  grpcCompression: GrpcCompressionConfig;
   headers: Option<Record<string, MetadataValue>>;
   apiKey: Option<string>;
   disableErrorCodeMetricTags: boolean;
@@ -167,6 +168,16 @@ export interface HttpConnectProxyBasicAuth {
 
 export interface DnsLoadBalancingConfig {
   resolutionIntervalMillis: number;
+}
+
+export type GrpcCompressionConfig = GzipGrpcCompressionConfig | NoneGrpcCompressionConfig;
+
+export interface GzipGrpcCompressionConfig {
+  codec: 'gzip';
+}
+
+export interface NoneGrpcCompressionConfig {
+  codec: 'none';
 }
 
 export interface RpcCall {

--- a/packages/test/src/test-bridge.ts
+++ b/packages/test/src/test-bridge.ts
@@ -252,6 +252,7 @@ const GenericConfigs = {
       tls: null,
       httpConnectProxy: null,
       dnsLoadBalancingConfig: null,
+      grpcCompression: { codec: 'gzip' },
       headers: null,
       apiKey: null,
       disableErrorCodeMetricTags: false,

--- a/packages/test/src/test-native-connection.ts
+++ b/packages/test/src/test-native-connection.ts
@@ -510,3 +510,13 @@ test('NativeConnection: DNS load balancing config is converted to native millise
   });
   t.deepEqual(options.dnsLoadBalancingConfig, { resolutionIntervalMillis: 5000 });
 });
+
+test('NativeConnection: gRPC compression defaults to gzip', (t) => {
+  const options = toNativeClientOptions({});
+  t.deepEqual(options.grpcCompression, { codec: 'gzip' });
+});
+
+test('NativeConnection: gRPC compression can be disabled', (t) => {
+  const options = toNativeClientOptions({ grpcCompression: { codec: 'none' } });
+  t.deepEqual(options.grpcCompression, { codec: 'none' });
+});

--- a/packages/worker/src/connection-options.ts
+++ b/packages/worker/src/connection-options.ts
@@ -26,6 +26,25 @@ export interface DNSLoadBalancingConfig {
 }
 
 /**
+ * Use gzip for transport-level gRPC compression.
+ */
+export interface GzipGrpcCompressionConfig {
+  codec: 'gzip';
+}
+
+/**
+ * Disable transport-level gRPC compression.
+ */
+export interface NoneGrpcCompressionConfig {
+  codec: 'none';
+}
+
+/**
+ * Transport-level gRPC compression configuration.
+ */
+export type GrpcCompressionConfig = GzipGrpcCompressionConfig | NoneGrpcCompressionConfig;
+
+/**
  * The default Temporal Server's TCP port for public gRPC connections.
  */
 const DEFAULT_TEMPORAL_GRPC_PORT = 7233;
@@ -63,6 +82,14 @@ export interface NativeConnectionOptions {
    * is disabled because the two options are mutually exclusive.
    */
   dnsLoadBalancingConfig?: DNSLoadBalancingConfig | null;
+
+  /**
+   * Transport-level gRPC compression configuration for Core service requests.
+   *
+   * Defaults to gzip, which compresses outbound request bodies and accepts
+   * gzip-compressed responses. Set to `{ codec: 'none' }` to opt out.
+   */
+  grpcCompression?: GrpcCompressionConfig;
 
   /**
    * Optional mapping of gRPC metadata (HTTP headers) to send with each request to the server.
@@ -138,6 +165,15 @@ export function toNativeClientOptions(options: NativeConnectionOptions): native.
       }
     : null;
 
+  const grpcCompression: native.GrpcCompressionConfig = options.grpcCompression ?? { codec: 'gzip' };
+  switch (grpcCompression.codec) {
+    case 'gzip':
+    case 'none':
+      break;
+    default:
+      throw new TypeError(`Unsupported gRPC compression codec: ${(grpcCompression as { codec: string }).codec}`);
+  }
+
   if (options?.apiKey && options.metadata?.['Authorization']) {
     throw new TypeError(
       'Both `apiKey` option and `Authorization` header were provided. Only one makes sense to use at a time.'
@@ -163,6 +199,7 @@ export function toNativeClientOptions(options: NativeConnectionOptions): native.
     tls,
     httpConnectProxy,
     dnsLoadBalancingConfig,
+    grpcCompression,
     headers,
     apiKey: options.apiKey ?? null,
     disableErrorCodeMetricTags: options.disableErrorCodeMetricTags ?? false,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -35,7 +35,12 @@
  */
 
 export { NativeConnection, NativeConnectionPlugin } from './connection';
-export { DNSLoadBalancingConfig, NativeConnectionOptions, TLSConfig } from './connection-options';
+export {
+  DNSLoadBalancingConfig,
+  GrpcCompressionConfig,
+  NativeConnectionOptions,
+  TLSConfig,
+} from './connection-options';
 export { startDebugReplayer } from './debug-replayer';
 export { IllegalStateError } from '@temporalio/common';
 export {


### PR DESCRIPTION
## Summary
- expose gRPC compression as explicit discriminated option variants on NativeConnection
- keep gzip as the default while allowing `grpcCompression: { codec: 'none' }` to opt out
- model the public/native types so future variants can add variant-specific fields, e.g. `{ codec: 'zstd', level: 3 }`, without adding `level` to gzip

## Testing
- `pnpm exec prettier --write packages/worker/src/connection-options.ts packages/core-bridge/ts/native.ts`
- `pnpm -C packages/worker run build`
- `pnpm -C packages/test run build:ts`
- `pnpm -C packages/test exec ava ./lib/test-native-connection.js --match='NativeConnection: gRPC compression*'`