### PR TITLE
Make the Bundler's webpack-module-cache hijack more reliable (#2195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,19 @@ to docs, or any other relevant information.
 
 # Changelog
 
-## [1.19.0]
+## [Unreleased]
+
+### Fixed
+
+- Workflow Bundler: further strengthening of the `__webpack_module_cache__` replacement logic, addressing regressions introduced by the fix in 1.19.1.
+
+## [1.19.1] - 2026-07-07
+
+### Fixed
+
+- Workflow Bundler: fix a bug in our replacement of `__webpack_module_cache__` logic introduced by webpack 5.108.0, resulting in breaking workflow context isolation (fix #2170).
+
+## [1.19.0] - 2026-07-01
 
 ### Added
 
@@ -47,5 +59,3 @@ to docs, or any other relevant information.
 
 - fix(openai-agents): correct misleading legacy-query comment in resolveQueryKey
 - avoid logging `NativeConnection` on worker startup
-
-## [Unreleased]

--- a/packages/nyc-test-coverage/package.json
+++ b/packages/nyc-test-coverage/package.json
@@ -43,7 +43,7 @@
     "@types/istanbul-lib-instrument": "^1.7.7",
     "@types/webpack": "^5.28.5",
     "typescript": "^5.6.3",
-    "webpack": "^5.106.2"
+    "webpack": "^5.108.4"
   },
   "peerDependencies": {
     "@temporalio/common": "workspace:*",

--- a/packages/test/src/test-bundler.ts
+++ b/packages/test/src/test-bundler.ts
@@ -11,10 +11,11 @@ import test from 'ava';
 import { moduleMatches } from '@temporalio/worker/lib/workflow/bundler';
 import type { LogEntry, WorkerOptions } from '@temporalio/worker';
 import { bundleWorkflowCode, DefaultLogger } from '@temporalio/worker';
-import { WorkflowClient } from '@temporalio/client';
+import { Client } from '@temporalio/client';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
 import { issue516 } from './mocks/workflows-with-node-dependencies/issue-516';
 import { preloadSharedCounter } from './workflows/preload-shared-counter';
+import { workflowWithPrebundledDep } from './workflows/workflow-with-prebundled-dep';
 import { successString } from './workflows';
 
 test('moduleMatches works', (t) => {
@@ -28,15 +29,15 @@ async function runPreloadSharedCounter(
   workerOptions: Pick<WorkerOptions, 'bundlerOptions' | 'workflowBundle' | 'workflowsPath'>
 ): Promise<[number, number]> {
   const taskQueue = `${t.title}-${randomUUID()}`;
-  const client = new WorkflowClient();
+  const client = new Client();
   const worker = await Worker.create({
     taskQueue,
     reuseV8Context: true,
     ...workerOptions,
   });
   return await worker.runUntil(async () => {
-    const first = await client.execute(preloadSharedCounter, { taskQueue, workflowId: randomUUID() });
-    const second = await client.execute(preloadSharedCounter, { taskQueue, workflowId: randomUUID() });
+    const first = await client.workflow.execute(preloadSharedCounter, { taskQueue, workflowId: randomUUID() });
+    const second = await client.workflow.execute(preloadSharedCounter, { taskQueue, workflowId: randomUUID() });
     return [first, second];
   });
 }
@@ -51,8 +52,8 @@ if (RUN_INTEGRATION_TESTS) {
       taskQueue,
       workflowBundle,
     });
-    const client = new WorkflowClient();
-    await worker.runUntil(client.execute(successString, { taskQueue, workflowId: randomUUID() }));
+    const client = new Client();
+    await worker.runUntil(client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
     t.pass();
   });
 
@@ -69,9 +70,9 @@ if (RUN_INTEGRATION_TESTS) {
       taskQueue,
       workflowBundle,
     });
-    const client = new WorkflowClient();
+    const client = new Client();
     try {
-      await worker.runUntil(client.execute(successString, { taskQueue, workflowId: randomUUID() }));
+      await worker.runUntil(client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
     } finally {
       await unlink(codePath);
     }
@@ -88,8 +89,8 @@ if (RUN_INTEGRATION_TESTS) {
       taskQueue,
       workflowBundle,
     });
-    const client = new WorkflowClient();
-    await worker.runUntil(client.execute(issue516, { taskQueue, workflowId: randomUUID() }));
+    const client = new Client();
+    await worker.runUntil(client.workflow.execute(issue516, { taskQueue, workflowId: randomUUID() }));
     t.pass();
   });
 
@@ -235,4 +236,104 @@ if (RUN_INTEGRATION_TESTS) {
     const protoSources = sources.filter((s) => s.includes('/packages/proto/') || s.includes('@temporalio/proto'));
     t.deepEqual(protoSources, [], `@temporalio/proto must not appear in workflow bundle sources.}`);
   });
+
+  // Regression test for https://github.com/temporalio/sdk-typescript/issues/2188:
+  // module state must remain isolated even when a pre-bundled dependency (shipping
+  // its own nested `__webpack_module_cache__`) is included in the Workflow bundle.
+  test('Workflow bundle keeps module state isolated with a pre-bundled dependency (#2188)', async (t) => {
+    const taskQueue = `${t.title}-${randomUUID()}`;
+    const workflowBundle = await bundleWorkflowCode({
+      workflowsPath: require.resolve('./workflows/workflow-with-prebundled-dep'),
+    });
+    const client = new Client();
+    const worker = await Worker.create({ taskQueue, reuseV8Context: true, workflowBundle });
+    const results = await worker.runUntil(async () => {
+      const first = await client.workflow.execute(workflowWithPrebundledDep, { taskQueue, workflowId: randomUUID() });
+      const second = await client.workflow.execute(workflowWithPrebundledDep, { taskQueue, workflowId: randomUUID() });
+      return [first, second];
+    });
+    t.deepEqual(results, [1, 1]);
+  });
+
+  // Regression test for https://github.com/temporalio/sdk-typescript/issues/2170#issuecomment-4925636742:
+  // module state must remain isolated even when the bundle is minified after webpack.
+  test('Workflow bundle keeps module state isolated when minified after webpack (#2170 (comment))', async (t) => {
+    const workflowBundle = await bundleWorkflowCode({
+      workflowsPath: require.resolve('./workflows/preload-shared-counter'),
+      webpackConfigHook: (config) => {
+        config.plugins = [...(config.plugins ?? []), new ModuleCacheWhitespaceCollapsePlugin()];
+        return config;
+      },
+    });
+
+    t.deepEqual(await runPreloadSharedCounter(t, { workflowBundle }), [1, 1]);
+  });
+}
+
+// Regression test for https://github.com/temporalio/sdk-typescript/issues/2188:
+// a dependency that ships its own pre-bundled webpack runtime carries a nested,
+// private `__webpack_module_cache__`. The bundler must redirect only the top-level
+// runtime's cache to the injected global, and leave the nested one untouched.
+test('Workflow bundle redirects the module cache with a pre-bundled dependency (#2188)', async (t) => {
+  const { code } = await bundleWorkflowCode({
+    workflowsPath: require.resolve('./workflows/workflow-with-prebundled-dep'),
+  });
+  // The top-level runtime cache is redirected to the runtime-injected global...
+  t.true(code.includes('globalThis.__webpack_module_cache__'), 'top-level module cache should be redirected');
+  // ...while the dependency's nested, private cache is left untouched (still `= {}`), and
+  // is the only remaining bare initializer.
+  const remainingBareInitializers = code.match(/__webpack_module_cache__ = \{\}/g) ?? [];
+  t.is(remainingBareInitializers.length, 1, 'the nested private cache should be left untouched');
+});
+
+// Regression test for https://github.com/temporalio/sdk-typescript/issues/2170:
+// when the bundle is post-processed by a minifier, a text find-and-replace over
+// the final output no longer matches. The redirection must happen inside the
+// render pipeline, before minification.
+test('Workflow bundle redirects the module cache when minified after webpack (#2170)', async (t) => {
+  const { code } = await bundleWorkflowCode({
+    workflowsPath: require.resolve('./workflows/preload-shared-counter'),
+    webpackConfigHook: (config) => {
+      config.plugins = [...(config.plugins ?? []), new ModuleCacheWhitespaceCollapsePlugin()];
+      return config;
+    },
+  });
+  t.true(code.includes('globalThis.__webpack_module_cache__'), 'module cache should be redirected before minification');
+});
+
+/**
+ * A webpack plugin that mimics a minifier (e.g. terser) added by a user through
+ * `webpackConfigHook`: it rewrites the emitted bundle at the same `processAssets`
+ * stage terser uses, collapsing the `__webpack_module_cache__ = {}` declaration
+ * to `__webpack_module_cache__={}`. This is enough to defeat a naive text
+ * find-and-replace run over the final bundle.
+ *
+ * See https://github.com/temporalio/sdk-typescript/issues/2170#issuecomment-4925636742.
+ */
+class ModuleCacheWhitespaceCollapsePlugin {
+  apply(compiler: any): void {
+    const { Compilation, sources } = compiler.webpack;
+
+    compiler.hooks.compilation.tap('ModuleCacheWhitespaceCollapse', (compilation: any) => {
+      compilation.hooks.processAssets.tap(
+        { name: 'ModuleCacheWhitespaceCollapse', stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE },
+
+        (assets: any) => {
+          for (const name of Object.keys(assets)) {
+            if (!name.endsWith('.js')) continue;
+            const asset = assets[name];
+            const code = asset.source().toString();
+            // Use a ReplaceSource (rather than a fresh RawSource) so the source-map chain
+            // is preserved for the downstream inline-source-map devtool step.
+            const replaced = new sources.ReplaceSource(asset);
+            const re = /(var|let|const) __webpack_module_cache__ = \{\}/g;
+            for (let m = re.exec(code); m !== null; m = re.exec(code)) {
+              replaced.replace(m.index, m.index + m[0].length - 1, `${m[1]} __webpack_module_cache__={}`);
+            }
+            assets[name] = replaced;
+          }
+        }
+      );
+    });
+  }
 }

--- a/packages/test/src/workflows/prebundled-webpack-dep.ts
+++ b/packages/test/src/workflows/prebundled-webpack-dep.ts
@@ -1,0 +1,22 @@
+// This module simulates a dependency that ships its own *pre-bundled* webpack
+// output (e.g. `node_modules/ejson/index.js`), carrying its own function-scoped
+// `__webpack_module_cache__`. When such a dependency is pulled into a Workflow bundle,
+// the emitted bundle ends up containing more than one `__webpack_module_cache__`
+// declaration: the real top-level runtime one, plus one (or more) nested, private ones.
+//
+// See https://github.com/temporalio/sdk-typescript/issues/2188.
+function nestedWebpackRuntime(): { greet: () => string } {
+  const __webpack_module_cache__: Record<string, any> = {};
+  return {
+    greet: () => {
+      if (__webpack_module_cache__['greeting'] === undefined) {
+        __webpack_module_cache__['greeting'] = 'hello from a pre-bundled dependency';
+      }
+      return __webpack_module_cache__['greeting'];
+    },
+  };
+}
+
+export function greet(): string {
+  return nestedWebpackRuntime().greet();
+}

--- a/packages/test/src/workflows/workflow-with-prebundled-dep.ts
+++ b/packages/test/src/workflows/workflow-with-prebundled-dep.ts
@@ -1,0 +1,15 @@
+import { greet } from './prebundled-webpack-dep';
+import { nextPreloadedCounterValue } from './preload-shared-counter-helper';
+
+// This Workflow pulls a pre-bundled dependency (which ships its own nested
+// `__webpack_module_cache__`) into the Workflow bundle, and also relies on
+// module-level state (the shared counter) so that Workflow isolation can
+// be verified.
+//
+// See https://github.com/temporalio/sdk-typescript/issues/2188.
+export async function workflowWithPrebundledDep(): Promise<number> {
+  if (typeof greet() !== 'string') {
+    throw new Error('Expected the pre-bundled dependency to return a string');
+  }
+  return nextPreloadedCounterValue();
+}

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -35,7 +35,7 @@
     "supports-color": "^8.1.1",
     "swc-loader": "^0.2.3",
     "unionfs": "^4.5.1",
-    "webpack": "^5.106.2"
+    "webpack": "^5.108.4"
   },
   "devDependencies": {
     "@types/supports-color": "^8.1.3"

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -9,6 +9,10 @@ import { webpack, NormalModuleReplacementPlugin } from 'webpack';
 import type { Logger } from '../logger';
 import { DefaultLogger, hasColorSupport } from '../logger';
 import { toMB } from '../utils';
+import {
+  InjectWorkflowModuleCacheGlobalPlugin,
+  assertWorkflowModuleCacheGlobalApplied,
+} from './bundler/patch-module-cache';
 
 export const defaultWorkflowInterceptorModules = [require.resolve('../workflow-log-interceptor')];
 
@@ -133,24 +137,9 @@ export class WorkflowCodeBundler {
 
     this.genEntrypoint(vol, entrypointPath);
     const bundleFilePath = await this.bundle(ufs, memoryFs, entrypointPath, distDir);
-    let code = memoryFs.readFileSync(bundleFilePath, 'utf8') as string;
-    // Replace webpack's module cache with an object injected by the runtime.
-    // This is the key to reusing a single v8 context.
-    // Webpack may emit the declaration as `var`, `let`, or `const` depending on the
-    // configured output environment (webpack >= 5.108.0 defaults to `const`).
-    let cacheDeclarationsPatched = 0;
-    code = code.replace(/(^|\s)(var|let|const) __webpack_module_cache__ = \{\}/gm, (_match, prefix, keyword) => {
-      cacheDeclarationsPatched++;
-      return `${prefix}${keyword} __webpack_module_cache__ = globalThis.__webpack_module_cache__`;
-    });
-    if (cacheDeclarationsPatched !== 1) {
-      throw new Error(
-        `Failed to patch the Workflow bundle: expected to find exactly one __webpack_module_cache__ declaration ` +
-          `emitted by webpack, but found ${cacheDeclarationsPatched}. Without this patch, Workflow isolation ` +
-          `would be broken. This is likely due to a change in webpack output; please report this at ` +
-          `https://github.com/temporalio/sdk-typescript/issues`
-      );
-    }
+
+    const code = memoryFs.readFileSync(bundleFilePath, 'utf8') as string;
+    assertWorkflowModuleCacheGlobalApplied(code);
 
     this.logger.info('Workflow bundle created', { size: `${toMB(code.length)}MB` });
 
@@ -251,6 +240,9 @@ exports.importInterceptors = function importInterceptors() {
         },
       },
       plugins: [
+        // Redirect webpack's module cache to a runtime-injected global so that a single V8
+        // context can be reused across Workflow executions while keeping module state isolated.
+        new InjectWorkflowModuleCacheGlobalPlugin(),
         // The OpenTelemetry interceptor packages only require `@temporalio/workflow` for interceptors that run in workflow context.
         // In order to keep `@temporalio/workflow` as an optional peer dependency for those packages
         // we use `workflow-imports` to reexport all required imports from `@temporalio/workflow`.

--- a/packages/worker/src/workflow/bundler/patch-module-cache.ts
+++ b/packages/worker/src/workflow/bundler/patch-module-cache.ts
@@ -1,0 +1,177 @@
+import type { Compiler, Compilation } from 'webpack';
+import { javascript, sources, WebpackError } from 'webpack';
+
+type Source = sources.Source;
+
+const PLUGIN_NAME = 'TemporalWorkflowModuleCachePlugin';
+
+/**
+ * The runtime-injected global that holds the Workflow bundle's module cache.
+ *
+ * When running Workflows in a reusable V8 context, the Worker injects an object under this
+ * name into the sandbox global (see `reusable-vm.ts`). Redirecting webpack's module cache
+ * to this global is what makes per-Workflow module isolation possible while sharing a
+ * single V8 context.
+ */
+const MODULE_CACHE_GLOBAL = 'globalThis.__webpack_module_cache__';
+
+/**
+ * A fixed, high-entropy marker that we inject into the top-level webpack runtime's
+ * `__webpack_require__` function body.
+ *
+ * The marker is used to reliably locate the *real* (top-level) module-cache declaration
+ * emitted by this run of webpack (vs nested dependencies that have themselves been
+ * bundled with webpack and thus carry their own module cache declarations).The marker
+ * is stripped from the bundle before the final output is produced, so it never ships.
+ *
+ * It is intentionally a *stable constant* (not randomly generated per build): the marker
+ * participates in webpack's chunk/`[fullhash]` computation, so a random value would make
+ * the bundle's content hash — and therefore its filename — non-deterministic across
+ * otherwise-identical builds.
+ */
+const MODULE_CACHE_MARKER = '__temporal_module_cache_marker_5f2e9c8a1b7d4e60a3__';
+const MARKER_COMMENT = `/* ${MODULE_CACHE_MARKER} */\n`;
+
+// Matches webpack's top-level module-cache initializer, regardless of the declaration
+// keyword used (webpack < 5.108 emits `var`; >= 5.108 may emit `const`, 'let' or `var`).
+const MODULE_CACHE_DECLARATION = /(?:var|let|const)\s+__webpack_module_cache__\s*=\s*\{\}/g;
+
+/**
+ * Webpack plugin that redirects the Workflow bundle's top-level module cache to a
+ * runtime-injected global (`globalThis.__webpack_module_cache__`).
+ *
+ * This plugin operates inside the webpack render pipeline using in two phases:
+ *   1. `renderRequire` injects a stable marker into the top-level runtime's
+ *      `__webpack_require__` body. That hook is only ever invoked for the bundle's own
+ *      runtime, so the marker unambiguously identifies the real module cache — nested,
+ *      pre-bundled runtimes carry their own already-rendered require functions and never
+ *      pass through this hook.
+ *   2. `renderMain` uses the marker to locate the top-level module-cache declaration
+ *      (the nearest one preceding the marker), redirects it to the injected global, and
+ *      strips the marker. This runs during chunk rendering — before any `processAssets`
+ *      stage, hence before minification — and returns a `ReplaceSource` so source maps
+ *      are preserved.
+ */
+export class InjectWorkflowModuleCacheGlobalPlugin {
+  apply(compiler: Compiler): void {
+    compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation: Compilation) => {
+      const hooks = javascript.JavascriptModulesPlugin.getCompilationHooks(compilation);
+
+      hooks.renderRequire.tap(PLUGIN_NAME, (code: string) => {
+        return `${MARKER_COMMENT}${code}`;
+      });
+
+      hooks.renderMain.tap(PLUGIN_NAME, (source: Source) => {
+        return this.redirectModuleCache(source);
+      });
+    });
+  }
+
+  private redirectModuleCache(source: Source): Source {
+    const code = source.source().toString();
+
+    // We're only interested in the chunk that carries the top-level runtime marker
+    const markerIndex = code.indexOf(MARKER_COMMENT);
+    if (markerIndex === -1) {
+      return source;
+    }
+
+    // The marker is injected exactly once, into the single top-level
+    // require function. Confirm there isn't another marker in the code.
+    if (code.indexOf(MARKER_COMMENT, markerIndex + MARKER_COMMENT.length) !== -1) {
+      throw new WebpackError(
+        `Failed to patch the Workflow bundle: expected exactly one module-cache marker, but found more than one. ` +
+          `This is likely due to a change in webpack output; please report this at ` +
+          `https://github.com/temporalio/sdk-typescript/issues`
+      );
+    }
+
+    // The top-level module-cache declaration is the one immediately preceding the marked
+    // require function. Any other `__webpack_module_cache__ = {}` occurrences belong to
+    // nested, pre-bundled dependencies and appear earlier in the emitted module content, so
+    // the nearest match before the marker is always the real one.
+    let declaration: RegExpExecArray | null = null;
+    // Because of the `/g` flag, the regexp is stateful. We must reset the regexp's
+    // lastIndex to 0 to make sure it starts from the beginning of the code, rather
+    // than continuing from the last match position of a previous iteration.
+    MODULE_CACHE_DECLARATION.lastIndex = 0;
+    for (let match = MODULE_CACHE_DECLARATION.exec(code); match !== null; match = MODULE_CACHE_DECLARATION.exec(code)) {
+      if (match.index >= markerIndex) break;
+      declaration = match;
+    }
+
+    if (declaration === null) {
+      throw new WebpackError(
+        `Failed to patch the Workflow bundle: found the module-cache marker but no preceding ` +
+          `'__webpack_module_cache__' declaration to redirect. Without this patch, Workflow isolation ` +
+          `would be broken. This is likely due to a change in webpack output; please report this at ` +
+          `https://github.com/temporalio/sdk-typescript/issues`
+      );
+    }
+
+    const replaced = new sources.ReplaceSource(source);
+
+    // Redirect the top-level declaration to the runtime-injected global.
+    const declStart = declaration.index;
+    const declEndInclusive = declStart + declaration[0].length - 1;
+    replaced.replace(declStart, declEndInclusive, declaration[0].replace('= {}', `= ${MODULE_CACHE_GLOBAL}`));
+
+    // Strip the marker so it never ships.
+    // Note that `ReplaceSource.replace()` takes character indices from the
+    // _original_ source; there's thereforre no need to adjust the indices to
+    // account for the replacement we just performed (`= {}` => MODULE_CACHE_GLOBAL).
+    const markerEndInclusive = markerIndex + MARKER_COMMENT.length - 1;
+    replaced.replace(markerIndex, markerEndInclusive, '');
+
+    return replaced;
+  }
+}
+
+/**
+ * Asserts that the generated Workflow bundle has been correctly patched to redirect the
+ * module cache to the runtime-injected global (`globalThis.__webpack_module_cache__`)
+ * by `InjectWorkflowModuleCacheGlobalPlugin`.
+ *
+ * These sanity checks are meant to catch and fail loudly on some specific eventual regressions
+ * in the webpack library or configuration that would prevent hijacking webpack's module cache,
+ * and thus result in silent reoccurences of #2170 or #2188.
+ */
+export function assertWorkflowModuleCacheGlobalApplied(code: string): void {
+  // Webpack's bootstrap code should contain a declaration of the module cache, similar to:
+  //     const __webpack_module_cache__ = {};
+  //
+  // That line should have been replaced by `InjectWorkflowModuleCacheGlobalPlugin` to:
+  //     const __webpack_module_cache__ = globalThis.__webpack_module_cache__;
+  //
+  // Further webpack plugins (e.g. minification) might further transform that line (e.g. removing
+  // spaces or renaming the scoped variable), but the global variable should remain unchanged.
+  // Absence of references to that global variable would be an error.
+  if (!code.includes(MODULE_CACHE_GLOBAL)) {
+    throw new Error(
+      `Failed to patch the Workflow bundle: the module cache was not redirected to ` +
+        `'${MODULE_CACHE_GLOBAL}'. Without this, Workflow isolation would be broken.` +
+        `This may be the result of uncommon and unsupported webpack configurations, ` +
+        `but most likely indicates a change in webpack's output format or a bug in the ` +
+        `Temporal SDK. Please report this at https://github.com/temporalio/sdk-typescript/issues.`
+    );
+  }
+
+  // There could be multiple occurences of "__webpack_module_cache__" in the code produced
+  // by webpack if the bundle contains nested, pre-bundled dependencies (see #2188).
+  // To correctly determine the one to be rewritten, `InjectWorkflowModuleCacheGlobalPlugin`
+  // temporarily injects a marker into the top-level runtime's `__webpack_require__` function
+  // body. The marker is stripped from the bundle before the final output is produced.
+  //
+  // The marker being still present in the final bundle code, though unharmful by itself,
+  // would be unexpected and should raise doubts about the correctness of the module cache
+  // rewrite process.
+  if (code.includes(MODULE_CACHE_MARKER)) {
+    throw new Error(
+      `Failed to patch the Workflow bundle: the internal module-cache marker was ` +
+        `not stripped from the output. There's a risk that Workflow isolation would be broken.` +
+        `This may be the result of uncommon and unsupported webpack configurations, ` +
+        `but most likely indicates a change in webpack's output format or a bug in the ` +
+        `Temporal SDK. Please report this at https://github.com/temporalio/sdk-typescript/issues.`
+    );
+  }
+}

--- a/packages/worker/src/workflow/reusable-vm.ts
+++ b/packages/worker/src/workflow/reusable-vm.ts
@@ -267,9 +267,32 @@ export class ReusableVMWorkflowCreator implements WorkflowCreator {
     isolateExecutionTimeoutMs: number,
     registeredActivityNames: Set<string>
   ): Promise<InstanceType<T>> {
+    // The Reusable V8 Context executor needs to take control of Webpack's require
+    // cache in order to provide per-Workflow isolation of non-shared modules.
+    // In order to achieve that, the Workflow Bundler must rewrites webpack's module
+    // cache declaration to initilize it with `globalThis.__webpack_module_cache__`
+    // instead of an empty object.
+    //
+    // Loading a bundle that does not correctly rewrite the webpack's module cache to
+    // `globalThis.__webpack_module_cache__` in the Reusable V8 Context executor will
+    // result in silent breakage of Workflow isolation. See #2170 and #2188 for details.
+    //
+    // The following is a sanity check to catch eventual regressions, or attempts by
+    // users to use the Reusable V8 Context executor with bundles that were not produced
+    // with a compatible Workflow Bundler.
+    if (!workflowBundle.code.includes('globalThis.__webpack_module_cache__')) {
+      throw new Error(
+        `The provided Workflow Bundle is not compatible with the Reusable V8 Context executor: it does ` +
+          `not route its module cache through 'globalThis.__webpack_module_cache__', which is required to ` +
+          `keep module state isolated across Workflow executions. Make sure the bundle was produced by a ` +
+          `compatible version of the Temporal SDK, or disable the Reusable V8 Context executor by setting ` +
+          `'WorkerOptions.reuseV8Context' to false.`
+      );
+    }
+
+    const script = new vm.Script(workflowBundle.code, { filename: workflowBundle.filename });
     globalHandlers.install(); // Call is idempotent
     await globalHandlers.addWorkflowBundle(workflowBundle);
-    const script = new vm.Script(workflowBundle.code, { filename: workflowBundle.filename });
     return new this(script, workflowBundle, isolateExecutionTimeoutMs, registeredActivityNames) as InstanceType<T>;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -707,7 +707,7 @@ importers:
         version: 6.0.1
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.6.3)(webpack@5.107.2)
+        version: 9.5.1(typescript@5.6.3)(webpack@5.108.4)
     devDependencies:
       '@temporalio/common':
         specifier: workspace:*
@@ -734,8 +734,8 @@ importers:
         specifier: ^5.6.3
         version: 5.6.3
       webpack:
-        specifier: ^5.106.2
-        version: 5.107.2
+        specifier: ^5.108.4
+        version: 5.108.4
 
   packages/plugin:
     devDependencies:
@@ -1006,19 +1006,19 @@ importers:
         version: 0.7.4
       source-map-loader:
         specifier: ^5.0.0
-        version: 5.0.0(webpack@5.107.2(@swc/core@1.3.102))
+        version: 5.0.0(webpack@5.108.4(@swc/core@1.3.102))
       supports-color:
         specifier: ^8.1.1
         version: 8.1.1
       swc-loader:
         specifier: ^0.2.3
-        version: 0.2.3(@swc/core@1.3.102)(webpack@5.107.2(@swc/core@1.3.102))
+        version: 0.2.3(@swc/core@1.3.102)(webpack@5.108.4(@swc/core@1.3.102))
       unionfs:
         specifier: ^4.5.1
         version: 4.5.1
       webpack:
-        specifier: ^5.106.2
-        version: 5.107.2(@swc/core@1.3.102)
+        specifier: ^5.108.4
+        version: 5.108.4(@swc/core@1.3.102)
     devDependencies:
       '@types/supports-color':
         specifier: ^8.1.3
@@ -1640,23 +1640,29 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
   '@jridgewell/gen-mapping@0.3.3':
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/resolve-uri@3.1.1':
-    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/set-array@1.1.2':
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/source-map@0.3.5':
-    resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
 
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
@@ -2246,6 +2252,9 @@ packages:
 
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  '@types/node@26.0.1':
+    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -3249,8 +3258,8 @@ packages:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
 
-  enhanced-resolve@5.22.0:
-    resolution: {integrity: sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==}
+  enhanced-resolve@5.24.1:
+    resolution: {integrity: sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==}
     engines: {node: '>=10.13.0'}
 
   entities@2.1.0:
@@ -3700,9 +3709,6 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
-
-  glob-to-regexp@0.4.1:
-    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -4462,6 +4468,49 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minimizer-webpack-plugin@5.6.1:
+    resolution: {integrity: sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@minify-html/node': '*'
+      '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
+      esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
+      '@swc/core':
+        optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
+      esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
+        optional: true
+      uglify-js:
+        optional: true
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -5262,51 +5311,8 @@ packages:
     resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
     engines: {node: '>=14.16'}
 
-  terser-webpack-plugin@5.6.0:
-    resolution: {integrity: sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@minify-html/node': '*'
-      '@swc/core': '*'
-      '@swc/css': '*'
-      '@swc/html': '*'
-      clean-css: '*'
-      cssnano: '*'
-      csso: '*'
-      esbuild: '*'
-      html-minifier-terser: '*'
-      lightningcss: '*'
-      postcss: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@minify-html/node':
-        optional: true
-      '@swc/core':
-        optional: true
-      '@swc/css':
-        optional: true
-      '@swc/html':
-        optional: true
-      clean-css:
-        optional: true
-      cssnano:
-        optional: true
-      csso:
-        optional: true
-      esbuild:
-        optional: true
-      html-minifier-terser:
-        optional: true
-      lightningcss:
-        optional: true
-      postcss:
-        optional: true
-      uglify-js:
-        optional: true
-
-  terser@5.46.0:
-    resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
+  terser@5.48.0:
+    resolution: {integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5482,6 +5488,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
   unionfs@4.5.1:
     resolution: {integrity: sha512-hn8pzkh0/80mpsIT/YBJKa4+BF/9pNh0IgysBi0CjL95Uok8Hus69TNfgeJckoUNwfTpBq26+F7edO1oBINaIw==}
 
@@ -5553,8 +5562,8 @@ packages:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
 
-  watchpack@2.5.1:
-    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
+  watchpack@2.5.2:
+    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
 
   web-streams-polyfill@4.2.0:
@@ -5568,8 +5577,8 @@ packages:
     resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
     engines: {node: '>=10.13.0'}
 
-  webpack@5.107.2:
-    resolution: {integrity: sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==}
+  webpack@5.108.4:
+    resolution: {integrity: sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -6441,27 +6450,34 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/gen-mapping@0.3.3':
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@jridgewell/resolve-uri@3.1.1': {}
+  '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/set-array@1.1.2': {}
 
-  '@jridgewell/source-map@0.3.5':
+  '@jridgewell/source-map@0.3.11':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
@@ -7171,6 +7187,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@26.0.1':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/parse-json@4.0.2': {}
 
   '@types/pidusage@2.0.5': {}
@@ -7200,7 +7220,7 @@ snapshots:
     dependencies:
       '@types/node': 20.19.41
       tapable: 2.2.1
-      webpack: 5.107.2
+      webpack: 5.108.4
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -8381,7 +8401,7 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
-  enhanced-resolve@5.22.0:
+  enhanced-resolve@5.24.1:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -9017,8 +9037,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob-to-regexp@0.4.1: {}
-
   glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
@@ -9426,7 +9444,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.19.41
+      '@types/node': 26.0.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -9751,6 +9769,24 @@ snapshots:
       brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
+
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.3.102)(webpack@5.108.4(@swc/core@1.3.102)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.48.0
+      webpack: 5.108.4(@swc/core@1.3.102)
+    optionalDependencies:
+      '@swc/core': 1.3.102
+
+  minimizer-webpack-plugin@5.6.1(webpack@5.108.4):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.48.0
+      webpack: 5.108.4
 
   minipass@7.1.2: {}
 
@@ -10463,11 +10499,11 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
-  source-map-loader@5.0.0(webpack@5.107.2(@swc/core@1.3.102)):
+  source-map-loader@5.0.0(webpack@5.108.4(@swc/core@1.3.102)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.0
-      webpack: 5.107.2(@swc/core@1.3.102)
+      webpack: 5.108.4(@swc/core@1.3.102)
 
   source-map-support@0.5.21:
     dependencies:
@@ -10598,10 +10634,10 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swc-loader@0.2.3(@swc/core@1.3.102)(webpack@5.107.2(@swc/core@1.3.102)):
+  swc-loader@0.2.3(@swc/core@1.3.102)(webpack@5.108.4(@swc/core@1.3.102)):
     dependencies:
       '@swc/core': 1.3.102
-      webpack: 5.107.2(@swc/core@1.3.102)
+      webpack: 5.108.4(@swc/core@1.3.102)
 
   tapable@2.2.1: {}
 
@@ -10628,27 +10664,9 @@ snapshots:
 
   temp-dir@3.0.0: {}
 
-  terser-webpack-plugin@5.6.0(@swc/core@1.3.102)(webpack@5.107.2(@swc/core@1.3.102)):
+  terser@5.48.0:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.46.0
-      webpack: 5.107.2(@swc/core@1.3.102)
-    optionalDependencies:
-      '@swc/core': 1.3.102
-
-  terser-webpack-plugin@5.6.0(webpack@5.107.2):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.46.0
-      webpack: 5.107.2
-
-  terser@5.46.0:
-    dependencies:
-      '@jridgewell/source-map': 0.3.5
+      '@jridgewell/source-map': 0.3.11
       acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
@@ -10713,7 +10731,7 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
-  ts-loader@9.5.1(typescript@5.6.3)(webpack@5.107.2):
+  ts-loader@9.5.1(typescript@5.6.3)(webpack@5.108.4):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.19.0
@@ -10721,7 +10739,7 @@ snapshots:
       semver: 7.7.3
       source-map: 0.7.4
       typescript: 5.6.3
-      webpack: 5.107.2
+      webpack: 5.108.4
 
   ts-morph@13.0.3:
     dependencies:
@@ -10843,6 +10861,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@8.3.0: {}
+
   unionfs@4.5.1:
     dependencies:
       fs-monkey: 1.0.5
@@ -10951,9 +10971,8 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  watchpack@2.5.1:
+  watchpack@2.5.2:
     dependencies:
-      glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
   web-streams-polyfill@4.2.0: {}
@@ -10962,7 +10981,7 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.107.2:
+  webpack@5.108.4:
     dependencies:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
@@ -10973,19 +10992,18 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.1
       chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.22.0
+      enhanced-resolve: 5.24.1
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
-      glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(webpack@5.108.4)
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.6.0(webpack@5.107.2)
-      watchpack: 2.5.1
+      watchpack: 2.5.2
       webpack-sources: 3.5.0
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -11001,7 +11019,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.107.2(@swc/core@1.3.102):
+  webpack@5.108.4(@swc/core@1.3.102):
     dependencies:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
@@ -11012,19 +11030,18 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.1
       chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.22.0
+      enhanced-resolve: 5.24.1
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
-      glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.3.102)(webpack@5.108.4(@swc/core@1.3.102))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.6.0(@swc/core@1.3.102)(webpack@5.107.2(@swc/core@1.3.102))
-      watchpack: 2.5.1
+      watchpack: 2.5.2
       webpack-sources: 3.5.0
     transitivePeerDependencies:
       - '@minify-html/node'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,6 +36,10 @@ minimumReleaseAgeExclude:
   - '@temporalio/*'
   - nexus-rpc
 
+  # Allow as part of #2170 mitigation to make sure our tests confirm validity
+  # of our fix against the behavior change introduced by webpack@5.108.0
+  - webpack@5.108.4
+
 peerDependencyRules:
   ignoreMissing:
     # Peer of json-joy@9.9.1, missing in memfs@4.6.0


### PR DESCRIPTION
Backport of #2195 to `releases/1.19.x`.

## Summary

- Cherry-picks the bundler fix that makes the `__webpack_module_cache__` hijack reliable across webpack's render/minify pipeline (the `patch-module-cache` rewrite, `bundler.ts` / `reusable-vm.ts` changes, and the `#2170`/`#2188` regression tests).
- Bumps `webpack` to `^5.108.4` (in `@temporalio/worker` and `nyc-test-coverage`) plus the `pnpm-workspace.yaml` `minimumReleaseAgeExclude` entry, matching main.
- **Excludes** the `contrib/strands` change from #2195: that package does not exist on this release branch.
- CHANGELOG: aligned with the corrected #2195 changelog, restricted to this branch's lineage (no `1.20.x` entries); the unreleased bundler fix is under `[Unreleased]` (no version bump here — handled by the release PR).

## Test plan

- `pnpm build` (full recursive build) ✓
- `pnpm exec ava ./lib/test-bundler.js` → 17 tests passed (incl. integration tests against a local server) ✓