### PR TITLE
AI-310: streaming support for @temporalio/openai-agents

### DIFF
--- a/contrib/openai-agents/README.md
+++ b/contrib/openai-agents/README.md
@@ -170,7 +170,18 @@ Pass `{ stream: true }` to `run()` to stream incremental events as the model res
 
 External consumers (UIs, tracing pipelines) observe events as they arrive by hosting a [`WorkflowStream`](../workflow-streams/README.md) in the Workflow and subscribing with `WorkflowStreamClient`. The streaming Activity publishes each event to the topic configured on `modelParams.streamingTopic`. The topic is required for streaming runs; calling `run(agent, input, { stream: true })` without a configured topic throws before any Activity is scheduled.
 
-Configure the topic on the plugin and host a `WorkflowStream` in the Workflow:
+Streaming requires a `streamingTopic`. Set it on the `modelParams` of the plugin registered on the **Client** — the Client interceptor injects the config header into every Workflow-starting call:
+
+```ts
+const plugin = new OpenAIAgentsPlugin({
+  modelProvider: new OpenAIProvider(),
+  modelParams: { streamingTopic: 'events', streamingBatchInterval: '100ms' },
+});
+
+const client = new Client({ connection, plugins: [plugin] });
+```
+
+Workflows started without that Client — by a Schedule or the Temporal UI/CLI — receive no config header. Supply Workflow-authored defaults through the runner's `defaultModelParams`; unlike the header, these can carry a function-form `summary`. Host a `WorkflowStream` in the Workflow to receive the publishes:
 
 ```ts
 import { Agent } from '@openai/agents-core';
@@ -180,7 +191,7 @@ import { WorkflowStream } from '@temporalio/workflow-streams/workflow';
 export async function streamingWorkflow(prompt: string): Promise<string> {
   new WorkflowStream();
   const agent = new Agent({ name: 'Assistant', instructions: '...' });
-  const runner = new TemporalOpenAIRunner();
+  const runner = new TemporalOpenAIRunner({ defaultModelParams: { streamingTopic: 'events' } });
   const result = await runner.run(agent, prompt, { stream: true });
   for await (const event of result) {
     if (event.type === 'raw_model_stream_event' && event.data.type === 'output_text_delta') {
@@ -191,12 +202,7 @@ export async function streamingWorkflow(prompt: string): Promise<string> {
 }
 ```
 
-```ts
-new OpenAIAgentsPlugin({
-  modelProvider,
-  modelParams: { streamingTopic: 'events', streamingBatchInterval: '100ms' },
-});
-```
+The two layers combine per field: the Client's `modelParams` overrides the runner's `defaultModelParams`.
 
 External subscribers receive the unwrapped native model events directly:
 
@@ -207,6 +213,8 @@ for await (const item of WorkflowStreamClient.create(client, workflowId).topic('
   // item.data — native model stream event
 }
 ```
+
+The hosted `WorkflowStream` retains every published event on the Workflow heap and in history until `truncate(upToOffset)` is called. A streaming agent publishes many events per run, so a long-running or high-volume Workflow that never truncates will eventually hit Temporal's Workflow history size limits. Call `truncate(upToOffset)` periodically to keep the heap and history bounded; see [`@temporalio/workflow-streams`](../workflow-streams/README.md) for the offset model and batching.
 
 Streaming is incompatible with `useLocalActivity`, which supports neither Activity heartbeats nor the Workflow Stream signal channel. See [`@temporalio/workflow-streams`](../workflow-streams/README.md) for the publisher/subscriber API and delivery semantics.
 

--- a/contrib/openai-agents/README.md
+++ b/contrib/openai-agents/README.md
@@ -99,7 +99,6 @@ Differences from the upstream runner:
 
 - `runConfig.model` must be a model name string. The Worker's `modelProvider` resolves it inside the model Activity.
 - `signal` is not supported. Use Temporal cancellation APIs, such as `CancellationScope`, to cancel Workflow work.
-- `runStreamed()` is not currently supported.
 
 ### Run state and approvals
 
@@ -162,6 +161,54 @@ export async function approvalWorkflow(input: ApprovalInput = {}): Promise<strin
 ```
 
 The agent passed to `RunState.fromString` must define the same tool names, handoff graph, and MCP servers as the run that produced the serialized state.
+
+### Streaming
+
+> **Experimental** — streaming support is subject to change prior to General Availability.
+
+Pass `{ stream: true }` to `run()` to stream incremental events as the model responds. The call returns the upstream `StreamedRunResult`, an async-iterable of agent-SDK stream events. Inside a Workflow, each model call executes as a streaming Activity (`invokeModelStreamActivity`) that consumes `Model.getStreamedResponse` and returns the collected list of native model events. The Workflow yields those events deterministically from the Activity's return value — it never polls the live stream, so replay stays deterministic.
+
+External consumers (UIs, tracing pipelines) observe events as they arrive by hosting a [`WorkflowStream`](../workflow-streams/README.md) in the Workflow and subscribing with `WorkflowStreamClient`. The streaming Activity publishes each event to the topic configured on `modelParams.streamingTopic`. The topic is required for streaming runs; calling `run(agent, input, { stream: true })` without a configured topic throws before any Activity is scheduled.
+
+Configure the topic on the plugin and host a `WorkflowStream` in the Workflow:
+
+```ts
+import { Agent } from '@openai/agents-core';
+import { TemporalOpenAIRunner } from '@temporalio/openai-agents/workflow';
+import { WorkflowStream } from '@temporalio/workflow-streams/workflow';
+
+export async function streamingWorkflow(prompt: string): Promise<string> {
+  new WorkflowStream();
+  const agent = new Agent({ name: 'Assistant', instructions: '...' });
+  const runner = new TemporalOpenAIRunner();
+  const result = await runner.run(agent, prompt, { stream: true });
+  for await (const event of result) {
+    if (event.type === 'raw_model_stream_event' && event.data.type === 'output_text_delta') {
+      // event.data.delta — incremental text
+    }
+  }
+  return result.finalOutput ?? '';
+}
+```
+
+```ts
+new OpenAIAgentsPlugin({
+  modelProvider,
+  modelParams: { streamingTopic: 'events', streamingBatchInterval: '100ms' },
+});
+```
+
+External subscribers receive the unwrapped native model events directly:
+
+```ts
+import { WorkflowStreamClient } from '@temporalio/workflow-streams/client';
+
+for await (const item of WorkflowStreamClient.create(client, workflowId).topic('events').subscribe()) {
+  // item.data — native model stream event
+}
+```
+
+Streaming is incompatible with `useLocalActivity`, which supports neither Activity heartbeats nor the Workflow Stream signal channel. See [`@temporalio/workflow-streams`](../workflow-streams/README.md) for the publisher/subscriber API and delivery semantics.
 
 ### Sessions
 
@@ -569,25 +616,25 @@ There is no public TypeScript testing subpath.
 
 Any OpenAI Agents SDK `ModelProvider` can be passed as `modelProvider`. The provider runs in the model Activity, never inside the Workflow sandbox.
 
-| Feature                 | Status        | Notes                                                                                   |
-| :---------------------- | :------------ | :-------------------------------------------------------------------------------------- |
-| Multi-turn agents       | Supported     | Agent loop runs durably in the Workflow                                                 |
-| Handoffs                | Supported     | `Agent` and `handoff()` forms                                                           |
-| Inline function tools   | Supported     | Must be deterministic                                                                   |
-| Activity-backed tools   | Supported     | Via `activityAsTool()`                                                                  |
-| Nexus operation tools   | Supported     | Via `nexusOperationAsTool()`                                                            |
-| Nested agent tools      | Supported     | Via `agentAsTool()`                                                                     |
-| Hosted tools            | Supported     | Executed server-side by the model provider                                              |
-| Stateless MCP servers   | Supported     | Via `StatelessMCPServerProvider` and `statelessMcpServer()`                             |
-| Stateful MCP servers    | Supported     | Via `StatefulMCPServerProvider` and `statefulMcpServer()`                               |
-| Sessions                | Supported     | Via `WorkflowSafeMemorySession`; upstream `MemorySession` is rejected                   |
-| Run state and approvals | Supported     | Serialize with `result.state.toString()` and rehydrate with `RunState.fromString`       |
-| Guardrails              | Supported     | Guardrail callbacks must be deterministic                                               |
-| Tracing                 | Supported     | OpenAI hosted traces, custom `TracingProcessor`s, OTel, and optional `temporal:*` spans |
-| Agent context           | Supported     | Activity tools receive a copy                                                           |
-| `continueAsNew`         | Supported     | Plugin config propagates to the continuation                                            |
-| Child Workflows         | Supported     | Plugin config propagates to children                                                    |
-| Local Activities        | Supported     | Set `useLocalActivity: true` in `modelParams`                                           |
-| Model override per run  | Supported     | `runConfig.model` accepts a string model name                                           |
-| Streaming               | Not supported | Use `runner.run()`                                                                      |
-| Voice agents            | Not supported |                                                                                         |
+| Feature                 | Status                   | Notes                                                                                          |
+| :---------------------- | :----------------------- | :--------------------------------------------------------------------------------------------- |
+| Multi-turn agents       | Supported                | Agent loop runs durably in the Workflow                                                        |
+| Handoffs                | Supported                | `Agent` and `handoff()` forms                                                                  |
+| Inline function tools   | Supported                | Must be deterministic                                                                          |
+| Activity-backed tools   | Supported                | Via `activityAsTool()`                                                                         |
+| Nexus operation tools   | Supported                | Via `nexusOperationAsTool()`                                                                   |
+| Nested agent tools      | Supported                | Via `agentAsTool()`                                                                            |
+| Hosted tools            | Supported                | Executed server-side by the model provider                                                     |
+| Stateless MCP servers   | Supported                | Via `StatelessMCPServerProvider` and `statelessMcpServer()`                                    |
+| Stateful MCP servers    | Supported                | Via `StatefulMCPServerProvider` and `statefulMcpServer()`                                      |
+| Sessions                | Supported                | Via `WorkflowSafeMemorySession`; upstream `MemorySession` is rejected                          |
+| Run state and approvals | Supported                | Serialize with `result.state.toString()` and rehydrate with `RunState.fromString`              |
+| Guardrails              | Supported                | Guardrail callbacks must be deterministic                                                      |
+| Tracing                 | Supported                | OpenAI hosted traces, custom `TracingProcessor`s, OTel, and optional `temporal:*` spans        |
+| Agent context           | Supported                | Activity tools receive a copy                                                                  |
+| `continueAsNew`         | Supported                | Plugin config propagates to the continuation                                                   |
+| Child Workflows         | Supported                | Plugin config propagates to children                                                           |
+| Local Activities        | Supported                | Set `useLocalActivity: true` in `modelParams`                                                  |
+| Model override per run  | Supported                | `runConfig.model` accepts a string model name                                                  |
+| Streaming               | Supported (experimental) | `run(agent, input, { stream: true })`; requires `streamingTopic` and a hosted `WorkflowStream` |
+| Voice agents            | Not supported            |                                                                                                |

--- a/contrib/openai-agents/package.json
+++ b/contrib/openai-agents/package.json
@@ -74,6 +74,7 @@
     "@temporalio/plugin": "workspace:*",
     "@temporalio/worker": "workspace:*",
     "@temporalio/workflow": "workspace:*",
+    "@temporalio/workflow-streams": "workspace:*",
     "@ungap/structured-clone": "^1.3.1",
     "headers-polyfill": "^4.0.3",
     "web-streams-polyfill": "^4.2.0"

--- a/contrib/openai-agents/src/__tests__/activity-backed-model.test.ts
+++ b/contrib/openai-agents/src/__tests__/activity-backed-model.test.ts
@@ -1,0 +1,123 @@
+import test from 'ava';
+import {
+  Agent,
+  getGlobalTraceProvider,
+  setTraceProcessors,
+  withTrace,
+  type ModelRequest,
+  type Span as AgentSpan,
+  type SpanData,
+} from '@openai/agents-core';
+import { ActivityBackedModel } from '../workflow/activity-backed-model';
+import type { ModelSummaryProvider } from '../common/model-activity-options';
+import { streamingTextEvents } from './stubs/openai-agents-fakes';
+
+function minimalRequest(): ModelRequest {
+  return {
+    systemInstructions: 'sys',
+    input: 'hi',
+    modelSettings: {},
+    tools: [],
+    toolsExplicitlyProvided: false,
+    outputType: 'text',
+    handoffs: [],
+    tracing: false,
+  } as unknown as ModelRequest;
+}
+
+function fakeStreamActivities(returnEvents: unknown[]) {
+  const plain: unknown[] = [];
+  const withOptions: Array<{ opts: any; args: any[] }> = [];
+  const fn = Object.assign(
+    (input: unknown) => {
+      plain.push(input);
+      return Promise.resolve(returnEvents);
+    },
+    {
+      executeWithOptions: (opts: any, args: any[]) => {
+        withOptions.push({ opts, args });
+        return Promise.resolve(returnEvents);
+      },
+    }
+  );
+  return { activities: { invokeModelStreamActivity: fn }, plain, withOptions };
+}
+
+async function drain<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const e of iter) out.push(e);
+  return out;
+}
+
+test('getStreamedResponse: dynamic summary routes through executeWithOptions', async (t) => {
+  const events = streamingTextEvents('hello');
+  let provided: { agent: unknown; instructions: string | undefined; input: unknown } | undefined;
+  const provider: ModelSummaryProvider = {
+    provide: (agent, instructions, input) => {
+      provided = { agent, instructions, input };
+      return 'dynamic summary';
+    },
+  };
+  const model = new ActivityBackedModel('gpt-4o', {
+    startToCloseTimeout: '60s',
+    streamingTopic: 'events',
+    summary: provider,
+  });
+  const agent = new Agent({ name: 'A', model: 'gpt-4o' });
+  model.setAgent(agent);
+  const fake = fakeStreamActivities(events);
+  (model as any).activities = fake.activities;
+
+  const yielded = await withTrace('test', () => drain(model.getStreamedResponse(minimalRequest())));
+
+  t.is(fake.withOptions.length, 1);
+  t.is(fake.plain.length, 0);
+  t.is(fake.withOptions[0]?.opts.summary, 'dynamic summary');
+  t.is(provided?.instructions, 'sys');
+  t.is(provided?.input, 'hi');
+  t.is(provided?.agent, agent);
+  t.is(yielded.length, events.length);
+});
+
+test('getStreamedResponse: no dynamic summary uses the plain proxy call', async (t) => {
+  const events = streamingTextEvents('hi');
+  const model = new ActivityBackedModel('gpt-4o', { startToCloseTimeout: '60s', streamingTopic: 'events' });
+  const fake = fakeStreamActivities(events);
+  (model as any).activities = fake.activities;
+
+  const yielded = await withTrace('test', () => drain(model.getStreamedResponse(minimalRequest())));
+
+  t.is(fake.plain.length, 1);
+  t.is(fake.withOptions.length, 0);
+  t.is(yielded.length, events.length);
+});
+
+test.serial('getStreamedResponse: opens a generation span carrying the model name', async (t) => {
+  const events = streamingTextEvents('hi');
+  const generationModels: Array<string | undefined> = [];
+  const recorder = {
+    onTraceStart: async () => {},
+    onTraceEnd: async () => {},
+    onSpanStart: async () => {},
+    onSpanEnd: async (span: AgentSpan<SpanData>) => {
+      const d = span.spanData as { type: string; model?: string };
+      if (d.type === 'generation') generationModels.push(d.model);
+    },
+    forceFlush: async () => {},
+    shutdown: async () => {},
+  };
+  setTraceProcessors([recorder as any]);
+  getGlobalTraceProvider().setDisabled(false);
+
+  try {
+    const model = new ActivityBackedModel('gpt-4o-mini', { startToCloseTimeout: '60s', streamingTopic: 'events' });
+    (model as any).activities = fakeStreamActivities(events).activities;
+    await withTrace('test', async () => {
+      await drain(model.getStreamedResponse(minimalRequest()));
+    });
+  } finally {
+    getGlobalTraceProvider().setDisabled(true);
+  }
+
+  t.deepEqual(generationModels, ['gpt-4o-mini']);
+});

--- a/contrib/openai-agents/src/__tests__/runner-layering.test.ts
+++ b/contrib/openai-agents/src/__tests__/runner-layering.test.ts
@@ -1,0 +1,68 @@
+import test from 'ava';
+import { layerModelParams } from '../workflow/runner';
+import { DEFAULT_MODEL_ACTIVITY_OPTIONS, type ModelSummaryProvider } from '../common/model-activity-options';
+
+test('layerModelParams: header only — per-client fields win over DEFAULT', (t) => {
+  const merged = layerModelParams(undefined, { startToCloseTimeout: '99s', useLocalActivity: true });
+  t.is(merged.startToCloseTimeout, '99s');
+  t.is(merged.useLocalActivity, true);
+});
+
+test('layerModelParams: neither header nor constructor — returns DEFAULT', (t) => {
+  const merged = layerModelParams(undefined, undefined);
+  t.is(merged.startToCloseTimeout, DEFAULT_MODEL_ACTIVITY_OPTIONS.startToCloseTimeout);
+  t.is(merged.useLocalActivity, DEFAULT_MODEL_ACTIVITY_OPTIONS.useLocalActivity);
+});
+
+test('layerModelParams: constructor only, no header — header-less Workflow gets defaultModelParams', (t) => {
+  // A Schedule/UI/CLI-started Workflow has no config header, so the constructor
+  // default is the only source layered above DEFAULT.
+  const merged = layerModelParams({ startToCloseTimeout: '120s', streamingTopic: 'events' }, undefined);
+  t.is(merged.startToCloseTimeout, '120s');
+  t.is(merged.streamingTopic, 'events');
+  t.is(merged.useLocalActivity, false);
+});
+
+test('layerModelParams: both present — client overrides matching field, non-overlapping constructor fields survive', (t) => {
+  // Merge-trap regression: the header layer must carry ONLY client-set fields. If
+  // DEFAULT were pre-baked into it, DEFAULT's startToCloseTimeout/useLocalActivity
+  // would clobber the constructor's even though the client never set them.
+  const merged = layerModelParams(
+    { startToCloseTimeout: '120s', useLocalActivity: true, streamingTopic: 'events' },
+    { startToCloseTimeout: '30s' }
+  );
+  t.is(merged.startToCloseTimeout, '30s');
+  t.is(merged.streamingTopic, 'events');
+  t.is(merged.useLocalActivity, true);
+});
+
+test('layerModelParams: streamingTopic supplied only via defaultModelParams', (t) => {
+  const merged = layerModelParams({ streamingTopic: 'events' }, { startToCloseTimeout: '30s' });
+  t.is(merged.streamingTopic, 'events');
+});
+
+test('layerModelParams: an explicit undefined field never clobbers a lower layer', (t) => {
+  const merged = layerModelParams({ streamingTopic: 'events' }, {
+    streamingTopic: undefined,
+    startToCloseTimeout: '30s',
+  } as any);
+  t.is(merged.streamingTopic, 'events');
+});
+
+test('layerModelParams: a defined falsy field in the header overrides a truthy lower layer', (t) => {
+  // Guards definedFields against a truthiness check: `false` is defined and must
+  // win over the constructor's `true`, not be dropped as if it were unset.
+  const merged = layerModelParams({ useLocalActivity: true }, { useLocalActivity: false });
+  t.is(merged.useLocalActivity, false);
+});
+
+test('layerModelParams: a defined 0 in the header overrides a lower layer', (t) => {
+  const merged = layerModelParams({ streamingBatchInterval: 100 }, { streamingBatchInterval: 0 });
+  t.is(merged.streamingBatchInterval, 0);
+});
+
+test('layerModelParams: function-form summary from defaultModelParams passes through', (t) => {
+  const provider: ModelSummaryProvider = { provide: () => 'dynamic' };
+  const merged = layerModelParams({ summary: provider }, undefined);
+  t.is(merged.summary, provider);
+});

--- a/contrib/openai-agents/src/__tests__/streaming-activity.test.ts
+++ b/contrib/openai-agents/src/__tests__/streaming-activity.test.ts
@@ -1,0 +1,74 @@
+import test from 'ava';
+import type { ModelProvider, StreamEvent } from '@openai/agents-core';
+import type { Client } from '@temporalio/client';
+import { MockActivityEnvironment } from '@temporalio/testing';
+import { createModelActivity } from '../worker/activities';
+import type {
+  InvokeModelStreamActivityInput,
+  SerializedModelRequest,
+  SerializedStreamEvent,
+} from '../common/serialized-model';
+import { streamingTextEvents } from './stubs/openai-agents-fakes';
+
+function minimalRequest(): SerializedModelRequest {
+  return {
+    input: 'hi',
+    modelSettings: {},
+    tools: [],
+    toolsExplicitlyProvided: false,
+    outputType: 'text',
+    handoffs: [],
+    tracing: false,
+    overridePromptModel: false,
+  };
+}
+
+function streamingProvider(events: StreamEvent[]): ModelProvider {
+  return {
+    getModel: () => ({
+      async getResponse() {
+        throw new Error('unused');
+      },
+      async *getStreamedResponse() {
+        for (const event of events) yield event;
+      },
+    }),
+  };
+}
+
+function recordingClient(published: unknown[][]): Client {
+  return {
+    withAbortSignal: <R>(_signal: AbortSignal, fn: () => Promise<R>) => fn(),
+    workflow: {
+      getHandle: (workflowId: string) => ({
+        workflowId,
+        async signal(_name: string, input: { items: Array<{ data: string }> }) {
+          published.push(input.items);
+        },
+      }),
+    },
+  } as unknown as Client;
+}
+
+test('invokeModelStreamActivity publishes each event and returns the collected list', async (t) => {
+  const events = streamingTextEvents('hello');
+  const { invokeModelStreamActivity } = createModelActivity(streamingProvider(events));
+
+  const published: unknown[][] = [];
+  const env = new MockActivityEnvironment(undefined, { client: recordingClient(published) });
+
+  const input: InvokeModelStreamActivityInput = {
+    modelName: 'test-model',
+    request: minimalRequest(),
+    streamingTopic: 'events',
+    streamingBatchInterval: '10ms',
+  };
+
+  const returned: SerializedStreamEvent[] = await env.run(invokeModelStreamActivity, input);
+
+  t.is(returned.length, events.length, 'returns every event from the model stream');
+  t.deepEqual(returned, events as unknown[]);
+
+  const totalPublished = published.reduce((sum, batch) => sum + batch.length, 0);
+  t.is(totalPublished, events.length, 'publishes every event live to the stream topic');
+});

--- a/contrib/openai-agents/src/__tests__/stubs/openai-agents-fakes.ts
+++ b/contrib/openai-agents/src/__tests__/stubs/openai-agents-fakes.ts
@@ -59,6 +59,65 @@ export class FakeModelProvider implements ModelProvider {
   }
 }
 
+/**
+ * Build a deterministic stream-event sequence for `text`: one text-delta event
+ * followed by the terminal `response_done` event the agents run loop turns into
+ * the final `ModelResponse`.
+ */
+export function streamingTextEvents(text: string): StreamEvent[] {
+  const output: AgentOutputItem[] = [
+    {
+      type: 'message',
+      id: 'msg_fake_stream_001',
+      role: 'assistant',
+      content: [{ type: 'output_text', text }],
+      status: 'completed',
+    },
+  ];
+  return [
+    { type: 'output_text_delta', delta: text },
+    {
+      type: 'response_done',
+      response: {
+        id: 'resp_fake_stream_001',
+        usage: {
+          requests: 1,
+          inputTokens: 10,
+          outputTokens: text.length,
+          totalTokens: 10 + text.length,
+        },
+        output,
+      },
+    },
+  ] as StreamEvent[];
+}
+
+export class StreamingFakeModel implements Model {
+  constructor(private readonly events: StreamEvent[]) {}
+
+  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+    throw new Error('StreamingFakeModel only supports getStreamedResponse');
+  }
+
+  async *getStreamedResponse(_request: ModelRequest): AsyncIterable<StreamEvent> {
+    for (const event of this.events) {
+      yield event;
+    }
+  }
+}
+
+export class StreamingFakeModelProvider implements ModelProvider {
+  private readonly model: StreamingFakeModel;
+
+  constructor(events: StreamEvent[]) {
+    this.model = new StreamingFakeModel(events);
+  }
+
+  getModel(_name?: string): Model {
+    return this.model;
+  }
+}
+
 function fakeUsage(outputTokens: number): Usage {
   return new Usage({
     requests: 1,

--- a/contrib/openai-agents/src/__tests__/test-openai-agents.ts
+++ b/contrib/openai-agents/src/__tests__/test-openai-agents.ts
@@ -21,6 +21,7 @@ import {
   statefulMcpHeartbeatTimeoutWorkflow,
   statefulMcpSlowConnectHeartbeatWorkflow,
   streamingAgentWorkflow,
+  streamingLocalActivityWorkflow,
   streamingNoTopicWorkflow,
 } from './workflows/openai-agents';
 import { makeTestFunction } from './helpers/test-fn';
@@ -493,5 +494,33 @@ test('Streaming: missing streamingTopic fails fast before scheduling an Activity
           e.activityTaskScheduledEventAttributes?.activityType?.name === 'invokeModelStreamActivity'
       ) ?? [];
     t.is(modelStreamScheduled.length, 0, 'no streaming Activity should be scheduled when the topic is unset');
+  });
+});
+
+test('Streaming: useLocalActivity fails fast before scheduling an Activity', async (t) => {
+  const { createWorker, taskQueue } = helpers(t);
+
+  const worker = await createWorker({
+    plugins: [
+      new OpenAIAgentsPlugin({
+        modelProvider: new StreamingFakeModelProvider(streamingTextEvents('unused')),
+      }),
+    ],
+  });
+
+  const wfClient = new WorkflowClient({
+    connection: (t.context as any).env.connection,
+  });
+
+  await worker.runUntil(async () => {
+    const handle = await wfClient.start(streamingLocalActivityWorkflow, {
+      taskQueue,
+      workflowId: `streaming-local-activity-${Date.now()}`,
+      args: ['Hi'],
+      workflowExecutionTimeout: '30 seconds',
+    });
+
+    const result = await handle.result();
+    t.is(result, 'StreamingLocalActivityUnsupported');
   });
 });

--- a/contrib/openai-agents/src/__tests__/test-openai-agents.ts
+++ b/contrib/openai-agents/src/__tests__/test-openai-agents.ts
@@ -5,6 +5,7 @@ import type { MCPServer } from '@openai/agents-core';
 import { WorkflowClient } from '@temporalio/client';
 import { temporal } from '@temporalio/proto';
 import { helpers } from '@temporalio/test-helpers';
+import { WorkflowStreamClient } from '@temporalio/workflow-streams/client';
 import {
   OpenAIAgentsPlugin,
   OpenAIAgentsTraceClientInterceptor,
@@ -19,9 +20,12 @@ import {
   statefulMcpIsolationWorkflow,
   statefulMcpHeartbeatTimeoutWorkflow,
   statefulMcpSlowConnectHeartbeatWorkflow,
+  streamingAgentWorkflow,
+  streamingNoTopicWorkflow,
 } from './workflows/openai-agents';
 import { makeTestFunction } from './helpers/test-fn';
 import { FakeModelProvider, textResponse, toolCallResponse } from './stubs/openai-agents';
+import { StreamingFakeModelProvider, streamingTextEvents } from './stubs/openai-agents-fakes';
 import EventType = temporal.api.enums.v1.EventType;
 
 // Upstream auto-disables agent-SDK tracing under NODE_ENV=test; opt back in for the integration tests.
@@ -395,5 +399,99 @@ test('Stateful MCP: slow connect heartbeat regression', async (t) => {
     const result = await handle.result();
     t.regex(result, /^connected:/, `Expected connected:N result, got: ${result}`);
     t.true(connectCallCount > 0, 'connect() should have been called');
+  });
+});
+
+test('Streaming: external subscriber and in-workflow result see the same events', async (t) => {
+  const { createWorker, taskQueue } = helpers(t);
+
+  const events = streamingTextEvents('Hello streamed world');
+  const worker = await createWorker({
+    plugins: [
+      new OpenAIAgentsPlugin({
+        modelProvider: new StreamingFakeModelProvider(events),
+        modelParams: { streamingTopic: 'events', streamingBatchInterval: '50ms' },
+      }),
+    ],
+  });
+
+  // Match the modelParams the plugin uses so the config header carries streamingTopic.
+  const wfClient = new WorkflowClient({
+    connection: (t.context as any).env.connection,
+    interceptors: [
+      new OpenAIAgentsTraceClientInterceptor({
+        modelParams: { streamingTopic: 'events', streamingBatchInterval: '50ms' },
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const handle = await wfClient.start(streamingAgentWorkflow, {
+      taskQueue,
+      workflowId: `streaming-${Date.now()}`,
+      args: ['Hi'],
+      workflowExecutionTimeout: '30 seconds',
+    });
+
+    const streamClient = WorkflowStreamClient.create(t.context.env.client, handle.workflowId);
+    const received: Array<{ type?: string; delta?: string }> = [];
+    const gen = streamClient.topic<{ type?: string; delta?: string }>('events').subscribe(0, { pollCooldown: 0 });
+    const collect = (async () => {
+      for await (const item of gen) {
+        received.push(item.data);
+        if (received.length >= events.length) {
+          await gen.return();
+          break;
+        }
+      }
+    })();
+
+    const result = await handle.result();
+    await collect;
+
+    t.deepEqual(result.deltas, ['Hello streamed world'], 'in-workflow result yields the text deltas in order');
+    t.is(result.finalOutput, 'Hello streamed world');
+
+    t.is(received.length, events.length, 'external subscriber receives every published event in order');
+    t.is(received[0]!.type, 'output_text_delta');
+    t.is(received[0]!.delta, 'Hello streamed world');
+    t.is(received[received.length - 1]!.type, 'response_done');
+  });
+});
+
+test('Streaming: missing streamingTopic fails fast before scheduling an Activity', async (t) => {
+  const { createWorker, taskQueue } = helpers(t);
+
+  const worker = await createWorker({
+    plugins: [
+      new OpenAIAgentsPlugin({
+        modelProvider: new StreamingFakeModelProvider(streamingTextEvents('unused')),
+      }),
+    ],
+  });
+
+  const wfClient = new WorkflowClient({
+    connection: (t.context as any).env.connection,
+  });
+
+  await worker.runUntil(async () => {
+    const handle = await wfClient.start(streamingNoTopicWorkflow, {
+      taskQueue,
+      workflowId: `streaming-no-topic-${Date.now()}`,
+      args: ['Hi'],
+      workflowExecutionTimeout: '30 seconds',
+    });
+
+    const result = await handle.result();
+    t.is(result, 'StreamingTopicNotConfigured');
+
+    const { events } = await handle.fetchHistory();
+    const modelStreamScheduled =
+      events?.filter(
+        (e) =>
+          e.eventType === EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED &&
+          e.activityTaskScheduledEventAttributes?.activityType?.name === 'invokeModelStreamActivity'
+      ) ?? [];
+    t.is(modelStreamScheduled.length, 0, 'no streaming Activity should be scheduled when the topic is unset');
   });
 });

--- a/contrib/openai-agents/src/__tests__/workflows/openai-agents.ts
+++ b/contrib/openai-agents/src/__tests__/workflows/openai-agents.ts
@@ -1,6 +1,54 @@
 import { Agent } from '@openai/agents-core';
 import { ApplicationFailure } from '@temporalio/workflow';
+import { WorkflowStream } from '@temporalio/workflow-streams/workflow';
 import { TemporalOpenAIRunner, statelessMcpServer, statefulMcpServer } from '../../workflow';
+
+export interface StreamingAgentResult {
+  finalOutput: string;
+  /** `output_text_delta` deltas observed in-workflow, in order. */
+  deltas: string[];
+}
+
+export async function streamingAgentWorkflow(prompt: string): Promise<StreamingAgentResult> {
+  new WorkflowStream();
+  const agent = new Agent({
+    name: 'StreamingAgent',
+    instructions: 'You are a helpful assistant.',
+    model: 'gpt-4o-mini',
+  });
+  const runner = new TemporalOpenAIRunner();
+  const result = await runner.run(agent, prompt, { stream: true });
+
+  const deltas: string[] = [];
+  for await (const event of result) {
+    if (event.type === 'raw_model_stream_event' && event.data.type === 'output_text_delta') {
+      deltas.push(event.data.delta);
+    }
+  }
+  await result.completed;
+  return { finalOutput: result.finalOutput ?? '', deltas };
+}
+
+export async function streamingNoTopicWorkflow(prompt: string): Promise<string> {
+  new WorkflowStream();
+  const agent = new Agent({
+    name: 'StreamingAgent',
+    instructions: 'You are a helpful assistant.',
+    model: 'gpt-4o-mini',
+  });
+  const runner = new TemporalOpenAIRunner();
+  try {
+    const result = await runner.run(agent, prompt, { stream: true });
+    for await (const _event of result);
+    await result.completed;
+    return 'unexpected-success';
+  } catch (err: unknown) {
+    if (err instanceof ApplicationFailure) {
+      return `${err.type}`;
+    }
+    throw err;
+  }
+}
 
 export async function localActivityAgentWorkflow(prompt: string): Promise<string> {
   const agent = new Agent({

--- a/contrib/openai-agents/src/__tests__/workflows/openai-agents.ts
+++ b/contrib/openai-agents/src/__tests__/workflows/openai-agents.ts
@@ -50,6 +50,29 @@ export async function streamingNoTopicWorkflow(prompt: string): Promise<string> 
   }
 }
 
+export async function streamingLocalActivityWorkflow(prompt: string): Promise<string> {
+  new WorkflowStream();
+  const agent = new Agent({
+    name: 'StreamingAgent',
+    instructions: 'You are a helpful assistant.',
+    model: 'gpt-4o-mini',
+  });
+  const runner = new TemporalOpenAIRunner({
+    defaultModelParams: { streamingTopic: 'events', useLocalActivity: true },
+  });
+  try {
+    const result = await runner.run(agent, prompt, { stream: true });
+    for await (const _event of result);
+    await result.completed;
+    return 'unexpected-success';
+  } catch (err: unknown) {
+    if (err instanceof ApplicationFailure) {
+      return `${err.type}`;
+    }
+    throw err;
+  }
+}
+
 export async function localActivityAgentWorkflow(prompt: string): Promise<string> {
   const agent = new Agent({
     name: 'LocalActivityAgent',

--- a/contrib/openai-agents/src/common/model-activity-options.ts
+++ b/contrib/openai-agents/src/common/model-activity-options.ts
@@ -54,6 +54,7 @@ export const DEFAULT_MODEL_ACTIVITY_OPTIONS: SerializableModelActivityOptions = 
 export const STREAMING_TOPIC_NOT_CONFIGURED = {
   type: 'StreamingTopicNotConfigured',
   message:
-    'Streaming requires modelParams.streamingTopic to be set on OpenAIAgentsPlugin. ' +
-    'Host a WorkflowStream in your Workflow and configure the topic to use run(agent, input, { stream: true }).',
+    "Streaming requires a streamingTopic. Set it via the plugin's modelParams on the client, " +
+    "or via the runner's defaultModelParams (new TemporalOpenAIRunner({ defaultModelParams: { streamingTopic } })). " +
+    'Host a WorkflowStream in your Workflow to use run(agent, input, { stream: true }).',
 } as const;

--- a/contrib/openai-agents/src/common/model-activity-options.ts
+++ b/contrib/openai-agents/src/common/model-activity-options.ts
@@ -1,5 +1,5 @@
 import type { Agent, AgentInputItem } from '@openai/agents-core';
-import type { ActivityOptions } from '@temporalio/common';
+import type { ActivityOptions, Duration } from '@temporalio/common';
 
 export interface ModelSummaryProvider {
   /**
@@ -18,6 +18,22 @@ export interface ModelActivityOptions extends Omit<ActivityOptions, 'summary'> {
   useLocalActivity?: boolean;
   /** Activity summary shown in the Temporal UI. String for static text, ModelSummaryProvider for dynamic. */
   summary?: string | ModelSummaryProvider;
+  /**
+   * Topic that the streaming model Activity publishes raw model stream events to
+   * for live external consumption. Required when running with `{ stream: true }`;
+   * `run()` throws before scheduling any Activity if it is unset. The Workflow must
+   * host a `WorkflowStream` (from `@temporalio/workflow-streams/workflow`) to receive
+   * the publishes.
+   *
+   * @experimental Streaming support is experimental and may change without notice.
+   */
+  streamingTopic?: string;
+  /**
+   * Batch flush interval for the stream publisher used by the streaming Activity.
+   *
+   * @experimental Streaming support is experimental and may change without notice.
+   */
+  streamingBatchInterval?: Duration;
 }
 
 /**
@@ -34,3 +50,10 @@ export const DEFAULT_MODEL_ACTIVITY_OPTIONS: SerializableModelActivityOptions = 
   startToCloseTimeout: '60s',
   useLocalActivity: false,
 };
+
+export const STREAMING_TOPIC_NOT_CONFIGURED = {
+  type: 'StreamingTopicNotConfigured',
+  message:
+    'Streaming requires modelParams.streamingTopic to be set on OpenAIAgentsPlugin. ' +
+    'Host a WorkflowStream in your Workflow and configure the topic to use run(agent, input, { stream: true }).',
+} as const;

--- a/contrib/openai-agents/src/common/model-activity-options.ts
+++ b/contrib/openai-agents/src/common/model-activity-options.ts
@@ -58,3 +58,11 @@ export const STREAMING_TOPIC_NOT_CONFIGURED = {
     "or via the runner's defaultModelParams (new TemporalOpenAIRunner({ defaultModelParams: { streamingTopic } })). " +
     'Host a WorkflowStream in your Workflow to use run(agent, input, { stream: true }).',
 } as const;
+
+export const STREAMING_LOCAL_ACTIVITY_UNSUPPORTED = {
+  type: 'StreamingLocalActivityUnsupported',
+  message:
+    'Streaming is incompatible with useLocalActivity. Local Activities cannot heartbeat, so a ' +
+    'long-running streaming model call cannot extend past its startToCloseTimeout. ' +
+    'Set useLocalActivity: false (the default) for streaming runs.',
+} as const;

--- a/contrib/openai-agents/src/common/serialized-model.ts
+++ b/contrib/openai-agents/src/common/serialized-model.ts
@@ -1,4 +1,10 @@
-import type { ModelSettings, SerializedHandoff, SerializedOutputType, SerializedTool } from '@openai/agents-core';
+import type {
+  ModelSettings,
+  SerializedHandoff,
+  SerializedOutputType,
+  SerializedTool,
+  StreamEvent,
+} from '@openai/agents-core';
 
 export type JsonValue = null | string | number | boolean | JsonValue[] | { [k: string]: JsonValue };
 
@@ -29,4 +35,24 @@ export interface SerializedModelResponse {
 export interface InvokeModelActivityInput {
   modelName: string;
   request: SerializedModelRequest;
+}
+
+export type SerializedStreamEvent = JsonValue;
+
+// StreamEvents are JSON-by-construction (zod-inferred), so the cast is a no-op at
+// runtime. Centralize it here so the boundary assumption is documented, not scattered.
+export function toSerializedStreamEvent(event: StreamEvent): SerializedStreamEvent {
+  return event as unknown as SerializedStreamEvent;
+}
+
+export function fromSerializedStreamEvent(event: SerializedStreamEvent): StreamEvent {
+  return event as unknown as StreamEvent;
+}
+
+export interface InvokeModelStreamActivityInput {
+  modelName: string;
+  request: SerializedModelRequest;
+  streamingTopic: string;
+  /** Stream publisher batch flush interval, as a Duration string. */
+  streamingBatchInterval?: string;
 }

--- a/contrib/openai-agents/src/worker/activities.ts
+++ b/contrib/openai-agents/src/worker/activities.ts
@@ -1,11 +1,15 @@
-import type { AgentInputItem, ModelProvider, ModelRequest, ModelResponse } from '@openai/agents-core';
+import type { AgentInputItem, ModelProvider, ModelRequest, ModelResponse, StreamEvent } from '@openai/agents-core';
 import { APIError } from 'openai';
-import { ApplicationFailure } from '@temporalio/common';
+import { ApplicationFailure, type Duration } from '@temporalio/common';
+import { WorkflowStreamClient } from '@temporalio/workflow-streams/client';
 import {
+  toSerializedStreamEvent,
   type InvokeModelActivityInput,
+  type InvokeModelStreamActivityInput,
   type JsonValue,
   type SerializedModelRequest,
   type SerializedModelResponse,
+  type SerializedStreamEvent,
 } from '../common/serialized-model';
 import { startAdaptiveHeartbeat } from './heartbeat';
 
@@ -53,12 +57,76 @@ function fromSerializedModelRequest(wire: SerializedModelRequest): ModelRequest 
   };
 }
 
+function toModelInvocationFailure(error: unknown): ApplicationFailure {
+  if (error instanceof APIError) {
+    const status = error.status;
+    const headers = error.headers;
+
+    // Prefer retry-after-ms (ms precision) over Retry-After (seconds).
+    let nextRetryDelay: number | undefined;
+    if (headers) {
+      const ms = headers.get('retry-after-ms');
+      if (ms) {
+        const parsed = parseFloat(ms);
+        if (!Number.isNaN(parsed)) nextRetryDelay = parsed;
+      }
+      if (nextRetryDelay === undefined) {
+        const s = headers.get('retry-after');
+        if (s) {
+          const parsed = parseFloat(s);
+          if (!Number.isNaN(parsed)) nextRetryDelay = parsed * 1000;
+        }
+      }
+    }
+
+    // `x-should-retry` overrides status-based classification.
+    let nonRetryable: boolean;
+    const shouldRetry = headers?.get('x-should-retry');
+    if (shouldRetry === 'true') {
+      nonRetryable = false;
+    } else if (shouldRetry === 'false') {
+      nonRetryable = true;
+    } else if (status !== undefined && (status === 408 || status === 409 || status === 429 || status >= 500)) {
+      nonRetryable = false;
+    } else {
+      nonRetryable = true;
+    }
+
+    let type: string;
+    if (status === 429) type = 'ModelInvocationError.RateLimit';
+    else if (status === 401 || status === 403) type = 'ModelInvocationError.Authentication';
+    else if (status === 400 || status === 422) type = 'ModelInvocationError.BadRequest';
+    else if (status === 408) type = 'ModelInvocationError.Timeout';
+    else if (status === 409) type = 'ModelInvocationError.Conflict';
+    else if (status !== undefined && status >= 500) type = 'ModelInvocationError.ServerError';
+    else type = 'ModelInvocationError';
+
+    return ApplicationFailure.create({
+      message: `Model invocation failed: ${error.message}`,
+      type,
+      nonRetryable,
+      cause: error,
+      ...(nextRetryDelay !== undefined ? { nextRetryDelay } : {}),
+    });
+  }
+
+  // Non-APIError: wrap and let Temporal's retry policy decide.
+  const message = error instanceof Error ? error.message : String(error);
+  return ApplicationFailure.create({
+    message: `Model invocation failed: ${message}`,
+    type: 'ModelInvocationError',
+    nonRetryable: false,
+    cause: error instanceof Error ? error : new Error(String(error)),
+  });
+}
+
 /**
  * Creates the model Activity functions registered with the Worker. Activities
  * use the provided ModelProvider to resolve models and execute LLM calls.
  */
 export function createModelActivity(modelProvider: ModelProvider): {
   invokeModelActivity: (input: InvokeModelActivityInput) => Promise<SerializedModelResponse>;
+  invokeModelStreamActivity: (input: InvokeModelStreamActivityInput) => Promise<SerializedStreamEvent[]>;
 } {
   return {
     async invokeModelActivity(input: InvokeModelActivityInput): Promise<SerializedModelResponse> {
@@ -72,66 +140,48 @@ export function createModelActivity(modelProvider: ModelProvider): {
         const response = await model.getResponse(fromSerializedModelRequest(input.request));
         return toSerializedModelResponse(response);
       } catch (error) {
-        if (error instanceof APIError) {
-          const status = error.status;
-          const headers = error.headers;
+        throw toModelInvocationFailure(error);
+      } finally {
+        stopHeartbeat();
+      }
+    },
 
-          // Prefer retry-after-ms (ms precision) over Retry-After (seconds).
-          let nextRetryDelay: number | undefined;
-          if (headers) {
-            const ms = headers.get('retry-after-ms');
-            if (ms) {
-              const parsed = parseFloat(ms);
-              if (!Number.isNaN(parsed)) nextRetryDelay = parsed;
-            }
-            if (nextRetryDelay === undefined) {
-              const s = headers.get('retry-after');
-              if (s) {
-                const parsed = parseFloat(s);
-                if (!Number.isNaN(parsed)) nextRetryDelay = parsed * 1000;
-              }
-            }
+    async invokeModelStreamActivity(input: InvokeModelStreamActivityInput): Promise<SerializedStreamEvent[]> {
+      const stopHeartbeat = startAdaptiveHeartbeat();
+
+      try {
+        const model = await Promise.resolve(modelProvider.getModel(input.modelName));
+        const events: SerializedStreamEvent[] = [];
+        const stream = WorkflowStreamClient.fromWithinActivity(
+          input.streamingBatchInterval !== undefined
+            ? { batchInterval: input.streamingBatchInterval as Duration }
+            : undefined
+        );
+        const topic = stream.topic<StreamEvent>(input.streamingTopic);
+
+        // Drain the publisher explicitly rather than via `await using` so a model
+        // error always wins over a secondary flush failure: a model error rethrows
+        // even if the drain also throws; a clean run still surfaces drain failures.
+        let modelError: unknown;
+        try {
+          for await (const event of model.getStreamedResponse(fromSerializedModelRequest(input.request))) {
+            events.push(toSerializedStreamEvent(event));
+            topic.publish(event);
           }
-
-          // `x-should-retry` overrides status-based classification.
-          let nonRetryable: boolean;
-          const shouldRetry = headers?.get('x-should-retry');
-          if (shouldRetry === 'true') {
-            nonRetryable = false;
-          } else if (shouldRetry === 'false') {
-            nonRetryable = true;
-          } else if (status !== undefined && (status === 408 || status === 409 || status === 429 || status >= 500)) {
-            nonRetryable = false;
-          } else {
-            nonRetryable = true;
-          }
-
-          let type: string;
-          if (status === 429) type = 'ModelInvocationError.RateLimit';
-          else if (status === 401 || status === 403) type = 'ModelInvocationError.Authentication';
-          else if (status === 400 || status === 422) type = 'ModelInvocationError.BadRequest';
-          else if (status === 408) type = 'ModelInvocationError.Timeout';
-          else if (status === 409) type = 'ModelInvocationError.Conflict';
-          else if (status !== undefined && status >= 500) type = 'ModelInvocationError.ServerError';
-          else type = 'ModelInvocationError';
-
-          throw ApplicationFailure.create({
-            message: `Model invocation failed: ${error.message}`,
-            type,
-            nonRetryable,
-            cause: error,
-            ...(nextRetryDelay !== undefined ? { nextRetryDelay } : {}),
-          });
+        } catch (error) {
+          modelError = error;
         }
 
-        // Non-APIError: wrap and let Temporal's retry policy decide.
-        const message = error instanceof Error ? error.message : String(error);
-        throw ApplicationFailure.create({
-          message: `Model invocation failed: ${message}`,
-          type: 'ModelInvocationError',
-          nonRetryable: false,
-          cause: error instanceof Error ? error : new Error(String(error)),
-        });
+        try {
+          await stream[Symbol.asyncDispose]();
+        } catch (drainError) {
+          if (modelError === undefined) throw drainError;
+        }
+        if (modelError !== undefined) throw modelError;
+
+        return events;
+      } catch (error) {
+        throw toModelInvocationFailure(error);
       } finally {
         stopHeartbeat();
       }

--- a/contrib/openai-agents/src/workflow.ts
+++ b/contrib/openai-agents/src/workflow.ts
@@ -1,6 +1,6 @@
 // Workflow-safe exports — importable from Workflow code running in the V8 sandbox.
 export { TemporalOpenAIRunner } from './workflow/runner';
-export type { TemporalRunOptions } from './workflow/runner';
+export type { TemporalRunOptions, TemporalOpenAIRunnerOptions } from './workflow/runner';
 export { activityAsTool, ToolSerializationError } from './workflow/tools';
 export type { ActivityToolDefinition, ActivityAsToolOptions, JsonObjectSchema } from './workflow/tools';
 export { WorkflowSafeMemorySession } from './workflow/session';

--- a/contrib/openai-agents/src/workflow/activity-backed-model.ts
+++ b/contrib/openai-agents/src/workflow/activity-backed-model.ts
@@ -147,9 +147,21 @@ export class ActivityBackedModel implements Model {
       }),
     };
 
+    const events = await withGenerationSpan(async (span) => {
+      span.spanData.model = this.modelName;
+
+      const modelSummary = this.modelParams.summary;
+      if (modelSummary && typeof modelSummary !== 'string') {
+        const provider = modelSummary as ModelSummaryProvider;
+        const summary = provider.provide(this.agent, request.systemInstructions, request.input);
+        return this.activities.invokeModelStreamActivity.executeWithOptions({ summary }, [input]);
+      }
+
+      return this.activities.invokeModelStreamActivity(input);
+    });
+
     // The Activity collects and returns the full event list; yielding from that
     // return value (rather than polling the live stream) keeps replay deterministic.
-    const events = await this.activities.invokeModelStreamActivity(input);
     for (const event of events) {
       yield fromSerializedStreamEvent(event);
     }

--- a/contrib/openai-agents/src/workflow/activity-backed-model.ts
+++ b/contrib/openai-agents/src/workflow/activity-backed-model.ts
@@ -15,13 +15,20 @@ import {
   type ActivityInterfaceFor,
   type LocalActivityInterfaceFor,
 } from '@temporalio/workflow';
-import type { ActivityOptions, LocalActivityOptions } from '@temporalio/common';
-import type { ModelActivityOptions, ModelSummaryProvider } from '../common/model-activity-options';
+import { ApplicationFailure, type ActivityOptions, type LocalActivityOptions } from '@temporalio/common';
 import {
+  STREAMING_TOPIC_NOT_CONFIGURED,
+  type ModelActivityOptions,
+  type ModelSummaryProvider,
+} from '../common/model-activity-options';
+import {
+  fromSerializedStreamEvent,
   type InvokeModelActivityInput,
+  type InvokeModelStreamActivityInput,
   type JsonValue,
   type SerializedModelRequest,
   type SerializedModelResponse,
+  type SerializedStreamEvent,
 } from '../common/serialized-model';
 
 export function toSerializedModelRequest(request: ModelRequest): SerializedModelRequest {
@@ -52,6 +59,7 @@ function fromSerializedModelResponse(wire: SerializedModelResponse): ModelRespon
 
 interface ModelActivities {
   invokeModelActivity(input: InvokeModelActivityInput): Promise<SerializedModelResponse>;
+  invokeModelStreamActivity(input: InvokeModelStreamActivityInput): Promise<SerializedStreamEvent[]>;
 }
 
 /**
@@ -117,10 +125,33 @@ export class ActivityBackedModel implements Model {
     });
   }
 
-  // eslint-disable-next-line require-yield
-  async *getStreamedResponse(_request: ModelRequest): AsyncIterable<StreamEvent> {
-    throw new Error(
-      'Streaming is not supported in Temporal workflows. ' + 'Use non-streaming mode with TemporalOpenAIRunner.'
-    );
+  async *getStreamedResponse(request: ModelRequest): AsyncIterable<StreamEvent> {
+    const streamingTopic = this.modelParams.streamingTopic;
+    if (streamingTopic === undefined) {
+      throw ApplicationFailure.create({
+        message: STREAMING_TOPIC_NOT_CONFIGURED.message,
+        type: STREAMING_TOPIC_NOT_CONFIGURED.type,
+        nonRetryable: true,
+      });
+    }
+
+    const input: InvokeModelStreamActivityInput = {
+      modelName: this.modelName,
+      request: toSerializedModelRequest(request),
+      streamingTopic,
+      ...(this.modelParams.streamingBatchInterval !== undefined && {
+        streamingBatchInterval:
+          typeof this.modelParams.streamingBatchInterval === 'number'
+            ? `${this.modelParams.streamingBatchInterval}ms`
+            : this.modelParams.streamingBatchInterval,
+      }),
+    };
+
+    // The Activity collects and returns the full event list; yielding from that
+    // return value (rather than polling the live stream) keeps replay deterministic.
+    const events = await this.activities.invokeModelStreamActivity(input);
+    for (const event of events) {
+      yield fromSerializedStreamEvent(event);
+    }
   }
 }

--- a/contrib/openai-agents/src/workflow/load-polyfills.ts
+++ b/contrib/openai-agents/src/workflow/load-polyfills.ts
@@ -54,6 +54,12 @@ export function installPolyfills(): void {
     (globalThis as any).crypto.randomUUID = (): string => uuid4();
   }
 
+  // The sandbox exposes AbortController but not the AbortSignal global; agents-core's
+  // streaming path references AbortSignal directly. Derive it from a controller's signal.
+  if (typeof (globalThis as any).AbortSignal === 'undefined' && typeof globalThis.AbortController !== 'undefined') {
+    (globalThis as any).AbortSignal = new globalThis.AbortController().signal.constructor;
+  }
+
   if (typeof (globalThis as any).EventTarget === 'undefined') {
     (globalThis as any).EventTarget = EventTargetPolyfill;
   }

--- a/contrib/openai-agents/src/workflow/runner.ts
+++ b/contrib/openai-agents/src/workflow/runner.ts
@@ -13,10 +13,15 @@ import {
   type RunResult,
   type Session,
   type SessionInputCallback,
+  type StreamedRunResult,
   type TracingConfig,
 } from '@openai/agents-core';
 import { ApplicationFailure } from '@temporalio/common';
-import { DEFAULT_MODEL_ACTIVITY_OPTIONS, type ModelActivityOptions } from '../common/model-activity-options';
+import {
+  DEFAULT_MODEL_ACTIVITY_OPTIONS,
+  STREAMING_TOPIC_NOT_CONFIGURED,
+  type ModelActivityOptions,
+} from '../common/model-activity-options';
 import { unwrapTemporalFailure } from '../common/errors';
 import { convertAgent } from './convert-agent';
 import { ensureTracingProcessorRegistered } from './tracing';
@@ -40,6 +45,14 @@ export interface TemporalRunOptions<TContext = undefined> {
   callModelInputFilter?: CallModelInputFilter;
   /** Per-run tracing config override */
   tracing?: TracingConfig;
+  /**
+   * Stream incremental events as the model responds. Requires
+   * `modelParams.streamingTopic` to be configured on the plugin and a hosted
+   * `WorkflowStream` in the Workflow.
+   *
+   * @experimental Streaming support is experimental and may change without notice.
+   */
+  stream?: boolean;
   // signal intentionally omitted — use Temporal CancellationScope for Workflow cancellation
 
   /** Runner-level config overrides */
@@ -72,8 +85,10 @@ export interface TemporalRunOptions<TContext = undefined> {
 /**
  * A Temporal-aware agent runner that delegates model calls to Activities.
  *
- * Streaming is not supported in Temporal Workflows because Activities are
- * request-response. Use run() for all agent invocations.
+ * Use `run(agent, input)` for request-response runs. Pass `{ stream: true }` to
+ * stream incremental events as the model responds — the returned
+ * `StreamedRunResult` is async-iterable. Streaming requires
+ * `modelParams.streamingTopic` and a hosted `WorkflowStream` in the Workflow.
  */
 export class TemporalOpenAIRunner {
   private readonly modelParams: ModelActivityOptions;
@@ -89,17 +104,37 @@ export class TemporalOpenAIRunner {
    * deserialized `RunState` to resume a previous run across `continueAsNew`.
    * Capture the current `RunState` via `result.state.toString()`.
    */
+  run<TAgent extends Agent<any, any>, TContext = undefined>(
+    agent: TAgent,
+    input: string | AgentInputItem[] | RunState<TContext, TAgent>,
+    options?: TemporalRunOptions<TContext> & { stream?: false }
+  ): Promise<RunResult<any, TAgent>>;
+  run<TAgent extends Agent<any, any>, TContext = undefined>(
+    agent: TAgent,
+    input: string | AgentInputItem[] | RunState<TContext, TAgent>,
+    options: TemporalRunOptions<TContext> & { stream: true }
+  ): Promise<StreamedRunResult<TContext, TAgent>>;
   async run<TAgent extends Agent<any, any>, TContext = undefined>(
     agent: TAgent,
     input: string | AgentInputItem[] | RunState<TContext, TAgent>,
     options?: TemporalRunOptions<TContext>
-  ): Promise<RunResult<any, TAgent>> {
+  ): Promise<RunResult<any, TAgent> | StreamedRunResult<TContext, TAgent>> {
     const session = options?.session;
     if (session instanceof MemorySession) {
       throw ApplicationFailure.create({
         message:
           'Pass WorkflowSafeMemorySession to TemporalOpenAIRunner.run({ session }); the upstream MemorySession is not safe inside a Workflow (heap-only state without Temporal Event History backing). See @temporalio/openai-agents/workflow.',
         type: 'UnsafeSessionError',
+        nonRetryable: true,
+      });
+    }
+
+    // Fail fast before the upstream streaming runner starts, so a missing topic
+    // surfaces as a clean error rather than being captured into the streamed result.
+    if (options?.stream === true && this.modelParams.streamingTopic === undefined) {
+      throw ApplicationFailure.create({
+        message: STREAMING_TOPIC_NOT_CONFIGURED.message,
+        type: STREAMING_TOPIC_NOT_CONFIGURED.type,
         nonRetryable: true,
       });
     }
@@ -122,17 +157,25 @@ export class TemporalOpenAIRunner {
 
     const innerRunner = new Runner({ ...runnerConfigOverrides });
 
+    const sharedRunOptions = {
+      maxTurns: options?.maxTurns,
+      context: options?.context,
+      previousResponseId: options?.previousResponseId,
+      conversationId: options?.conversationId,
+      session: options?.session,
+      sessionInputCallback: options?.sessionInputCallback,
+      callModelInputFilter: options?.callModelInputFilter,
+      tracing: options?.tracing,
+    };
+
     try {
-      return (await innerRunner.run(converted, preparedInput as any, {
-        maxTurns: options?.maxTurns,
-        context: options?.context,
-        previousResponseId: options?.previousResponseId,
-        conversationId: options?.conversationId,
-        session: options?.session,
-        sessionInputCallback: options?.sessionInputCallback,
-        callModelInputFilter: options?.callModelInputFilter,
-        tracing: options?.tracing,
-      })) as RunResult<any, TAgent>;
+      if (options?.stream === true) {
+        return (await innerRunner.run(converted, preparedInput as any, {
+          ...sharedRunOptions,
+          stream: true,
+        })) as StreamedRunResult<TContext, TAgent>;
+      }
+      return (await innerRunner.run(converted, preparedInput as any, sharedRunOptions)) as RunResult<any, TAgent>;
     } catch (error) {
       throw normalizeAgentsRunError(error);
     } finally {

--- a/contrib/openai-agents/src/workflow/runner.ts
+++ b/contrib/openai-agents/src/workflow/runner.ts
@@ -19,6 +19,7 @@ import {
 import { ApplicationFailure } from '@temporalio/common';
 import {
   DEFAULT_MODEL_ACTIVITY_OPTIONS,
+  STREAMING_LOCAL_ACTIVITY_UNSUPPORTED,
   STREAMING_TOPIC_NOT_CONFIGURED,
   type ModelActivityOptions,
   type SerializableModelActivityOptions,
@@ -174,6 +175,14 @@ export class TemporalOpenAIRunner {
       throw ApplicationFailure.create({
         message: STREAMING_TOPIC_NOT_CONFIGURED.message,
         type: STREAMING_TOPIC_NOT_CONFIGURED.type,
+        nonRetryable: true,
+      });
+    }
+
+    if (options?.stream === true && this.modelParams.useLocalActivity === true) {
+      throw ApplicationFailure.create({
+        message: STREAMING_LOCAL_ACTIVITY_UNSUPPORTED.message,
+        type: STREAMING_LOCAL_ACTIVITY_UNSUPPORTED.type,
         nonRetryable: true,
       });
     }

--- a/contrib/openai-agents/src/workflow/runner.ts
+++ b/contrib/openai-agents/src/workflow/runner.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_MODEL_ACTIVITY_OPTIONS,
   STREAMING_TOPIC_NOT_CONFIGURED,
   type ModelActivityOptions,
+  type SerializableModelActivityOptions,
 } from '../common/model-activity-options';
 import { unwrapTemporalFailure } from '../common/errors';
 import { convertAgent } from './convert-agent';
@@ -46,9 +47,9 @@ export interface TemporalRunOptions<TContext = undefined> {
   /** Per-run tracing config override */
   tracing?: TracingConfig;
   /**
-   * Stream incremental events as the model responds. Requires
-   * `modelParams.streamingTopic` to be configured on the plugin and a hosted
-   * `WorkflowStream` in the Workflow.
+   * Stream incremental events as the model responds. Requires a `streamingTopic`
+   * (set via the plugin's `modelParams` or the runner's `defaultModelParams`) and a
+   * hosted `WorkflowStream` in the Workflow.
    *
    * @experimental Streaming support is experimental and may change without notice.
    */
@@ -82,21 +83,59 @@ export interface TemporalRunOptions<TContext = undefined> {
   };
 }
 
+export interface TemporalOpenAIRunnerOptions {
+  /**
+   * Workflow-authored default Model Activity options, layered UNDER the client's
+   * `modelParams` header: a client-set field wins, otherwise this default applies.
+   * Because these options are constructed in the Workflow (not JSON-propagated),
+   * they can carry the function form of `summary`. Use this to configure Workflows
+   * started without the client interceptor, e.g. by a Schedule or the Temporal UI/CLI.
+   */
+  defaultModelParams?: ModelActivityOptions;
+}
+
+/**
+ * Layers Model Activity options least→most significant:
+ * package `DEFAULT_MODEL_ACTIVITY_OPTIONS` < constructor `defaultModelParams` <
+ * client header `modelParams`. Undefined field values are dropped at each layer so
+ * an absent option never clobbers a value set by a lower layer.
+ */
+export function layerModelParams(
+  defaultModelParams: ModelActivityOptions | undefined,
+  headerModelParams: SerializableModelActivityOptions | undefined
+): ModelActivityOptions {
+  return {
+    ...DEFAULT_MODEL_ACTIVITY_OPTIONS,
+    ...definedFields(defaultModelParams),
+    ...definedFields(headerModelParams),
+  };
+}
+
+function definedFields<T extends object>(obj: T | undefined): Partial<T> {
+  if (obj === undefined) return {};
+  const result: Partial<T> = {};
+  for (const key of Object.keys(obj) as (keyof T)[]) {
+    if (obj[key] !== undefined) result[key] = obj[key];
+  }
+  return result;
+}
+
 /**
  * A Temporal-aware agent runner that delegates model calls to Activities.
  *
  * Use `run(agent, input)` for request-response runs. Pass `{ stream: true }` to
  * stream incremental events as the model responds — the returned
- * `StreamedRunResult` is async-iterable. Streaming requires
- * `modelParams.streamingTopic` and a hosted `WorkflowStream` in the Workflow.
+ * `StreamedRunResult` is async-iterable. Streaming requires a `streamingTopic`
+ * (set via the plugin's `modelParams` or the runner's `defaultModelParams`) and a
+ * hosted `WorkflowStream` in the Workflow.
  */
 export class TemporalOpenAIRunner {
   private readonly modelParams: ModelActivityOptions;
 
-  constructor() {
+  constructor(options?: TemporalOpenAIRunnerOptions) {
     ensureTracingProcessorRegistered();
     const fromHeader = getCurrentPluginConfig();
-    this.modelParams = fromHeader?.modelParams ?? DEFAULT_MODEL_ACTIVITY_OPTIONS;
+    this.modelParams = layerModelParams(options?.defaultModelParams, fromHeader?.modelParams);
   }
 
   /**

--- a/contrib/openai-agents/src/workflow/trace-interceptor.ts
+++ b/contrib/openai-agents/src/workflow/trace-interceptor.ts
@@ -35,7 +35,6 @@ import {
   withIsolatedAgentsTraceContext,
   withSpanAsCurrent,
 } from '../common/trace-context';
-import { DEFAULT_MODEL_ACTIVITY_OPTIONS } from '../common/model-activity-options';
 import {
   captureHeaderUnderMaybeInstantSpan,
   isFireAndForgetActivity,
@@ -75,7 +74,10 @@ class OpenAIAgentsTraceInboundInterceptor implements WorkflowInboundCallsInterce
       const headerConfig: PluginConfig = {
         addTemporalSpans: configHeader.addTemporalSpans ?? false,
         useOtelInstrumentation: configHeader.useOtelInstrumentation ?? false,
-        modelParams: { ...DEFAULT_MODEL_ACTIVITY_OPTIONS, ...configHeader.modelParams },
+        // Store only the client-explicitly-set fields; the runner applies
+        // DEFAULT_MODEL_ACTIVITY_OPTIONS as the base layer so pre-baked defaults
+        // don't clobber the runner's defaultModelParams.
+        modelParams: configHeader.modelParams ?? {},
       };
       setPluginConfig(headerConfig);
     }

--- a/contrib/openai-agents/tsconfig.json
+++ b/contrib/openai-agents/tsconfig.json
@@ -13,7 +13,8 @@
     { "path": "../../packages/common" },
     { "path": "../../packages/proto" },
     { "path": "../../packages/test-helpers" },
-    { "path": "../../packages/testing" }
+    { "path": "../../packages/testing" },
+    { "path": "../workflow-streams" }
   ],
   "include": ["./src/**/*.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
       '@temporalio/workflow':
         specifier: workspace:*
         version: link:../../packages/workflow
+      '@temporalio/workflow-streams':
+        specifier: workspace:*
+        version: link:../workflow-streams
       '@ungap/structured-clone':
         specifier: ^1.3.1
         version: 1.3.1


### PR DESCRIPTION
Adds streaming to the OpenAI Agents integration by wiring in the @temporalio/workflow-streams primitive, mirroring the Python SDK. An agent running inside a Workflow can stream model events to an external subscriber via a Workflow Stream topic, exposed through `run(agent, input, { stream: true })`.

The streaming model Activity publishes each event live to the configured topic and returns the full event list, which the Workflow yields deterministically on replay rather than polling the live stream. The user hosts the `WorkflowStream`; the topic name is plugin config via `modelParams.streamingTopic`.