### PR TITLE
fix(logger): avoid logging `NativeConnection` on worker startup

### DIFF
--- a/packages/test/src/test-worker-lifecycle.ts
+++ b/packages/test/src/test-worker-lifecycle.ts
@@ -7,11 +7,12 @@
 import { setTimeout } from 'timers/promises';
 import { randomUUID } from 'crypto';
 import test from 'ava';
-import { Runtime, PromiseCompletionTimeoutError } from '@temporalio/worker';
+import type { LogEntry, NativeConnection } from '@temporalio/worker';
+import { Runtime, PromiseCompletionTimeoutError, DefaultLogger, MetricsBuffer } from '@temporalio/worker';
 import { TransportError, UnexpectedError } from '@temporalio/worker/lib/errors';
 import { Client } from '@temporalio/client';
 import { isBun, RUN_INTEGRATION_TESTS, Worker } from './helpers';
-import { defaultOptions, isolateFreeWorker } from './mock-native-worker';
+import { defaultOptions, isolateFreeWorker, Worker as MockWorker } from './mock-native-worker';
 import { fillMemory } from './workflows';
 
 if (RUN_INTEGRATION_TESTS) {
@@ -130,6 +131,44 @@ if (RUN_INTEGRATION_TESTS) {
     }
   });
 }
+
+test.serial('Worker.create debug log options are JSON serializable with buffered metrics and connection', async (t) => {
+  const logEntries: LogEntry[] = [];
+  const logger = new DefaultLogger('DEBUG', (entry) => {
+    JSON.stringify(entry.meta);
+    logEntries.push(entry);
+  });
+  const runtime = Runtime.install({
+    logger,
+    telemetryOptions: {
+      metrics: {
+        buffer: new MetricsBuffer(),
+      },
+    },
+  });
+  const connection = {
+    plugins: [],
+    referenceHolders: new Set(),
+    runtime,
+  } as unknown as NativeConnection;
+
+  try {
+    await MockWorker.create({
+      taskQueue: `json-logger-${randomUUID()}`,
+      activities: {
+        noop: async () => undefined,
+      },
+      connection,
+    });
+
+    const creatingWorkerLog = logEntries.find((entry) => entry.message === 'Creating worker');
+    t.truthy(creatingWorkerLog);
+    t.is(creatingWorkerLog?.meta?.options.connection, '<NativeConnection>');
+  } finally {
+    (connection as any).referenceHolders.clear();
+    await Runtime._instance?.shutdown();
+  }
+});
 
 test.serial('Mocked run shuts down gracefully', async (t) => {
   try {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -509,6 +509,12 @@ export class Worker {
     logger.debug('Creating worker', {
       options: {
         ...compiledOptions,
+        // Avoid dumping NativeConnection which contains Runtime that might have ciruclar references
+        ...(compiledOptions.connection !== undefined
+          ? {
+              connection: '<NativeConnection>',
+            }
+          : {}),
         ...(compiledOptions.workflowBundle && isCodeBundleOption(compiledOptions.workflowBundle)
           ? {
               // Avoid dumping workflow bundle code to the console


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Strip out `NativeConnection` from debug logger call on worker startup.

## Why?
`NativeConnection` held a `Runtime` reference which when constructed with `MetricsBuffer` would result in a circular reference. A user logger that blindly called `JSON.stringify` on the log metadata would trigger an exception.

Went with just stripping out passing this object blindly as there `NativeConnection` is not meaningfully serializable. The options that are serializable are already part of the log metadata.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added regression test in first commit that fails with:
```
Worker.create debug log options are JSON serializable with buffered metrics and connection

  Rejected promise returned by test. Reason:

  TypeError {
    message: `Converting circular structure to JSON␊
        --> starting at object with constructor 'Runtime'␊
        |     property 'options' -> object with constructor 'Object'␊
        |     property 'metricsBuffer' -> object with constructor 'MetricsBuffer'␊
        --- property 'runtime' closes the circle`,
  }
```

3. Any docs updates needed?
N/A