### PR TITLE
test(update): remove flake in first-WFT update integration tests

### DIFF
--- a/packages/test/src/test-integration-update.ts
+++ b/packages/test/src/test-integration-update.ts
@@ -564,12 +564,15 @@ export async function setUpdateHandlerAndExit(): Promise<string> {
 }
 
 test('Update is always delivered', async (t) => {
-  const { createWorker, startWorkflow } = helpers(t);
+  const { createWorker, startWorkflow, updateHasBeenAdmitted } = helpers(t);
   const wfHandle = await startWorkflow(setUpdateHandlerAndExit, { startDelay: '10000 days' });
 
-  wfHandle.executeUpdate(stateMutatingUpdate).catch(() => {
+  const updateId = 'update-id';
+  wfHandle.executeUpdate(stateMutatingUpdate, { updateId }).catch(() => {
     /* ignore */
   });
+  await waitUntil(() => updateHasBeenAdmitted(wfHandle, updateId), 5000);
+
   const worker = await createWorker();
   await worker.runUntil(async () => {
     // Worker receives activation: [doUpdate, startWorkflow]
@@ -579,18 +582,20 @@ test('Update is always delivered', async (t) => {
 });
 
 test('Two Updates in first WFT', async (t) => {
-  const { createWorker, startWorkflow } = helpers(t);
+  const { createWorker, startWorkflow, updateHasBeenAdmitted } = helpers(t);
   const wfHandle = await startWorkflow(workflowWithUpdates, { startDelay: '10000 days' });
 
-  wfHandle.executeUpdate(update, { args: ['1'] }).catch(() => {
+  const firstUpdateId = 'update-1';
+  wfHandle.executeUpdate(update, { args: ['1'], updateId: firstUpdateId }).catch(() => {
     /* ignore */
   });
-  wfHandle.executeUpdate(doneUpdate).catch(() => {
+  await waitUntil(() => updateHasBeenAdmitted(wfHandle, firstUpdateId), 5000);
+
+  const secondUpdateId = 'update-2';
+  wfHandle.executeUpdate(doneUpdate, { updateId: secondUpdateId }).catch(() => {
     /* ignore */
   });
-  // Race condition: we want the second update to be in the WFT together with
-  // the first, so allow some time to ensure that happens.
-  await new Promise((res) => setTimeout(res, 500));
+  await waitUntil(() => updateHasBeenAdmitted(wfHandle, secondUpdateId), 5000);
 
   const worker = await createWorker();
   await worker.runUntil(async () => {
@@ -624,14 +629,15 @@ export async function updateReplayTestWorkflow(): Promise<boolean> {
 }
 
 test('Update handler is called at same point during first execution and replay', async (t) => {
-  const { createWorker, startWorkflow } = helpers(t);
+  const { createWorker, startWorkflow, updateHasBeenAdmitted } = helpers(t);
 
   // Start a Workflow and an Update of that Workflow.
   const wfHandle = await startWorkflow(updateReplayTestWorkflow, { startDelay: '10000 days' });
-  wfHandle.executeUpdate(earlyExecutedUpdate).catch(() => {
+  const updateId = 'update-id';
+  wfHandle.executeUpdate(earlyExecutedUpdate, { updateId }).catch(() => {
     /* ignore */
   });
-  await new Promise((res) => setTimeout(res, 1000));
+  await waitUntil(() => updateHasBeenAdmitted(wfHandle, updateId), 5000);
 
   // Avoid waiting for sticky execution timeout on worker transition
   const worker1 = await createWorker({ maxCachedWorkflows: 0 });


### PR DESCRIPTION
## What changed
- Some `test-integration-update.ts` tests need their `updates` delivered in the first WFT (bundled with `startWorkflow`), which they set up via a large `startDelay`.
- They relied on explicit timing ( e.g. `setTimeout`) to get updates admitted before the worker polls which is flakey.

## Fix
- Replaces the timing-based waits with the `updateHasBeenAdmitted` + `waitUntil` admission poll.
- For the two-update test, await the first update's admission before sending the second so their order is deterministic.