### PR TITLE
chore(test): add test displaying langsmith signal with start breakage

### DIFF
--- a/contrib/langsmith/src/__tests__/activities/langsmith.ts
+++ b/contrib/langsmith/src/__tests__/activities/langsmith.ts
@@ -10,6 +10,18 @@ export async function simpleActivity(input: string): Promise<string> {
   return `did:${input}`;
 }
 
+export async function a(): Promise<string> {
+  return 'a';
+}
+
+export async function b(): Promise<string> {
+  return 'b';
+}
+
+export async function c(): Promise<string> {
+  return 'c';
+}
+
 /** A plain activity with no `traceable` in its body. */
 export async function plainActivity(input: string): Promise<string> {
   return `plain:${input}`;

--- a/contrib/langsmith/src/__tests__/test-signal-start.ts
+++ b/contrib/langsmith/src/__tests__/test-signal-start.ts
@@ -1,0 +1,40 @@
+/**
+ * Start-with-signal ordering under the LangSmith signal inbound interceptor.
+ *
+ * The workflow buffers the start signal until after activity `a`, installs an
+ * async signal handler that awaits activity `b`, then schedules activity `c`.
+ * The LangSmith signal interceptor must not introduce an async boundary that
+ * lets `c` run before the signal handler's `b`.
+ *
+ * @module
+ */
+
+import test from 'ava';
+
+import * as activities from './activities/langsmith';
+import { InMemoryRunCollector, withTracingWorker } from './helpers';
+import * as workflows from './workflows/langsmith';
+
+process.env.LANGSMITH_TRACING = 'true';
+process.env.LANGCHAIN_CALLBACKS_BACKGROUND = 'false';
+
+test.serial('signalWithStart: LangSmith signal interceptor preserves workflow ordering', async (t) => {
+  const collector = new InMemoryRunCollector();
+
+  const result = await withTracingWorker({
+    collector,
+    options: { addTemporalRuns: true },
+    activities: { a: activities.a, b: activities.b, c: activities.c },
+    body: async ({ client, taskQueue }) => {
+      const handle = await client.workflow.signalWithStart(workflows.SignalStartOrderingWorkflow, {
+        taskQueue,
+        workflowId: `signal-start-ordering-${Date.now()}`,
+        signal: workflows.startSignal,
+      });
+      return handle.result();
+    },
+  });
+
+  t.is(result, 'abc');
+  t.truthy(collector.byName('HandleSignal:startSignal'), 'LangSmith signal interceptor emitted the handler run');
+});

--- a/contrib/langsmith/src/__tests__/workflows/langsmith.ts
+++ b/contrib/langsmith/src/__tests__/workflows/langsmith.ts
@@ -13,6 +13,7 @@ import {
   defineSignal,
   defineUpdate,
   proxyActivities,
+  proxyLocalActivities,
   setHandler,
   startChild,
   uuid4,
@@ -23,6 +24,11 @@ import { ApplicationFailureCategory } from '@temporalio/common';
 import type * as activities from '../activities/langsmith';
 
 const { simpleActivity, plainActivity, failingActivity, benignFailingActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '1 minute',
+  retry: { maximumAttempts: 1 },
+});
+
+const { a, b, c } = proxyLocalActivities<typeof activities>({
   startToCloseTimeout: '1 minute',
   retry: { maximumAttempts: 1 },
 });
@@ -50,6 +56,7 @@ export async function PlainWorkflow(input: string): Promise<string> {
 export const mySignal = defineSignal<[string]>('my_signal');
 export const completeSignal = defineSignal('complete');
 export const myQuery = defineQuery<string>('my_query');
+export const startSignal = defineSignal('startSignal');
 
 /** Sets a query handler and a releasing signal, then waits. */
 export async function HandlersWorkflow(): Promise<string> {
@@ -81,6 +88,17 @@ export async function SignalChildWorkflow(input: string): Promise<string> {
   });
   await child.signal(mySignal, input);
   return child.result();
+}
+
+/** Start-with-signal ordering reproducer for async signal inbound interceptors. */
+export async function SignalStartOrderingWorkflow(): Promise<string> {
+  const order: string[] = [];
+  order.push(await a());
+  setHandler(startSignal, async () => {
+    order.push(await b());
+  });
+  order.push(await c());
+  return order.join('');
 }
 
 /** Calls an activity that fails with a non-benign error. */

--- a/contrib/langsmith/src/workflow-interceptors.ts
+++ b/contrib/langsmith/src/workflow-interceptors.ts
@@ -401,7 +401,7 @@ class LangSmithWorkflowInbound implements WorkflowInboundCallsInterceptor {
       inputs,
       generateNewUuid4,
     });
-    await run.postRun();
+    void run.postRun();
     const body = async (): Promise<unknown> => {
       try {
         const result = await next();


### PR DESCRIPTION
Backport of #2184 to `releases/1.20.x` for the 1.20.3 patch release. Removes the `await run.postRun()` yield point (fixes signal-with-start command ordering) and adds the demonstrating test.