### PR TITLE
Add patch activation callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ to docs, or any other relevant information.
 
 ### Added
 
+- Added experimental `WorkerOptions.patchActivationCallback` to control whether newly encountered Workflow patches
+  activate and write a patch marker.
 - Nexus operation link propagation for signals. When a Nexus operation handler signals a workflow
   (including signal-with-start), the inbound Nexus request links are now forwarded onto the signaled
   workflow so its history events link back to the caller, and the link the server returns for the

--- a/packages/test/src/test-integration-patch-activation-callback.ts
+++ b/packages/test/src/test-integration-patch-activation-callback.ts
@@ -1,0 +1,77 @@
+import { temporal } from '@temporalio/proto';
+import { createTestWorkflowBundle, helpers, makeTestFunction } from './helpers-integration';
+import {
+  finishPatchActivationWorkflow,
+  patchActivationResult,
+  patchActivationRolloutWorkflow,
+} from './workflows/patch-activation-callback-new';
+
+const test = makeTestFunction({
+  workflowsPath: require.resolve('./workflows/patch-activation-callback-new'),
+});
+
+test.serial('declined patch can roll back to old Workflow code', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+  let callbackCalls = 0;
+  const newWorker = await createWorker({
+    patchActivationCallback(input) {
+      callbackCalls++;
+      t.is(input.workflowInfo.workflowType, 'patchActivationRolloutWorkflow');
+      t.is(input.patchId, 'patch-activation-callback-rollout');
+      return false;
+    },
+  });
+  const handle = await startWorkflow(patchActivationRolloutWorkflow);
+  t.false(await newWorker.runUntil(() => handle.query(patchActivationResult)));
+  t.is(callbackCalls, 1);
+
+  const oldBundle = await createTestWorkflowBundle({
+    workflowsPath: require.resolve('./workflows/patch-activation-callback-old'),
+  });
+  const oldWorker = await createWorker({ workflowBundle: oldBundle });
+  const result = await oldWorker.runUntil(async () => {
+    await handle.signal(finishPatchActivationWorkflow);
+    return await handle.result();
+  });
+  t.is(result, 'old');
+
+  const history = await handle.fetchHistory();
+  t.false(
+    history.events?.some((event) => event.eventType === temporal.api.enums.v1.EventType.EVENT_TYPE_MARKER_RECORDED) ??
+      false
+  );
+});
+
+test.serial('recorded patch bypasses declining callback on a new Worker', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+  let activatingCalls = 0;
+  const activatingWorker = await createWorker({
+    patchActivationCallback() {
+      activatingCalls++;
+      return true;
+    },
+  });
+  const handle = await startWorkflow(patchActivationRolloutWorkflow);
+  t.true(await activatingWorker.runUntil(() => handle.query(patchActivationResult)));
+  t.is(activatingCalls, 1);
+
+  let decliningCalls = 0;
+  const decliningWorker = await createWorker({
+    patchActivationCallback() {
+      decliningCalls++;
+      return false;
+    },
+  });
+  const result = await decliningWorker.runUntil(async () => {
+    await handle.signal(finishPatchActivationWorkflow);
+    return await handle.result();
+  });
+  t.is(result, 'new');
+  t.is(decliningCalls, 0);
+
+  const history = await handle.fetchHistory();
+  t.true(
+    history.events?.some((event) => event.eventType === temporal.api.enums.v1.EventType.EVENT_TYPE_MARKER_RECORDED) ??
+      false
+  );
+});

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -2055,12 +2055,12 @@ test('threaded patch activation callback preserves closures patchedWorkflow', as
   t.is(calls.length, 1);
 });
 
-test.serial(
+// Bun does not count time spent waiting for a main-thread callback toward the Workflow VM timeout.
+(isBun ? test.skip : test.serial)(
   'slow patch activation callback blocks the Worker and counts toward isolate timeout patchedWorkflow',
   async (t) => {
     const isolateExecutionTimeoutMs = 100;
     const delayMs = 200;
-    const waitBuffer = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
     let callbackDurationMs = 0;
     let mainThreadTimerFired = false;
     let mainThreadTimerFiredBeforeCallbackReturned = false;
@@ -2075,8 +2075,9 @@ test.serial(
           }, 0);
         });
         const startedAt = Date.now();
-        Atomics.wait(waitBuffer, 0, 0, delayMs);
-        callbackDurationMs = Date.now() - startedAt;
+        do {
+          callbackDurationMs = Date.now() - startedAt;
+        } while (callbackDurationMs <= delayMs);
         mainThreadTimerFiredBeforeCallbackReturned = mainThreadTimerFired;
         return false;
       },

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -1890,6 +1890,7 @@ interface RunPatchedWorkflowWithCallbackOptions {
   initialActivation?: coresdk.workflow_activation.IWorkflowActivation;
   workflowType?: string;
   logger?: Logger;
+  isolateExecutionTimeoutMs?: number;
 }
 
 async function runPatchedWorkflowWithCallback(
@@ -1900,6 +1901,7 @@ async function runPatchedWorkflowWithCallback(
     initialActivation,
     workflowType = 'patchedWorkflow',
     logger = new DefaultLogger('ERROR'),
+    isolateExecutionTimeoutMs = 400,
   }: RunPatchedWorkflowWithCallbackOptions = {}
 ): Promise<{ first: coresdk.workflow_completion.IWorkflowActivationCompletion; calls: PatchActivationInput[] }> {
   const calls: PatchActivationInput[] = [];
@@ -1918,7 +1920,7 @@ async function runPatchedWorkflowWithCallback(
     creator = await ThreadedVMWorkflowCreator.create({
       workflowBundle,
       threadPoolSize: 1,
-      isolateExecutionTimeoutMs: 400,
+      isolateExecutionTimeoutMs,
       reuseV8Context: REUSE_V8_CONTEXT,
       registeredActivityNames: new Set(),
       logger,
@@ -1928,9 +1930,19 @@ async function runPatchedWorkflowWithCallback(
     const internalCallback = (info: WorkflowInfo, patchId: string) =>
       invokePatchActivationCallback(recordingCallback, info, patchId);
     if (REUSE_V8_CONTEXT) {
-      creator = await TestReusableVMWorkflowCreator.create(workflowBundle, 400, new Set(), internalCallback);
+      creator = await TestReusableVMWorkflowCreator.create(
+        workflowBundle,
+        isolateExecutionTimeoutMs,
+        new Set(),
+        internalCallback
+      );
     } else {
-      creator = await TestVMWorkflowCreator.create(workflowBundle, 400, new Set(), internalCallback);
+      creator = await TestVMWorkflowCreator.create(
+        workflowBundle,
+        isolateExecutionTimeoutMs,
+        new Set(),
+        internalCallback
+      );
     }
   }
   const runId = t.context.runId;
@@ -2042,6 +2054,46 @@ test('threaded patch activation callback preserves closures patchedWorkflow', as
   t.is(invoked, 1);
   t.is(calls.length, 1);
 });
+
+test.serial(
+  'slow patch activation callback blocks the Worker and counts toward isolate timeout patchedWorkflow',
+  async (t) => {
+    const isolateExecutionTimeoutMs = 100;
+    const delayMs = 200;
+    const waitBuffer = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    let callbackDurationMs = 0;
+    let mainThreadTimerFired = false;
+    let mainThreadTimerFiredBeforeCallbackReturned = false;
+    let mainThreadTimer: Promise<void> | undefined;
+    const { first, calls } = await runPatchedWorkflowWithCallback(
+      t,
+      () => {
+        mainThreadTimer = new Promise((resolve) => {
+          setTimeout(() => {
+            mainThreadTimerFired = true;
+            resolve();
+          }, 0);
+        });
+        const startedAt = Date.now();
+        Atomics.wait(waitBuffer, 0, 0, delayMs);
+        callbackDurationMs = Date.now() - startedAt;
+        mainThreadTimerFiredBeforeCallbackReturned = mainThreadTimerFired;
+        return false;
+      },
+      { threaded: true, isolateExecutionTimeoutMs }
+    );
+
+    await mainThreadTimer;
+    t.true(callbackDurationMs > isolateExecutionTimeoutMs);
+    t.false(mainThreadTimerFiredBeforeCallbackReturned);
+    t.true(mainThreadTimerFired);
+    t.regex(
+      first.failed?.failure?.message ?? '',
+      new RegExp(`Script execution timed out after ${isolateExecutionTimeoutMs}ms`)
+    );
+    t.is(calls.length, 1);
+  }
+);
 
 test('history patch marker bypasses patch activation callback patchedWorkflow', async (t) => {
   const initialActivation: coresdk.workflow_activation.IWorkflowActivation = {

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -4,7 +4,7 @@ import type { ExecutionContext, TestFn } from 'ava';
 import anyTest from 'ava';
 import dedent from 'dedent';
 import Long from 'long';
-import type { Payload } from '@temporalio/common';
+import type { Logger, Payload } from '@temporalio/common';
 import {
   ApplicationFailure,
   defaultFailureConverter,
@@ -15,10 +15,16 @@ import {
 } from '@temporalio/common';
 import { msToTs } from '@temporalio/common/lib/time';
 import { coresdk, temporal } from '@temporalio/proto';
-import { LogTimestamp } from '@temporalio/worker';
+import { sleep as workflowSleep, type WorkflowInfo } from '@temporalio/workflow';
+import { DefaultLogger, LogTimestamp, type LogEntry } from '@temporalio/worker';
 import { WorkflowCodeBundler } from '@temporalio/worker/lib/workflow/bundler';
+import { invokePatchActivationCallback } from '@temporalio/worker/lib/workflow/patch-activation-callback';
+import { ThreadedVMWorkflowCreator } from '@temporalio/worker/lib/workflow/threaded-vm';
+import type { WorkflowBundleWithSourceMapAndFilename } from '@temporalio/worker/lib/workflow/workflow-worker-thread/input';
+import type { PatchActivationCallback, PatchActivationInput } from '@temporalio/worker';
 import type { VMWorkflow } from '@temporalio/worker/lib/workflow/vm';
 import { VMWorkflowCreator } from '@temporalio/worker/lib/workflow/vm';
+import type { WorkflowCreator } from '@temporalio/worker/lib/workflow/interface';
 import type { SdkFlag } from '@temporalio/workflow/lib/flags';
 import { SdkFlags } from '@temporalio/workflow/lib/flags';
 import { createUnsafeRandomSource } from '@temporalio/workflow/lib/random-helpers';
@@ -36,6 +42,7 @@ export interface Context {
   startTime: number;
   runId: string;
   workflowCreator: TestVMWorkflowCreator | TestReusableVMWorkflowCreator;
+  workflowBundle: WorkflowBundleWithSourceMapAndFilename;
 }
 
 const test = anyTest as TestFn<Context>;
@@ -71,6 +78,7 @@ test.before(async (t) => {
   const workflowsPath = path.join(__dirname, 'workflows');
   const bundler = new WorkflowCodeBundler({ workflowsPath });
   const workflowBundle = parseWorkflowCode((await bundler.createBundle()).code);
+  t.context.workflowBundle = workflowBundle;
   // FIXME: isolateExecutionTimeoutMs used to be 200 ms, but that's causing
   //        lot of flakes on CI. Revert this after investigation / resolution.
   t.context.workflowCreator = REUSE_V8_CONTEXT
@@ -96,6 +104,7 @@ test.beforeEach(async (t) => {
     runId,
     workflowType,
     workflowCreator,
+    workflowBundle: t.context.workflowBundle,
     startTime,
     workflow,
   };
@@ -109,38 +118,42 @@ async function createWorkflow(
   workflowType: string,
   runId: string,
   startTime: number,
-  workflowCreator: VMWorkflowCreator | ReusableVMWorkflowCreator
+  workflowCreator: WorkflowCreator
 ) {
   const workflow = (await workflowCreator.createWorkflow({
-    info: {
-      workflowType,
-      runId,
-      workflowId: 'test-workflowId',
-      namespace: 'default',
-      firstExecutionRunId: runId,
-      attempt: 1,
-      taskTimeoutMs: 1000,
-      taskQueue: 'test',
-      searchAttributes: {},
-      typedSearchAttributes: new TypedSearchAttributes(),
-      historyLength: 3,
-      historySize: 300,
-      continueAsNewSuggested: false,
-      targetWorkerDeploymentVersionChanged: false,
-      unsafe: {
-        isReplaying: false,
-        isReplayingHistoryEvents: false,
-        now: Date.now,
-        random: createUnsafeRandomSource(Math.random),
-      },
-      startTime: new Date(),
-      runStartTime: new Date(),
-    },
+    info: makeWorkflowInfo(workflowType, runId),
     randomnessSeed: Long.fromInt(1337).toBytes(),
     now: startTime,
     showStackTraceSources: true,
   })) as VMWorkflow;
   return workflow;
+}
+
+function makeWorkflowInfo(workflowType: string, runId: string): WorkflowInfo {
+  return {
+    workflowType,
+    runId,
+    workflowId: 'test-workflowId',
+    namespace: 'default',
+    firstExecutionRunId: runId,
+    attempt: 1,
+    taskTimeoutMs: 1000,
+    taskQueue: 'test',
+    searchAttributes: {},
+    typedSearchAttributes: new TypedSearchAttributes(),
+    historyLength: 3,
+    historySize: 300,
+    continueAsNewSuggested: false,
+    targetWorkerDeploymentVersionChanged: false,
+    unsafe: {
+      isReplaying: false,
+      isReplayingHistoryEvents: false,
+      now: Date.now,
+      random: createUnsafeRandomSource(Math.random),
+    },
+    startTime: new Date(),
+    runStartTime: new Date(),
+  };
 }
 
 async function activate(t: ExecutionContext<Context>, activation: coresdk.workflow_activation.IWorkflowActivation) {
@@ -1870,6 +1883,231 @@ test('not-replay patchedWorkflow', async (t) => {
     compareCompletion(t, req, makeSuccess([makeCompleteWorkflowExecution()]));
   }
   t.deepEqual(logs, [['has change'], ['has change 2']]);
+});
+
+interface RunPatchedWorkflowWithCallbackOptions {
+  threaded?: boolean;
+  initialActivation?: coresdk.workflow_activation.IWorkflowActivation;
+  workflowType?: string;
+  logger?: Logger;
+}
+
+async function runPatchedWorkflowWithCallback(
+  t: ExecutionContext<Context>,
+  callback: PatchActivationCallback,
+  {
+    threaded = false,
+    initialActivation,
+    workflowType = 'patchedWorkflow',
+    logger = new DefaultLogger('ERROR'),
+  }: RunPatchedWorkflowWithCallbackOptions = {}
+): Promise<{ first: coresdk.workflow_completion.IWorkflowActivationCompletion; calls: PatchActivationInput[] }> {
+  const calls: PatchActivationInput[] = [];
+  const recordingCallback: PatchActivationCallback = (input) => {
+    calls.push(input);
+    return callback(input);
+  };
+  // VM creators share source maps by bundle filename, so the temporary creator needs its own key
+  // to avoid removing the suite-wide creator's source map when it is destroyed.
+  const workflowBundle = {
+    ...t.context.workflowBundle,
+    filename: `${t.context.workflowBundle.filename}-${t.context.runId}`,
+  };
+  let creator: WorkflowCreator;
+  if (threaded) {
+    creator = await ThreadedVMWorkflowCreator.create({
+      workflowBundle,
+      threadPoolSize: 1,
+      isolateExecutionTimeoutMs: 400,
+      reuseV8Context: REUSE_V8_CONTEXT,
+      registeredActivityNames: new Set(),
+      logger,
+      patchActivationCallback: recordingCallback,
+    });
+  } else {
+    const internalCallback = (info: WorkflowInfo, patchId: string) =>
+      invokePatchActivationCallback(recordingCallback, info, patchId);
+    if (REUSE_V8_CONTEXT) {
+      creator = await TestReusableVMWorkflowCreator.create(workflowBundle, 400, new Set(), internalCallback);
+    } else {
+      creator = await TestVMWorkflowCreator.create(workflowBundle, 400, new Set(), internalCallback);
+    }
+  }
+  const runId = t.context.runId;
+  if (creator instanceof TestVMWorkflowCreator || creator instanceof TestReusableVMWorkflowCreator) {
+    creator.logs[runId] = [];
+  }
+  const workflow = await createWorkflow(workflowType, runId, Date.now(), creator);
+  try {
+    const first = await workflow.activate(initialActivation ?? makeStartWorkflow(workflowType));
+    if (first.successful?.commands?.some((command) => command.startTimer !== undefined)) {
+      await workflow.activate(makeFireTimer(1));
+    }
+    return { first, calls };
+  } finally {
+    await workflow.dispose();
+    await creator.destroy();
+  }
+}
+
+test('patch activation callback true patchedWorkflow', async (t) => {
+  const { first, calls } = await runPatchedWorkflowWithCallback(t, () => true);
+  compareCompletion(
+    t,
+    first,
+    makeSuccess([
+      makeSetPatchMarker('my-change-id', false),
+      makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(100) }),
+    ])
+  );
+  t.is(calls.length, 1);
+  t.is(calls[0]?.workflowInfo.workflowId, 'test-workflowId');
+  t.is(calls[0]?.patchId, 'my-change-id');
+});
+
+test('patch activation callback false patchedWorkflow', async (t) => {
+  const { first, calls } = await runPatchedWorkflowWithCallback(t, () => false);
+  compareCompletion(t, first, makeSuccess([makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(100) })]));
+  t.is(calls.length, 1);
+});
+
+test('patch activation callback validates result patchedWorkflow', async (t) => {
+  const { first } = await runPatchedWorkflowWithCallback(t, () => 'yes' as unknown as boolean, { threaded: true });
+  t.regex(first.failed?.failure?.message ?? '', /patchActivationCallback must return a boolean, got string/);
+});
+
+test('patch activation callback uses the same Worker snapshot in debug and threaded modes patchedWorkflow', async (t) => {
+  const expectedObservation = {
+    inputFrozen: true,
+    infoFrozen: true,
+    startTimeIsDate: true,
+    typedSearchAttributesRestored: true,
+    nowWorks: true,
+    randomWorks: true,
+  };
+  const observations: Array<Record<string, boolean>> = [];
+  for (const threaded of [false, true]) {
+    let sideEffects = 0;
+    const { first } = await runPatchedWorkflowWithCallback(
+      t,
+      (input) => {
+        sideEffects++;
+        observations.push({
+          inputFrozen: Object.isFrozen(input),
+          infoFrozen: Object.isFrozen(input.workflowInfo),
+          startTimeIsDate: input.workflowInfo.startTime instanceof Date,
+          typedSearchAttributesRestored: input.workflowInfo.typedSearchAttributes instanceof TypedSearchAttributes,
+          nowWorks: Number.isFinite(input.workflowInfo.unsafe.now()),
+          randomWorks: input.workflowInfo.unsafe.random.random() >= 0,
+        });
+        t.throws(() => workflowSleep(1), { message: /Workflow Execution/ });
+        return false;
+      },
+      { threaded }
+    );
+    t.falsy(first.failed);
+    t.is(sideEffects, 1);
+  }
+  t.is(observations.length, 2);
+  for (const observation of observations) {
+    t.deepEqual(observation, expectedObservation);
+  }
+});
+
+test('patch activation callback receives a detached WorkflowInfo snapshot patchedWorkflow', (t) => {
+  const workflowInfo = makeWorkflowInfo('patchedWorkflow', 'snapshot-run-id');
+  workflowInfo.searchAttributes.SnapshotKeywordField = ['original'];
+  invokePatchActivationCallback(
+    (input) => {
+      (input.workflowInfo.searchAttributes.SnapshotKeywordField as string[]).push('callback');
+      return false;
+    },
+    workflowInfo,
+    'my-change-id'
+  );
+  t.deepEqual(workflowInfo.searchAttributes.SnapshotKeywordField, ['original']);
+});
+
+test('threaded patch activation callback preserves closures patchedWorkflow', async (t) => {
+  let invoked = 0;
+  const { first, calls } = await runPatchedWorkflowWithCallback(
+    t,
+    () => {
+      invoked++;
+      return false;
+    },
+    { threaded: true }
+  );
+  t.falsy(first.failed);
+  t.is(invoked, 1);
+  t.is(calls.length, 1);
+});
+
+test('history patch marker bypasses patch activation callback patchedWorkflow', async (t) => {
+  const initialActivation: coresdk.workflow_activation.IWorkflowActivation = {
+    runId: 'test-runId',
+    timestamp: msToTs(Date.now()),
+    isReplaying: true,
+    jobs: [makeInitializeWorkflowJob('patchedWorkflow'), makeNotifyHasPatchJob('my-change-id')],
+  };
+  const { first, calls } = await runPatchedWorkflowWithCallback(t, () => false, { initialActivation });
+  t.falsy(first.failed);
+  t.is(calls.length, 0);
+});
+
+test('replay without marker defers patch activation callback until live activation patchedWorkflow', async (t) => {
+  const initialActivation: coresdk.workflow_activation.IWorkflowActivation = {
+    runId: 'test-runId',
+    timestamp: msToTs(Date.now()),
+    isReplaying: true,
+    jobs: [makeInitializeWorkflowJob('patchedWorkflow')],
+  };
+  const { first, calls } = await runPatchedWorkflowWithCallback(
+    t,
+    (input) => {
+      t.false(input.workflowInfo.unsafe.isReplaying);
+      return false;
+    },
+    { initialActivation }
+  );
+  t.falsy(first.failed);
+  t.is(calls.length, 1);
+});
+
+test('deprecated patch bypasses patch activation callback deprecatePatchWorkflow', async (t) => {
+  const { first, calls } = await runPatchedWorkflowWithCallback(
+    t,
+    () => {
+      throw new Error('Patch activation callback should not be called');
+    },
+    { workflowType: 'deprecatePatchWorkflow' }
+  );
+  compareCompletion(t, first, makeSuccess([makeSetPatchMarker('my-change-id', true), makeCompleteWorkflowExecution()]));
+  t.is(calls.length, 0);
+});
+
+test('threaded patch activation callback logs complete errors before returning a compact failure patchedWorkflow', async (t) => {
+  const entries: LogEntry[] = [];
+  const logger = new DefaultLogger('WARN', (entry) => entries.push(entry));
+  const callbackError = new Error('callback failure with stack');
+  const { first } = await runPatchedWorkflowWithCallback(
+    t,
+    () => {
+      throw callbackError;
+    },
+    { threaded: true, logger }
+  );
+
+  t.regex(first.failed?.failure?.message ?? '', /Error: callback failure with stack/);
+  t.is(entries.length, 1);
+  t.is(entries[0]?.level, 'WARN');
+  t.is(entries[0]?.message, 'Patch activation callback failed');
+  t.is(entries[0]?.meta?.error, callbackError);
+  t.is(entries[0]?.meta?.workflowId, 'test-workflowId');
+  t.is(entries[0]?.meta?.runId, t.context.runId);
+  t.is(entries[0]?.meta?.workflowType, 'patchedWorkflow');
+  t.is(entries[0]?.meta?.patchId, 'my-change-id');
+  t.truthy(callbackError.stack);
 });
 
 test('replay-no-marker patchedWorkflow', async (t) => {

--- a/packages/test/src/workflows/deprecate-patch.ts
+++ b/packages/test/src/workflows/deprecate-patch.ts
@@ -1,6 +1,9 @@
-import { deprecatePatch } from '@temporalio/workflow';
+import { deprecatePatch, patched } from '@temporalio/workflow';
 
 export async function deprecatePatchWorkflow(): Promise<void> {
   deprecatePatch('my-change-id');
+  if (!patched('my-change-id')) {
+    throw new Error('Deprecated patch must remain active');
+  }
   console.log('has change');
 }

--- a/packages/test/src/workflows/patch-activation-callback-new.ts
+++ b/packages/test/src/workflows/patch-activation-callback-new.ts
@@ -1,0 +1,15 @@
+import { condition, defineQuery, defineSignal, patched, setHandler } from '@temporalio/workflow';
+
+export const finishPatchActivationWorkflow = defineSignal('finishPatchActivationWorkflow');
+export const patchActivationResult = defineQuery<boolean>('patchActivationResult');
+
+export async function patchActivationRolloutWorkflow(): Promise<'old' | 'new'> {
+  const activated = patched('patch-activation-callback-rollout');
+  let finish = false;
+  setHandler(patchActivationResult, () => activated);
+  setHandler(finishPatchActivationWorkflow, () => {
+    finish = true;
+  });
+  await condition(() => finish);
+  return activated ? 'new' : 'old';
+}

--- a/packages/test/src/workflows/patch-activation-callback-old.ts
+++ b/packages/test/src/workflows/patch-activation-callback-old.ts
@@ -1,0 +1,14 @@
+import { condition, defineQuery, defineSignal, setHandler } from '@temporalio/workflow';
+
+export const finishPatchActivationWorkflow = defineSignal('finishPatchActivationWorkflow');
+export const patchActivationResult = defineQuery<boolean>('patchActivationResult');
+
+export async function patchActivationRolloutWorkflow(): Promise<'old'> {
+  let finish = false;
+  setHandler(patchActivationResult, () => false);
+  setHandler(finishPatchActivationWorkflow, () => {
+    finish = true;
+  });
+  await condition(() => finish);
+  return 'old';
+}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -69,6 +69,8 @@ export * from './sinks';
 export { DataConverter, defaultPayloadConverter, State, Worker, WorkerStatus } from './worker';
 export {
   CompiledWorkerOptions,
+  PatchActivationCallback,
+  PatchActivationInput,
   ReplayWorkerOptions,
   WorkerDeploymentOptions,
   WorkerOptions,

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -13,7 +13,7 @@ import type {
 import type { Duration } from '@temporalio/common/lib/time';
 import { msOptionalToNumber, msToNumber } from '@temporalio/common/lib/time';
 import { loadDataConverter } from '@temporalio/common/lib/internal-non-workflow';
-import type { LoggerSinks } from '@temporalio/workflow';
+import type { LoggerSinks, WorkflowInfo } from '@temporalio/workflow';
 import type { Context } from '@temporalio/activity';
 import type { native } from '@temporalio/core-bridge';
 import { throwIfReservedName } from '@temporalio/common/lib/reserved';
@@ -109,6 +109,19 @@ export interface WorkerOptions {
    * Mapping of activity name to implementation
    */
   activities?: object;
+
+  /**
+   * Called when a Workflow first encounters a non-deprecated patch on a non-replay activation.
+   * Returning `false` leaves the patch inactive and does not record a patch marker. The decision is
+   * memoized for the lifetime of the Workflow Execution.
+   *
+   * The callback runs synchronously in the Worker context, where it may use normal time, randomness, and other
+   * side effects. Workflow APIs are unavailable. It must return an actual boolean and should return promptly to
+   * avoid blocking the Worker.
+   *
+   * @experimental
+   */
+  patchActivationCallback?: PatchActivationCallback;
 
   /**
    * An array of Nexus services
@@ -745,6 +758,7 @@ export interface ReplayWorkerOptions
     | 'stickyQueueScheduleToStartTimeout'
     | 'maxCachedWorkflows'
     | 'useVersioning'
+    | 'patchActivationCallback'
   > {
   /**
    *  A optional name for this replay worker. It will be combined with an incremental ID to form a unique
@@ -754,6 +768,16 @@ export interface ReplayWorkerOptions
    */
   replayName?: string;
 }
+
+/** @experimental */
+export interface PatchActivationInput {
+  /** A detached snapshot of Workflow information at the time the patch is encountered. */
+  readonly workflowInfo: Readonly<WorkflowInfo>;
+  readonly patchId: string;
+}
+
+/** @experimental */
+export type PatchActivationCallback = (input: PatchActivationInput) => boolean;
 
 // Workflow Bundle /////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -115,11 +115,13 @@ export interface WorkerOptions {
    * Returning `false` leaves the patch inactive and does not record a patch marker. The decision is
    * memoized for the lifetime of the Workflow Execution.
    *
-   * The callback runs synchronously in the Worker context, where it may use normal time, randomness, and other
-   * side effects. Workflow APIs are unavailable. It must return an actual boolean and should return promptly because
-   * it blocks the Worker main thread. Time spent in the callback counts toward the Workflow isolate execution timeout
-   * (5 seconds by default). A callback that never returns cannot be interrupted locally and will continue blocking the
-   * Worker even after the server times out the Workflow Task.
+   * The callback runs synchronously in the Worker context, where it may use normal time,
+   * randomness, and other side effects. Workflow APIs are unavailable. It must return an actual
+   * boolean and should return promptly because it blocks the Worker main thread. Time spent in the
+   * callback counts toward the Workflow isolate execution timeout (5 seconds by default), except in
+   * Bun which does not currently count time spent waiting for a callback running on the Worker main
+   * thread toward this timeout. A callback that never returns cannot be interrupted locally and
+   * will continue blocking the Worker even after the server times out the Workflow Task.
    *
    * @experimental
    */
@@ -556,26 +558,26 @@ export interface WorkerOptions {
    * The types of errors that, if thrown by a Workflow function, a signal handler, or an update
    * handler, will cause the Workflow Execution or the Update to fail instead of failing the
    * Workflow Task (which would result in retrying the Workflow Task until it eventually succeeds).
-   * 
+   *
    * This property expects a record of Workflow-type names to the list of error types that will
    * cause that type of Workflow to fail. Uses the `'*'` key to specify a list of error types that
    * applies to all Workflow types. This is a worker-level equivalent of
    * {@link WorkflowDefinitionOptions.failureExceptionTypes}. Both settings are evaluated; an error
    * matching either will cause Workflow failure.
-   * 
+   *
    * Unlike {@link WorkflowDefinitionOptions.failureExceptionTypes}, this setting requires error
    * types to be specified as string names, not actual class references, and consequently, doesn't
    * support subclass matching via `instanceof`. It however allows failing the workflow execution
    * on _non-determinism errors_, by including the `NondeterminismError` type to the list of error
    * types, either globally (via the `'*'` key) or per-Workflow-type.
-   * 
+   *
    * Passing the `'Error'` error type string here will result in failing the Workflow on any error,
    * including non-determinism errors.
 
    * Note that {@link TemporalFailure} subclasses (with the exception of {@link ApplicationFailure})
    * and cancellation errors that bubbles out of the Workflow always fail the Workflow Execution,
    * regardless of either this and the {@link WorkflowDefinitionOptions.failureExceptionTypes} settings.
-   * 
+   *
    * @experimental
    */
   workflowFailureErrorTypes?: Record<

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -116,8 +116,10 @@ export interface WorkerOptions {
    * memoized for the lifetime of the Workflow Execution.
    *
    * The callback runs synchronously in the Worker context, where it may use normal time, randomness, and other
-   * side effects. Workflow APIs are unavailable. It must return an actual boolean and should return promptly to
-   * avoid blocking the Worker.
+   * side effects. Workflow APIs are unavailable. It must return an actual boolean and should return promptly because
+   * it blocks the Worker main thread. Time spent in the callback counts toward the Workflow isolate execution timeout
+   * (5 seconds by default). A callback that never returns cannot be interrupted locally and will continue blocking the
+   * Worker even after the server times out the Workflow Task.
    *
    * @experimental
    */

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -94,6 +94,7 @@ import type { Workflow, WorkflowCreator } from './workflow/interface';
 import { ReusableVMWorkflowCreator } from './workflow/reusable-vm';
 import { ThreadedVMWorkflowCreator } from './workflow/threaded-vm';
 import { VMWorkflowCreator } from './workflow/vm';
+import { invokePatchActivationCallback } from './workflow/patch-activation-callback';
 import type { WorkflowBundleWithSourceMapAndFilename } from './workflow/workflow-worker-thread/input';
 import {
   CombinedWorkerRunError,
@@ -575,6 +576,11 @@ export class Worker {
     logger: Logger
   ): Promise<WorkflowCreator> {
     const registeredActivityNames = new Set(compiledOptions.activities.keys());
+    const patchActivationCallback =
+      compiledOptions.patchActivationCallback === undefined
+        ? undefined
+        : (info: WorkflowInfo, patchId: string) =>
+            invokePatchActivationCallback(compiledOptions.patchActivationCallback!, info, patchId);
     // This isn't required for vscode, only for Chrome Dev Tools which doesn't support debugging worker threads.
     // We also rely on this in debug-replayer where we inject a global variable to be read from workflow context.
     if (compiledOptions.debugMode) {
@@ -582,13 +588,15 @@ export class Worker {
         return await ReusableVMWorkflowCreator.create(
           workflowBundle,
           compiledOptions.isolateExecutionTimeoutMs,
-          registeredActivityNames
+          registeredActivityNames,
+          patchActivationCallback
         );
       }
       return await VMWorkflowCreator.create(
         workflowBundle,
         compiledOptions.isolateExecutionTimeoutMs,
-        registeredActivityNames
+        registeredActivityNames,
+        patchActivationCallback
       );
     } else {
       return await ThreadedVMWorkflowCreator.create({
@@ -598,6 +606,7 @@ export class Worker {
         reuseV8Context: compiledOptions.reuseV8Context ?? true,
         registeredActivityNames,
         logger,
+        patchActivationCallback: compiledOptions.patchActivationCallback,
       });
     }
   }

--- a/packages/worker/src/workflow/patch-activation-callback.ts
+++ b/packages/worker/src/workflow/patch-activation-callback.ts
@@ -1,0 +1,122 @@
+import { IllegalStateError, TypedSearchAttributes, type SearchAttributePair } from '@temporalio/common';
+import type { WorkflowInfo } from '@temporalio/workflow';
+import { createUnsafeRandomSource } from '@temporalio/workflow/lib/random-helpers';
+import type { PatchActivationCallback, PatchActivationInput } from '../worker-options';
+
+// ts-prune-ignore-next (used by the workflow Worker thread entry point)
+export const PATCH_ACTIVATION_CALLBACK_BUFFER_SIZE = 64 * 1024;
+export const PATCH_ACTIVATION_CALLBACK_HEADER_SIZE = 3 * Int32Array.BYTES_PER_ELEMENT;
+
+export const enum PatchActivationCallbackStatus {
+  Pending = 0,
+  True = 1,
+  False = 2,
+  Error = 3,
+}
+
+export type WorkflowPatchActivationCallback = (workflowInfo: WorkflowInfo, patchId: string) => boolean;
+
+export type PatchActivationWorkflowInfoSnapshot = Omit<WorkflowInfo, 'typedSearchAttributes' | 'unsafe'> & {
+  typedSearchAttributes: SearchAttributePair[];
+  unsafe: Pick<WorkflowInfo['unsafe'], 'isReplaying' | 'isReplayingHistoryEvents'>;
+};
+
+export function makePatchActivationWorkflowInfoSnapshot(
+  workflowInfo: WorkflowInfo
+): PatchActivationWorkflowInfoSnapshot {
+  const snapshot: PatchActivationWorkflowInfoSnapshot = {
+    ...workflowInfo,
+    unsafe: {
+      isReplaying: workflowInfo.unsafe.isReplaying,
+      isReplayingHistoryEvents: workflowInfo.unsafe.isReplayingHistoryEvents,
+    },
+    // Structured cloning strips class prototypes, so preserve the public representation and
+    // reconstruct TypedSearchAttributes when the Worker-side callback input is created.
+    typedSearchAttributes: workflowInfo.typedSearchAttributes.toJSON(),
+  };
+  return structuredClone(snapshot);
+}
+
+function makePatchActivationInput(
+  workflowInfo: PatchActivationWorkflowInfoSnapshot,
+  patchId: string
+): PatchActivationInput {
+  const info = Object.freeze({
+    ...workflowInfo,
+    typedSearchAttributes: new TypedSearchAttributes(workflowInfo.typedSearchAttributes),
+    unsafe: Object.freeze({
+      ...workflowInfo.unsafe,
+      now: Date.now,
+      random: Object.freeze(createUnsafeRandomSource(Math.random)),
+    }),
+  }) as WorkflowInfo;
+  return Object.freeze({ workflowInfo: info, patchId });
+}
+
+export function invokePatchActivationCallbackWithSnapshot(
+  callback: PatchActivationCallback,
+  workflowInfo: PatchActivationWorkflowInfoSnapshot,
+  patchId: string
+): boolean {
+  const result = callback(makePatchActivationInput(workflowInfo, patchId));
+  if (typeof result !== 'boolean') {
+    throw new TypeError(`patchActivationCallback must return a boolean, got ${typeof result}`);
+  }
+  return result;
+}
+
+export function invokePatchActivationCallback(
+  callback: PatchActivationCallback,
+  workflowInfo: WorkflowInfo,
+  patchId: string
+): boolean {
+  return invokePatchActivationCallbackWithSnapshot(
+    callback,
+    makePatchActivationWorkflowInfoSnapshot(workflowInfo),
+    patchId
+  );
+}
+
+function getHeader(resultBuffer: SharedArrayBuffer): Int32Array {
+  return new Int32Array(resultBuffer, 0, 3);
+}
+
+export function writePatchActivationCallbackResult(resultBuffer: SharedArrayBuffer, result: boolean): void {
+  Atomics.store(
+    getHeader(resultBuffer),
+    1,
+    result ? PatchActivationCallbackStatus.True : PatchActivationCallbackStatus.False
+  );
+}
+
+export function writePatchActivationCallbackError(resultBuffer: SharedArrayBuffer, error: unknown): void {
+  const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  const encoded = new TextEncoder().encode(message);
+  const output = new Uint8Array(resultBuffer, PATCH_ACTIVATION_CALLBACK_HEADER_SIZE);
+  const length = Math.min(encoded.length, output.length);
+  output.set(encoded.subarray(0, length));
+  const header = getHeader(resultBuffer);
+  Atomics.store(header, 2, length);
+  Atomics.store(header, 1, PatchActivationCallbackStatus.Error);
+}
+
+export function completePatchActivationCallback(resultBuffer: SharedArrayBuffer): void {
+  const header = getHeader(resultBuffer);
+  Atomics.store(header, 0, 1);
+  Atomics.notify(header, 0);
+}
+
+// ts-prune-ignore-next (used by the workflow Worker thread entry point)
+export function waitForPatchActivationCallbackResult(resultBuffer: SharedArrayBuffer): boolean {
+  const header = getHeader(resultBuffer);
+  Atomics.wait(header, 0, PatchActivationCallbackStatus.Pending);
+  const status = Atomics.load(header, 1);
+  if (status === PatchActivationCallbackStatus.True) return true;
+  if (status === PatchActivationCallbackStatus.False) return false;
+  if (status === PatchActivationCallbackStatus.Error) {
+    const length = Atomics.load(header, 2);
+    const bytes = new Uint8Array(resultBuffer, PATCH_ACTIVATION_CALLBACK_HEADER_SIZE, length);
+    throw new Error(new TextDecoder().decode(bytes));
+  }
+  throw new IllegalStateError(`Invalid patch activation callback response status: ${status}`);
+}

--- a/packages/worker/src/workflow/reusable-vm.ts
+++ b/packages/worker/src/workflow/reusable-vm.ts
@@ -6,6 +6,7 @@ import type { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interfa
 import type { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
 import { BaseVMWorkflow, globalHandlers, injectGlobals, setUnhandledRejectionHandler } from './vm-shared';
 import { isBun } from './bun';
+import type { WorkflowPatchActivationCallback } from './patch-activation-callback';
 
 interface BagHolder {
   bag: any;
@@ -129,7 +130,8 @@ export class ReusableVMWorkflowCreator implements WorkflowCreator {
     protected readonly workflowBundle: WorkflowBundleWithSourceMapAndFilename,
     protected readonly isolateExecutionTimeoutMs: number,
     /** Known activity names registered on the executing worker */
-    protected readonly registeredActivityNames: Set<string>
+    protected readonly registeredActivityNames: Set<string>,
+    protected readonly patchActivationCallback?: WorkflowPatchActivationCallback
   ) {
     if (!ReusableVMWorkflowCreator.unhandledRejectionHandlerHasBeenSet) {
       setUnhandledRejectionHandler((runId) => ReusableVMWorkflowCreator.workflowByRunId.get(runId));
@@ -249,6 +251,7 @@ export class ReusableVMWorkflowCreator implements WorkflowCreator {
       getTimeOfDay: native.getTimeOfDay,
       registeredActivityNames: this.registeredActivityNames,
       stackTracesEnabled: globalHandlers.promiseHookInstalled,
+      patchActivationCallback: this.patchActivationCallback,
     });
     const activator = context.__TEMPORAL_ACTIVATOR__!;
     const newVM = new ReusableVMWorkflow(options.info.runId, context, activator, workflowModule);
@@ -265,7 +268,8 @@ export class ReusableVMWorkflowCreator implements WorkflowCreator {
     this: T,
     workflowBundle: WorkflowBundleWithSourceMapAndFilename,
     isolateExecutionTimeoutMs: number,
-    registeredActivityNames: Set<string>
+    registeredActivityNames: Set<string>,
+    patchActivationCallback?: WorkflowPatchActivationCallback
   ): Promise<InstanceType<T>> {
     // The Reusable V8 Context executor needs to take control of Webpack's require
     // cache in order to provide per-Workflow isolation of non-shared modules.
@@ -293,7 +297,13 @@ export class ReusableVMWorkflowCreator implements WorkflowCreator {
     const script = new vm.Script(workflowBundle.code, { filename: workflowBundle.filename });
     globalHandlers.install(); // Call is idempotent
     await globalHandlers.addWorkflowBundle(workflowBundle);
-    return new this(script, workflowBundle, isolateExecutionTimeoutMs, registeredActivityNames) as InstanceType<T>;
+    return new this(
+      script,
+      workflowBundle,
+      isolateExecutionTimeoutMs,
+      registeredActivityNames,
+      patchActivationCallback
+    ) as InstanceType<T>;
   }
 
   /**

--- a/packages/worker/src/workflow/threaded-vm.ts
+++ b/packages/worker/src/workflow/threaded-vm.ts
@@ -15,8 +15,10 @@ import { coresdk } from '@temporalio/proto';
 import { IllegalStateError, type SinkCall } from '@temporalio/workflow';
 import { createUnsafeRandomSource } from '@temporalio/workflow/lib/random-helpers';
 import type { Logger } from '@temporalio/common';
+import type { PatchActivationCallback } from '../worker-options';
 import { UnexpectedError } from '../errors';
 import type {
+  PatchActivationCallbackRequest,
   WorkflowBundleWithSourceMapAndFilename,
   WorkerThreadInput,
   WorkerThreadRequest,
@@ -24,6 +26,12 @@ import type {
 import type { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interface';
 import type { WorkerThreadOutput, WorkerThreadResponse } from './workflow-worker-thread/output';
 import { isBun } from './bun';
+import {
+  completePatchActivationCallback,
+  invokePatchActivationCallbackWithSnapshot,
+  writePatchActivationCallbackError,
+  writePatchActivationCallbackResult,
+} from './patch-activation-callback';
 
 // https://nodejs.org/api/worker_threads.html#event-exit
 // Bun exits with code 0 instead of 1
@@ -65,9 +73,15 @@ export class WorkerThreadClient {
 
   constructor(
     protected workerThread: NodeWorker,
-    protected logger: Logger
+    protected logger: Logger,
+    protected patchActivationCallback?: PatchActivationCallback
   ) {
-    workerThread.on('message', ({ requestId, result }: WorkerThreadResponse) => {
+    workerThread.on('message', (message: WorkerThreadResponse | PatchActivationCallbackRequest) => {
+      if (!('requestId' in message)) {
+        this.handlePatchActivationCallback(message);
+        return;
+      }
+      const { requestId, result } = message;
       const completion = this.requestIdToCompletion.get(requestId);
       if (completion === undefined) {
         throw new IllegalStateError(`Got completion for unknown requestId ${requestId}`);
@@ -104,6 +118,31 @@ export class WorkerThreadClient {
         completion.reject(error);
       }
     });
+  }
+
+  private handlePatchActivationCallback(request: PatchActivationCallbackRequest): void {
+    try {
+      if (this.patchActivationCallback === undefined) {
+        throw new IllegalStateError('Received patch activation callback request without a configured callback');
+      }
+      const result = invokePatchActivationCallbackWithSnapshot(
+        this.patchActivationCallback,
+        request.workflowInfo,
+        request.patchId
+      );
+      writePatchActivationCallbackResult(request.resultBuffer, result);
+    } catch (err) {
+      writePatchActivationCallbackError(request.resultBuffer, err);
+      this.logger.warn('Patch activation callback failed', {
+        error: err,
+        workflowId: request.workflowInfo.workflowId,
+        runId: request.workflowInfo.runId,
+        workflowType: request.workflowInfo.workflowType,
+        patchId: request.patchId,
+      });
+    } finally {
+      completePatchActivationCallback(request.resultBuffer);
+    }
   }
 
   /**
@@ -176,6 +215,7 @@ export interface ThreadedVMWorkflowCreatorOptions {
   reuseV8Context: boolean;
   registeredActivityNames: Set<string>;
   logger: Logger;
+  patchActivationCallback?: PatchActivationCallback;
 }
 
 /**
@@ -194,10 +234,18 @@ export class ThreadedVMWorkflowCreator implements WorkflowCreator {
     reuseV8Context,
     registeredActivityNames,
     logger,
+    patchActivationCallback,
   }: ThreadedVMWorkflowCreatorOptions): Promise<ThreadedVMWorkflowCreator> {
     const workerThreadClients = Array(threadPoolSize)
       .fill(0)
-      .map(() => new WorkerThreadClient(new NodeWorker(require.resolve('./workflow-worker-thread')), logger));
+      .map(
+        () =>
+          new WorkerThreadClient(
+            new NodeWorker(require.resolve('./workflow-worker-thread')),
+            logger,
+            patchActivationCallback
+          )
+      );
     await Promise.all(
       workerThreadClients.map((client) =>
         client.send({
@@ -206,6 +254,7 @@ export class ThreadedVMWorkflowCreator implements WorkflowCreator {
           isolateExecutionTimeoutMs,
           reuseV8Context,
           registeredActivityNames,
+          hasPatchActivationCallback: patchActivationCallback !== undefined,
         })
       )
     );

--- a/packages/worker/src/workflow/vm.ts
+++ b/packages/worker/src/workflow/vm.ts
@@ -6,6 +6,7 @@ import type { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-t
 import type { WorkflowModule } from './vm-shared';
 import { BaseVMWorkflow, globalHandlers, injectGlobals, setUnhandledRejectionHandler } from './vm-shared';
 import { isBun } from './bun';
+import type { WorkflowPatchActivationCallback } from './patch-activation-callback';
 
 /**
  * A WorkflowCreator that creates VMWorkflows in the current isolate
@@ -20,7 +21,8 @@ export class VMWorkflowCreator implements WorkflowCreator {
     script: vm.Script,
     protected readonly workflowBundle: WorkflowBundleWithSourceMapAndFilename,
     protected readonly isolateExecutionTimeoutMs: number,
-    protected readonly registeredActivityNames: Set<string>
+    protected readonly registeredActivityNames: Set<string>,
+    protected readonly patchActivationCallback?: WorkflowPatchActivationCallback
   ) {
     if (!VMWorkflowCreator.unhandledRejectionHandlerHasBeenSet) {
       setUnhandledRejectionHandler((runId) => VMWorkflowCreator.workflowByRunId.get(runId));
@@ -59,6 +61,7 @@ export class VMWorkflowCreator implements WorkflowCreator {
       getTimeOfDay: native.getTimeOfDay,
       registeredActivityNames: this.registeredActivityNames,
       stackTracesEnabled: globalHandlers.promiseHookInstalled,
+      patchActivationCallback: this.patchActivationCallback,
     });
     const activator = context.__TEMPORAL_ACTIVATOR__!;
     const newVM = new VMWorkflow(options.info.runId, context, activator, workflowModule);
@@ -101,12 +104,19 @@ export class VMWorkflowCreator implements WorkflowCreator {
     this: T,
     workflowBundle: WorkflowBundleWithSourceMapAndFilename,
     isolateExecutionTimeoutMs: number,
-    registeredActivityNames: Set<string>
+    registeredActivityNames: Set<string>,
+    patchActivationCallback?: WorkflowPatchActivationCallback
   ): Promise<InstanceType<T>> {
     globalHandlers.install();
     await globalHandlers.addWorkflowBundle(workflowBundle);
     const script = new vm.Script(workflowBundle.code, { filename: workflowBundle.filename });
-    return new this(script, workflowBundle, isolateExecutionTimeoutMs, registeredActivityNames) as InstanceType<T>;
+    return new this(
+      script,
+      workflowBundle,
+      isolateExecutionTimeoutMs,
+      registeredActivityNames,
+      patchActivationCallback
+    ) as InstanceType<T>;
   }
 
   /**

--- a/packages/worker/src/workflow/workflow-worker-thread.ts
+++ b/packages/worker/src/workflow/workflow-worker-thread.ts
@@ -1,12 +1,18 @@
 import { isMainThread, parentPort as parentPortOrNull } from 'node:worker_threads';
 import { IllegalStateError } from '@temporalio/common';
 import { coresdk } from '@temporalio/proto';
+import type { WorkflowInfo } from '@temporalio/workflow';
 import type { Workflow, WorkflowCreator } from './interface';
 import { ReusableVMWorkflowCreator } from './reusable-vm';
 import { VMWorkflowCreator } from './vm';
-import type { WorkerThreadRequest } from './workflow-worker-thread/input';
+import type { PatchActivationCallbackRequest, WorkerThreadRequest } from './workflow-worker-thread/input';
 import type { WorkerThreadResponse } from './workflow-worker-thread/output';
 import { isBun } from './bun';
+import {
+  makePatchActivationWorkflowInfoSnapshot,
+  PATCH_ACTIVATION_CALLBACK_BUFFER_SIZE,
+  waitForPatchActivationCallbackResult,
+} from './patch-activation-callback';
 
 if (isMainThread) {
   throw new IllegalStateError(`Imported ${__filename} from main thread`);
@@ -26,6 +32,18 @@ function ok(requestId: bigint): WorkerThreadResponse {
 let workflowCreator: WorkflowCreator | undefined;
 let workflowGetter: (runId: string) => Workflow | undefined;
 
+function requestPatchActivation(workflowInfo: WorkflowInfo, patchId: string): boolean {
+  const resultBuffer = new SharedArrayBuffer(PATCH_ACTIVATION_CALLBACK_BUFFER_SIZE);
+  const request: PatchActivationCallbackRequest = {
+    type: 'patch-activation-callback',
+    workflowInfo: makePatchActivationWorkflowInfoSnapshot(workflowInfo),
+    patchId,
+    resultBuffer,
+  };
+  parentPort.postMessage(request);
+  return waitForPatchActivationCallbackResult(resultBuffer);
+}
+
 /**
  * Process a `WorkerThreadRequest` and resolve with a `WorkerThreadResponse`.
  */
@@ -36,14 +54,16 @@ async function handleRequest({ requestId, input }: WorkerThreadRequest): Promise
         workflowCreator = await ReusableVMWorkflowCreator.create(
           input.workflowBundle,
           input.isolateExecutionTimeoutMs,
-          input.registeredActivityNames
+          input.registeredActivityNames,
+          input.hasPatchActivationCallback ? requestPatchActivation : undefined
         );
         workflowGetter = (runId) => ReusableVMWorkflowCreator.workflowByRunId.get(runId);
       } else {
         workflowCreator = await VMWorkflowCreator.create(
           input.workflowBundle,
           input.isolateExecutionTimeoutMs,
-          input.registeredActivityNames
+          input.registeredActivityNames,
+          input.hasPatchActivationCallback ? requestPatchActivation : undefined
         );
         workflowGetter = (runId) => VMWorkflowCreator.workflowByRunId.get(runId);
       }

--- a/packages/worker/src/workflow/workflow-worker-thread/input.ts
+++ b/packages/worker/src/workflow/workflow-worker-thread/input.ts
@@ -1,6 +1,7 @@
 import type { RawSourceMap } from 'source-map';
 import type { coresdk } from '@temporalio/proto';
 import type { WorkflowCreateOptions } from '../interface';
+import type { PatchActivationWorkflowInfoSnapshot } from '../patch-activation-callback';
 
 export interface WorkflowBundleWithSourceMapAndFilename {
   code: string;
@@ -17,6 +18,7 @@ export interface Init {
   workflowBundle: WorkflowBundleWithSourceMapAndFilename;
   registeredActivityNames: Set<string>;
   reuseV8Context: boolean;
+  hasPatchActivationCallback: boolean;
 }
 
 /**
@@ -68,4 +70,12 @@ export type WorkerThreadInput = Init | Destroy | CreateWorkflow | ActivateWorkfl
 export interface WorkerThreadRequest {
   requestId: bigint;
   input: WorkerThreadInput;
+}
+
+/** A synchronous callback request sent from a Workflow thread to its owning Worker. */
+export interface PatchActivationCallbackRequest {
+  type: 'patch-activation-callback';
+  workflowInfo: PatchActivationWorkflowInfoSnapshot;
+  patchId: string;
+  resultBuffer: SharedArrayBuffer;
 }

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -688,6 +688,7 @@ export interface WorkflowCreateOptionsInternal extends WorkflowCreateOptions {
   registeredActivityNames: Set<string>;
   getTimeOfDay(): bigint;
   stackTracesEnabled: boolean;
+  patchActivationCallback?(workflowInfo: WorkflowInfo, patchId: string): boolean;
 }
 
 /**

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -475,6 +475,9 @@ export class Activator implements ActivationHandler {
    */
   private readonly sentPatches = new Set<string>();
 
+  /** Resolved patch activation decisions, including callback decisions that leave a patch inactive. */
+  private readonly patchDecisions = new Map<string, boolean>();
+
   private readonly knownFlags = new Set<number>();
 
   sdkVersion?: string;
@@ -502,6 +505,8 @@ export class Activator implements ActivationHandler {
 
   protected readonly stackTracesEnabled: boolean;
 
+  private readonly patchActivationCallback?: (workflowInfo: WorkflowInfo, patchId: string) => boolean;
+
   constructor({
     info,
     now,
@@ -512,6 +517,7 @@ export class Activator implements ActivationHandler {
     registeredActivityNames,
     stackTracesEnabled,
     failureExceptionTypeNames,
+    patchActivationCallback,
   }: WorkflowCreateOptionsInternal) {
     this.getTimeOfDay = getTimeOfDay;
     this.info = info;
@@ -523,6 +529,7 @@ export class Activator implements ActivationHandler {
     this.registeredActivityNames = registeredActivityNames;
     this.stackTracesEnabled = stackTracesEnabled;
     this.failureExceptionTypeNames = failureExceptionTypeNames ?? [];
+    this.patchActivationCallback = patchActivationCallback;
   }
 
   protected setRandomnessSeed(randomnessSeed: number[]): void {
@@ -1199,7 +1206,24 @@ export class Activator implements ActivationHandler {
     if (this.workflow === undefined) {
       throw new IllegalStateError('Patches cannot be used before Workflow starts');
     }
-    const usePatch = !this.info.unsafe.isReplaying || this.knownPresentPatches.has(patchId);
+    const previousDecision = this.patchDecisions.get(patchId);
+    if (previousDecision !== undefined) {
+      return previousDecision;
+    }
+
+    const knownPresent = this.knownPresentPatches.has(patchId);
+    // A missing marker during replay is not a final decision because this cached Workflow may
+    // subsequently reach live execution, where the patch can activate and record its marker.
+    if (this.info.unsafe.isReplaying && !knownPresent) {
+      return false;
+    }
+
+    const usePatch =
+      !knownPresent && !deprecated && this.patchActivationCallback !== undefined
+        ? this.patchActivationCallback(this.info, patchId)
+        : true;
+    this.patchDecisions.set(patchId, usePatch);
+
     // Avoid sending commands for patches core already knows about.
     // This optimization enables development of automatic patching tools.
     if (usePatch && !this.sentPatches.has(patchId)) {


### PR DESCRIPTION
## What was changed

Added an experimental `WorkerOptions.patchActivationCallback` that lets a worker decide whether the first newly encountered, non-replay `patched` call activates a patch.

The callback receives frozen workflow information and the patch ID. Its strict boolean decision is memoized for the workflow run. Declined patches return `false` without recording a marker, while replay, existing history markers, and deprecated patches retain their existing behavior.

Because Workflow code normally executes in worker threads while `patched` is synchronous, the implementation uses a scoped synchronous worker-thread bridge based on `SharedArrayBuffer` and `Atomics`. The callback closure stays on the Worker side and is never serialized or evaluated from source.

This ports the behavior introduced by https://github.com/temporalio/sdk-ruby/pull/481.

## Why?

This allows workflow changes using `patched` to roll out gradually without every new-code worker immediately recording a marker that older workers cannot replay.

## Testing

- Worker, Workflow, and test TypeScript builds
- Focused runtime suite: 7 cases
- Live rolling-worker integration suite: 2 cases
- Focused ESLint and Prettier checks
- Diff and sdk-core submodule cleanliness checks