### PR TITLE
fix(langsmith): resolve workflow interceptor module by absolute path

### DIFF
--- a/contrib/langsmith/src/__tests__/test-unit.ts
+++ b/contrib/langsmith/src/__tests__/test-unit.ts
@@ -1,15 +1,20 @@
 /**
- * Pure-function unit tests. These run with no Temporal server and no LangSmith
- * backend — they exercise the propagation codec, query filter,
- * sensitive-key scrubbing, error rendering, run-name builders, and the test
- * harness's own collector / tree renderer.
+ * Unit tests that run with no Temporal server and no LangSmith backend. They
+ * cover pure functions (propagation codec, query filter, sensitive-key
+ * scrubbing, error rendering, run-name builders, the harness collector / tree
+ * renderer) and the plugin's static interceptor-module registration.
  *
  * @module
  */
 
+import { existsSync } from 'node:fs';
+import { isAbsolute } from 'node:path';
+
 import test from 'ava';
 
 import { ApplicationFailure, ApplicationFailureCategory } from '@temporalio/common';
+import type { BundleOptions, WorkerOptions } from '@temporalio/worker';
+import { LangSmithPlugin } from '../index';
 import {
   HEADER_KEY,
   decodeContextString,
@@ -133,6 +138,20 @@ test('run-name builders build the documented names', (t) => {
   t.is(signalChildWorkflowRunName('s'), 'SignalChildWorkflow:s');
   t.is(signalExternalWorkflowRunName('s'), 'SignalExternalWorkflow:s');
   t.is(startNexusOperationRunName('Svc', 'op'), 'StartNexusOperation:Svc/op');
+});
+
+test('plugin registers the workflow interceptor module as an absolute, resolvable path', (t) => {
+  const plugin = new LangSmithPlugin();
+
+  const worker = plugin.configureWorker({ taskQueue: 'tq' } as WorkerOptions);
+  const workflowModules = worker.interceptors?.workflowModules ?? [];
+  t.is(workflowModules.length, 1);
+  const workflowModule = workflowModules[0]!;
+  t.true(isAbsolute(workflowModule), `expected absolute path, got ${workflowModule}`);
+  t.true(existsSync(workflowModule));
+
+  const bundler = plugin.configureBundler({ workflowsPath: 'wf' } as BundleOptions);
+  t.deepEqual(bundler.workflowInterceptorModules, [workflowModule]);
 });
 
 const run = (id: string, name: string, parent?: string): CollectedRun => ({ id, name, parent_run_id: parent });

--- a/contrib/langsmith/src/plugin.ts
+++ b/contrib/langsmith/src/plugin.ts
@@ -91,11 +91,7 @@ export class LangSmithPlugin extends SimplePlugin {
   private readonly client: Client;
   private readonly emitter: EmitterConfig;
   private readonly workflowConfig: WorkflowLangSmithConfig;
-  // Absolute path to the workflow-side interceptors. The workflow bundler resolves
-  // interceptor modules relative to the generated workflow entrypoint, not this
-  // plugin's location, so a bare `@temporalio/langsmith/workflow-interceptors`
-  // specifier isn't reachable under strict/isolated pnpm. Resolving here roots the
-  // lookup in the plugin's own install tree, so it works under any layout.
+  // Absolute path so the workflow bundler resolves it under strict pnpm.
   private readonly workflowInterceptorModule = require.resolve('./workflow-interceptors');
 
   constructor(options: LangSmithPluginOptions = {}) {

--- a/contrib/langsmith/src/plugin.ts
+++ b/contrib/langsmith/src/plugin.ts
@@ -34,11 +34,6 @@ import type { WorkflowLangSmithConfig } from './workflow-interceptors';
 // Derived: @temporalio/worker doesn't export WebpackConfiguration from its root.
 type WebpackConfiguration = Parameters<NonNullable<BundleOptions['webpackConfigHook']>>[0];
 
-/**
- * The module specifier for the workflow-side interceptors.
- */
-const WORKFLOW_INTERCEPTOR_MODULE = '@temporalio/langsmith/workflow-interceptors';
-
 // Bare identifier (not dotted) so DefinePlugin substitutes textually.
 const CONFIG_GLOBAL = '__TEMPORAL_LANGSMITH_CONFIG__';
 
@@ -96,6 +91,12 @@ export class LangSmithPlugin extends SimplePlugin {
   private readonly client: Client;
   private readonly emitter: EmitterConfig;
   private readonly workflowConfig: WorkflowLangSmithConfig;
+  // Absolute path to the workflow-side interceptors. The workflow bundler resolves
+  // interceptor modules relative to the generated workflow entrypoint, not this
+  // plugin's location, so a bare `@temporalio/langsmith/workflow-interceptors`
+  // specifier isn't reachable under strict/isolated pnpm. Resolving here roots the
+  // lookup in the plugin's own install tree, so it works under any layout.
+  private readonly workflowInterceptorModule = require.resolve('./workflow-interceptors');
 
   constructor(options: LangSmithPluginOptions = {}) {
     // super() reads options.name immediately
@@ -140,8 +141,8 @@ export class LangSmithPlugin extends SimplePlugin {
     activityInbound.push(createActivityInboundInterceptor(this.emitter));
 
     const workflowModules = [...(interceptors.workflowModules ?? [])];
-    if (!workflowModules.includes(WORKFLOW_INTERCEPTOR_MODULE)) {
-      workflowModules.push(WORKFLOW_INTERCEPTOR_MODULE);
+    if (!workflowModules.includes(this.workflowInterceptorModule)) {
+      workflowModules.push(this.workflowInterceptorModule);
     }
 
     const nexusInbound = createNexusInboundInterceptor(this.emitter);
@@ -161,8 +162,8 @@ export class LangSmithPlugin extends SimplePlugin {
   override configureBundler(options: BundleOptions): BundleOptions {
     const base = super.configureBundler(options);
     const workflowInterceptorModules = [...(base.workflowInterceptorModules ?? [])];
-    if (!workflowInterceptorModules.includes(WORKFLOW_INTERCEPTOR_MODULE)) {
-      workflowInterceptorModules.push(WORKFLOW_INTERCEPTOR_MODULE);
+    if (!workflowInterceptorModules.includes(this.workflowInterceptorModule)) {
+      workflowInterceptorModules.push(this.workflowInterceptorModule);
     }
     // Dismiss the SDK bundler's disallowed-builtin guard for `async_hooks` (see aliasAsyncHooks).
     const ignoreModules = [...(base.ignoreModules ?? [])];
@@ -175,7 +176,7 @@ export class LangSmithPlugin extends SimplePlugin {
       // Double-encode so the injected token is a string literal in the bundle.
       const definitions = { [CONFIG_GLOBAL]: JSON.stringify(JSON.stringify(this.workflowConfig)) };
       const withDefine = injectDefinePlugin(merged, definitions);
-      return aliasLangSmithNodeUtils(aliasAsyncHooks(withDefine));
+      return aliasLangSmithNodeUtils(aliasAsyncHooks(withDefine, this.workflowInterceptorModule));
     };
     return { ...base, workflowInterceptorModules, ignoreModules, webpackConfigHook };
   }
@@ -208,10 +209,10 @@ export class LangSmithPlugin extends SimplePlugin {
  * resolution, so `resolve.alias` cannot do this; `NormalModuleReplacementPlugin`
  * rewrites the request in `beforeResolve` instead. Must be paired with the
  * `ignoreModules` whitelist (see {@link LangSmithPlugin.configureBundler}). The
- * rewrite target is the package specifier so webpack dedupes to one isolate
- * instance regardless of issuer.
+ * rewrite target is the resolved absolute module path so webpack dedupes to one
+ * isolate instance regardless of issuer.
  */
-function aliasAsyncHooks(config: WebpackConfiguration): WebpackConfiguration {
+function aliasAsyncHooks(config: WebpackConfiguration, workflowInterceptorModule: string): WebpackConfiguration {
   const plugins = [...(config.plugins ?? [])];
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -220,7 +221,7 @@ function aliasAsyncHooks(config: WebpackConfiguration): WebpackConfiguration {
     };
     plugins.push(
       new webpack.NormalModuleReplacementPlugin(/^node:async_hooks$/, (resource) => {
-        resource.request = WORKFLOW_INTERCEPTOR_MODULE;
+        resource.request = workflowInterceptorModule;
       }) as (typeof plugins)[number]
     );
   } catch (err) {


### PR DESCRIPTION
The LangSmith plugin registered its workflow-side interceptor module by the bare specifier `@temporalio/langsmith/workflow-interceptors`. The workflow bundler resolves interceptor modules relative to the generated workflow entrypoint, so under strict/isolated pnpm the bare cross-package specifier isn't reachable and workflow-body tracing fails to bundle with `Module not found`.

This resolves it with `require.resolve` to an absolute path rooted in the plugin's own install tree, so it works under any install layout — matching the `interceptors-opentelemetry` plugins.