### PR TITLE
Extend test harness to support envconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,6 @@ to docs, or any other relevant information.
 
 - `TEMPORAL_TLS` existing behavior when enabled was to _disable_ TLS configuration. This has been corrected,
   setting `TEMPORAL_TLS` now _enables_ TLS configuration
-  
 
 ## [1.20.3] - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ to docs, or any other relevant information.
 - **Experimental** New `@temporalio/strands-agents` package for building workflows with Strand Agents.
 - **Experimental**: `@temporalio/openai-agents` now supports streaming model events from Workflows.
 
+- Added opt-in `envconfig` support to the test workflow environment. This enables testing against arbitrary
+  Temporal server environments (i.e. local, staging, prod)
+
 ### Breaking Changes
 
 - By default, workers now proactively validate outbound payload/memo sizes before sending: a field
@@ -81,6 +84,10 @@ to docs, or any other relevant information.
 - strands: add `@aws-sdk/client-s3` to the workflow bundler ignore list, fixing bundler errors when
   using the S3-backed `context-offloader` vended plugin. The package is dynamically imported
   worker-side and is never reached from workflow code.
+
+- `TEMPORAL_TLS` existing behavior when enabled was to _disable_ TLS configuration. This has been corrected,
+  setting `TEMPORAL_TLS` now _enables_ TLS configuration
+  
 
 ## [1.20.3] - 2026-07-13
 

--- a/packages/envconfig/src/__tests__/test-envconfig.ts
+++ b/packages/envconfig/src/__tests__/test-envconfig.ts
@@ -586,6 +586,27 @@ test('TLS disabled tri-state behavior', (t) => {
   t.is(configTrue.connectionOptions.tls, false); // TLS explicitly disabled even with API key
 });
 
+test('TEMPORAL_TLS uses enabled semantics', (t) => {
+  const configSource = dataSource(dedent`
+    [profile.default]
+    address = "my-address"
+  `);
+
+  const enabledProfile = loadClientConfigProfile({
+    configSource,
+    overrideEnvVars: { TEMPORAL_TLS: 'true' },
+  });
+  t.is(enabledProfile.tls?.disabled, false);
+  t.truthy(toClientOptions(enabledProfile).connectionOptions.tls);
+
+  const disabledProfile = loadClientConfigProfile({
+    configSource,
+    overrideEnvVars: { TEMPORAL_TLS: 'false' },
+  });
+  t.is(disabledProfile.tls?.disabled, true);
+  t.is(toClientOptions(disabledProfile).connectionOptions.tls, false);
+});
+
 // =============================================================================
 // 🚫 ERROR HANDLING
 // =============================================================================

--- a/packages/envconfig/src/envconfig-toml.ts
+++ b/packages/envconfig/src/envconfig-toml.ts
@@ -233,8 +233,9 @@ function applyProfileEnvVars(profile: TomlClientConfigProfile, envProvider: Reco
 }
 
 function getTLSFromEnvVars(envProvider: Record<string, string | undefined>): TomlClientConfigTLS | undefined {
+  const tlsEnabled = envVarToBool(envProvider['TEMPORAL_TLS']);
   const tlsConfig: TomlClientConfigTLS = filterNullAndUndefined({
-    disabled: envVarToBool(envProvider['TEMPORAL_TLS']),
+    disabled: tlsEnabled === undefined ? undefined : !tlsEnabled,
     client_cert_path: envProvider['TEMPORAL_TLS_CLIENT_CERT_PATH'],
     client_cert_data: envProvider['TEMPORAL_TLS_CLIENT_CERT_DATA'],
     client_key_path: envProvider['TEMPORAL_TLS_CLIENT_KEY_PATH'],

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@temporalio/common": "workspace:*",
+    "@temporalio/envconfig": "workspace:*",
     "@temporalio/proto": "workspace:*",
     "@temporalio/testing": "workspace:*",
     "@temporalio/worker": "workspace:*",

--- a/packages/test-helpers/src/bundler.ts
+++ b/packages/test-helpers/src/bundler.ts
@@ -8,6 +8,7 @@ export const baseBundlerIgnoreModules = [
   // This is a bit ugly but it does the trick, when a test that includes workflow code tries to import a forbidden
   // workflow module, add it to this list:
   '@temporalio/common/lib/internal-non-workflow',
+  '@temporalio/envconfig',
   '@temporalio/activity',
   '@temporalio/client',
   '@temporalio/testing',

--- a/packages/test-helpers/src/environment.ts
+++ b/packages/test-helpers/src/environment.ts
@@ -1,10 +1,12 @@
 import type { LocalTestWorkflowEnvironmentOptions } from '@temporalio/testing';
 import { workflowInterceptorModules as defaultWorkflowInterceptorModules } from '@temporalio/testing';
+import { loadClientConnectConfig, type LoadClientProfileOptions } from '@temporalio/envconfig';
 import type { BundlerPlugin, WorkflowBundleWithSourceMap, BundleOptions } from '@temporalio/worker';
 import { bundleWorkflowCode, DefaultLogger } from '@temporalio/worker';
 import { defineSearchAttributeKey, SearchAttributeType } from '@temporalio/common/lib/search-attributes';
 import { TestWorkflowEnvironment } from './wrappers';
 import { baseBundlerIgnoreModules } from './bundler';
+import { isSet } from './flags';
 
 export const defaultDynamicConfigOptions = [
   'system.enableActivityEagerExecution=true',
@@ -76,20 +78,31 @@ export async function createLocalTestEnvironment(
 }
 
 /**
- * Create a test workflow environment, using an existing server if TEMPORAL_SERVICE_ADDRESS is set,
- * otherwise creating a local one.
+ * Create a test workflow environment.
+ *
+ * Uses envconfig for the test server connection when TEMPORAL_TEST_ENV_CONFIG_SERVER is truthy, uses
+ * TEMPORAL_SERVICE_ADDRESS as a legacy existing-server shortcut when set, otherwise creates a local environment.
  */
 export async function createTestWorkflowEnvironment(
-  opts?: LocalTestWorkflowEnvironmentOptions
+  opts?: LocalTestWorkflowEnvironmentOptions,
+  envconfigOpts?: LoadClientProfileOptions
 ): Promise<TestWorkflowEnvironment> {
-  let env: TestWorkflowEnvironment;
+  if (isSet(process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER, false)) {
+    const { namespace, connectionOptions } = loadClientConnectConfig(envconfigOpts);
+    const { address, apiKey, metadata, tls } = connectionOptions;
+    return await TestWorkflowEnvironment.createFromExistingServer({
+      address,
+      namespace,
+      connectionOptions: { apiKey, metadata, tls },
+      client: opts?.client,
+      plugins: opts?.plugins,
+    });
+  }
   if (process.env.TEMPORAL_SERVICE_ADDRESS) {
-    env = await TestWorkflowEnvironment.createFromExistingServer({
+    return await TestWorkflowEnvironment.createFromExistingServer({
       address: process.env.TEMPORAL_SERVICE_ADDRESS,
       plugins: opts?.plugins,
     });
-  } else {
-    env = await createLocalTestEnvironment(opts);
   }
-  return env;
+  return await createLocalTestEnvironment(opts);
 }

--- a/packages/test-helpers/src/environment.ts
+++ b/packages/test-helpers/src/environment.ts
@@ -1,6 +1,5 @@
 import type { LocalTestWorkflowEnvironmentOptions } from '@temporalio/testing';
 import { workflowInterceptorModules as defaultWorkflowInterceptorModules } from '@temporalio/testing';
-import { loadClientConnectConfig, type LoadClientProfileOptions } from '@temporalio/envconfig';
 import type { BundlerPlugin, WorkflowBundleWithSourceMap, BundleOptions } from '@temporalio/worker';
 import { bundleWorkflowCode, DefaultLogger } from '@temporalio/worker';
 import { defineSearchAttributeKey, SearchAttributeType } from '@temporalio/common/lib/search-attributes';
@@ -84,16 +83,10 @@ export async function createLocalTestEnvironment(
  * TEMPORAL_SERVICE_ADDRESS as a legacy existing-server shortcut when set, otherwise creates a local environment.
  */
 export async function createTestWorkflowEnvironment(
-  opts?: LocalTestWorkflowEnvironmentOptions,
-  envconfigOpts?: LoadClientProfileOptions
+  opts?: LocalTestWorkflowEnvironmentOptions
 ): Promise<TestWorkflowEnvironment> {
   if (isSet(process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER, false)) {
-    const { namespace, connectionOptions } = loadClientConnectConfig(envconfigOpts);
-    const { address, apiKey, metadata, tls } = connectionOptions;
-    return await TestWorkflowEnvironment.createFromExistingServer({
-      address,
-      namespace,
-      connectionOptions: { apiKey, metadata, tls },
+    return await TestWorkflowEnvironment.createFromEnvConfig(undefined, {
       client: opts?.client,
       plugins: opts?.plugins,
     });

--- a/packages/test-helpers/src/helpers.ts
+++ b/packages/test-helpers/src/helpers.ts
@@ -73,6 +73,7 @@ export function helpers<TEnv extends AnyTestWorkflowEnvironment = TestWorkflowEn
     async createWorker(workerOpts?: Partial<WorkerOptions>): Promise<Worker> {
       return await Worker.create({
         connection: env.nativeConnection,
+        namespace: env.namespace,
         workflowBundle,
         taskQueue,
         showStackTraceSources: true,

--- a/packages/test-helpers/src/wrappers.ts
+++ b/packages/test-helpers/src/wrappers.ts
@@ -4,6 +4,7 @@ import type {
   TimeSkippingTestWorkflowEnvironmentOptions,
 } from '@temporalio/testing';
 import { TestWorkflowEnvironment as RealTestWorkflowEnvironment } from '@temporalio/testing';
+import { loadClientConnectConfig, type LoadClientProfileOptions } from '@temporalio/envconfig';
 import * as worker from '@temporalio/worker';
 import type { WorkerOptions } from '@temporalio/worker';
 import { Worker as RealWorker } from '@temporalio/worker';
@@ -76,5 +77,19 @@ export class TestWorkflowEnvironment extends RealTestWorkflowEnvironment {
     opts?: ExistingServerTestWorkflowEnvironmentOptions
   ): Promise<TestWorkflowEnvironment> {
     return RealTestWorkflowEnvironment.createFromExistingServer(opts);
+  }
+
+  static async createFromEnvConfig(
+    envconfigOpts?: LoadClientProfileOptions,
+    opts?: Pick<ExistingServerTestWorkflowEnvironmentOptions, 'client' | 'plugins'>
+  ): Promise<TestWorkflowEnvironment> {
+    const { namespace, connectionOptions } = loadClientConnectConfig(envconfigOpts);
+    const { address, apiKey, metadata, tls } = connectionOptions;
+    return await TestWorkflowEnvironment.createFromExistingServer({
+      address,
+      namespace,
+      connectionOptions: { apiKey, metadata, tls },
+      ...opts,
+    });
   }
 }

--- a/packages/test-helpers/tsconfig.json
+++ b/packages/test-helpers/tsconfig.json
@@ -7,6 +7,7 @@
   "references": [
     { "path": "../client" },
     { "path": "../common" },
+    { "path": "../envconfig" },
     { "path": "../proto" },
     { "path": "../testing" },
     { "path": "../worker" },

--- a/packages/test/src/helpers-integration.ts
+++ b/packages/test/src/helpers-integration.ts
@@ -2,6 +2,7 @@ import { status as grpcStatus } from '@grpc/grpc-js';
 import type { ErrorConstructor, ExecutionContext, TestFn } from 'ava';
 import type { WorkflowHandle } from '@temporalio/client';
 import { isGrpcServiceError, WorkflowFailedError, WorkflowUpdateFailedError } from '@temporalio/client';
+import type { LoadClientProfileOptions } from '@temporalio/envconfig';
 import type { LocalTestWorkflowEnvironmentOptions, NexusEndpointIdentifier } from '@temporalio/testing';
 import type {
   BundlerPlugin,
@@ -106,6 +107,7 @@ export function makeConfigurableEnvironmentTestFn<T>(opts: {
 export interface TestFunctionOptions<C extends Context = Context> {
   workflowsPath: string;
   workflowEnvironmentOpts?: LocalTestWorkflowEnvironmentOptions;
+  envconfigOpts?: LoadClientProfileOptions;
   workflowInterceptorModules?: string[];
   recordedLogs?: { [workflowId: string]: LogEntry[] };
   runtimeOpts?: Partial<RuntimeOptions> | (() => Promise<[Partial<RuntimeOptions>, Partial<C>]>) | undefined;
@@ -126,21 +128,25 @@ export function makeTestFunction<C extends Context = Context>(opts: TestFunction
 
 export function makeDefaultTestContextFunction(opts: TestFunctionOptions): (t: ExecutionContext) => Promise<Context> {
   return async (_t: ExecutionContext): Promise<Context> => {
-    const env = await createTestWorkflowEnvironment(opts.workflowEnvironmentOpts);
-    return {
-      workflowBundle: await createTestWorkflowBundle({
+    const env = await createTestWorkflowEnvironment(opts.workflowEnvironmentOpts, opts.envconfigOpts);
+    try {
+      const workflowBundle = await createTestWorkflowBundle({
         workflowsPath: opts.workflowsPath,
         workflowInterceptorModules: opts.workflowInterceptorModules,
-      }),
-      env,
-    };
+      });
+      return { workflowBundle, env };
+    } catch (err) {
+      await env.teardown();
+      throw err;
+    }
   };
 }
 
 export async function createTestWorkflowEnvironment(
-  opts?: LocalTestWorkflowEnvironmentOptions
+  opts?: LocalTestWorkflowEnvironmentOptions,
+  envconfigOpts?: LoadClientProfileOptions
 ): Promise<TestWorkflowEnvironment> {
-  return createTestWorkflowEnvironmentBase(opts);
+  return createTestWorkflowEnvironmentBase(opts, envconfigOpts);
 }
 
 /**
@@ -171,7 +177,7 @@ export function helpers(t: ExecutionContext<Context>, env?: TestWorkflowEnvironm
   return {
     ...base,
     async createNativeConnection(opts?: Partial<NativeConnectionOptions>): Promise<NativeConnection> {
-      return await NativeConnection.connect({ address: testEnv.address, ...opts });
+      return await NativeConnection.connect({ ...testEnv.connectionOptions, address: testEnv.address, ...opts });
     },
     async runReplayHistory(
       opts: Partial<ReplayWorkerOptions>,

--- a/packages/test/src/helpers-integration.ts
+++ b/packages/test/src/helpers-integration.ts
@@ -2,7 +2,6 @@ import { status as grpcStatus } from '@grpc/grpc-js';
 import type { ErrorConstructor, ExecutionContext, TestFn } from 'ava';
 import type { WorkflowHandle } from '@temporalio/client';
 import { isGrpcServiceError, WorkflowFailedError, WorkflowUpdateFailedError } from '@temporalio/client';
-import type { LoadClientProfileOptions } from '@temporalio/envconfig';
 import type { LocalTestWorkflowEnvironmentOptions, NexusEndpointIdentifier } from '@temporalio/testing';
 import type {
   BundlerPlugin,
@@ -107,7 +106,6 @@ export function makeConfigurableEnvironmentTestFn<T>(opts: {
 export interface TestFunctionOptions<C extends Context = Context> {
   workflowsPath: string;
   workflowEnvironmentOpts?: LocalTestWorkflowEnvironmentOptions;
-  envconfigOpts?: LoadClientProfileOptions;
   workflowInterceptorModules?: string[];
   recordedLogs?: { [workflowId: string]: LogEntry[] };
   runtimeOpts?: Partial<RuntimeOptions> | (() => Promise<[Partial<RuntimeOptions>, Partial<C>]>) | undefined;
@@ -128,7 +126,7 @@ export function makeTestFunction<C extends Context = Context>(opts: TestFunction
 
 export function makeDefaultTestContextFunction(opts: TestFunctionOptions): (t: ExecutionContext) => Promise<Context> {
   return async (_t: ExecutionContext): Promise<Context> => {
-    const env = await createTestWorkflowEnvironment(opts.workflowEnvironmentOpts, opts.envconfigOpts);
+    const env = await createTestWorkflowEnvironment(opts.workflowEnvironmentOpts);
     try {
       const workflowBundle = await createTestWorkflowBundle({
         workflowsPath: opts.workflowsPath,
@@ -143,10 +141,9 @@ export function makeDefaultTestContextFunction(opts: TestFunctionOptions): (t: E
 }
 
 export async function createTestWorkflowEnvironment(
-  opts?: LocalTestWorkflowEnvironmentOptions,
-  envconfigOpts?: LoadClientProfileOptions
+  opts?: LocalTestWorkflowEnvironmentOptions
 ): Promise<TestWorkflowEnvironment> {
-  return createTestWorkflowEnvironmentBase(opts, envconfigOpts);
+  return createTestWorkflowEnvironmentBase(opts);
 }
 
 /**

--- a/packages/test/src/test-integration-envconfig.ts
+++ b/packages/test/src/test-integration-envconfig.ts
@@ -1,0 +1,44 @@
+import test from 'ava';
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { createTestWorkflowEnvironment } from './helpers-integration';
+
+const namespace = 'envconfig-test';
+
+test.serial('Shared integration harness connects through envconfig', async (t) => {
+  const originalGate = process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+  const sourceEnv = await TestWorkflowEnvironment.createLocal({ server: { namespace } });
+  let env: TestWorkflowEnvironment | undefined;
+
+  try {
+    process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER = 'true';
+    env = await createTestWorkflowEnvironment(undefined, {
+      configSource: {
+        data: `[profile.default]
+address = "${sourceEnv.address}"
+namespace = "${namespace}"
+api_key = "envconfig-api-key"
+
+[profile.default.tls]
+disabled = true
+
+[profile.default.grpc_meta]
+"test-header" = "envconfig-test"
+`,
+      },
+      disableEnv: true,
+    });
+
+    t.is(env.address, sourceEnv.address);
+    t.is(env.namespace, namespace);
+    t.is(env.connectionOptions.apiKey, 'envconfig-api-key');
+    t.is(env.connectionOptions.metadata?.['test-header'], 'envconfig-test');
+    t.is(env.connectionOptions.tls, false);
+  } finally {
+    if (originalGate === undefined) {
+      delete process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+    } else {
+      process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER = originalGate;
+    }
+    await Promise.all([env?.teardown(), sourceEnv.teardown()]);
+  }
+});

--- a/packages/test/src/test-integration-envconfig.ts
+++ b/packages/test/src/test-integration-envconfig.ts
@@ -1,17 +1,14 @@
 import test from 'ava';
-import { TestWorkflowEnvironment } from '@temporalio/testing';
-import { createTestWorkflowEnvironment } from './helpers-integration';
+import { TestWorkflowEnvironment } from '@temporalio/test-helpers';
 
 const namespace = 'envconfig-test';
 
-test.serial('Shared integration harness connects through envconfig', async (t) => {
-  const originalGate = process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+test('Envconfig factory connects through envconfig', async (t) => {
   const sourceEnv = await TestWorkflowEnvironment.createLocal({ server: { namespace } });
   let env: TestWorkflowEnvironment | undefined;
 
   try {
-    process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER = 'true';
-    env = await createTestWorkflowEnvironment(undefined, {
+    env = await TestWorkflowEnvironment.createFromEnvConfig({
       configSource: {
         data: `[profile.default]
 address = "${sourceEnv.address}"
@@ -34,11 +31,6 @@ disabled = true
     t.is(env.connectionOptions.metadata?.['test-header'], 'envconfig-test');
     t.is(env.connectionOptions.tls, false);
   } finally {
-    if (originalGate === undefined) {
-      delete process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
-    } else {
-      process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER = originalGate;
-    }
     await Promise.all([env?.teardown(), sourceEnv.teardown()]);
   }
 });

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -14,6 +14,7 @@ export {
   TestWorkflowEnvironment,
   type LocalTestWorkflowEnvironmentOptions,
   type TimeSkippingTestWorkflowEnvironmentOptions,
+  type ExistingServerConnectionOptions,
   type ExistingServerTestWorkflowEnvironmentOptions,
   type NexusEndpointIdentifier,
 } from './testing-workflow-environment';

--- a/packages/testing/src/testing-workflow-environment.ts
+++ b/packages/testing/src/testing-workflow-environment.ts
@@ -33,14 +33,19 @@ export type TimeSkippingTestWorkflowEnvironmentOptions = {
   plugins?: (ClientPlugin | ConnectionPlugin | NativeConnectionPlugin)[];
 };
 
+export type ExistingServerConnectionOptions = Pick<NativeConnectionOptions, 'apiKey' | 'metadata' | 'tls'>;
+
 /**
- * Options for {@link TestWorkflowEnvironment.createExistingServer}
+ * Options for {@link TestWorkflowEnvironment.createFromExistingServer}
+ *
+ * Accepts connection options that can be used for both the client and worker connections.
  */
 export type ExistingServerTestWorkflowEnvironmentOptions = {
   /** If not set, defaults to localhost:7233 */
   address?: string;
   /** If not set, defaults to default */
   namespace?: string;
+  connectionOptions?: ExistingServerConnectionOptions;
   client?: ClientOptionsForTestEnv;
   plugins?: (ClientPlugin | ConnectionPlugin | NativeConnectionPlugin)[];
 };
@@ -99,7 +104,11 @@ export class TestWorkflowEnvironment {
     /**
      * Address used when constructing `connection` and `nativeConnection`
      */
-    public readonly address: string
+    public readonly address: string,
+    /**
+     * Connection options used when constructing `connection` and `nativeConnection`.
+     */
+    public readonly connectionOptions: ExistingServerConnectionOptions = {}
   ) {
     this.connection = connection;
     this.nativeConnection = nativeConnection;
@@ -198,6 +207,7 @@ export class TestWorkflowEnvironment {
   static async createFromExistingServer(
     opts?: ExistingServerTestWorkflowEnvironmentOptions
   ): Promise<TestWorkflowEnvironment> {
+    const { apiKey, metadata, tls } = opts?.connectionOptions ?? {};
     return await this.create({
       server: { type: 'existing' },
       client: opts?.client,
@@ -205,6 +215,7 @@ export class TestWorkflowEnvironment {
       namespace: opts?.namespace ?? 'default',
       supportsTimeSkipping: false,
       address: opts?.address,
+      connectionOptions: { apiKey, metadata, tls },
     });
   }
 
@@ -216,9 +227,10 @@ export class TestWorkflowEnvironment {
       supportsTimeSkipping: boolean;
       namespace?: string;
       address?: string;
+      connectionOptions?: ExistingServerConnectionOptions;
     }
   ): Promise<TestWorkflowEnvironment> {
-    const { supportsTimeSkipping, namespace, ...rest } = opts;
+    const { supportsTimeSkipping, namespace, connectionOptions, ...rest } = opts;
     const optsWithDefaults = addDefaults(filterNullAndUndefined(rest));
 
     let address: string;
@@ -243,12 +255,15 @@ export class TestWorkflowEnvironment {
       server = 'existing';
     }
 
+    const resolvedConnectionOptions = { ...(connectionOptions ?? {}) };
     const nativeConnection = await NativeConnection.connect(<NativeConnectionOptions & InternalConnectionOptions>{
+      ...resolvedConnectionOptions,
       address,
       plugins: opts.plugins,
       [InternalConnectionOptionsSymbol]: { supportsTestService: supportsTimeSkipping },
     });
     const connection = await Connection.connect(<ConnectionOptions & InternalConnectionOptions>{
+      ...resolvedConnectionOptions,
       address,
       plugins: opts.plugins,
       [InternalConnectionOptionsSymbol]: { supportsTestService: supportsTimeSkipping },
@@ -262,7 +277,8 @@ export class TestWorkflowEnvironment {
       connection,
       nativeConnection,
       namespace,
-      address
+      address,
+      resolvedConnectionOptions
     );
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1030,6 +1030,9 @@ importers:
       '@temporalio/common':
         specifier: workspace:*
         version: link:../common
+      '@temporalio/envconfig':
+        specifier: workspace:*
+        version: link:../envconfig
       '@temporalio/proto':
         specifier: workspace:*
         version: link:../proto


### PR DESCRIPTION
## What was changed

Add opt-in envconfig support to the shared TypeScript integration-test harness.

When `TEMPORAL_TEST_ENV_CONFIG_SERVER` is truthy, the harness loads the server address, namespace, API key, TLS configuration, and gRPC metadata through `@temporalio/envconfig`. These settings are propagated to client, worker, and additional native connections.

When the opt-in is absent, existing behavior is preserved: `TEMPORAL_SERVICE_ADDRESS` selects the legacy existing-server path, otherwise the harness starts a local server.

This PR does not migrate individual integration-test call sites. Existing tests that use the shared `createTestWorkflowEnvironment` helper can opt in through environment variables; tests that instantiate `TestWorkflowEnvironment` directly remain unchanged. The envconfig factory remains internal SDK test infrastructure and is not added to public `@temporalio/testing` (this can be done in a follow-up PR, but requires removing a dependency cycle between the `envconfig` and `@temporalio/testing` packages).

**Note:** includes a bug fix with the `envconfig` package when reading `TEMPORAL_TLS` (setting to `true` _enables_ TLS, instead of disables TLS).

## Why?

This enables integration tests to target arbitrary Temporal server environments, including local, staging, release, and Temporal Cloud environments.

This is the first SDK implementation of the approach intended to be replicated across Temporal SDKs.

Part of https://github.com/temporalio/features/issues/851

## How was this tested?

  - A focused integration test creates a test environment from an inline envconfig profile and verifies address, namespace, API key, gRPC metadata, and explicit TLS-disabled propagation.
  - A focused envconfig unit test verifies that `TEMPORAL_TLS=true` enables TLS and `TEMPORAL_TLS=false` disables it.
  - The test-helper and test packages build successfully, and the focused integration test passes.

## Documentation

No user-facing documentation changes are required. This PR changes internal integration-test infrastructure.