### PR TITLE
chore(deps): unpin protobufjs and bump to 7.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,7 @@ to docs, or any other relevant information.
 - avoid logging `NativeConnection` on worker startup
 
 ## [Unreleased]
+
+### Changed
+
+- protobufjs bumped to ^7.6.4

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "pnpm": {
     "patchedDependencies": {
-      "protobufjs@7.6.2": "patches/protobufjs@7.6.2.patch"
+      "protobufjs@^7.6.3": "patches/protobufjs@7.6.2.patch"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "pnpm": {
     "patchedDependencies": {
-      "protobufjs@^7.6.3": "patches/protobufjs@7.6.2.patch"
+      "protobufjs@^7.6.4": "patches/protobufjs@7.6.2.patch"
     }
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,7 +24,7 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
-    "protobufjs": "^7.6.2"
+    "protobufjs": "^7.6.3"
   },
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,7 +24,7 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
-    "protobufjs": "^7.6.3"
+    "protobufjs": "^7.6.4"
   },
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -22,7 +22,7 @@
     "@temporalio/proto": "workspace:*"
   },
   "devDependencies": {
-    "protobufjs": "^7.6.2"
+    "protobufjs": "^7.6.3"
   },
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -22,7 +22,7 @@
     "@temporalio/proto": "workspace:*"
   },
   "devDependencies": {
-    "protobufjs": "^7.6.3"
+    "protobufjs": "^7.6.4"
   },
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "ava": "^5.3.1",
-    "protobufjs": "^7.6.2"
+    "protobufjs": "^7.6.3"
   },
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "ava": "^5.3.1",
-    "protobufjs": "^7.6.3"
+    "protobufjs": "^7.6.4"
   },
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "long": "^5.2.3",
-    "protobufjs": "7.6.2"
+    "protobufjs": "^7.6.3"
   },
   "devDependencies": {
     "glob": "^10.3.10",

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "long": "^5.2.3",
-    "protobufjs": "^7.6.3"
+    "protobufjs": "^7.6.4"
   },
   "devDependencies": {
     "glob": "^10.3.10",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -59,7 +59,7 @@
     "ms": "3.0.0-canary.1",
     "nexus-rpc": "^0.0.2",
     "pidusage": "^3.0.2",
-    "protobufjs": "^7.6.3",
+    "protobufjs": "^7.6.4",
     "protobufjs-cli": "^1.3.2",
     "rxjs": "7.8.1"
   },

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -59,7 +59,7 @@
     "ms": "3.0.0-canary.1",
     "nexus-rpc": "^0.0.2",
     "pidusage": "^3.0.2",
-    "protobufjs": "7.6.2",
+    "protobufjs": "^7.6.3",
     "protobufjs-cli": "^1.3.2",
     "rxjs": "7.8.1"
   },

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -28,7 +28,7 @@
     "heap-js": "^2.6.0",
     "memfs": "^4.6.0",
     "nexus-rpc": "^0.0.2",
-    "protobufjs": "^7.6.2",
+    "protobufjs": "^7.6.3",
     "rxjs": "^7.8.1",
     "source-map": "^0.7.4",
     "source-map-loader": "^5.0.0",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -28,7 +28,7 @@
     "heap-js": "^2.6.0",
     "memfs": "^4.6.0",
     "nexus-rpc": "^0.0.2",
-    "protobufjs": "^7.6.3",
+    "protobufjs": "^7.6.4",
     "rxjs": "^7.8.1",
     "source-map": "^0.7.4",
     "source-map-loader": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   handlebars: '>=4.7.9'
 
 patchedDependencies:
-  protobufjs@7.6.2:
+  protobufjs@^7.6.3:
     hash: e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b
     path: patches/protobufjs@7.6.2.patch
 
@@ -447,8 +447,8 @@ importers:
         version: 11.1.0
     devDependencies:
       protobufjs:
-        specifier: ^7.6.2
-        version: 7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
+        specifier: ^7.6.3
+        version: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
 
   packages/cloud:
     dependencies:
@@ -466,8 +466,8 @@ importers:
         version: link:../proto
     devDependencies:
       protobufjs:
-        specifier: ^7.6.2
-        version: 7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
+        specifier: ^7.6.3
+        version: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
 
   packages/common:
     dependencies:
@@ -491,8 +491,8 @@ importers:
         specifier: ^5.3.1
         version: 5.3.1
       protobufjs:
-        specifier: ^7.6.2
-        version: 7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
+        specifier: ^7.6.3
+        version: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
 
   packages/core-bridge:
     dependencies:
@@ -758,15 +758,15 @@ importers:
         specifier: ^5.2.3
         version: 5.2.3
       protobufjs:
-        specifier: 7.6.2
-        version: 7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
+        specifier: ^7.6.3
+        version: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
     devDependencies:
       glob:
         specifier: ^10.3.10
         version: 10.5.0
       protobufjs-cli:
         specifier: ^1.2.2
-        version: 1.3.1(protobufjs@7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b))
+        version: 1.3.1(protobufjs@7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b))
 
   packages/test:
     dependencies:
@@ -873,11 +873,11 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       protobufjs:
-        specifier: 7.6.2
-        version: 7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
+        specifier: ^7.6.3
+        version: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
       protobufjs-cli:
         specifier: ^1.3.2
-        version: 1.3.2(protobufjs@7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b))
+        version: 1.3.2(protobufjs@7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b))
       rxjs:
         specifier: 7.8.1
         version: 7.8.1
@@ -996,8 +996,8 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2
       protobufjs:
-        specifier: ^7.6.2
-        version: 7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
+        specifier: ^7.6.3
+        version: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -4813,8 +4813,8 @@ packages:
     peerDependencies:
       protobufjs: ^7.6.2
 
-  protobufjs@7.6.2:
-    resolution: {integrity: sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==}
+  protobufjs@7.6.4:
+    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
     engines: {node: '>=12.0.0'}
 
   protobufjs@8.0.1:
@@ -6401,14 +6401,14 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.2.3
-      protobufjs: 7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
+      protobufjs: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.1':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.2.3
-      protobufjs: 7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
+      protobufjs: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
       yargs: 17.7.2
 
   '@hono/node-server@1.19.11(hono@4.12.5)':
@@ -6801,7 +6801,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.52.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.25.1(@opentelemetry/api@1.9.0)
-      protobufjs: 7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
+      protobufjs: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
 
   '@opentelemetry/propagator-b3@1.25.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -10030,9 +10030,9 @@ snapshots:
 
   proto3-json-serializer@2.0.0:
     dependencies:
-      protobufjs: 7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
+      protobufjs: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
 
-  protobufjs-cli@1.3.1(protobufjs@7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)):
+  protobufjs-cli@1.3.1(protobufjs@7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)):
     dependencies:
       chalk: 4.1.2
       escodegen: 1.14.3
@@ -10041,12 +10041,12 @@ snapshots:
       glob: 8.1.0
       jsdoc: 4.0.2
       minimist: 1.2.8
-      protobufjs: 7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
+      protobufjs: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
       semver: 7.7.4
       tmp: 0.2.5
       uglify-js: 3.19.3
 
-  protobufjs-cli@1.3.2(protobufjs@7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)):
+  protobufjs-cli@1.3.2(protobufjs@7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)):
     dependencies:
       chalk: 4.1.2
       escodegen: 1.14.3
@@ -10055,12 +10055,12 @@ snapshots:
       glob: 8.1.0
       jsdoc: 4.0.2
       minimist: 1.2.8
-      protobufjs: 7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
+      protobufjs: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
       semver: 7.7.4
       tmp: 0.2.5
       uglify-js: 3.19.3
 
-  protobufjs@7.6.2(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b):
+  protobufjs@7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b):
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -10068,7 +10068,6 @@ snapshots:
       '@protobufjs/eventemitter': 1.1.1
       '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   handlebars: '>=4.7.9'
 
 patchedDependencies:
-  protobufjs@^7.6.3:
+  protobufjs@^7.6.4:
     hash: e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b
     path: patches/protobufjs@7.6.2.patch
 
@@ -447,7 +447,7 @@ importers:
         version: 11.1.0
     devDependencies:
       protobufjs:
-        specifier: ^7.6.3
+        specifier: ^7.6.4
         version: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
 
   packages/cloud:
@@ -466,7 +466,7 @@ importers:
         version: link:../proto
     devDependencies:
       protobufjs:
-        specifier: ^7.6.3
+        specifier: ^7.6.4
         version: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
 
   packages/common:
@@ -491,7 +491,7 @@ importers:
         specifier: ^5.3.1
         version: 5.3.1
       protobufjs:
-        specifier: ^7.6.3
+        specifier: ^7.6.4
         version: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
 
   packages/core-bridge:
@@ -758,7 +758,7 @@ importers:
         specifier: ^5.2.3
         version: 5.2.3
       protobufjs:
-        specifier: ^7.6.3
+        specifier: ^7.6.4
         version: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
     devDependencies:
       glob:
@@ -873,7 +873,7 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       protobufjs:
-        specifier: ^7.6.3
+        specifier: ^7.6.4
         version: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
       protobufjs-cli:
         specifier: ^1.3.2
@@ -996,7 +996,7 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2
       protobufjs:
-        specifier: ^7.6.3
+        specifier: ^7.6.4
         version: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
       rxjs:
         specifier: ^7.8.1
@@ -6407,7 +6407,7 @@ snapshots:
   '@grpc/proto-loader@0.8.1':
     dependencies:
       lodash.camelcase: 4.3.0
-      long: 5.2.3
+      long: 5.3.2
       protobufjs: 7.6.4(patch_hash=e0f2d09b2fbf9f22b473e62de808b3e9e39e0088a35e16abce7b35645305724b)
       yargs: 17.7.2
 
@@ -10087,7 +10087,7 @@ snapshots:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
       '@types/node': 20.19.41
-      long: 5.2.3
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,4 +48,4 @@ overrides:
   handlebars: '>=4.7.9'
 
 patchedDependencies:
-  protobufjs@^7.6.3: patches/protobufjs@7.6.2.patch
+  protobufjs@^7.6.4: patches/protobufjs@7.6.2.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,4 +48,4 @@ overrides:
   handlebars: '>=4.7.9'
 
 patchedDependencies:
-  protobufjs@7.6.2: patches/protobufjs@7.6.2.patch
+  protobufjs@^7.6.3: patches/protobufjs@7.6.2.patch


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Switch back to using a version range for our `protobufjs` dependency in `@temporalio/protobuf`

## Why?
The version was pinned when we started needing to patch `protobufjs` as it tripped over parsing annotations in our proto files. This was overly cautious as we're able to specify a patch over a version range and `pnpm install` will fail if our patch cannot be applied. 

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
CI

3. Any docs updates needed?
N/A
