### PR TITLE
Fix test race flake: hot rxjs observable was emitting event before it had subscribers.

### DIFF
--- a/packages/test/src/test-async-completion.ts
+++ b/packages/test/src/test-async-completion.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import type { TestFn, ExecutionContext } from 'ava';
 import anyTest from 'ava';
 import type { Observable } from 'rxjs';
-import { Subject, firstValueFrom } from 'rxjs';
+import { ReplaySubject, firstValueFrom } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import type { ConnectionLike } from '@temporalio/client';
 import {
@@ -239,7 +239,7 @@ test('AsyncCompletionClient heartbeat with task token uses explicit activity con
 
 if (RUN_INTEGRATION_TESTS) {
   test.before(async (t) => {
-    const infoSubject = new Subject<Info>();
+    const infoSubject = new ReplaySubject<Info>();
 
     const worker = await Worker.create({
       workflowsPath: require.resolve('./workflows'),


### PR DESCRIPTION
A hot rxjs observable was occasionally emitting an event before it had subscribers causing tests to timeout waiting for a value.

## What was changed
Change `Subject` to `ReplaySubject` so events are replayed to subscribers.

## Why?
`test-async-completion.ts` calls ` client.activity.start('completeAsync', {...})` which emits an event (async) but doesn't subscribe to that event until the following line. I opted to use `ReplaySubject` instead of reorder every test because the replay subject will fix the issue regardless if the test logic is written in order. 
