### PR TITLE
chore: bump core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,3 +67,10 @@ to docs, or any other relevant information.
 ### Changed
 
 - protobufjs bumped to ^7.6.4
+- Updated Core to `5df57f6d`. Package-visible changes from this update include:
+  - `NativeConnection` initialization now retries without gRPC gzip compression if the server
+    cannot decompress the eager `GetSystemInfo` call.
+  - Workflow replay now honors SDK flags already recorded in history even when the server does not
+    advertise SDK metadata support.
+  - OTLP metric export failures from Core's periodic metric reader are now logged through Core
+    telemetry.

--- a/packages/core-bridge/Cargo.lock
+++ b/packages/core-bridge/Cargo.lock
@@ -870,7 +870,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1440,43 +1439,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-http"
-version = "0.31.0"
+name = "opentelemetry"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry",
- "reqwest 0.12.28",
+ "opentelemetry 0.32.0",
+ "reqwest 0.13.2",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "opentelemetry_sdk",
  "prost",
  "tonic",
@@ -1485,15 +1498,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.2",
  "thiserror 2.0.18",
  "tokio",
@@ -2049,29 +2063,21 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2089,6 +2095,7 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -2551,7 +2558,7 @@ dependencies = [
  "bridge-macros",
  "futures",
  "neon",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "os_pipe",
  "parking_lot",
  "prost",
@@ -2571,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "temporalio-client"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2602,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "temporalio-common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2616,7 +2623,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
@@ -2642,17 +2649,19 @@ dependencies = [
 
 [[package]]
 name = "temporalio-common-wasm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "bon",
+ "chrono",
  "crc32fast",
  "derive_more",
  "erased-serde",
  "futures",
  "parking_lot",
  "prost",
+ "prost-wkt-types",
  "serde",
  "serde_json",
  "temporalio-protos",
@@ -2665,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "temporalio-macros"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2674,7 +2683,7 @@ dependencies = [
 
 [[package]]
 name = "temporalio-protos"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2695,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "temporalio-sdk-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2991,6 +3000,17 @@ dependencies = [
  "syn",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
 ]
 
 [[package]]

--- a/packages/test/src/test-native-connection.ts
+++ b/packages/test/src/test-native-connection.ts
@@ -69,6 +69,20 @@ async function bindLocalhostTls(server: grpc.Server): Promise<number> {
   return await util.promisify(server.bindAsync.bind(server))('127.0.0.1:0', credentials);
 }
 
+function addGetSystemInfoMock(server: grpc.Server): void {
+  server.addService(workflowServiceProtoDescriptor.temporal.api.workflowservice.v1.WorkflowService.service, {
+    getSystemInfo(
+      _call: grpc.ServerUnaryCall<
+        temporal.api.workflowservice.v1.IGetSystemInfoRequest,
+        temporal.api.workflowservice.v1.IGetSystemInfoResponse
+      >,
+      callback: grpc.sendUnaryData<temporal.api.workflowservice.v1.IGetSystemInfoResponse>
+    ) {
+      callback(null, {});
+    },
+  });
+}
+
 test('NativeConnection.connect() throws meaningful error when passed invalid address', async (t) => {
   await t.throwsAsync(NativeConnection.connect({ address: ':invalid' }), {
     instanceOf: TypeError,
@@ -270,6 +284,7 @@ test('all WorkflowService methods are implemented', async (t) => {
 
 test('all OperatorService methods are implemented', async (t) => {
   const server = new grpc.Server();
+  addGetSystemInfoMock(server);
   const calledMethods = new Set<string>();
   server.addService(
     operatorServiceProtoDescriptor.temporal.api.operatorservice.v1.OperatorService.service,
@@ -315,6 +330,7 @@ test('all OperatorService methods are implemented', async (t) => {
 
 test('all HealthService methods are implemented', async (t) => {
   const server = new grpc.Server();
+  addGetSystemInfoMock(server);
   const calledMethods = new Set<string>();
   server.addService(
     healthServiceProtoDescriptor.grpc.health.v1.Health.service,
@@ -364,6 +380,7 @@ test('all HealthService methods are implemented', async (t) => {
 
 test('all TestService methods are implemented', async (t) => {
   const server = new grpc.Server();
+  addGetSystemInfoMock(server);
   const calledMethods = new Set<string>();
   server.addService(
     testServiceProtoDescriptor.temporal.api.testservice.v1.TestService.service,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
See changelog.

Add mock `GetSystemInfo` to our gRPC services used for verifying `NativeConnection` completeness.

See https://github.com/temporalio/sdk-rust/pull/1379 for more details. (The changes in this PR to our tests and the core PR are both not strictly necessary)

## Why?
Preparing for 1.20 release

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
CI

3. Any docs updates needed?
N/A
