### PR TITLE
VLN-1618: remediate checkout-below-v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         shell: bash
     steps:
       - name: 'Checkout code'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
 
@@ -145,7 +145,7 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: 'Checkout code'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
 

--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash
     steps:
       - name: 'Checkout code'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
 
@@ -155,7 +155,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
 
@@ -232,7 +232,7 @@ jobs:
       TEMPORAL_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
     steps:
       - name: 'Checkout code'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # We don't need the core submodule here since won't build the project
           submodules: false

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Print build info
         run: 'echo test-type: ${{ inputs.test-type }}, test-timeout-minutes: ${{ inputs.test-timeout-minutes }}, reuse-v8-context: $REUSE_V8_CONTEXT'
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
           ref: ${{ inputs.ref }}


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>checkout-below-v7</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/sdk-typescript</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1618">VLN-1618</a></td></tr>
</table>

## Summary

- `.github/workflows/ci.yml`: Pinned both `actions/checkout` steps to the required v7.0.0 commit SHA.
- `.github/workflows/conventions.yml`: Pinned the `actions/checkout` step to the required v7.0.0 commit SHA.
- `.github/workflows/docs.yml`: Pinned the `actions/checkout` step to the required v7.0.0 commit SHA.
- `.github/workflows/release.yml`: Pinned all three `actions/checkout` steps to the required v7.0.0 commit SHA.
- `.github/workflows/stress.yml`: Pinned the `actions/checkout` step to the required v7.0.0 commit SHA.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — regenerate the fix from scratch against the current base