### PR TITLE
Revert "fix: disable grpc compression by default (#2154)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,5 +52,4 @@ to docs, or any other relevant information.
 
 ### Changed
 
-- gRPC compression is disabled by default. Pass `grpcCompression: { codec: 'gzip' }` to enable it.
 - protobufjs bumped to ^7.6.4

--- a/packages/test/src/test-native-connection.ts
+++ b/packages/test/src/test-native-connection.ts
@@ -511,12 +511,12 @@ test('NativeConnection: DNS load balancing config is converted to native millise
   t.deepEqual(options.dnsLoadBalancingConfig, { resolutionIntervalMillis: 5000 });
 });
 
-test('NativeConnection: gRPC compression defaults to disabled', (t) => {
+test('NativeConnection: gRPC compression defaults to gzip', (t) => {
   const options = toNativeClientOptions({});
-  t.deepEqual(options.grpcCompression, { codec: 'none' });
+  t.deepEqual(options.grpcCompression, { codec: 'gzip' });
 });
 
-test('NativeConnection: gRPC compression can be enabled', (t) => {
-  const options = toNativeClientOptions({ grpcCompression: { codec: 'gzip' } });
-  t.deepEqual(options.grpcCompression, { codec: 'gzip' });
+test('NativeConnection: gRPC compression can be disabled', (t) => {
+  const options = toNativeClientOptions({ grpcCompression: { codec: 'none' } });
+  t.deepEqual(options.grpcCompression, { codec: 'none' });
 });

--- a/packages/worker/src/connection-options.ts
+++ b/packages/worker/src/connection-options.ts
@@ -86,8 +86,8 @@ export interface NativeConnectionOptions {
   /**
    * Transport-level gRPC compression configuration for Core service requests.
    *
-   * Defaults to no compression. Set to `{ codec: 'gzip' }` to compress outbound
-   * request bodies and accept gzip-compressed responses.
+   * Defaults to gzip, which compresses outbound request bodies and accepts
+   * gzip-compressed responses. Set to `{ codec: 'none' }` to opt out.
    */
   grpcCompression?: GrpcCompressionConfig;
 
@@ -165,7 +165,7 @@ export function toNativeClientOptions(options: NativeConnectionOptions): native.
       }
     : null;
 
-  const grpcCompression: native.GrpcCompressionConfig = options.grpcCompression ?? { codec: 'none' };
+  const grpcCompression: native.GrpcCompressionConfig = options.grpcCompression ?? { codec: 'gzip' };
   switch (grpcCompression.codec) {
     case 'gzip':
     case 'none':


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This reverts commit 57b54a969988e02e736ddc9bd46a35eb2319b37c.

## Why?
Decided to keep enabled to avoid ping-ponging configuration. The fix to resolve [errors on GetSystemInfo](https://status.temporal.io/incidents/0jgv2mpqw4ky) is already rolling out.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
