### PR TITLE
Make the Bundler's webpack-module-cache hijack more reliable (#2195)

### DIFF
--- a/packages/test/src/test-bundler.ts
+++ b/packages/test/src/test-bundler.ts
@@ -11,10 +11,11 @@ import test from 'ava';
 import { moduleMatches } from '@temporalio/worker/lib/workflow/bundler';
 import type { LogEntry, WorkerOptions } from '@temporalio/worker';
 import { bundleWorkflowCode, DefaultLogger } from '@temporalio/worker';
-import { WorkflowClient } from '@temporalio/client';
+import { Client } from '@temporalio/client';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
 import { issue516 } from './mocks/workflows-with-node-dependencies/issue-516';
 import { preloadSharedCounter } from './workflows/preload-shared-counter';
+import { workflowWithPrebundledDep } from './workflows/workflow-with-prebundled-dep';
 import { successString } from './workflows';
 
 test('moduleMatches works', (t) => {
@@ -28,15 +29,15 @@ async function runPreloadSharedCounter(
   workerOptions: Pick<WorkerOptions, 'bundlerOptions' | 'workflowBundle' | 'workflowsPath'>
 ): Promise<[number, number]> {
   const taskQueue = `${t.title}-${randomUUID()}`;
-  const client = new WorkflowClient();
+  const client = new Client();
   const worker = await Worker.create({
     taskQueue,
     reuseV8Context: true,
     ...workerOptions,
   });
   return await worker.runUntil(async () => {
-    const first = await client.execute(preloadSharedCounter, { taskQueue, workflowId: randomUUID() });
-    const second = await client.execute(preloadSharedCounter, { taskQueue, workflowId: randomUUID() });
+    const first = await client.workflow.execute(preloadSharedCounter, { taskQueue, workflowId: randomUUID() });
+    const second = await client.workflow.execute(preloadSharedCounter, { taskQueue, workflowId: randomUUID() });
     return [first, second];
   });
 }
@@ -51,8 +52,8 @@ if (RUN_INTEGRATION_TESTS) {
       taskQueue,
       workflowBundle,
     });
-    const client = new WorkflowClient();
-    await worker.runUntil(client.execute(successString, { taskQueue, workflowId: randomUUID() }));
+    const client = new Client();
+    await worker.runUntil(client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
     t.pass();
   });
 
@@ -69,9 +70,9 @@ if (RUN_INTEGRATION_TESTS) {
       taskQueue,
       workflowBundle,
     });
-    const client = new WorkflowClient();
+    const client = new Client();
     try {
-      await worker.runUntil(client.execute(successString, { taskQueue, workflowId: randomUUID() }));
+      await worker.runUntil(client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
     } finally {
       await unlink(codePath);
     }
@@ -88,8 +89,8 @@ if (RUN_INTEGRATION_TESTS) {
       taskQueue,
       workflowBundle,
     });
-    const client = new WorkflowClient();
-    await worker.runUntil(client.execute(issue516, { taskQueue, workflowId: randomUUID() }));
+    const client = new Client();
+    await worker.runUntil(client.workflow.execute(issue516, { taskQueue, workflowId: randomUUID() }));
     t.pass();
   });
 
@@ -226,4 +227,104 @@ if (RUN_INTEGRATION_TESTS) {
     const protoSources = sources.filter((s) => s.includes('/packages/proto/') || s.includes('@temporalio/proto'));
     t.deepEqual(protoSources, [], `@temporalio/proto must not appear in workflow bundle sources.}`);
   });
+
+  // Regression test for https://github.com/temporalio/sdk-typescript/issues/2188:
+  // module state must remain isolated even when a pre-bundled dependency (shipping
+  // its own nested `__webpack_module_cache__`) is included in the Workflow bundle.
+  test('Workflow bundle keeps module state isolated with a pre-bundled dependency (#2188)', async (t) => {
+    const taskQueue = `${t.title}-${randomUUID()}`;
+    const workflowBundle = await bundleWorkflowCode({
+      workflowsPath: require.resolve('./workflows/workflow-with-prebundled-dep'),
+    });
+    const client = new Client();
+    const worker = await Worker.create({ taskQueue, reuseV8Context: true, workflowBundle });
+    const results = await worker.runUntil(async () => {
+      const first = await client.workflow.execute(workflowWithPrebundledDep, { taskQueue, workflowId: randomUUID() });
+      const second = await client.workflow.execute(workflowWithPrebundledDep, { taskQueue, workflowId: randomUUID() });
+      return [first, second];
+    });
+    t.deepEqual(results, [1, 1]);
+  });
+
+  // Regression test for https://github.com/temporalio/sdk-typescript/issues/2170#issuecomment-4925636742:
+  // module state must remain isolated even when the bundle is minified after webpack.
+  test('Workflow bundle keeps module state isolated when minified after webpack (#2170 (comment))', async (t) => {
+    const workflowBundle = await bundleWorkflowCode({
+      workflowsPath: require.resolve('./workflows/preload-shared-counter'),
+      webpackConfigHook: (config) => {
+        config.plugins = [...(config.plugins ?? []), new ModuleCacheWhitespaceCollapsePlugin()];
+        return config;
+      },
+    });
+
+    t.deepEqual(await runPreloadSharedCounter(t, { workflowBundle }), [1, 1]);
+  });
+}
+
+// Regression test for https://github.com/temporalio/sdk-typescript/issues/2188:
+// a dependency that ships its own pre-bundled webpack runtime carries a nested,
+// private `__webpack_module_cache__`. The bundler must redirect only the top-level
+// runtime's cache to the injected global, and leave the nested one untouched.
+test('Workflow bundle redirects the module cache with a pre-bundled dependency (#2188)', async (t) => {
+  const { code } = await bundleWorkflowCode({
+    workflowsPath: require.resolve('./workflows/workflow-with-prebundled-dep'),
+  });
+  // The top-level runtime cache is redirected to the runtime-injected global...
+  t.true(code.includes('globalThis.__webpack_module_cache__'), 'top-level module cache should be redirected');
+  // ...while the dependency's nested, private cache is left untouched (still `= {}`), and
+  // is the only remaining bare initializer.
+  const remainingBareInitializers = code.match(/__webpack_module_cache__ = \{\}/g) ?? [];
+  t.is(remainingBareInitializers.length, 1, 'the nested private cache should be left untouched');
+});
+
+// Regression test for https://github.com/temporalio/sdk-typescript/issues/2170:
+// when the bundle is post-processed by a minifier, a text find-and-replace over
+// the final output no longer matches. The redirection must happen inside the
+// render pipeline, before minification.
+test('Workflow bundle redirects the module cache when minified after webpack (#2170)', async (t) => {
+  const { code } = await bundleWorkflowCode({
+    workflowsPath: require.resolve('./workflows/preload-shared-counter'),
+    webpackConfigHook: (config) => {
+      config.plugins = [...(config.plugins ?? []), new ModuleCacheWhitespaceCollapsePlugin()];
+      return config;
+    },
+  });
+  t.true(code.includes('globalThis.__webpack_module_cache__'), 'module cache should be redirected before minification');
+});
+
+/**
+ * A webpack plugin that mimics a minifier (e.g. terser) added by a user through
+ * `webpackConfigHook`: it rewrites the emitted bundle at the same `processAssets`
+ * stage terser uses, collapsing the `__webpack_module_cache__ = {}` declaration
+ * to `__webpack_module_cache__={}`. This is enough to defeat a naive text
+ * find-and-replace run over the final bundle.
+ *
+ * See https://github.com/temporalio/sdk-typescript/issues/2170#issuecomment-4925636742.
+ */
+class ModuleCacheWhitespaceCollapsePlugin {
+  apply(compiler: any): void {
+    const { Compilation, sources } = compiler.webpack;
+
+    compiler.hooks.compilation.tap('ModuleCacheWhitespaceCollapse', (compilation: any) => {
+      compilation.hooks.processAssets.tap(
+        { name: 'ModuleCacheWhitespaceCollapse', stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE },
+
+        (assets: any) => {
+          for (const name of Object.keys(assets)) {
+            if (!name.endsWith('.js')) continue;
+            const asset = assets[name];
+            const code = asset.source().toString();
+            // Use a ReplaceSource (rather than a fresh RawSource) so the source-map chain
+            // is preserved for the downstream inline-source-map devtool step.
+            const replaced = new sources.ReplaceSource(asset);
+            const re = /(var|let|const) __webpack_module_cache__ = \{\}/g;
+            for (let m = re.exec(code); m !== null; m = re.exec(code)) {
+              replaced.replace(m.index, m.index + m[0].length - 1, `${m[1]} __webpack_module_cache__={}`);
+            }
+            assets[name] = replaced;
+          }
+        }
+      );
+    });
+  }
 }

--- a/packages/test/src/workflows/prebundled-webpack-dep.ts
+++ b/packages/test/src/workflows/prebundled-webpack-dep.ts
@@ -1,0 +1,22 @@
+// This module simulates a dependency that ships its own *pre-bundled* webpack
+// output (e.g. `node_modules/ejson/index.js`), carrying its own function-scoped
+// `__webpack_module_cache__`. When such a dependency is pulled into a Workflow bundle,
+// the emitted bundle ends up containing more than one `__webpack_module_cache__`
+// declaration: the real top-level runtime one, plus one (or more) nested, private ones.
+//
+// See https://github.com/temporalio/sdk-typescript/issues/2188.
+function nestedWebpackRuntime(): { greet: () => string } {
+  const __webpack_module_cache__: Record<string, any> = {};
+  return {
+    greet: () => {
+      if (__webpack_module_cache__['greeting'] === undefined) {
+        __webpack_module_cache__['greeting'] = 'hello from a pre-bundled dependency';
+      }
+      return __webpack_module_cache__['greeting'];
+    },
+  };
+}
+
+export function greet(): string {
+  return nestedWebpackRuntime().greet();
+}

--- a/packages/test/src/workflows/workflow-with-prebundled-dep.ts
+++ b/packages/test/src/workflows/workflow-with-prebundled-dep.ts
@@ -1,0 +1,15 @@
+import { greet } from './prebundled-webpack-dep';
+import { nextPreloadedCounterValue } from './preload-shared-counter-helper';
+
+// This Workflow pulls a pre-bundled dependency (which ships its own nested
+// `__webpack_module_cache__`) into the Workflow bundle, and also relies on
+// module-level state (the shared counter) so that Workflow isolation can
+// be verified.
+//
+// See https://github.com/temporalio/sdk-typescript/issues/2188.
+export async function workflowWithPrebundledDep(): Promise<number> {
+  if (typeof greet() !== 'string') {
+    throw new Error('Expected the pre-bundled dependency to return a string');
+  }
+  return nextPreloadedCounterValue();
+}

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -9,6 +9,10 @@ import { webpack, NormalModuleReplacementPlugin } from 'webpack';
 import type { Logger } from '../logger';
 import { DefaultLogger, hasColorSupport } from '../logger';
 import { toMB } from '../utils';
+import {
+  InjectWorkflowModuleCacheGlobalPlugin,
+  assertWorkflowModuleCacheGlobalApplied,
+} from './bundler/patch-module-cache';
 
 export const defaultWorkflowInterceptorModules = [require.resolve('../workflow-log-interceptor')];
 
@@ -131,24 +135,9 @@ export class WorkflowCodeBundler {
 
     this.genEntrypoint(vol, entrypointPath);
     const bundleFilePath = await this.bundle(ufs, memoryFs, entrypointPath, distDir);
-    let code = memoryFs.readFileSync(bundleFilePath, 'utf8') as string;
-    // Replace webpack's module cache with an object injected by the runtime.
-    // This is the key to reusing a single v8 context.
-    // Webpack may emit the declaration as `var`, `let`, or `const` depending on the
-    // configured output environment (webpack >= 5.108.0 defaults to `const`).
-    let cacheDeclarationsPatched = 0;
-    code = code.replace(/(^|\s)(var|let|const) __webpack_module_cache__ = \{\}/gm, (_match, prefix, keyword) => {
-      cacheDeclarationsPatched++;
-      return `${prefix}${keyword} __webpack_module_cache__ = globalThis.__webpack_module_cache__`;
-    });
-    if (cacheDeclarationsPatched !== 1) {
-      throw new Error(
-        `Failed to patch the Workflow bundle: expected to find exactly one __webpack_module_cache__ declaration ` +
-          `emitted by webpack, but found ${cacheDeclarationsPatched}. Without this patch, Workflow isolation ` +
-          `would be broken. This is likely due to a change in webpack output; please report this at ` +
-          `https://github.com/temporalio/sdk-typescript/issues`
-      );
-    }
+
+    const code = memoryFs.readFileSync(bundleFilePath, 'utf8') as string;
+    assertWorkflowModuleCacheGlobalApplied(code);
 
     this.logger.info('Workflow bundle created', { size: `${toMB(code.length)}MB` });
 
@@ -249,6 +238,9 @@ exports.importInterceptors = function importInterceptors() {
         },
       },
       plugins: [
+        // Redirect webpack's module cache to a runtime-injected global so that a single V8
+        // context can be reused across Workflow executions while keeping module state isolated.
+        new InjectWorkflowModuleCacheGlobalPlugin(),
         // `@temporalio/interceptors-opentelemetry` only requires `@temporalio/workflow` for interceptors that run in workflow context.
         // In order to keep `@temporalio/workflow` as an optional peer dependency for `@temporalio/interceptors-opentelemetry`
         // we use `workflow-imports` to reexport all required imports from `@temporalio/workflow`.

--- a/packages/worker/src/workflow/bundler/patch-module-cache.ts
+++ b/packages/worker/src/workflow/bundler/patch-module-cache.ts
@@ -1,0 +1,177 @@
+import type { Compiler, Compilation } from 'webpack';
+import { javascript, sources, WebpackError } from 'webpack';
+
+type Source = sources.Source;
+
+const PLUGIN_NAME = 'TemporalWorkflowModuleCachePlugin';
+
+/**
+ * The runtime-injected global that holds the Workflow bundle's module cache.
+ *
+ * When running Workflows in a reusable V8 context, the Worker injects an object under this
+ * name into the sandbox global (see `reusable-vm.ts`). Redirecting webpack's module cache
+ * to this global is what makes per-Workflow module isolation possible while sharing a
+ * single V8 context.
+ */
+const MODULE_CACHE_GLOBAL = 'globalThis.__webpack_module_cache__';
+
+/**
+ * A fixed, high-entropy marker that we inject into the top-level webpack runtime's
+ * `__webpack_require__` function body.
+ *
+ * The marker is used to reliably locate the *real* (top-level) module-cache declaration
+ * emitted by this run of webpack (vs nested dependencies that have themselves been
+ * bundled with webpack and thus carry their own module cache declarations).The marker
+ * is stripped from the bundle before the final output is produced, so it never ships.
+ *
+ * It is intentionally a *stable constant* (not randomly generated per build): the marker
+ * participates in webpack's chunk/`[fullhash]` computation, so a random value would make
+ * the bundle's content hash — and therefore its filename — non-deterministic across
+ * otherwise-identical builds.
+ */
+const MODULE_CACHE_MARKER = '__temporal_module_cache_marker_5f2e9c8a1b7d4e60a3__';
+const MARKER_COMMENT = `/* ${MODULE_CACHE_MARKER} */\n`;
+
+// Matches webpack's top-level module-cache initializer, regardless of the declaration
+// keyword used (webpack < 5.108 emits `var`; >= 5.108 may emit `const`, 'let' or `var`).
+const MODULE_CACHE_DECLARATION = /(?:var|let|const)\s+__webpack_module_cache__\s*=\s*\{\}/g;
+
+/**
+ * Webpack plugin that redirects the Workflow bundle's top-level module cache to a
+ * runtime-injected global (`globalThis.__webpack_module_cache__`).
+ *
+ * This plugin operates inside the webpack render pipeline using in two phases:
+ *   1. `renderRequire` injects a stable marker into the top-level runtime's
+ *      `__webpack_require__` body. That hook is only ever invoked for the bundle's own
+ *      runtime, so the marker unambiguously identifies the real module cache — nested,
+ *      pre-bundled runtimes carry their own already-rendered require functions and never
+ *      pass through this hook.
+ *   2. `renderMain` uses the marker to locate the top-level module-cache declaration
+ *      (the nearest one preceding the marker), redirects it to the injected global, and
+ *      strips the marker. This runs during chunk rendering — before any `processAssets`
+ *      stage, hence before minification — and returns a `ReplaceSource` so source maps
+ *      are preserved.
+ */
+export class InjectWorkflowModuleCacheGlobalPlugin {
+  apply(compiler: Compiler): void {
+    compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation: Compilation) => {
+      const hooks = javascript.JavascriptModulesPlugin.getCompilationHooks(compilation);
+
+      hooks.renderRequire.tap(PLUGIN_NAME, (code: string) => {
+        return `${MARKER_COMMENT}${code}`;
+      });
+
+      hooks.renderMain.tap(PLUGIN_NAME, (source: Source) => {
+        return this.redirectModuleCache(source);
+      });
+    });
+  }
+
+  private redirectModuleCache(source: Source): Source {
+    const code = source.source().toString();
+
+    // We're only interested in the chunk that carries the top-level runtime marker
+    const markerIndex = code.indexOf(MARKER_COMMENT);
+    if (markerIndex === -1) {
+      return source;
+    }
+
+    // The marker is injected exactly once, into the single top-level
+    // require function. Confirm there isn't another marker in the code.
+    if (code.indexOf(MARKER_COMMENT, markerIndex + MARKER_COMMENT.length) !== -1) {
+      throw new WebpackError(
+        `Failed to patch the Workflow bundle: expected exactly one module-cache marker, but found more than one. ` +
+          `This is likely due to a change in webpack output; please report this at ` +
+          `https://github.com/temporalio/sdk-typescript/issues`
+      );
+    }
+
+    // The top-level module-cache declaration is the one immediately preceding the marked
+    // require function. Any other `__webpack_module_cache__ = {}` occurrences belong to
+    // nested, pre-bundled dependencies and appear earlier in the emitted module content, so
+    // the nearest match before the marker is always the real one.
+    let declaration: RegExpExecArray | null = null;
+    // Because of the `/g` flag, the regexp is stateful. We must reset the regexp's
+    // lastIndex to 0 to make sure it starts from the beginning of the code, rather
+    // than continuing from the last match position of a previous iteration.
+    MODULE_CACHE_DECLARATION.lastIndex = 0;
+    for (let match = MODULE_CACHE_DECLARATION.exec(code); match !== null; match = MODULE_CACHE_DECLARATION.exec(code)) {
+      if (match.index >= markerIndex) break;
+      declaration = match;
+    }
+
+    if (declaration === null) {
+      throw new WebpackError(
+        `Failed to patch the Workflow bundle: found the module-cache marker but no preceding ` +
+          `'__webpack_module_cache__' declaration to redirect. Without this patch, Workflow isolation ` +
+          `would be broken. This is likely due to a change in webpack output; please report this at ` +
+          `https://github.com/temporalio/sdk-typescript/issues`
+      );
+    }
+
+    const replaced = new sources.ReplaceSource(source);
+
+    // Redirect the top-level declaration to the runtime-injected global.
+    const declStart = declaration.index;
+    const declEndInclusive = declStart + declaration[0].length - 1;
+    replaced.replace(declStart, declEndInclusive, declaration[0].replace('= {}', `= ${MODULE_CACHE_GLOBAL}`));
+
+    // Strip the marker so it never ships.
+    // Note that `ReplaceSource.replace()` takes character indices from the
+    // _original_ source; there's thereforre no need to adjust the indices to
+    // account for the replacement we just performed (`= {}` => MODULE_CACHE_GLOBAL).
+    const markerEndInclusive = markerIndex + MARKER_COMMENT.length - 1;
+    replaced.replace(markerIndex, markerEndInclusive, '');
+
+    return replaced;
+  }
+}
+
+/**
+ * Asserts that the generated Workflow bundle has been correctly patched to redirect the
+ * module cache to the runtime-injected global (`globalThis.__webpack_module_cache__`)
+ * by `InjectWorkflowModuleCacheGlobalPlugin`.
+ *
+ * These sanity checks are meant to catch and fail loudly on some specific eventual regressions
+ * in the webpack library or configuration that would prevent hijacking webpack's module cache,
+ * and thus result in silent reoccurences of #2170 or #2188.
+ */
+export function assertWorkflowModuleCacheGlobalApplied(code: string): void {
+  // Webpack's bootstrap code should contain a declaration of the module cache, similar to:
+  //     const __webpack_module_cache__ = {};
+  //
+  // That line should have been replaced by `InjectWorkflowModuleCacheGlobalPlugin` to:
+  //     const __webpack_module_cache__ = globalThis.__webpack_module_cache__;
+  //
+  // Further webpack plugins (e.g. minification) might further transform that line (e.g. removing
+  // spaces or renaming the scoped variable), but the global variable should remain unchanged.
+  // Absence of references to that global variable would be an error.
+  if (!code.includes(MODULE_CACHE_GLOBAL)) {
+    throw new Error(
+      `Failed to patch the Workflow bundle: the module cache was not redirected to ` +
+        `'${MODULE_CACHE_GLOBAL}'. Without this, Workflow isolation would be broken.` +
+        `This may be the result of uncommon and unsupported webpack configurations, ` +
+        `but most likely indicates a change in webpack's output format or a bug in the ` +
+        `Temporal SDK. Please report this at https://github.com/temporalio/sdk-typescript/issues.`
+    );
+  }
+
+  // There could be multiple occurences of "__webpack_module_cache__" in the code produced
+  // by webpack if the bundle contains nested, pre-bundled dependencies (see #2188).
+  // To correctly determine the one to be rewritten, `InjectWorkflowModuleCacheGlobalPlugin`
+  // temporarily injects a marker into the top-level runtime's `__webpack_require__` function
+  // body. The marker is stripped from the bundle before the final output is produced.
+  //
+  // The marker being still present in the final bundle code, though unharmful by itself,
+  // would be unexpected and should raise doubts about the correctness of the module cache
+  // rewrite process.
+  if (code.includes(MODULE_CACHE_MARKER)) {
+    throw new Error(
+      `Failed to patch the Workflow bundle: the internal module-cache marker was ` +
+        `not stripped from the output. There's a risk that Workflow isolation would be broken.` +
+        `This may be the result of uncommon and unsupported webpack configurations, ` +
+        `but most likely indicates a change in webpack's output format or a bug in the ` +
+        `Temporal SDK. Please report this at https://github.com/temporalio/sdk-typescript/issues.`
+    );
+  }
+}

--- a/packages/worker/src/workflow/reusable-vm.ts
+++ b/packages/worker/src/workflow/reusable-vm.ts
@@ -267,9 +267,32 @@ export class ReusableVMWorkflowCreator implements WorkflowCreator {
     isolateExecutionTimeoutMs: number,
     registeredActivityNames: Set<string>
   ): Promise<InstanceType<T>> {
+    // The Reusable V8 Context executor needs to take control of Webpack's require
+    // cache in order to provide per-Workflow isolation of non-shared modules.
+    // In order to achieve that, the Workflow Bundler must rewrites webpack's module
+    // cache declaration to initilize it with `globalThis.__webpack_module_cache__`
+    // instead of an empty object.
+    //
+    // Loading a bundle that does not correctly rewrite the webpack's module cache to
+    // `globalThis.__webpack_module_cache__` in the Reusable V8 Context executor will
+    // result in silent breakage of Workflow isolation. See #2170 and #2188 for details.
+    //
+    // The following is a sanity check to catch eventual regressions, or attempts by
+    // users to use the Reusable V8 Context executor with bundles that were not produced
+    // with a compatible Workflow Bundler.
+    if (!workflowBundle.code.includes('globalThis.__webpack_module_cache__')) {
+      throw new Error(
+        `The provided Workflow Bundle is not compatible with the Reusable V8 Context executor: it does ` +
+          `not route its module cache through 'globalThis.__webpack_module_cache__', which is required to ` +
+          `keep module state isolated across Workflow executions. Make sure the bundle was produced by a ` +
+          `compatible version of the Temporal SDK, or disable the Reusable V8 Context executor by setting ` +
+          `'WorkerOptions.reuseV8Context' to false.`
+      );
+    }
+
+    const script = new vm.Script(workflowBundle.code, { filename: workflowBundle.filename });
     globalHandlers.install(); // Call is idempotent
     await globalHandlers.addWorkflowBundle(workflowBundle);
-    const script = new vm.Script(workflowBundle.code, { filename: workflowBundle.filename });
     return new this(script, workflowBundle, isolateExecutionTimeoutMs, registeredActivityNames) as InstanceType<T>;
   }
 


### PR DESCRIPTION
Backport of #2195 to `releases/1.18.x`.

## Summary

- Cherry-picks the bundler fix that makes the `__webpack_module_cache__` hijack reliable across webpack's render/minify pipeline (the `patch-module-cache` rewrite, `bundler.ts` / `reusable-vm.ts` changes, and the `#2170`/`#2188` regression tests).
- **Does not bump webpack** on this release branch: the branch keeps its existing `webpack` version (`^5.106.2`, resolving to `5.107.2`), and `pnpm-workspace.yaml` / `pnpm-lock.yaml` are unchanged. The fix is compatible with the branch's webpack version.
- **Excludes** the `contrib/strands` change from #2195 (package does not exist on this branch).
- No CHANGELOG changes (this release line does not maintain CHANGELOG.md).

## Test plan

- `pnpm build` (full recursive build) ✓
- `pnpm exec ava ./lib/test-bundler.js` → 16 tests passed (incl. #2170/#2188 regression tests and integration tests against a local server) ✓