### PR TITLE
fix(worker): patch workflow bundles with const/let/var

### DIFF
--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -229,7 +229,7 @@ exports.importInterceptors = function importInterceptors() {
       // Ignore the "node:" prefix if any.
       const module: string = data.request?.startsWith('node:')
         ? data.request.slice('node:'.length)
-        : (data.request ?? '');
+        : data.request ?? '';
 
       if (moduleMatches(module, disallowedModules) && !moduleMatches(module, this.ignoreModules)) {
         this.foundProblematicModules.add(module);

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -136,10 +136,21 @@ export class WorkflowCodeBundler {
     let code = memoryFs.readFileSync(bundleFilePath, 'utf8') as string;
     // Replace webpack's module cache with an object injected by the runtime.
     // This is the key to reusing a single v8 context.
-    code = code.replace(
-      'var __webpack_module_cache__ = {}',
-      'var __webpack_module_cache__ = globalThis.__webpack_module_cache__'
-    );
+    // Webpack may emit the declaration as `var`, `let`, or `const` depending on the
+    // configured output environment (webpack >= 5.108.0 defaults to `const`).
+    let cacheDeclarationsPatched = 0;
+    code = code.replace(/(^|\s)(var|let|const) __webpack_module_cache__ = \{\}/gm, (_match, prefix, keyword) => {
+      cacheDeclarationsPatched++;
+      return `${prefix}${keyword} __webpack_module_cache__ = globalThis.__webpack_module_cache__`;
+    });
+    if (cacheDeclarationsPatched !== 1) {
+      throw new Error(
+        `Failed to patch the Workflow bundle: expected to find exactly one __webpack_module_cache__ declaration ` +
+          `emitted by webpack, but found ${cacheDeclarationsPatched}. Without this patch, Workflow isolation ` +
+          `would be broken. This is likely due to a change in webpack output; please report this at ` +
+          `https://github.com/temporalio/sdk-typescript/issues`
+      );
+    }
 
     this.logger.info('Workflow bundle created', { size: `${toMB(code.length)}MB` });
 
@@ -218,7 +229,7 @@ exports.importInterceptors = function importInterceptors() {
       // Ignore the "node:" prefix if any.
       const module: string = data.request?.startsWith('node:')
         ? data.request.slice('node:'.length)
-        : data.request ?? '';
+        : (data.request ?? '');
 
       if (moduleMatches(module, disallowedModules) && !moduleMatches(module, this.ignoreModules)) {
         this.foundProblematicModules.add(module);


### PR DESCRIPTION
## What was changed

- In `packages/worker/src/workflow/bundler.ts`, we now use a regexp to match `(var|let|const) __webpack_module_cache__ = \{\}` instead of only `var`. Recent webpack versions emit `const`, and without this change, the patch doesn't happen and workflow isolation breaks.
- We also add a check that this patch happens exactly once. If it does not (for instance, a future webpack update changes the emitted code to `__wp_mod_c__`, breaking our replacement), then we throw an exception and fail the bundling operation.
    - Hopefully this catches any future similar issues early, at Temporal users' build-step, before they start seeing isolation failures in prod.


## Why?

- Without this patch, workflows share the same module scope, instead of hitting the runtime-injected proxy. This means their module-level variables won't be isolated between workflows.

## Note on lockfiles and `minimumReleaseAge`

This repo uses a pnpm lockfile, so that package developers all get the same dependency versions. However, when end-users install the package, their npm/pnpm/yarn/etc will NOT respect the lockfile in this package—instead, they'll resolve the latest versions permitted by the specifiers in the various `package.json`s. Additionally, a `minimumReleaseAge` pnpm config in this repo prevents SDK developers from installing package versions newer than 2 weeks old.

This bug was caused by a recently-released dependency version (at the time of writing, the `webpack` issue causing this bug was still <2weeks old, which falls inside the configured `minimumReleaseAge` window). **Because this repo uses a lockfile/minimumReleaseAge, the tests will NEVER catch issues with newly-released dependency versions**.

It might be worth investigating one of the following options:

- Remove the lockfile and `minimumReleaseAge` configuration
- Set up a regular GitHub Actions test job, which ignores the lockfile/minimumReleaseAge config, installing all packages like an end-user's package manager would, and runs the regular test suite.
    - This is probably the cleanest—because a failure in this job, while the main tests stay passing, would indicate "something is wrong with a recent dependency update"

## Checklist

1. Closes https://github.com/temporalio/sdk-typescript/issues/2166

2. How was this tested:
  - Tested against webpack `5.107.2` (which emits `var`) and webpack `5.108.4` (which emits `const`) using a manual version override.

3. ~~Any docs updates needed?~~ Nope

> **LLM disclosure**: This issue's text was hand-written, the small code patch was LLM-generated (Claude Fable 5).