### PR TITLE
External Storage pipeline integration

### DIFF
--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -39,6 +39,21 @@ import {
   decodeOptionalSinglePayload,
   encodeMapToPayloads,
   encodeToPayloadsWithContext,
+  extstoreRetrieveOptions,
+  extstoreStoreOptions,
+  visit,
+  walkExecuteMultiOperationRequest,
+  walkExecuteMultiOperationResponse,
+  walkGetWorkflowExecutionHistoryResponse,
+  walkPollWorkflowExecutionUpdateResponse,
+  walkQueryWorkflowRequest,
+  walkQueryWorkflowResponse,
+  walkSignalWithStartWorkflowExecutionRequest,
+  walkSignalWorkflowExecutionRequest,
+  walkStartWorkflowExecutionRequest,
+  walkTerminateWorkflowExecutionRequest,
+  walkUpdateWorkflowExecutionRequest,
+  walkUpdateWorkflowExecutionResponse,
 } from '@temporalio/common/lib/internal-non-workflow';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { temporal } from '@temporalio/proto';
@@ -818,6 +833,10 @@ export class WorkflowClient extends BaseClient {
       } catch (err) {
         this.rethrowGrpcError(err, 'Failed to get Workflow execution history', { workflowId, runId });
       }
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(res, walkGetWorkflowExecutionHistoryResponse, extstoreRetrieveOptions(externalStorage));
+      }
       const events = res.history?.events;
 
       if (events == null || events.length === 0) {
@@ -962,6 +981,20 @@ export class WorkflowClient extends BaseClient {
         header: { fields: input.headers },
       },
     };
+    const externalStorage = this.dataConverter.externalStorage;
+    if (externalStorage) {
+      await visit(
+        req,
+        walkQueryWorkflowRequest,
+        extstoreStoreOptions(externalStorage, {
+          initialTarget: {
+            kind: 'workflow',
+            namespace: this.options.namespace,
+            id: input.workflowExecution.workflowId ?? undefined,
+          },
+        })
+      );
+    }
     let response: temporal.api.workflowservice.v1.QueryWorkflowResponse;
     try {
       response = await this.workflowService.queryWorkflow(req);
@@ -973,6 +1006,9 @@ export class WorkflowClient extends BaseClient {
         }
       }
       this.rethrowGrpcError(err, 'Failed to query Workflow', input.workflowExecution);
+    }
+    if (externalStorage) {
+      await visit(response, walkQueryWorkflowResponse, extstoreRetrieveOptions(externalStorage));
     }
     if (response.queryRejected) {
       if (response.queryRejected.status === undefined || response.queryRejected.status === null) {
@@ -1034,6 +1070,20 @@ export class WorkflowClient extends BaseClient {
         : UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED;
 
     const request = await this._createUpdateWorkflowRequest(waitForStageProto, input);
+    const externalStorage = this.dataConverter.externalStorage;
+    if (externalStorage) {
+      await visit(
+        request,
+        walkUpdateWorkflowExecutionRequest,
+        extstoreStoreOptions(externalStorage, {
+          initialTarget: {
+            kind: 'workflow',
+            namespace: this.options.namespace,
+            id: input.workflowExecution.workflowId ?? undefined,
+          },
+        })
+      );
+    }
 
     // Repeatedly send UpdateWorkflowExecution until update is durable (if the server receives a request with
     // an update ID that already exists, it responds with information for the existing update). If the
@@ -1047,6 +1097,9 @@ export class WorkflowClient extends BaseClient {
       );
     } catch (err) {
       this.rethrowUpdateGrpcError(err, 'Workflow Update failed', input.workflowExecution);
+    }
+    if (externalStorage) {
+      await visit(response, walkUpdateWorkflowExecutionResponse, extstoreRetrieveOptions(externalStorage));
     }
     return {
       updateId: request.request!.meta!.updateId!,
@@ -1106,8 +1159,25 @@ export class WorkflowClient extends BaseClient {
       // Repeatedly send ExecuteMultiOperation until update is durable (if the server receives a request with
       // an update ID that already exists, it responds with information for the existing update). If the
       // requested wait stage is COMPLETED, further polling is done before returning the UpdateHandle.
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(
+          multiOpReq,
+          walkExecuteMultiOperationRequest,
+          extstoreStoreOptions(externalStorage, {
+            initialTarget: {
+              kind: 'workflow',
+              namespace: this.options.namespace,
+              id: input.workflowStartOptions.workflowId,
+            },
+          })
+        );
+      }
       do {
         multiOpResp = await this.workflowService.executeMultiOperation(multiOpReq);
+        if (externalStorage) {
+          await visit(multiOpResp, walkExecuteMultiOperationResponse, extstoreRetrieveOptions(externalStorage));
+        }
         startResp = multiOpResp.responses?.[0]
           ?.startWorkflow as temporal.api.workflowservice.v1.IStartWorkflowExecutionResponse;
         if (!seenStart) {
@@ -1193,6 +1263,10 @@ export class WorkflowClient extends BaseClient {
     for (;;) {
       try {
         const response = await this.workflowService.pollWorkflowExecutionUpdate(req);
+        const externalStorage = this.dataConverter.externalStorage;
+        if (externalStorage) {
+          await visit(response, walkPollWorkflowExecutionUpdateResponse, extstoreRetrieveOptions(externalStorage));
+        }
         if (response.outcome) {
           return response.outcome;
         }
@@ -1224,6 +1298,20 @@ export class WorkflowClient extends BaseClient {
       links: internalOptions?.links,
     };
     try {
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(
+          req,
+          walkSignalWorkflowExecutionRequest,
+          extstoreStoreOptions(externalStorage, {
+            initialTarget: {
+              kind: 'workflow',
+              namespace: this.options.namespace,
+              id: input.workflowExecution.workflowId,
+            },
+          })
+        );
+      }
       const response = await this.workflowService.signalWorkflowExecution(req);
       if (internalOptions != null) {
         // Servers that support CHASM signal response links (1.31 and up) return a response link
@@ -1281,6 +1369,16 @@ export class WorkflowClient extends BaseClient {
       links: internalOptions?.links,
     };
     try {
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(
+          req,
+          walkSignalWithStartWorkflowExecutionRequest,
+          extstoreStoreOptions(externalStorage, {
+            initialTarget: { kind: 'workflow', namespace: this.options.namespace, id: req.workflowId ?? undefined },
+          })
+        );
+      }
       const response = await this.workflowService.signalWithStartWorkflowExecution(req);
       if (internalOptions != null) {
         // Servers that support CHASM signal response links (1.31 and up) return a response link
@@ -1310,6 +1408,20 @@ export class WorkflowClient extends BaseClient {
     const { options: opts, workflowType } = input;
     const internalOptions = (opts as InternalWorkflowStartOptions)[InternalWorkflowStartOptionsSymbol];
     try {
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(
+          req,
+          walkStartWorkflowExecutionRequest,
+          extstoreStoreOptions(externalStorage, {
+            initialTarget: {
+              kind: 'workflow',
+              namespace: req.namespace ?? this.options.namespace,
+              id: req.workflowId ?? undefined,
+            },
+          })
+        );
+      }
       const response = await this.workflowService.startWorkflowExecution(req);
       if (internalOptions != null) {
         internalOptions.responseLink = response.link ?? undefined;
@@ -1401,6 +1513,20 @@ export class WorkflowClient extends BaseClient {
       firstExecutionRunId: input.firstExecutionRunId,
     };
     try {
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(
+          req,
+          walkTerminateWorkflowExecutionRequest,
+          extstoreStoreOptions(externalStorage, {
+            initialTarget: {
+              kind: 'workflow',
+              namespace: this.options.namespace,
+              id: input.workflowExecution.workflowId ?? undefined,
+            },
+          })
+        );
+      }
       return await this.workflowService.terminateWorkflowExecution(req);
     } catch (err) {
       this.rethrowGrpcError(err, 'Failed to terminate Workflow', input.workflowExecution);

--- a/packages/common/src/__tests__/test-payload-visitor.ts
+++ b/packages/common/src/__tests__/test-payload-visitor.ts
@@ -2,7 +2,11 @@ import test from 'ava';
 import { coresdk } from '@temporalio/proto';
 import { limit } from '../concurrency/limit';
 import type { Payload } from '../interfaces';
-import { visitWorkflowActivation, visitWorkflowActivationCompletion } from '../internal-non-workflow/payload-visitor';
+import {
+  visit,
+  walkWorkflowActivation,
+  walkWorkflowActivationCompletion,
+} from '../internal-non-workflow/payload-visitor';
 
 // Lets the event loop run every async step that is currently ready
 const tick = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
@@ -61,7 +65,7 @@ test('a failing transform surfaces its error and aborts in-flight siblings', asy
   };
 
   const error = await t.throwsAsync(
-    visitWorkflowActivation(activation, {
+    visit(activation, walkWorkflowActivation, {
       transformPayload: async (p, _context, signal) => {
         const tag = read(p);
         if (tag === 'boom') {
@@ -94,7 +98,7 @@ test('visitWorkflowActivationCompletion with an already-aborted signal skips the
   const counter = countingTransforms();
 
   const error = await t.throwsAsync(
-    visitWorkflowActivationCompletion(completionWith('a', 'b'), {
+    visit(completionWith('a', 'b'), walkWorkflowActivationCompletion, {
       ...counter.transforms,
       abortSignal: AbortSignal.abort(new Error('stop')),
     })
@@ -161,7 +165,7 @@ test('visits every payload site exactly once and writes back in place', async (t
   const activation = activationWithEveryPayloadSite();
 
   const seen: string[] = [];
-  await visitWorkflowActivation(activation, {
+  await visit(activation, walkWorkflowActivation, {
     ...perPayload<void>((p) => {
       seen.push(read(p));
       return payload(`${read(p)}#`);
@@ -172,8 +176,9 @@ test('visits every payload site exactly once and writes back in place', async (t
 
   // A second walk should observe the first walk's rewrites, proving writeback landed in place.
   const seenAgain: string[] = [];
-  await visitWorkflowActivation(
+  await visit(
     activation,
+    walkWorkflowActivation,
     perPayload<void>((p) => {
       seenAgain.push(read(p));
       return p;
@@ -189,10 +194,11 @@ test('visits every payload site exactly once and writes back in place', async (t
 test('an activation with no payloads makes no transform calls and resolves', async (t) => {
   const counter = countingTransforms();
 
-  await visitWorkflowActivation({ jobs: [] }, counter.transforms);
-  await visitWorkflowActivation({}, counter.transforms);
-  await visitWorkflowActivation(
+  await visit({ jobs: [] }, walkWorkflowActivation, counter.transforms);
+  await visit({}, walkWorkflowActivation, counter.transforms);
+  await visit(
     { jobs: [{ initializeWorkflow: { arguments: [], headers: {} } }, { fireTimer: {} }] },
+    walkWorkflowActivation,
     counter.transforms
   );
 
@@ -205,11 +211,11 @@ test('a repeated field may return any count, including zero', async (t) => {
   });
 
   const emptied = withInput();
-  await visitWorkflowActivation(emptied, { ...identity, transformPayloads: async () => [] });
+  await visit(emptied, walkWorkflowActivation, { ...identity, transformPayloads: async () => [] });
   t.deepEqual(emptied.jobs![0]!.signalWorkflow!.input, [], 'a repeated list can be emptied');
 
   const reframed = withInput();
-  await visitWorkflowActivation(reframed, { ...identity, transformPayloads: async () => [payload('merged')] });
+  await visit(reframed, walkWorkflowActivation, { ...identity, transformPayloads: async () => [payload('merged')] });
   t.deepEqual(reframed.jobs![0]!.signalWorkflow!.input!.map(read), ['merged'], 'count may shrink');
 });
 
@@ -219,7 +225,7 @@ test('context is derived per message and isolated across sibling jobs', async (t
   };
 
   const seen: Record<string, string> = {};
-  await visitWorkflowActivation<string>(activation, {
+  await visit(activation, walkWorkflowActivation, {
     initialContext: 'root',
     deriveContext: (_message, typeName, context) =>
       typeName === 'coresdk.workflow_activation.SignalWorkflow'
@@ -250,7 +256,7 @@ test('skipHeaders and skipSearchAttributes omit those sites', async (t) => {
   };
 
   const seen: string[] = [];
-  await visitWorkflowActivation(activation, {
+  await visit(activation, walkWorkflowActivation, {
     ...perPayload<void>((p) => {
       seen.push(read(p));
       return p;
@@ -273,8 +279,9 @@ test('visits completion command payloads: user metadata and a rejected update', 
   };
 
   const seen: string[] = [];
-  await visitWorkflowActivationCompletion(
+  await visit(
     completion,
+    walkWorkflowActivationCompletion,
     perPayload<void>((p) => {
       seen.push(read(p));
       return payload(`${read(p)}!`);
@@ -292,8 +299,9 @@ test('walks a decoded protobuf message instance, not just object literals', asyn
   const Type = coresdk.workflow_completion.WorkflowActivationCompletion;
   const decoded = Type.decode(Type.encode(completionWith('a', 'b')).finish());
 
-  await visitWorkflowActivationCompletion(
+  await visit(
     decoded,
+    walkWorkflowActivationCompletion,
     perPayload<void>((p) => payload(`${read(p)}!`))
   );
 
@@ -306,7 +314,7 @@ test('an identity transform leaves a real message byte-for-byte unchanged', asyn
   const original = Type.encode(activationWithEveryPayloadSite()).finish();
   const decoded = Type.decode(original);
 
-  await visitWorkflowActivation(decoded, identity);
+  await visit(decoded, walkWorkflowActivation, identity);
 
   t.deepEqual(Buffer.from(Type.encode(decoded).finish()), Buffer.from(original));
 });
@@ -344,7 +352,7 @@ test('a concurrency limit caps in-flight transforms across the whole activation'
   };
 
   const capped = tracked();
-  const cappedVisit = visitWorkflowActivation(activationWithEveryPayloadSite(), {
+  const cappedVisit = visit(activationWithEveryPayloadSite(), walkWorkflowActivation, {
     ...capped.transforms,
     limit: limit(4),
   });
@@ -354,7 +362,7 @@ test('a concurrency limit caps in-flight transforms across the whole activation'
   await cappedVisit;
 
   const sequential = tracked();
-  const sequentialVisit = visitWorkflowActivation(activationWithEveryPayloadSite(), {
+  const sequentialVisit = visit(activationWithEveryPayloadSite(), walkWorkflowActivation, {
     ...sequential.transforms,
     limit: limit(1),
   });
@@ -377,7 +385,7 @@ test('aborting mid-walk rejects and cancels in-flight transforms', async (t) => 
     }
   };
 
-  const visiting = visitWorkflowActivation(activationWithEveryPayloadSite(), {
+  const visiting = visit(activationWithEveryPayloadSite(), walkWorkflowActivation, {
     transformPayload: (p, _context, signal) => waitThenAbort(p, signal),
     transformPayloads: (ps, _context, signal) => waitThenAbort(ps, signal),
     limit: limit(16),

--- a/packages/common/src/converter/data-converter.ts
+++ b/packages/common/src/converter/data-converter.ts
@@ -1,3 +1,4 @@
+import type { ExternalStorage } from './extstore';
 import type { FailureConverter } from './failure-converter';
 import { DefaultFailureConverter } from './failure-converter';
 import type { PayloadCodec } from './payload-codec';
@@ -60,6 +61,12 @@ export interface LoadedDataConverter {
   payloadConverter: PayloadConverter;
   failureConverter: FailureConverter;
   payloadCodecs: PayloadCodec[];
+  
+  /**
+   * @internal
+   * @experimental
+   */
+  externalStorage?: ExternalStorage;
 }
 
 /**

--- a/packages/common/src/converter/data-converter.ts
+++ b/packages/common/src/converter/data-converter.ts
@@ -61,7 +61,7 @@ export interface LoadedDataConverter {
   payloadConverter: PayloadConverter;
   failureConverter: FailureConverter;
   payloadCodecs: PayloadCodec[];
-  
+
   /**
    * @internal
    * @experimental

--- a/packages/common/src/internal-non-workflow/external-storage-visitor.ts
+++ b/packages/common/src/internal-non-workflow/external-storage-visitor.ts
@@ -1,67 +1,67 @@
 /**
- * Visits payloads for External Storage and applies payload transformations via
+ * Visits payloads for External Storage and applies payload transformations via                                                                                                                                                             ║
  * {@link ExternalStorageRunner}.
  *
  * @module
  */
-import type { coresdk } from '@temporalio/proto';
-
 import type { ConcurrencyLimit } from '../concurrency/limit';
 import type { ExternalStorage, StorageDriverTargetInfo } from '../converter/extstore';
 import { ExternalStorageRunner } from './external-storage-runner';
-import { visitWorkflowActivation, visitWorkflowActivationCompletion } from './payload-visitor';
+import type { ContextDeriver, VisitOptions } from './payload-visitor';
 
 /**
- * Offload every eligible payload in a `WorkflowActivationCompletion` to external storage,
- * replacing it in place with a reference payload.
- *
- * @internal
- * @experimental
+ * The storage target in scope at a given payload site during a store walk. It starts at
+ * {@link ExternalStorageStoreOptions.initialTarget} and {@link ExternalStorageStoreOptions.deriveContext}
+ * may retarget it per message (e.g. a child-workflow command retargets its payloads at the child).
  */
-export function storeWorkflowActivationCompletion(
-  externalStorage: ExternalStorage,
-  completion: coresdk.workflow_completion.IWorkflowActivationCompletion,
-  {
-    target,
-    limit,
-    abortSignal,
-  }: {
-    /** Identity of the workflow / activity that produced the payloads, used for object naming. */
-    target?: StorageDriverTargetInfo;
-    /** Bounds concurrent transform calls across payload sites. Omit for sequential. */
-    limit?: ConcurrencyLimit;
-    /** Aborts the walk and every in-flight driver call. */
-    abortSignal?: AbortSignal;
-  } = {}
-): Promise<void> {
-  const runner = new ExternalStorageRunner(externalStorage);
-  return visitWorkflowActivationCompletion(completion, {
-    transformPayloads: (payloads, _context, signal) => runner.store(payloads, { target, abortSignal: signal }),
-    transformPayload: (payload, _context, signal) =>
-      runner.store([payload], { target, abortSignal: signal }).then((stored) => stored[0]!),
-    limit,
-    abortSignal,
-  });
+type StoreTarget = StorageDriverTargetInfo | undefined;
+
+/** @internal @experimental */
+export interface ExternalStorageStoreOptions {
+  /** Storage target before any message is entered (the initial enclosing workflow / activity). */
+  initialTarget?: StorageDriverTargetInfo;
+  /** Derives new storage target from the current message. */
+  deriveContext?: ContextDeriver<StoreTarget>;
+  /** Bounds concurrent transform calls across payload sites. Omit for sequential. */
+  limit?: ConcurrencyLimit;
+  /** Aborts the walk and every in-flight driver call. */
+  abortSignal?: AbortSignal;
 }
 
 /**
- * Replace every reference payload in a `WorkflowActivation` with the payload bytes fetched
- * from external storage, in place.
- *
  * @internal
  * @experimental
  */
-export function retrieveWorkflowActivation(
+export function extstoreStoreOptions(
   externalStorage: ExternalStorage,
-  activation: coresdk.workflow_activation.IWorkflowActivation,
-  { limit, abortSignal }: { limit?: ConcurrencyLimit; abortSignal?: AbortSignal } = {}
-): Promise<void> {
+  { initialTarget, deriveContext, limit, abortSignal }: ExternalStorageStoreOptions = {}
+): VisitOptions<StoreTarget> {
   const runner = new ExternalStorageRunner(externalStorage);
-  return visitWorkflowActivation(activation, {
+  return {
+    transformPayloads: (payloads, target, signal) => runner.store(payloads, { target, abortSignal: signal }),
+    transformPayload: (payload, target, signal) =>
+      runner.store([payload], { target, abortSignal: signal }).then((stored) => stored[0]!),
+    deriveContext,
+    initialContext: initialTarget,
+    limit,
+    abortSignal,
+  };
+}
+
+/**
+ * @internal
+ * @experimental
+ */
+export function extstoreRetrieveOptions(
+  externalStorage: ExternalStorage,
+  { limit, abortSignal }: { limit?: ConcurrencyLimit; abortSignal?: AbortSignal } = {}
+): VisitOptions<void> {
+  const runner = new ExternalStorageRunner(externalStorage);
+  return {
     transformPayloads: (payloads, _context, signal) => runner.retrieve(payloads, { abortSignal: signal }),
     transformPayload: (payload, _context, signal) =>
       runner.retrieve([payload], { abortSignal: signal }).then((retrieved) => retrieved[0]!),
     limit,
     abortSignal,
-  });
+  };
 }

--- a/packages/common/src/internal-non-workflow/external-storage-visitor.ts
+++ b/packages/common/src/internal-non-workflow/external-storage-visitor.ts
@@ -1,0 +1,67 @@
+/**
+ * Visits payloads for External Storage and applies payload transformations via
+ * {@link ExternalStorageRunner}.
+ *
+ * @module
+ */
+import type { coresdk } from '@temporalio/proto';
+
+import type { ConcurrencyLimit } from '../concurrency/limit';
+import type { ExternalStorage, StorageDriverTargetInfo } from '../converter/extstore';
+import { ExternalStorageRunner } from './external-storage-runner';
+import { visitWorkflowActivation, visitWorkflowActivationCompletion } from './payload-visitor';
+
+/**
+ * Offload every eligible payload in a `WorkflowActivationCompletion` to external storage,
+ * replacing it in place with a reference payload.
+ *
+ * @internal
+ * @experimental
+ */
+export function storeWorkflowActivationCompletion(
+  externalStorage: ExternalStorage,
+  completion: coresdk.workflow_completion.IWorkflowActivationCompletion,
+  {
+    target,
+    limit,
+    abortSignal,
+  }: {
+    /** Identity of the workflow / activity that produced the payloads, used for object naming. */
+    target?: StorageDriverTargetInfo;
+    /** Bounds concurrent transform calls across payload sites. Omit for sequential. */
+    limit?: ConcurrencyLimit;
+    /** Aborts the walk and every in-flight driver call. */
+    abortSignal?: AbortSignal;
+  } = {}
+): Promise<void> {
+  const runner = new ExternalStorageRunner(externalStorage);
+  return visitWorkflowActivationCompletion(completion, {
+    transformPayloads: (payloads, _context, signal) => runner.store(payloads, { target, abortSignal: signal }),
+    transformPayload: (payload, _context, signal) =>
+      runner.store([payload], { target, abortSignal: signal }).then((stored) => stored[0]!),
+    limit,
+    abortSignal,
+  });
+}
+
+/**
+ * Replace every reference payload in a `WorkflowActivation` with the payload bytes fetched
+ * from external storage, in place.
+ *
+ * @internal
+ * @experimental
+ */
+export function retrieveWorkflowActivation(
+  externalStorage: ExternalStorage,
+  activation: coresdk.workflow_activation.IWorkflowActivation,
+  { limit, abortSignal }: { limit?: ConcurrencyLimit; abortSignal?: AbortSignal } = {}
+): Promise<void> {
+  const runner = new ExternalStorageRunner(externalStorage);
+  return visitWorkflowActivation(activation, {
+    transformPayloads: (payloads, _context, signal) => runner.retrieve(payloads, { abortSignal: signal }),
+    transformPayload: (payload, _context, signal) =>
+      runner.retrieve([payload], { abortSignal: signal }).then((retrieved) => retrieved[0]!),
+    limit,
+    abortSignal,
+  });
+}

--- a/packages/common/src/internal-non-workflow/external-storage-visitor.ts
+++ b/packages/common/src/internal-non-workflow/external-storage-visitor.ts
@@ -1,5 +1,5 @@
 /**
- * Visits payloads for External Storage and applies payload transformations via                                                                                                                                                             ║
+ * Visits payloads for External Storage and applies payload transformations via
  * {@link ExternalStorageRunner}.
  *
  * @module
@@ -43,6 +43,8 @@ export function extstoreStoreOptions(
       runner.store([payload], { target, abortSignal: signal }).then((stored) => stored[0]!),
     deriveContext,
     initialContext: initialTarget,
+    // Search attributes must keep their literal values so the server can index/search on them.
+    skipSearchAttributes: true,
     limit,
     abortSignal,
   };
@@ -61,6 +63,7 @@ export function extstoreRetrieveOptions(
     transformPayloads: (payloads, _context, signal) => runner.retrieve(payloads, { abortSignal: signal }),
     transformPayload: (payload, _context, signal) =>
       runner.retrieve([payload], { abortSignal: signal }).then((retrieved) => retrieved[0]!),
+    skipSearchAttributes: true,
     limit,
     abortSignal,
   };

--- a/packages/common/src/internal-non-workflow/index.ts
+++ b/packages/common/src/internal-non-workflow/index.ts
@@ -9,6 +9,7 @@ export * from './data-converter-helpers';
 export * from './extstore-helpers';
 export * from './external-storage-runner';
 export * from './external-storage-visitor';
+export * from './payload-visitor';
 export * from './parse-host-uri';
 export * from './proxy-config';
 export * from './tls-config';

--- a/packages/common/src/internal-non-workflow/index.ts
+++ b/packages/common/src/internal-non-workflow/index.ts
@@ -8,6 +8,7 @@ export * from './codec-types';
 export * from './data-converter-helpers';
 export * from './extstore-helpers';
 export * from './external-storage-runner';
+export * from './external-storage-visitor';
 export * from './parse-host-uri';
 export * from './proxy-config';
 export * from './tls-config';

--- a/packages/common/src/internal-non-workflow/payload-visitor.ts
+++ b/packages/common/src/internal-non-workflow/payload-visitor.ts
@@ -1,13 +1,4 @@
-import type { coresdk } from '@temporalio/proto';
-import {
-  walkActivityTask,
-  walkActivityTaskCompletion,
-  walkNexusTask,
-  walkNexusTaskCompletion,
-  walkWorkflowActivation,
-  walkWorkflowActivationCompletion,
-  type WalkEnv,
-} from '@temporalio/proto/lib/payload-visitor.generated';
+import type { WalkEnv } from '@temporalio/proto/lib/payload-visitor.generated';
 import { sequential, type ConcurrencyLimit } from '../concurrency/limit';
 import type { Payload } from '../interfaces';
 
@@ -139,83 +130,20 @@ async function runVisit<Ctx>(
 }
 
 /**
- * Applies the payload transforms to every {@link Payload} in a `WorkflowActivation`, mutating it in place.
+ * Applies the payload transforms to every {@link Payload} in `root`, mutating it in place. Pass the
+ * generated `walk*` function for the root's message type (all are re-exported below).
  *
  * @internal
  * @experimental
  */
-export async function visitWorkflowActivation<Ctx = void>(
-  root: coresdk.workflow_activation.IWorkflowActivation,
+export async function visit<Root, Ctx = void>(
+  root: Root,
+  walk: (root: Root, env: WalkEnv<Ctx>, context: Ctx) => Promise<unknown>[],
   options: VisitOptions<Ctx>
 ): Promise<void> {
-  return runVisit(options, (env, context) => walkWorkflowActivation(root, env, context));
+  return runVisit(options, (env, context) => walk(root, env, context));
 }
 
-/**
- * Applies the payload transforms to every {@link Payload} in a `WorkflowActivationCompletion`, mutating
- * it in place.
- *
- * @internal
- * @experimental
- */
-export async function visitWorkflowActivationCompletion<Ctx = void>(
-  root: coresdk.workflow_completion.IWorkflowActivationCompletion,
-  options: VisitOptions<Ctx>
-): Promise<void> {
-  return runVisit(options, (env, context) => walkWorkflowActivationCompletion(root, env, context));
-}
-
-/**
- * Applies the payload transforms to every {@link Payload} in an `ActivityTask` (activity input and
- * last-recorded heartbeat details), mutating it in place.
- *
- * @internal
- * @experimental
- */
-export async function visitActivityTask<Ctx = void>(
-  root: coresdk.activity_task.IActivityTask,
-  options: VisitOptions<Ctx>
-): Promise<void> {
-  return runVisit(options, (env, context) => walkActivityTask(root, env, context));
-}
-
-/**
- * Applies the payload transforms to every {@link Payload} in an `ActivityTaskCompletion` (the activity
- * result / failure), mutating it in place.
- *
- * @internal
- * @experimental
- */
-export async function visitActivityTaskCompletion<Ctx = void>(
-  root: coresdk.IActivityTaskCompletion,
-  options: VisitOptions<Ctx>
-): Promise<void> {
-  return runVisit(options, (env, context) => walkActivityTaskCompletion(root, env, context));
-}
-
-/**
- * Applies the payload transforms to every {@link Payload} in a `NexusTask`, mutating it in place.
- *
- * @internal
- * @experimental
- */
-export async function visitNexusTask<Ctx = void>(
-  root: coresdk.nexus.INexusTask,
-  options: VisitOptions<Ctx>
-): Promise<void> {
-  return runVisit(options, (env, context) => walkNexusTask(root, env, context));
-}
-
-/**
- * Applies the payload transforms to every {@link Payload} in a `NexusTaskCompletion`, mutating it in
- * place.
- *
- * @internal
- * @experimental
- */
-export async function visitNexusTaskCompletion<Ctx = void>(
-  root: coresdk.nexus.INexusTaskCompletion,
-  options: VisitOptions<Ctx>
-): Promise<void> {
-  return runVisit(options, (env, context) => walkNexusTaskCompletion(root, env, context));
-}
+// Re-export every generated walker so consumers pair any of them with `visit` without a deep import
+// into the generated file.
+export * from '@temporalio/proto/lib/payload-visitor.generated';

--- a/packages/common/src/internal-non-workflow/payload-visitor.ts
+++ b/packages/common/src/internal-non-workflow/payload-visitor.ts
@@ -1,5 +1,9 @@
 import type { coresdk } from '@temporalio/proto';
 import {
+  walkActivityTask,
+  walkActivityTaskCompletion,
+  walkNexusTask,
+  walkNexusTaskCompletion,
   walkWorkflowActivation,
   walkWorkflowActivationCompletion,
   type WalkEnv,
@@ -159,4 +163,59 @@ export async function visitWorkflowActivationCompletion<Ctx = void>(
   options: VisitOptions<Ctx>
 ): Promise<void> {
   return runVisit(options, (env, context) => walkWorkflowActivationCompletion(root, env, context));
+}
+
+/**
+ * Applies the payload transforms to every {@link Payload} in an `ActivityTask` (activity input and
+ * last-recorded heartbeat details), mutating it in place.
+ *
+ * @internal
+ * @experimental
+ */
+export async function visitActivityTask<Ctx = void>(
+  root: coresdk.activity_task.IActivityTask,
+  options: VisitOptions<Ctx>
+): Promise<void> {
+  return runVisit(options, (env, context) => walkActivityTask(root, env, context));
+}
+
+/**
+ * Applies the payload transforms to every {@link Payload} in an `ActivityTaskCompletion` (the activity
+ * result / failure), mutating it in place.
+ *
+ * @internal
+ * @experimental
+ */
+export async function visitActivityTaskCompletion<Ctx = void>(
+  root: coresdk.IActivityTaskCompletion,
+  options: VisitOptions<Ctx>
+): Promise<void> {
+  return runVisit(options, (env, context) => walkActivityTaskCompletion(root, env, context));
+}
+
+/**
+ * Applies the payload transforms to every {@link Payload} in a `NexusTask`, mutating it in place.
+ *
+ * @internal
+ * @experimental
+ */
+export async function visitNexusTask<Ctx = void>(
+  root: coresdk.nexus.INexusTask,
+  options: VisitOptions<Ctx>
+): Promise<void> {
+  return runVisit(options, (env, context) => walkNexusTask(root, env, context));
+}
+
+/**
+ * Applies the payload transforms to every {@link Payload} in a `NexusTaskCompletion`, mutating it in
+ * place.
+ *
+ * @internal
+ * @experimental
+ */
+export async function visitNexusTaskCompletion<Ctx = void>(
+  root: coresdk.nexus.INexusTaskCompletion,
+  options: VisitOptions<Ctx>
+): Promise<void> {
+  return runVisit(options, (env, context) => walkNexusTaskCompletion(root, env, context));
 }

--- a/packages/proto/scripts/gen-payload-visitor.ts
+++ b/packages/proto/scripts/gen-payload-visitor.ts
@@ -11,8 +11,10 @@ import * as prettier from 'prettier';
 const PAYLOAD = 'temporal.api.common.v1.Payload';
 const ANY = 'google.protobuf.Any';
 
-// Namespaces scanned for root messages.
-const ROOT_NAMESPACES = ['coresdk'] as const;
+// Namespaces scanned for root messages. Every payload-bearing message declared under these gets an
+// exported entry point, so any message can be walked and new messages are covered automatically on
+// regen.
+const ROOT_NAMESPACES = ['coresdk', 'temporal.api.workflowservice.v1'] as const;
 
 const jsonModule = require(resolve(__dirname, '../protos/json-module.js'));
 const root = protobuf.Root.fromJSON(jsonModule);
@@ -72,8 +74,8 @@ const reachableTypes = (): Map<string, protobuf.Type> => {
 
 const types = reachableTypes();
 
-// Reverse reference index: `referrers.get(X)` is every type that has a field of type X. A type absent
-// from this map is embedded by nothing — that is the "is a root" test below.
+// Reverse reference index: `referrers.get(X)` is every type that has a field of type X. Used to walk
+// back from Payload and mark every type that can transitively contain one.
 const referrers = new Map<string, string[]>();
 for (const type of types.values()) {
   for (const field of type.fieldsArray) {
@@ -100,11 +102,18 @@ while (toVisit.length > 0) {
 // A message contains a Payload if it is one, or if it was marked above.
 const hasPayload = (type: protobuf.Type): boolean => fqn(type) === PAYLOAD || reachesPayload.has(fqn(type));
 
-// Roots: candidate messages that carry a payload and are embedded by no other message.
-const roots = candidates.filter((type) => hasPayload(type) && !referrers.has(fqn(type))).sort(byFqn);
+// Roots: every payload-bearing message declared in the scanned namespaces.
+const roots = candidates.filter((type) => hasPayload(type)).sort(byFqn);
 
-// Public entry-point name for a root, derived from its message name (e.g. `walkWorkflowActivation`).
-const entryName = (type: protobuf.Type): string => `walk${type.name}`;
+const simpleNameCounts = new Map<string, number>();
+for (const type of roots) simpleNameCounts.set(type.name, (simpleNameCounts.get(type.name) ?? 0) + 1);
+const entryName = (type: protobuf.Type): string =>
+  (simpleNameCounts.get(type.name) ?? 0) > 1
+    ? `walk${fqn(type)
+        .split(/[._]/)
+        .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+        .join('')}`
+    : `walk${type.name}`;
 
 // Guard: two roots that share a simple name would collide as exported entry points.
 const seenEntries = new Set<string>();

--- a/packages/proto/src/payload-visitor.generated.ts
+++ b/packages/proto/src/payload-visitor.generated.ts
@@ -12,6 +12,56 @@ export interface WalkEnv<Ctx> {
   skipSearchAttributes: boolean;
 }
 
+export function walkActivityExecutionResult<Ctx>(
+  root: coresdk.activity_result.IActivityExecutionResult,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_activity_result_ActivityExecutionResult(root, env, context, pending);
+  return pending;
+}
+
+export function walkActivityResolution<Ctx>(
+  root: coresdk.activity_result.IActivityResolution,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_activity_result_ActivityResolution(root, env, context, pending);
+  return pending;
+}
+
+export function walkCoresdkActivityResultCancellation<Ctx>(
+  root: coresdk.activity_result.ICancellation,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_activity_result_Cancellation(root, env, context, pending);
+  return pending;
+}
+
+export function walkCoresdkActivityResultFailure<Ctx>(
+  root: coresdk.activity_result.IFailure,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_activity_result_Failure(root, env, context, pending);
+  return pending;
+}
+
+export function walkCoresdkActivityResultSuccess<Ctx>(
+  root: coresdk.activity_result.ISuccess,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_activity_result_Success(root, env, context, pending);
+  return pending;
+}
+
 export function walkActivityTask<Ctx>(
   root: coresdk.activity_task.IActivityTask,
   env: WalkEnv<Ctx>,
@@ -19,6 +69,16 @@ export function walkActivityTask<Ctx>(
 ): Promise<unknown>[] {
   const pending: Promise<unknown>[] = [];
   walk_coresdk_activity_task_ActivityTask(root, env, context, pending);
+  return pending;
+}
+
+export function walkStart<Ctx>(
+  root: coresdk.activity_task.IStart,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_activity_task_Start(root, env, context, pending);
   return pending;
 }
 
@@ -42,6 +102,56 @@ export function walkActivityTaskCompletion<Ctx>(
   return pending;
 }
 
+export function walkCoresdkChildWorkflowCancellation<Ctx>(
+  root: coresdk.child_workflow.ICancellation,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_child_workflow_Cancellation(root, env, context, pending);
+  return pending;
+}
+
+export function walkChildWorkflowResult<Ctx>(
+  root: coresdk.child_workflow.IChildWorkflowResult,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_child_workflow_ChildWorkflowResult(root, env, context, pending);
+  return pending;
+}
+
+export function walkCoresdkChildWorkflowFailure<Ctx>(
+  root: coresdk.child_workflow.IFailure,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_child_workflow_Failure(root, env, context, pending);
+  return pending;
+}
+
+export function walkCoresdkChildWorkflowSuccess<Ctx>(
+  root: coresdk.child_workflow.ISuccess,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_child_workflow_Success(root, env, context, pending);
+  return pending;
+}
+
+export function walkNexusOperationResult<Ctx>(
+  root: coresdk.nexus.INexusOperationResult,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_nexus_NexusOperationResult(root, env, context, pending);
+  return pending;
+}
+
 export function walkNexusTask<Ctx>(
   root: coresdk.nexus.INexusTask,
   env: WalkEnv<Ctx>,
@@ -62,6 +172,126 @@ export function walkNexusTaskCompletion<Ctx>(
   return pending;
 }
 
+export function walkDoUpdate<Ctx>(
+  root: coresdk.workflow_activation.IDoUpdate,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_activation_DoUpdate(root, env, context, pending);
+  return pending;
+}
+
+export function walkInitializeWorkflow<Ctx>(
+  root: coresdk.workflow_activation.IInitializeWorkflow,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_activation_InitializeWorkflow(root, env, context, pending);
+  return pending;
+}
+
+export function walkQueryWorkflow<Ctx>(
+  root: coresdk.workflow_activation.IQueryWorkflow,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_activation_QueryWorkflow(root, env, context, pending);
+  return pending;
+}
+
+export function walkResolveActivity<Ctx>(
+  root: coresdk.workflow_activation.IResolveActivity,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_activation_ResolveActivity(root, env, context, pending);
+  return pending;
+}
+
+export function walkResolveChildWorkflowExecution<Ctx>(
+  root: coresdk.workflow_activation.IResolveChildWorkflowExecution,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_activation_ResolveChildWorkflowExecution(root, env, context, pending);
+  return pending;
+}
+
+export function walkResolveChildWorkflowExecutionStart<Ctx>(
+  root: coresdk.workflow_activation.IResolveChildWorkflowExecutionStart,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_activation_ResolveChildWorkflowExecutionStart(root, env, context, pending);
+  return pending;
+}
+
+export function walkResolveChildWorkflowExecutionStartCancelled<Ctx>(
+  root: coresdk.workflow_activation.IResolveChildWorkflowExecutionStartCancelled,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_activation_ResolveChildWorkflowExecutionStartCancelled(root, env, context, pending);
+  return pending;
+}
+
+export function walkResolveNexusOperation<Ctx>(
+  root: coresdk.workflow_activation.IResolveNexusOperation,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_activation_ResolveNexusOperation(root, env, context, pending);
+  return pending;
+}
+
+export function walkResolveNexusOperationStart<Ctx>(
+  root: coresdk.workflow_activation.IResolveNexusOperationStart,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_activation_ResolveNexusOperationStart(root, env, context, pending);
+  return pending;
+}
+
+export function walkResolveRequestCancelExternalWorkflow<Ctx>(
+  root: coresdk.workflow_activation.IResolveRequestCancelExternalWorkflow,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_activation_ResolveRequestCancelExternalWorkflow(root, env, context, pending);
+  return pending;
+}
+
+export function walkResolveSignalExternalWorkflow<Ctx>(
+  root: coresdk.workflow_activation.IResolveSignalExternalWorkflow,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_activation_ResolveSignalExternalWorkflow(root, env, context, pending);
+  return pending;
+}
+
+export function walkSignalWorkflow<Ctx>(
+  root: coresdk.workflow_activation.ISignalWorkflow,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_activation_SignalWorkflow(root, env, context, pending);
+  return pending;
+}
+
 export function walkWorkflowActivation<Ctx>(
   root: coresdk.workflow_activation.IWorkflowActivation,
   env: WalkEnv<Ctx>,
@@ -72,6 +302,176 @@ export function walkWorkflowActivation<Ctx>(
   return pending;
 }
 
+export function walkWorkflowActivationJob<Ctx>(
+  root: coresdk.workflow_activation.IWorkflowActivationJob,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_activation_WorkflowActivationJob(root, env, context, pending);
+  return pending;
+}
+
+export function walkCompleteWorkflowExecution<Ctx>(
+  root: coresdk.workflow_commands.ICompleteWorkflowExecution,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_commands_CompleteWorkflowExecution(root, env, context, pending);
+  return pending;
+}
+
+export function walkContinueAsNewWorkflowExecution<Ctx>(
+  root: coresdk.workflow_commands.IContinueAsNewWorkflowExecution,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_commands_ContinueAsNewWorkflowExecution(root, env, context, pending);
+  return pending;
+}
+
+export function walkFailWorkflowExecution<Ctx>(
+  root: coresdk.workflow_commands.IFailWorkflowExecution,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_commands_FailWorkflowExecution(root, env, context, pending);
+  return pending;
+}
+
+export function walkModifyWorkflowProperties<Ctx>(
+  root: coresdk.workflow_commands.IModifyWorkflowProperties,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_commands_ModifyWorkflowProperties(root, env, context, pending);
+  return pending;
+}
+
+export function walkQueryResult<Ctx>(
+  root: coresdk.workflow_commands.IQueryResult,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_commands_QueryResult(root, env, context, pending);
+  return pending;
+}
+
+export function walkQuerySuccess<Ctx>(
+  root: coresdk.workflow_commands.IQuerySuccess,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_commands_QuerySuccess(root, env, context, pending);
+  return pending;
+}
+
+export function walkScheduleActivity<Ctx>(
+  root: coresdk.workflow_commands.IScheduleActivity,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_commands_ScheduleActivity(root, env, context, pending);
+  return pending;
+}
+
+export function walkScheduleLocalActivity<Ctx>(
+  root: coresdk.workflow_commands.IScheduleLocalActivity,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_commands_ScheduleLocalActivity(root, env, context, pending);
+  return pending;
+}
+
+export function walkScheduleNexusOperation<Ctx>(
+  root: coresdk.workflow_commands.IScheduleNexusOperation,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_commands_ScheduleNexusOperation(root, env, context, pending);
+  return pending;
+}
+
+export function walkSignalExternalWorkflowExecution<Ctx>(
+  root: coresdk.workflow_commands.ISignalExternalWorkflowExecution,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_commands_SignalExternalWorkflowExecution(root, env, context, pending);
+  return pending;
+}
+
+export function walkStartChildWorkflowExecution<Ctx>(
+  root: coresdk.workflow_commands.IStartChildWorkflowExecution,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_commands_StartChildWorkflowExecution(root, env, context, pending);
+  return pending;
+}
+
+export function walkUpdateResponse<Ctx>(
+  root: coresdk.workflow_commands.IUpdateResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_commands_UpdateResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkUpsertWorkflowSearchAttributes<Ctx>(
+  root: coresdk.workflow_commands.IUpsertWorkflowSearchAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_commands_UpsertWorkflowSearchAttributes(root, env, context, pending);
+  return pending;
+}
+
+export function walkWorkflowCommand<Ctx>(
+  root: coresdk.workflow_commands.IWorkflowCommand,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_commands_WorkflowCommand(root, env, context, pending);
+  return pending;
+}
+
+export function walkCoresdkWorkflowCompletionFailure<Ctx>(
+  root: coresdk.workflow_completion.IFailure,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_completion_Failure(root, env, context, pending);
+  return pending;
+}
+
+export function walkCoresdkWorkflowCompletionSuccess<Ctx>(
+  root: coresdk.workflow_completion.ISuccess,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_coresdk_workflow_completion_Success(root, env, context, pending);
+  return pending;
+}
+
 export function walkWorkflowActivationCompletion<Ctx>(
   root: coresdk.workflow_completion.IWorkflowActivationCompletion,
   env: WalkEnv<Ctx>,
@@ -79,6 +479,751 @@ export function walkWorkflowActivationCompletion<Ctx>(
 ): Promise<unknown>[] {
   const pending: Promise<unknown>[] = [];
   walk_coresdk_workflow_completion_WorkflowActivationCompletion(root, env, context, pending);
+  return pending;
+}
+
+export function walkCountActivityExecutionsResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.ICountActivityExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_CountActivityExecutionsResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkTemporalApiWorkflowserviceV1CountActivityExecutionsResponseAggregationGroup<Ctx>(
+  root: temporal.api.workflowservice.v1.CountActivityExecutionsResponse.IAggregationGroup,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_CountActivityExecutionsResponse_AggregationGroup(root, env, context, pending);
+  return pending;
+}
+
+export function walkCountNexusOperationExecutionsResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.ICountNexusOperationExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_CountNexusOperationExecutionsResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkTemporalApiWorkflowserviceV1CountNexusOperationExecutionsResponseAggregationGroup<Ctx>(
+  root: temporal.api.workflowservice.v1.CountNexusOperationExecutionsResponse.IAggregationGroup,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_CountNexusOperationExecutionsResponse_AggregationGroup(
+    root,
+    env,
+    context,
+    pending
+  );
+  return pending;
+}
+
+export function walkCountSchedulesResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.ICountSchedulesResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_CountSchedulesResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkTemporalApiWorkflowserviceV1CountSchedulesResponseAggregationGroup<Ctx>(
+  root: temporal.api.workflowservice.v1.CountSchedulesResponse.IAggregationGroup,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_CountSchedulesResponse_AggregationGroup(root, env, context, pending);
+  return pending;
+}
+
+export function walkCountWorkflowExecutionsResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.ICountWorkflowExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_CountWorkflowExecutionsResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkTemporalApiWorkflowserviceV1CountWorkflowExecutionsResponseAggregationGroup<Ctx>(
+  root: temporal.api.workflowservice.v1.CountWorkflowExecutionsResponse.IAggregationGroup,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_CountWorkflowExecutionsResponse_AggregationGroup(root, env, context, pending);
+  return pending;
+}
+
+export function walkCreateScheduleRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.ICreateScheduleRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_CreateScheduleRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkCreateWorkerDeploymentVersionRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.ICreateWorkerDeploymentVersionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_CreateWorkerDeploymentVersionRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkDescribeActivityExecutionResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IDescribeActivityExecutionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_DescribeActivityExecutionResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkDescribeDeploymentResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IDescribeDeploymentResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_DescribeDeploymentResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkDescribeNexusOperationExecutionResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IDescribeNexusOperationExecutionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_DescribeNexusOperationExecutionResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkDescribeScheduleResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IDescribeScheduleResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_DescribeScheduleResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkDescribeWorkerDeploymentVersionResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IDescribeWorkerDeploymentVersionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_DescribeWorkerDeploymentVersionResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkDescribeWorkflowExecutionResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IDescribeWorkflowExecutionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_DescribeWorkflowExecutionResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkExecuteMultiOperationRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IExecuteMultiOperationRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_ExecuteMultiOperationRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkOperation<Ctx>(
+  root: temporal.api.workflowservice.v1.ExecuteMultiOperationRequest.IOperation,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_ExecuteMultiOperationRequest_Operation(root, env, context, pending);
+  return pending;
+}
+
+export function walkExecuteMultiOperationResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IExecuteMultiOperationResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_ExecuteMultiOperationResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.ExecuteMultiOperationResponse.IResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_ExecuteMultiOperationResponse_Response(root, env, context, pending);
+  return pending;
+}
+
+export function walkGetCurrentDeploymentResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IGetCurrentDeploymentResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_GetCurrentDeploymentResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkGetDeploymentReachabilityResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IGetDeploymentReachabilityResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_GetDeploymentReachabilityResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkGetWorkflowExecutionHistoryResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IGetWorkflowExecutionHistoryResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_GetWorkflowExecutionHistoryResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkGetWorkflowExecutionHistoryReverseResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IGetWorkflowExecutionHistoryReverseResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_GetWorkflowExecutionHistoryReverseResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkListActivityExecutionsResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IListActivityExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_ListActivityExecutionsResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkListArchivedWorkflowExecutionsResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IListArchivedWorkflowExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_ListArchivedWorkflowExecutionsResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkListClosedWorkflowExecutionsResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IListClosedWorkflowExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_ListClosedWorkflowExecutionsResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkListNexusOperationExecutionsResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IListNexusOperationExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_ListNexusOperationExecutionsResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkListOpenWorkflowExecutionsResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IListOpenWorkflowExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_ListOpenWorkflowExecutionsResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkListSchedulesResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IListSchedulesResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_ListSchedulesResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkListWorkflowExecutionsResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IListWorkflowExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_ListWorkflowExecutionsResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkPollActivityExecutionResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IPollActivityExecutionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_PollActivityExecutionResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkPollActivityTaskQueueResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IPollActivityTaskQueueResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_PollActivityTaskQueueResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkPollNexusOperationExecutionResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IPollNexusOperationExecutionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_PollNexusOperationExecutionResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkPollNexusTaskQueueResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IPollNexusTaskQueueResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_PollNexusTaskQueueResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkPollWorkflowExecutionUpdateResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IPollWorkflowExecutionUpdateResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_PollWorkflowExecutionUpdateResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkPollWorkflowTaskQueueResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IPollWorkflowTaskQueueResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_PollWorkflowTaskQueueResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkQueryWorkflowRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IQueryWorkflowRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_QueryWorkflowRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkQueryWorkflowResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IQueryWorkflowResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_QueryWorkflowResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkRecordActivityTaskHeartbeatByIdRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IRecordActivityTaskHeartbeatByIdRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RecordActivityTaskHeartbeatByIdRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkRecordActivityTaskHeartbeatRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IRecordActivityTaskHeartbeatRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RecordActivityTaskHeartbeatRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkResetWorkflowExecutionRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IResetWorkflowExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_ResetWorkflowExecutionRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkRespondActivityTaskCanceledByIdRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IRespondActivityTaskCanceledByIdRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RespondActivityTaskCanceledByIdRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkRespondActivityTaskCanceledRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IRespondActivityTaskCanceledRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RespondActivityTaskCanceledRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkRespondActivityTaskCompletedByIdRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IRespondActivityTaskCompletedByIdRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RespondActivityTaskCompletedByIdRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkRespondActivityTaskCompletedRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IRespondActivityTaskCompletedRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RespondActivityTaskCompletedRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkRespondActivityTaskFailedByIdRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IRespondActivityTaskFailedByIdRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RespondActivityTaskFailedByIdRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkRespondActivityTaskFailedByIdResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IRespondActivityTaskFailedByIdResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RespondActivityTaskFailedByIdResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkRespondActivityTaskFailedRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IRespondActivityTaskFailedRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RespondActivityTaskFailedRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkRespondActivityTaskFailedResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IRespondActivityTaskFailedResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RespondActivityTaskFailedResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkRespondNexusTaskCompletedRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IRespondNexusTaskCompletedRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RespondNexusTaskCompletedRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkRespondNexusTaskFailedRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IRespondNexusTaskFailedRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RespondNexusTaskFailedRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkRespondQueryTaskCompletedRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IRespondQueryTaskCompletedRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RespondQueryTaskCompletedRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkRespondWorkflowTaskCompletedRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IRespondWorkflowTaskCompletedRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RespondWorkflowTaskCompletedRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkRespondWorkflowTaskCompletedResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IRespondWorkflowTaskCompletedResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RespondWorkflowTaskCompletedResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkRespondWorkflowTaskFailedRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IRespondWorkflowTaskFailedRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_RespondWorkflowTaskFailedRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkScanWorkflowExecutionsResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IScanWorkflowExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_ScanWorkflowExecutionsResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkSetCurrentDeploymentRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.ISetCurrentDeploymentRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_SetCurrentDeploymentRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkSetCurrentDeploymentResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.ISetCurrentDeploymentResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_SetCurrentDeploymentResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkSignalWithStartWorkflowExecutionRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.ISignalWithStartWorkflowExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_SignalWithStartWorkflowExecutionRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkSignalWorkflowExecutionRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.ISignalWorkflowExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_SignalWorkflowExecutionRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkStartActivityExecutionRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IStartActivityExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_StartActivityExecutionRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkStartBatchOperationRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IStartBatchOperationRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_StartBatchOperationRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkStartNexusOperationExecutionRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IStartNexusOperationExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_StartNexusOperationExecutionRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkStartWorkflowExecutionRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IStartWorkflowExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_StartWorkflowExecutionRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkStartWorkflowExecutionResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IStartWorkflowExecutionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_StartWorkflowExecutionResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkTerminateWorkflowExecutionRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.ITerminateWorkflowExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_TerminateWorkflowExecutionRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkUpdateScheduleRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IUpdateScheduleRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_UpdateScheduleRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkUpdateWorkerDeploymentVersionComputeConfigRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IUpdateWorkerDeploymentVersionComputeConfigRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_UpdateWorkerDeploymentVersionComputeConfigRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkUpdateWorkerDeploymentVersionMetadataRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IUpdateWorkerDeploymentVersionMetadataRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_UpdateWorkerDeploymentVersionMetadataRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkUpdateWorkerDeploymentVersionMetadataResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IUpdateWorkerDeploymentVersionMetadataResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_UpdateWorkerDeploymentVersionMetadataResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkUpdateWorkflowExecutionRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IUpdateWorkflowExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_UpdateWorkflowExecutionRequest(root, env, context, pending);
+  return pending;
+}
+
+export function walkUpdateWorkflowExecutionResponse<Ctx>(
+  root: temporal.api.workflowservice.v1.IUpdateWorkflowExecutionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_UpdateWorkflowExecutionResponse(root, env, context, pending);
+  return pending;
+}
+
+export function walkValidateWorkerDeploymentVersionComputeConfigRequest<Ctx>(
+  root: temporal.api.workflowservice.v1.IValidateWorkerDeploymentVersionComputeConfigRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx
+): Promise<unknown>[] {
+  const pending: Promise<unknown>[] = [];
+  walk_temporal_api_workflowservice_v1_ValidateWorkerDeploymentVersionComputeConfigRequest(root, env, context, pending);
   return pending;
 }
 
@@ -1146,6 +2291,450 @@ function walk_coresdk_workflow_completion_WorkflowActivationCompletion<Ctx>(
   }
 }
 
+function walk_temporal_api_activity_v1_ActivityExecutionInfo<Ctx>(
+  o: temporal.api.activity.v1.IActivityExecutionInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.activity.v1.ActivityExecutionInfo', context)
+    : context;
+  {
+    const c = o.heartbeatDetails;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.lastFailure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.userMetadata;
+    if (c != null) walk_temporal_api_sdk_v1_UserMetadata(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_activity_v1_ActivityExecutionListInfo<Ctx>(
+  o: temporal.api.activity.v1.IActivityExecutionListInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.activity.v1.ActivityExecutionListInfo', context)
+    : context;
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+}
+
+function walk_temporal_api_activity_v1_ActivityExecutionOutcome<Ctx>(
+  o: temporal.api.activity.v1.IActivityExecutionOutcome,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.activity.v1.ActivityExecutionOutcome', context)
+    : context;
+  {
+    const c = o.result;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_activity_v1_CallbackInfo<Ctx>(
+  o: temporal.api.activity.v1.ICallbackInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.activity.v1.CallbackInfo', context) : context;
+  {
+    const c = o.info;
+    if (c != null) walk_temporal_api_callback_v1_CallbackInfo(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_batch_v1_BatchOperationReset<Ctx>(
+  o: temporal.api.batch.v1.IBatchOperationReset,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.batch.v1.BatchOperationReset', context) : context;
+  {
+    const a = o.postResetOperations;
+    if (a) for (const v of a) walk_temporal_api_workflow_v1_PostResetOperation(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_batch_v1_BatchOperationSignal<Ctx>(
+  o: temporal.api.batch.v1.IBatchOperationSignal,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.batch.v1.BatchOperationSignal', context) : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_batch_v1_BatchOperationTermination<Ctx>(
+  o: temporal.api.batch.v1.IBatchOperationTermination,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.batch.v1.BatchOperationTermination', context)
+    : context;
+  {
+    const c = o.details;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_callback_v1_CallbackInfo<Ctx>(
+  o: temporal.api.callback.v1.ICallbackInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.callback.v1.CallbackInfo', context) : context;
+  {
+    const c = o.lastAttemptFailure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_command_v1_CancelWorkflowExecutionCommandAttributes<Ctx>(
+  o: temporal.api.command.v1.ICancelWorkflowExecutionCommandAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.command.v1.CancelWorkflowExecutionCommandAttributes', context)
+    : context;
+  {
+    const c = o.details;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_command_v1_Command<Ctx>(
+  o: temporal.api.command.v1.ICommand,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.command.v1.Command', context) : context;
+  {
+    const c = o.userMetadata;
+    if (c != null) walk_temporal_api_sdk_v1_UserMetadata(c, env, ctx, pending);
+  }
+  {
+    const a = o.eventGroupMarkers;
+    if (a) for (const v of a) walk_temporal_api_sdk_v1_EventGroupMarker(v, env, ctx, pending);
+  }
+  {
+    const c = o.scheduleActivityTaskCommandAttributes;
+    if (c != null) walk_temporal_api_command_v1_ScheduleActivityTaskCommandAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.completeWorkflowExecutionCommandAttributes;
+    if (c != null) walk_temporal_api_command_v1_CompleteWorkflowExecutionCommandAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.failWorkflowExecutionCommandAttributes;
+    if (c != null) walk_temporal_api_command_v1_FailWorkflowExecutionCommandAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.cancelWorkflowExecutionCommandAttributes;
+    if (c != null) walk_temporal_api_command_v1_CancelWorkflowExecutionCommandAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.recordMarkerCommandAttributes;
+    if (c != null) walk_temporal_api_command_v1_RecordMarkerCommandAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.continueAsNewWorkflowExecutionCommandAttributes;
+    if (c != null) walk_temporal_api_command_v1_ContinueAsNewWorkflowExecutionCommandAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.startChildWorkflowExecutionCommandAttributes;
+    if (c != null) walk_temporal_api_command_v1_StartChildWorkflowExecutionCommandAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.signalExternalWorkflowExecutionCommandAttributes;
+    if (c != null) walk_temporal_api_command_v1_SignalExternalWorkflowExecutionCommandAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.upsertWorkflowSearchAttributesCommandAttributes;
+    if (c != null) walk_temporal_api_command_v1_UpsertWorkflowSearchAttributesCommandAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.modifyWorkflowPropertiesCommandAttributes;
+    if (c != null) walk_temporal_api_command_v1_ModifyWorkflowPropertiesCommandAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.scheduleNexusOperationCommandAttributes;
+    if (c != null) walk_temporal_api_command_v1_ScheduleNexusOperationCommandAttributes(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_command_v1_CompleteWorkflowExecutionCommandAttributes<Ctx>(
+  o: temporal.api.command.v1.ICompleteWorkflowExecutionCommandAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.command.v1.CompleteWorkflowExecutionCommandAttributes', context)
+    : context;
+  {
+    const c = o.result;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_command_v1_ContinueAsNewWorkflowExecutionCommandAttributes<Ctx>(
+  o: temporal.api.command.v1.IContinueAsNewWorkflowExecutionCommandAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes', context)
+    : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+  {
+    const c = o.lastCompletionResult;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.memo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+}
+
+function walk_temporal_api_command_v1_FailWorkflowExecutionCommandAttributes<Ctx>(
+  o: temporal.api.command.v1.IFailWorkflowExecutionCommandAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.command.v1.FailWorkflowExecutionCommandAttributes', context)
+    : context;
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_command_v1_ModifyWorkflowPropertiesCommandAttributes<Ctx>(
+  o: temporal.api.command.v1.IModifyWorkflowPropertiesCommandAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.command.v1.ModifyWorkflowPropertiesCommandAttributes', context)
+    : context;
+  {
+    const c = o.upsertedMemo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_command_v1_RecordMarkerCommandAttributes<Ctx>(
+  o: temporal.api.command.v1.IRecordMarkerCommandAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.command.v1.RecordMarkerCommandAttributes', context)
+    : context;
+  {
+    const m = o.details;
+    if (m) for (const v of Object.values(m)) walk_temporal_api_common_v1_Payloads(v, env, ctx, pending);
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_command_v1_ScheduleActivityTaskCommandAttributes<Ctx>(
+  o: temporal.api.command.v1.IScheduleActivityTaskCommandAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.command.v1.ScheduleActivityTaskCommandAttributes', context)
+    : context;
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_command_v1_ScheduleNexusOperationCommandAttributes<Ctx>(
+  o: temporal.api.command.v1.IScheduleNexusOperationCommandAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.command.v1.ScheduleNexusOperationCommandAttributes', context)
+    : context;
+  {
+    const p = o.input;
+    if (p != null)
+      pending.push(
+        env.transformPayload(p, ctx).then((r) => {
+          o.input = r;
+        })
+      );
+  }
+}
+
+function walk_temporal_api_command_v1_SignalExternalWorkflowExecutionCommandAttributes<Ctx>(
+  o: temporal.api.command.v1.ISignalExternalWorkflowExecutionCommandAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes', context)
+    : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_command_v1_StartChildWorkflowExecutionCommandAttributes<Ctx>(
+  o: temporal.api.command.v1.IStartChildWorkflowExecutionCommandAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes', context)
+    : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.memo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+}
+
+function walk_temporal_api_command_v1_UpsertWorkflowSearchAttributesCommandAttributes<Ctx>(
+  o: temporal.api.command.v1.IUpsertWorkflowSearchAttributesCommandAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.command.v1.UpsertWorkflowSearchAttributesCommandAttributes', context)
+    : context;
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+}
+
+function walk_temporal_api_common_v1_Header<Ctx>(
+  o: temporal.api.common.v1.IHeader,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.common.v1.Header', context) : context;
+  {
+    const m = o.fields;
+    if (m)
+      for (const [k, v] of Object.entries(m))
+        pending.push(
+          env.transformPayload(v, ctx).then((r) => {
+            m[k] = r;
+          })
+        );
+  }
+}
+
 function walk_temporal_api_common_v1_Memo<Ctx>(
   o: temporal.api.common.v1.IMemo,
   env: WalkEnv<Ctx>,
@@ -1199,6 +2788,168 @@ function walk_temporal_api_common_v1_SearchAttributes<Ctx>(
             m[k] = r;
           })
         );
+  }
+}
+
+function walk_temporal_api_compute_v1_ComputeConfig<Ctx>(
+  o: temporal.api.compute.v1.IComputeConfig,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.compute.v1.ComputeConfig', context) : context;
+  {
+    const m = o.scalingGroups;
+    if (m)
+      for (const v of Object.values(m)) walk_temporal_api_compute_v1_ComputeConfigScalingGroup(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_compute_v1_ComputeConfigScalingGroup<Ctx>(
+  o: temporal.api.compute.v1.IComputeConfigScalingGroup,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.compute.v1.ComputeConfigScalingGroup', context)
+    : context;
+  {
+    const c = o.provider;
+    if (c != null) walk_temporal_api_compute_v1_ComputeProvider(c, env, ctx, pending);
+  }
+  {
+    const c = o.scaler;
+    if (c != null) walk_temporal_api_compute_v1_ComputeScaler(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_compute_v1_ComputeConfigScalingGroupUpdate<Ctx>(
+  o: temporal.api.compute.v1.IComputeConfigScalingGroupUpdate,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.compute.v1.ComputeConfigScalingGroupUpdate', context)
+    : context;
+  {
+    const c = o.scalingGroup;
+    if (c != null) walk_temporal_api_compute_v1_ComputeConfigScalingGroup(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_compute_v1_ComputeProvider<Ctx>(
+  o: temporal.api.compute.v1.IComputeProvider,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.compute.v1.ComputeProvider', context) : context;
+  {
+    const p = o.details;
+    if (p != null)
+      pending.push(
+        env.transformPayload(p, ctx).then((r) => {
+          o.details = r;
+        })
+      );
+  }
+}
+
+function walk_temporal_api_compute_v1_ComputeScaler<Ctx>(
+  o: temporal.api.compute.v1.IComputeScaler,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.compute.v1.ComputeScaler', context) : context;
+  {
+    const p = o.details;
+    if (p != null)
+      pending.push(
+        env.transformPayload(p, ctx).then((r) => {
+          o.details = r;
+        })
+      );
+  }
+}
+
+function walk_temporal_api_deployment_v1_DeploymentInfo<Ctx>(
+  o: temporal.api.deployment.v1.IDeploymentInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.deployment.v1.DeploymentInfo', context) : context;
+  {
+    const m = o.metadata;
+    if (m)
+      for (const [k, v] of Object.entries(m))
+        pending.push(
+          env.transformPayload(v, ctx).then((r) => {
+            m[k] = r;
+          })
+        );
+  }
+}
+
+function walk_temporal_api_deployment_v1_UpdateDeploymentMetadata<Ctx>(
+  o: temporal.api.deployment.v1.IUpdateDeploymentMetadata,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.deployment.v1.UpdateDeploymentMetadata', context)
+    : context;
+  {
+    const m = o.upsertEntries;
+    if (m)
+      for (const [k, v] of Object.entries(m))
+        pending.push(
+          env.transformPayload(v, ctx).then((r) => {
+            m[k] = r;
+          })
+        );
+  }
+}
+
+function walk_temporal_api_deployment_v1_VersionMetadata<Ctx>(
+  o: temporal.api.deployment.v1.IVersionMetadata,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.deployment.v1.VersionMetadata', context) : context;
+  {
+    const m = o.entries;
+    if (m)
+      for (const [k, v] of Object.entries(m))
+        pending.push(
+          env.transformPayload(v, ctx).then((r) => {
+            m[k] = r;
+          })
+        );
+  }
+}
+
+function walk_temporal_api_deployment_v1_WorkerDeploymentVersionInfo<Ctx>(
+  o: temporal.api.deployment.v1.IWorkerDeploymentVersionInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.deployment.v1.WorkerDeploymentVersionInfo', context)
+    : context;
+  {
+    const c = o.metadata;
+    if (c != null) walk_temporal_api_deployment_v1_VersionMetadata(c, env, ctx, pending);
+  }
+  {
+    const c = o.computeConfig;
+    if (c != null) walk_temporal_api_compute_v1_ComputeConfig(c, env, ctx, pending);
   }
 }
 
@@ -1298,6 +3049,840 @@ function walk_temporal_api_failure_v1_TimeoutFailureInfo<Ctx>(
   }
 }
 
+function walk_temporal_api_history_v1_ActivityTaskCanceledEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IActivityTaskCanceledEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.ActivityTaskCanceledEventAttributes', context)
+    : context;
+  {
+    const c = o.details;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_ActivityTaskCompletedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IActivityTaskCompletedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.ActivityTaskCompletedEventAttributes', context)
+    : context;
+  {
+    const c = o.result;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_ActivityTaskFailedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IActivityTaskFailedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.ActivityTaskFailedEventAttributes', context)
+    : context;
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_ActivityTaskScheduledEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IActivityTaskScheduledEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.ActivityTaskScheduledEventAttributes', context)
+    : context;
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_ActivityTaskStartedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IActivityTaskStartedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.ActivityTaskStartedEventAttributes', context)
+    : context;
+  {
+    const c = o.lastFailure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_ActivityTaskTimedOutEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IActivityTaskTimedOutEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.ActivityTaskTimedOutEventAttributes', context)
+    : context;
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_ChildWorkflowExecutionCanceledEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IChildWorkflowExecutionCanceledEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.ChildWorkflowExecutionCanceledEventAttributes', context)
+    : context;
+  {
+    const c = o.details;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_ChildWorkflowExecutionCompletedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IChildWorkflowExecutionCompletedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.ChildWorkflowExecutionCompletedEventAttributes', context)
+    : context;
+  {
+    const c = o.result;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_ChildWorkflowExecutionFailedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IChildWorkflowExecutionFailedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.ChildWorkflowExecutionFailedEventAttributes', context)
+    : context;
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_ChildWorkflowExecutionStartedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IChildWorkflowExecutionStartedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.ChildWorkflowExecutionStartedEventAttributes', context)
+    : context;
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_History<Ctx>(
+  o: temporal.api.history.v1.IHistory,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.history.v1.History', context) : context;
+  {
+    const a = o.events;
+    if (a) for (const v of a) walk_temporal_api_history_v1_HistoryEvent(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_HistoryEvent<Ctx>(
+  o: temporal.api.history.v1.IHistoryEvent,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.history.v1.HistoryEvent', context) : context;
+  {
+    const c = o.userMetadata;
+    if (c != null) walk_temporal_api_sdk_v1_UserMetadata(c, env, ctx, pending);
+  }
+  {
+    const a = o.eventGroupMarkers;
+    if (a) for (const v of a) walk_temporal_api_sdk_v1_EventGroupMarker(v, env, ctx, pending);
+  }
+  {
+    const c = o.workflowExecutionStartedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_WorkflowExecutionStartedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.workflowExecutionCompletedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_WorkflowExecutionCompletedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.workflowExecutionFailedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_WorkflowExecutionFailedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.workflowTaskFailedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_WorkflowTaskFailedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.activityTaskScheduledEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_ActivityTaskScheduledEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.activityTaskStartedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_ActivityTaskStartedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.activityTaskCompletedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_ActivityTaskCompletedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.activityTaskFailedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_ActivityTaskFailedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.activityTaskTimedOutEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_ActivityTaskTimedOutEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.activityTaskCanceledEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_ActivityTaskCanceledEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.markerRecordedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_MarkerRecordedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.workflowExecutionSignaledEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_WorkflowExecutionSignaledEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.workflowExecutionTerminatedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_WorkflowExecutionTerminatedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.workflowExecutionCanceledEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_WorkflowExecutionCanceledEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.workflowExecutionContinuedAsNewEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_WorkflowExecutionContinuedAsNewEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.startChildWorkflowExecutionInitiatedEventAttributes;
+    if (c != null)
+      walk_temporal_api_history_v1_StartChildWorkflowExecutionInitiatedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.childWorkflowExecutionStartedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_ChildWorkflowExecutionStartedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.childWorkflowExecutionCompletedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_ChildWorkflowExecutionCompletedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.childWorkflowExecutionFailedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_ChildWorkflowExecutionFailedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.childWorkflowExecutionCanceledEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_ChildWorkflowExecutionCanceledEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.signalExternalWorkflowExecutionInitiatedEventAttributes;
+    if (c != null)
+      walk_temporal_api_history_v1_SignalExternalWorkflowExecutionInitiatedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.upsertWorkflowSearchAttributesEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_UpsertWorkflowSearchAttributesEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.workflowExecutionUpdateAcceptedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_WorkflowExecutionUpdateAcceptedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.workflowExecutionUpdateRejectedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_WorkflowExecutionUpdateRejectedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.workflowExecutionUpdateCompletedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_WorkflowExecutionUpdateCompletedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.workflowPropertiesModifiedExternallyEventAttributes;
+    if (c != null)
+      walk_temporal_api_history_v1_WorkflowPropertiesModifiedExternallyEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.workflowPropertiesModifiedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_WorkflowPropertiesModifiedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.workflowExecutionUpdateAdmittedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_WorkflowExecutionUpdateAdmittedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.nexusOperationScheduledEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_NexusOperationScheduledEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.nexusOperationCompletedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_NexusOperationCompletedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.nexusOperationFailedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_NexusOperationFailedEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.nexusOperationCanceledEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_NexusOperationCanceledEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.nexusOperationTimedOutEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_NexusOperationTimedOutEventAttributes(c, env, ctx, pending);
+  }
+  {
+    const c = o.nexusOperationCancelRequestFailedEventAttributes;
+    if (c != null) walk_temporal_api_history_v1_NexusOperationCancelRequestFailedEventAttributes(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_MarkerRecordedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IMarkerRecordedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.MarkerRecordedEventAttributes', context)
+    : context;
+  {
+    const m = o.details;
+    if (m) for (const v of Object.values(m)) walk_temporal_api_common_v1_Payloads(v, env, ctx, pending);
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_NexusOperationCanceledEventAttributes<Ctx>(
+  o: temporal.api.history.v1.INexusOperationCanceledEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.NexusOperationCanceledEventAttributes', context)
+    : context;
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_NexusOperationCancelRequestFailedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.INexusOperationCancelRequestFailedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.NexusOperationCancelRequestFailedEventAttributes', context)
+    : context;
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_NexusOperationCompletedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.INexusOperationCompletedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.NexusOperationCompletedEventAttributes', context)
+    : context;
+  {
+    const p = o.result;
+    if (p != null)
+      pending.push(
+        env.transformPayload(p, ctx).then((r) => {
+          o.result = r;
+        })
+      );
+  }
+}
+
+function walk_temporal_api_history_v1_NexusOperationFailedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.INexusOperationFailedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.NexusOperationFailedEventAttributes', context)
+    : context;
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_NexusOperationScheduledEventAttributes<Ctx>(
+  o: temporal.api.history.v1.INexusOperationScheduledEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.NexusOperationScheduledEventAttributes', context)
+    : context;
+  {
+    const p = o.input;
+    if (p != null)
+      pending.push(
+        env.transformPayload(p, ctx).then((r) => {
+          o.input = r;
+        })
+      );
+  }
+}
+
+function walk_temporal_api_history_v1_NexusOperationTimedOutEventAttributes<Ctx>(
+  o: temporal.api.history.v1.INexusOperationTimedOutEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.NexusOperationTimedOutEventAttributes', context)
+    : context;
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_SignalExternalWorkflowExecutionInitiatedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.ISignalExternalWorkflowExecutionInitiatedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.SignalExternalWorkflowExecutionInitiatedEventAttributes', context)
+    : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_StartChildWorkflowExecutionInitiatedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IStartChildWorkflowExecutionInitiatedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.StartChildWorkflowExecutionInitiatedEventAttributes', context)
+    : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.memo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+}
+
+function walk_temporal_api_history_v1_UpsertWorkflowSearchAttributesEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IUpsertWorkflowSearchAttributesEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.UpsertWorkflowSearchAttributesEventAttributes', context)
+    : context;
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+}
+
+function walk_temporal_api_history_v1_WorkflowExecutionCanceledEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IWorkflowExecutionCanceledEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.WorkflowExecutionCanceledEventAttributes', context)
+    : context;
+  {
+    const c = o.details;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_WorkflowExecutionCompletedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IWorkflowExecutionCompletedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.WorkflowExecutionCompletedEventAttributes', context)
+    : context;
+  {
+    const c = o.result;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_WorkflowExecutionContinuedAsNewEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IWorkflowExecutionContinuedAsNewEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.WorkflowExecutionContinuedAsNewEventAttributes', context)
+    : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+  {
+    const c = o.lastCompletionResult;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.memo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+}
+
+function walk_temporal_api_history_v1_WorkflowExecutionFailedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IWorkflowExecutionFailedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.WorkflowExecutionFailedEventAttributes', context)
+    : context;
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_WorkflowExecutionSignaledEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IWorkflowExecutionSignaledEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.WorkflowExecutionSignaledEventAttributes', context)
+    : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_WorkflowExecutionStartedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IWorkflowExecutionStartedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.WorkflowExecutionStartedEventAttributes', context)
+    : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.continuedFailure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+  {
+    const c = o.lastCompletionResult;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.memo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_WorkflowExecutionTerminatedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IWorkflowExecutionTerminatedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.WorkflowExecutionTerminatedEventAttributes', context)
+    : context;
+  {
+    const c = o.details;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_WorkflowExecutionUpdateAcceptedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IWorkflowExecutionUpdateAcceptedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.WorkflowExecutionUpdateAcceptedEventAttributes', context)
+    : context;
+  {
+    const c = o.acceptedRequest;
+    if (c != null) walk_temporal_api_update_v1_Request(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_WorkflowExecutionUpdateAdmittedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IWorkflowExecutionUpdateAdmittedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.WorkflowExecutionUpdateAdmittedEventAttributes', context)
+    : context;
+  {
+    const c = o.request;
+    if (c != null) walk_temporal_api_update_v1_Request(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_WorkflowExecutionUpdateCompletedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IWorkflowExecutionUpdateCompletedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.WorkflowExecutionUpdateCompletedEventAttributes', context)
+    : context;
+  {
+    const c = o.outcome;
+    if (c != null) walk_temporal_api_update_v1_Outcome(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_WorkflowExecutionUpdateRejectedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IWorkflowExecutionUpdateRejectedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.WorkflowExecutionUpdateRejectedEventAttributes', context)
+    : context;
+  {
+    const c = o.rejectedRequest;
+    if (c != null) walk_temporal_api_update_v1_Request(c, env, ctx, pending);
+  }
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_WorkflowPropertiesModifiedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IWorkflowPropertiesModifiedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.WorkflowPropertiesModifiedEventAttributes', context)
+    : context;
+  {
+    const c = o.upsertedMemo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_WorkflowPropertiesModifiedExternallyEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IWorkflowPropertiesModifiedExternallyEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.WorkflowPropertiesModifiedExternallyEventAttributes', context)
+    : context;
+  {
+    const c = o.upsertedMemo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_history_v1_WorkflowTaskFailedEventAttributes<Ctx>(
+  o: temporal.api.history.v1.IWorkflowTaskFailedEventAttributes,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.history.v1.WorkflowTaskFailedEventAttributes', context)
+    : context;
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_nexus_v1_NexusOperationExecutionCancellationInfo<Ctx>(
+  o: temporal.api.nexus.v1.INexusOperationExecutionCancellationInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.nexus.v1.NexusOperationExecutionCancellationInfo', context)
+    : context;
+  {
+    const c = o.lastAttemptFailure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_nexus_v1_NexusOperationExecutionInfo<Ctx>(
+  o: temporal.api.nexus.v1.INexusOperationExecutionInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.nexus.v1.NexusOperationExecutionInfo', context)
+    : context;
+  {
+    const c = o.lastAttemptFailure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+  {
+    const c = o.cancellationInfo;
+    if (c != null) walk_temporal_api_nexus_v1_NexusOperationExecutionCancellationInfo(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+  {
+    const c = o.userMetadata;
+    if (c != null) walk_temporal_api_sdk_v1_UserMetadata(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_nexus_v1_NexusOperationExecutionListInfo<Ctx>(
+  o: temporal.api.nexus.v1.INexusOperationExecutionListInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.nexus.v1.NexusOperationExecutionListInfo', context)
+    : context;
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+}
+
 function walk_temporal_api_nexus_v1_Request<Ctx>(
   o: temporal.api.nexus.v1.IRequest,
   env: WalkEnv<Ctx>,
@@ -1383,6 +3968,116 @@ function walk_temporal_api_nexus_v1_StartOperationResponse_Sync<Ctx>(
   }
 }
 
+function walk_temporal_api_query_v1_WorkflowQuery<Ctx>(
+  o: temporal.api.query.v1.IWorkflowQuery,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.query.v1.WorkflowQuery', context) : context;
+  {
+    const c = o.queryArgs;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_query_v1_WorkflowQueryResult<Ctx>(
+  o: temporal.api.query.v1.IWorkflowQueryResult,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.query.v1.WorkflowQueryResult', context) : context;
+  {
+    const c = o.answer;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_schedule_v1_Schedule<Ctx>(
+  o: temporal.api.schedule.v1.ISchedule,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.schedule.v1.Schedule', context) : context;
+  {
+    const c = o.action;
+    if (c != null) walk_temporal_api_schedule_v1_ScheduleAction(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_schedule_v1_ScheduleAction<Ctx>(
+  o: temporal.api.schedule.v1.IScheduleAction,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.schedule.v1.ScheduleAction', context) : context;
+  {
+    const c = o.startWorkflow;
+    if (c != null) walk_temporal_api_workflow_v1_NewWorkflowExecutionInfo(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_schedule_v1_ScheduleListEntry<Ctx>(
+  o: temporal.api.schedule.v1.IScheduleListEntry,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.schedule.v1.ScheduleListEntry', context) : context;
+  {
+    const c = o.memo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+}
+
+function walk_temporal_api_sdk_v1_EventGroupMarker<Ctx>(
+  o: temporal.api.sdk.v1.IEventGroupMarker,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.sdk.v1.EventGroupMarker', context) : context;
+  {
+    const c = o.label;
+    if (c != null) walk_temporal_api_sdk_v1_EventGroupMarker_Label(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_sdk_v1_EventGroupMarker_Label<Ctx>(
+  o: temporal.api.sdk.v1.EventGroupMarker.ILabel,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.sdk.v1.EventGroupMarker.Label', context) : context;
+  {
+    const p = o.label;
+    if (p != null)
+      pending.push(
+        env.transformPayload(p, ctx).then((r) => {
+          o.label = r;
+        })
+      );
+  }
+}
+
 function walk_temporal_api_sdk_v1_UserMetadata<Ctx>(
   o: temporal.api.sdk.v1.IUserMetadata,
   env: WalkEnv<Ctx>,
@@ -1410,6 +4105,868 @@ function walk_temporal_api_sdk_v1_UserMetadata<Ctx>(
   }
 }
 
+function walk_temporal_api_update_v1_Input<Ctx>(
+  o: temporal.api.update.v1.IInput,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.update.v1.Input', context) : context;
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.args;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_update_v1_Outcome<Ctx>(
+  o: temporal.api.update.v1.IOutcome,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.update.v1.Outcome', context) : context;
+  {
+    const c = o.success;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_update_v1_Request<Ctx>(
+  o: temporal.api.update.v1.IRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.update.v1.Request', context) : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_update_v1_Input(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflow_v1_CallbackInfo<Ctx>(
+  o: temporal.api.workflow.v1.ICallbackInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext ? env.deriveContext(o, 'temporal.api.workflow.v1.CallbackInfo', context) : context;
+  {
+    const c = o.lastAttemptFailure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflow_v1_NewWorkflowExecutionInfo<Ctx>(
+  o: temporal.api.workflow.v1.INewWorkflowExecutionInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflow.v1.NewWorkflowExecutionInfo', context)
+    : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.memo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.userMetadata;
+    if (c != null) walk_temporal_api_sdk_v1_UserMetadata(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflow_v1_NexusOperationCancellationInfo<Ctx>(
+  o: temporal.api.workflow.v1.INexusOperationCancellationInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflow.v1.NexusOperationCancellationInfo', context)
+    : context;
+  {
+    const c = o.lastAttemptFailure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflow_v1_PendingActivityInfo<Ctx>(
+  o: temporal.api.workflow.v1.IPendingActivityInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflow.v1.PendingActivityInfo', context)
+    : context;
+  {
+    const c = o.heartbeatDetails;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.lastFailure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflow_v1_PendingNexusOperationInfo<Ctx>(
+  o: temporal.api.workflow.v1.IPendingNexusOperationInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflow.v1.PendingNexusOperationInfo', context)
+    : context;
+  {
+    const c = o.lastAttemptFailure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+  {
+    const c = o.cancellationInfo;
+    if (c != null) walk_temporal_api_workflow_v1_NexusOperationCancellationInfo(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflow_v1_PostResetOperation<Ctx>(
+  o: temporal.api.workflow.v1.IPostResetOperation,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflow.v1.PostResetOperation', context)
+    : context;
+  {
+    const c = o.signalWorkflow;
+    if (c != null) walk_temporal_api_workflow_v1_PostResetOperation_SignalWorkflow(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflow_v1_PostResetOperation_SignalWorkflow<Ctx>(
+  o: temporal.api.workflow.v1.PostResetOperation.ISignalWorkflow,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflow.v1.PostResetOperation.SignalWorkflow', context)
+    : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflow_v1_WorkflowExecutionConfig<Ctx>(
+  o: temporal.api.workflow.v1.IWorkflowExecutionConfig,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflow.v1.WorkflowExecutionConfig', context)
+    : context;
+  {
+    const c = o.userMetadata;
+    if (c != null) walk_temporal_api_sdk_v1_UserMetadata(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflow_v1_WorkflowExecutionInfo<Ctx>(
+  o: temporal.api.workflow.v1.IWorkflowExecutionInfo,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflow.v1.WorkflowExecutionInfo', context)
+    : context;
+  {
+    const c = o.memo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_CountActivityExecutionsResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.ICountActivityExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.CountActivityExecutionsResponse', context)
+    : context;
+  {
+    const a = o.groups;
+    if (a)
+      for (const v of a)
+        walk_temporal_api_workflowservice_v1_CountActivityExecutionsResponse_AggregationGroup(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_CountActivityExecutionsResponse_AggregationGroup<Ctx>(
+  o: temporal.api.workflowservice.v1.CountActivityExecutionsResponse.IAggregationGroup,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.CountActivityExecutionsResponse.AggregationGroup', context)
+    : context;
+  {
+    const a = o.groupValues;
+    if (a && a.length)
+      pending.push(
+        env.transformPayloads(a, ctx).then((r) => {
+          o.groupValues = r;
+        })
+      );
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_CountNexusOperationExecutionsResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.ICountNexusOperationExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.CountNexusOperationExecutionsResponse', context)
+    : context;
+  {
+    const a = o.groups;
+    if (a)
+      for (const v of a)
+        walk_temporal_api_workflowservice_v1_CountNexusOperationExecutionsResponse_AggregationGroup(
+          v,
+          env,
+          ctx,
+          pending
+        );
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_CountNexusOperationExecutionsResponse_AggregationGroup<Ctx>(
+  o: temporal.api.workflowservice.v1.CountNexusOperationExecutionsResponse.IAggregationGroup,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(
+        o,
+        'temporal.api.workflowservice.v1.CountNexusOperationExecutionsResponse.AggregationGroup',
+        context
+      )
+    : context;
+  {
+    const a = o.groupValues;
+    if (a && a.length)
+      pending.push(
+        env.transformPayloads(a, ctx).then((r) => {
+          o.groupValues = r;
+        })
+      );
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_CountSchedulesResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.ICountSchedulesResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.CountSchedulesResponse', context)
+    : context;
+  {
+    const a = o.groups;
+    if (a)
+      for (const v of a)
+        walk_temporal_api_workflowservice_v1_CountSchedulesResponse_AggregationGroup(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_CountSchedulesResponse_AggregationGroup<Ctx>(
+  o: temporal.api.workflowservice.v1.CountSchedulesResponse.IAggregationGroup,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.CountSchedulesResponse.AggregationGroup', context)
+    : context;
+  {
+    const a = o.groupValues;
+    if (a && a.length)
+      pending.push(
+        env.transformPayloads(a, ctx).then((r) => {
+          o.groupValues = r;
+        })
+      );
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_CountWorkflowExecutionsResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.ICountWorkflowExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.CountWorkflowExecutionsResponse', context)
+    : context;
+  {
+    const a = o.groups;
+    if (a)
+      for (const v of a)
+        walk_temporal_api_workflowservice_v1_CountWorkflowExecutionsResponse_AggregationGroup(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_CountWorkflowExecutionsResponse_AggregationGroup<Ctx>(
+  o: temporal.api.workflowservice.v1.CountWorkflowExecutionsResponse.IAggregationGroup,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.CountWorkflowExecutionsResponse.AggregationGroup', context)
+    : context;
+  {
+    const a = o.groupValues;
+    if (a && a.length)
+      pending.push(
+        env.transformPayloads(a, ctx).then((r) => {
+          o.groupValues = r;
+        })
+      );
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_CreateScheduleRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.ICreateScheduleRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.CreateScheduleRequest', context)
+    : context;
+  {
+    const c = o.schedule;
+    if (c != null) walk_temporal_api_schedule_v1_Schedule(c, env, ctx, pending);
+  }
+  {
+    const c = o.memo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_CreateWorkerDeploymentVersionRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.ICreateWorkerDeploymentVersionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.CreateWorkerDeploymentVersionRequest', context)
+    : context;
+  {
+    const c = o.computeConfig;
+    if (c != null) walk_temporal_api_compute_v1_ComputeConfig(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_DescribeActivityExecutionResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IDescribeActivityExecutionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.DescribeActivityExecutionResponse', context)
+    : context;
+  {
+    const c = o.info;
+    if (c != null) walk_temporal_api_activity_v1_ActivityExecutionInfo(c, env, ctx, pending);
+  }
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.outcome;
+    if (c != null) walk_temporal_api_activity_v1_ActivityExecutionOutcome(c, env, ctx, pending);
+  }
+  {
+    const a = o.callbacks;
+    if (a) for (const v of a) walk_temporal_api_activity_v1_CallbackInfo(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_DescribeDeploymentResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IDescribeDeploymentResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.DescribeDeploymentResponse', context)
+    : context;
+  {
+    const c = o.deploymentInfo;
+    if (c != null) walk_temporal_api_deployment_v1_DeploymentInfo(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_DescribeNexusOperationExecutionResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IDescribeNexusOperationExecutionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.DescribeNexusOperationExecutionResponse', context)
+    : context;
+  {
+    const c = o.info;
+    if (c != null) walk_temporal_api_nexus_v1_NexusOperationExecutionInfo(c, env, ctx, pending);
+  }
+  {
+    const p = o.input;
+    if (p != null)
+      pending.push(
+        env.transformPayload(p, ctx).then((r) => {
+          o.input = r;
+        })
+      );
+  }
+  {
+    const p = o.result;
+    if (p != null)
+      pending.push(
+        env.transformPayload(p, ctx).then((r) => {
+          o.result = r;
+        })
+      );
+  }
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_DescribeScheduleResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IDescribeScheduleResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.DescribeScheduleResponse', context)
+    : context;
+  {
+    const c = o.schedule;
+    if (c != null) walk_temporal_api_schedule_v1_Schedule(c, env, ctx, pending);
+  }
+  {
+    const c = o.memo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_DescribeWorkerDeploymentVersionResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IDescribeWorkerDeploymentVersionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.DescribeWorkerDeploymentVersionResponse', context)
+    : context;
+  {
+    const c = o.workerDeploymentVersionInfo;
+    if (c != null) walk_temporal_api_deployment_v1_WorkerDeploymentVersionInfo(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_DescribeWorkflowExecutionResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IDescribeWorkflowExecutionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.DescribeWorkflowExecutionResponse', context)
+    : context;
+  {
+    const c = o.executionConfig;
+    if (c != null) walk_temporal_api_workflow_v1_WorkflowExecutionConfig(c, env, ctx, pending);
+  }
+  {
+    const c = o.workflowExecutionInfo;
+    if (c != null) walk_temporal_api_workflow_v1_WorkflowExecutionInfo(c, env, ctx, pending);
+  }
+  {
+    const a = o.pendingActivities;
+    if (a) for (const v of a) walk_temporal_api_workflow_v1_PendingActivityInfo(v, env, ctx, pending);
+  }
+  {
+    const a = o.callbacks;
+    if (a) for (const v of a) walk_temporal_api_workflow_v1_CallbackInfo(v, env, ctx, pending);
+  }
+  {
+    const a = o.pendingNexusOperations;
+    if (a) for (const v of a) walk_temporal_api_workflow_v1_PendingNexusOperationInfo(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_ExecuteMultiOperationRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IExecuteMultiOperationRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.ExecuteMultiOperationRequest', context)
+    : context;
+  {
+    const a = o.operations;
+    if (a)
+      for (const v of a)
+        walk_temporal_api_workflowservice_v1_ExecuteMultiOperationRequest_Operation(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_ExecuteMultiOperationRequest_Operation<Ctx>(
+  o: temporal.api.workflowservice.v1.ExecuteMultiOperationRequest.IOperation,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.ExecuteMultiOperationRequest.Operation', context)
+    : context;
+  {
+    const c = o.startWorkflow;
+    if (c != null) walk_temporal_api_workflowservice_v1_StartWorkflowExecutionRequest(c, env, ctx, pending);
+  }
+  {
+    const c = o.updateWorkflow;
+    if (c != null) walk_temporal_api_workflowservice_v1_UpdateWorkflowExecutionRequest(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_ExecuteMultiOperationResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IExecuteMultiOperationResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.ExecuteMultiOperationResponse', context)
+    : context;
+  {
+    const a = o.responses;
+    if (a)
+      for (const v of a)
+        walk_temporal_api_workflowservice_v1_ExecuteMultiOperationResponse_Response(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_ExecuteMultiOperationResponse_Response<Ctx>(
+  o: temporal.api.workflowservice.v1.ExecuteMultiOperationResponse.IResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.ExecuteMultiOperationResponse.Response', context)
+    : context;
+  {
+    const c = o.startWorkflow;
+    if (c != null) walk_temporal_api_workflowservice_v1_StartWorkflowExecutionResponse(c, env, ctx, pending);
+  }
+  {
+    const c = o.updateWorkflow;
+    if (c != null) walk_temporal_api_workflowservice_v1_UpdateWorkflowExecutionResponse(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_GetCurrentDeploymentResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IGetCurrentDeploymentResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.GetCurrentDeploymentResponse', context)
+    : context;
+  {
+    const c = o.currentDeploymentInfo;
+    if (c != null) walk_temporal_api_deployment_v1_DeploymentInfo(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_GetDeploymentReachabilityResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IGetDeploymentReachabilityResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.GetDeploymentReachabilityResponse', context)
+    : context;
+  {
+    const c = o.deploymentInfo;
+    if (c != null) walk_temporal_api_deployment_v1_DeploymentInfo(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_GetWorkflowExecutionHistoryResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IGetWorkflowExecutionHistoryResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse', context)
+    : context;
+  {
+    const c = o.history;
+    if (c != null) walk_temporal_api_history_v1_History(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_GetWorkflowExecutionHistoryReverseResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IGetWorkflowExecutionHistoryReverseResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryReverseResponse', context)
+    : context;
+  {
+    const c = o.history;
+    if (c != null) walk_temporal_api_history_v1_History(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_ListActivityExecutionsResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IListActivityExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.ListActivityExecutionsResponse', context)
+    : context;
+  {
+    const a = o.executions;
+    if (a) for (const v of a) walk_temporal_api_activity_v1_ActivityExecutionListInfo(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_ListArchivedWorkflowExecutionsResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IListArchivedWorkflowExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.ListArchivedWorkflowExecutionsResponse', context)
+    : context;
+  {
+    const a = o.executions;
+    if (a) for (const v of a) walk_temporal_api_workflow_v1_WorkflowExecutionInfo(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_ListClosedWorkflowExecutionsResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IListClosedWorkflowExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.ListClosedWorkflowExecutionsResponse', context)
+    : context;
+  {
+    const a = o.executions;
+    if (a) for (const v of a) walk_temporal_api_workflow_v1_WorkflowExecutionInfo(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_ListNexusOperationExecutionsResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IListNexusOperationExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.ListNexusOperationExecutionsResponse', context)
+    : context;
+  {
+    const a = o.operations;
+    if (a) for (const v of a) walk_temporal_api_nexus_v1_NexusOperationExecutionListInfo(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_ListOpenWorkflowExecutionsResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IListOpenWorkflowExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.ListOpenWorkflowExecutionsResponse', context)
+    : context;
+  {
+    const a = o.executions;
+    if (a) for (const v of a) walk_temporal_api_workflow_v1_WorkflowExecutionInfo(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_ListSchedulesResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IListSchedulesResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.ListSchedulesResponse', context)
+    : context;
+  {
+    const a = o.schedules;
+    if (a) for (const v of a) walk_temporal_api_schedule_v1_ScheduleListEntry(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_ListWorkflowExecutionsResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IListWorkflowExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.ListWorkflowExecutionsResponse', context)
+    : context;
+  {
+    const a = o.executions;
+    if (a) for (const v of a) walk_temporal_api_workflow_v1_WorkflowExecutionInfo(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_PollActivityExecutionResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IPollActivityExecutionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.PollActivityExecutionResponse', context)
+    : context;
+  {
+    const c = o.outcome;
+    if (c != null) walk_temporal_api_activity_v1_ActivityExecutionOutcome(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_PollActivityTaskQueueResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IPollActivityTaskQueueResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.PollActivityTaskQueueResponse', context)
+    : context;
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.heartbeatDetails;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_PollNexusOperationExecutionResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IPollNexusOperationExecutionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.PollNexusOperationExecutionResponse', context)
+    : context;
+  {
+    const p = o.result;
+    if (p != null)
+      pending.push(
+        env.transformPayload(p, ctx).then((r) => {
+          o.result = r;
+        })
+      );
+  }
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
 function walk_temporal_api_workflowservice_v1_PollNexusTaskQueueResponse<Ctx>(
   o: temporal.api.workflowservice.v1.IPollNexusTaskQueueResponse,
   env: WalkEnv<Ctx>,
@@ -1422,5 +4979,735 @@ function walk_temporal_api_workflowservice_v1_PollNexusTaskQueueResponse<Ctx>(
   {
     const c = o.request;
     if (c != null) walk_temporal_api_nexus_v1_Request(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_PollWorkflowExecutionUpdateResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IPollWorkflowExecutionUpdateResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.PollWorkflowExecutionUpdateResponse', context)
+    : context;
+  {
+    const c = o.outcome;
+    if (c != null) walk_temporal_api_update_v1_Outcome(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_PollWorkflowTaskQueueResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IPollWorkflowTaskQueueResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse', context)
+    : context;
+  {
+    const c = o.history;
+    if (c != null) walk_temporal_api_history_v1_History(c, env, ctx, pending);
+  }
+  {
+    const c = o.query;
+    if (c != null) walk_temporal_api_query_v1_WorkflowQuery(c, env, ctx, pending);
+  }
+  {
+    const m = o.queries;
+    if (m) for (const v of Object.values(m)) walk_temporal_api_query_v1_WorkflowQuery(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_QueryWorkflowRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IQueryWorkflowRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.QueryWorkflowRequest', context)
+    : context;
+  {
+    const c = o.query;
+    if (c != null) walk_temporal_api_query_v1_WorkflowQuery(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_QueryWorkflowResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IQueryWorkflowResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.QueryWorkflowResponse', context)
+    : context;
+  {
+    const c = o.queryResult;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RecordActivityTaskHeartbeatByIdRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IRecordActivityTaskHeartbeatByIdRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatByIdRequest', context)
+    : context;
+  {
+    const c = o.details;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RecordActivityTaskHeartbeatRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IRecordActivityTaskHeartbeatRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatRequest', context)
+    : context;
+  {
+    const c = o.details;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_ResetWorkflowExecutionRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IResetWorkflowExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.ResetWorkflowExecutionRequest', context)
+    : context;
+  {
+    const a = o.postResetOperations;
+    if (a) for (const v of a) walk_temporal_api_workflow_v1_PostResetOperation(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RespondActivityTaskCanceledByIdRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IRespondActivityTaskCanceledByIdRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RespondActivityTaskCanceledByIdRequest', context)
+    : context;
+  {
+    const c = o.details;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RespondActivityTaskCanceledRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IRespondActivityTaskCanceledRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RespondActivityTaskCanceledRequest', context)
+    : context;
+  {
+    const c = o.details;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RespondActivityTaskCompletedByIdRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IRespondActivityTaskCompletedByIdRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RespondActivityTaskCompletedByIdRequest', context)
+    : context;
+  {
+    const c = o.result;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RespondActivityTaskCompletedRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IRespondActivityTaskCompletedRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RespondActivityTaskCompletedRequest', context)
+    : context;
+  {
+    const c = o.result;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RespondActivityTaskFailedByIdRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IRespondActivityTaskFailedByIdRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RespondActivityTaskFailedByIdRequest', context)
+    : context;
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+  {
+    const c = o.lastHeartbeatDetails;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RespondActivityTaskFailedByIdResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IRespondActivityTaskFailedByIdResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RespondActivityTaskFailedByIdResponse', context)
+    : context;
+  {
+    const a = o.failures;
+    if (a) for (const v of a) walk_temporal_api_failure_v1_Failure(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RespondActivityTaskFailedRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IRespondActivityTaskFailedRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RespondActivityTaskFailedRequest', context)
+    : context;
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+  {
+    const c = o.lastHeartbeatDetails;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RespondActivityTaskFailedResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IRespondActivityTaskFailedResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RespondActivityTaskFailedResponse', context)
+    : context;
+  {
+    const a = o.failures;
+    if (a) for (const v of a) walk_temporal_api_failure_v1_Failure(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RespondNexusTaskCompletedRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IRespondNexusTaskCompletedRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RespondNexusTaskCompletedRequest', context)
+    : context;
+  {
+    const c = o.response;
+    if (c != null) walk_temporal_api_nexus_v1_Response(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RespondNexusTaskFailedRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IRespondNexusTaskFailedRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RespondNexusTaskFailedRequest', context)
+    : context;
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RespondQueryTaskCompletedRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IRespondQueryTaskCompletedRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RespondQueryTaskCompletedRequest', context)
+    : context;
+  {
+    const c = o.queryResult;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RespondWorkflowTaskCompletedRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IRespondWorkflowTaskCompletedRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RespondWorkflowTaskCompletedRequest', context)
+    : context;
+  {
+    const a = o.commands;
+    if (a) for (const v of a) walk_temporal_api_command_v1_Command(v, env, ctx, pending);
+  }
+  {
+    const m = o.queryResults;
+    if (m) for (const v of Object.values(m)) walk_temporal_api_query_v1_WorkflowQueryResult(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RespondWorkflowTaskCompletedResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IRespondWorkflowTaskCompletedResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RespondWorkflowTaskCompletedResponse', context)
+    : context;
+  {
+    const c = o.workflowTask;
+    if (c != null) walk_temporal_api_workflowservice_v1_PollWorkflowTaskQueueResponse(c, env, ctx, pending);
+  }
+  {
+    const a = o.activityTasks;
+    if (a) for (const v of a) walk_temporal_api_workflowservice_v1_PollActivityTaskQueueResponse(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_RespondWorkflowTaskFailedRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IRespondWorkflowTaskFailedRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.RespondWorkflowTaskFailedRequest', context)
+    : context;
+  {
+    const c = o.failure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_ScanWorkflowExecutionsResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IScanWorkflowExecutionsResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.ScanWorkflowExecutionsResponse', context)
+    : context;
+  {
+    const a = o.executions;
+    if (a) for (const v of a) walk_temporal_api_workflow_v1_WorkflowExecutionInfo(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_SetCurrentDeploymentRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.ISetCurrentDeploymentRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.SetCurrentDeploymentRequest', context)
+    : context;
+  {
+    const c = o.updateMetadata;
+    if (c != null) walk_temporal_api_deployment_v1_UpdateDeploymentMetadata(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_SetCurrentDeploymentResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.ISetCurrentDeploymentResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.SetCurrentDeploymentResponse', context)
+    : context;
+  {
+    const c = o.currentDeploymentInfo;
+    if (c != null) walk_temporal_api_deployment_v1_DeploymentInfo(c, env, ctx, pending);
+  }
+  {
+    const c = o.previousDeploymentInfo;
+    if (c != null) walk_temporal_api_deployment_v1_DeploymentInfo(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_SignalWithStartWorkflowExecutionRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.ISignalWithStartWorkflowExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest', context)
+    : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.signalInput;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.memo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.userMetadata;
+    if (c != null) walk_temporal_api_sdk_v1_UserMetadata(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_SignalWorkflowExecutionRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.ISignalWorkflowExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.SignalWorkflowExecutionRequest', context)
+    : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_StartActivityExecutionRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IStartActivityExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.StartActivityExecutionRequest', context)
+    : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.userMetadata;
+    if (c != null) walk_temporal_api_sdk_v1_UserMetadata(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_StartBatchOperationRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IStartBatchOperationRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.StartBatchOperationRequest', context)
+    : context;
+  {
+    const c = o.terminationOperation;
+    if (c != null) walk_temporal_api_batch_v1_BatchOperationTermination(c, env, ctx, pending);
+  }
+  {
+    const c = o.signalOperation;
+    if (c != null) walk_temporal_api_batch_v1_BatchOperationSignal(c, env, ctx, pending);
+  }
+  {
+    const c = o.resetOperation;
+    if (c != null) walk_temporal_api_batch_v1_BatchOperationReset(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_StartNexusOperationExecutionRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IStartNexusOperationExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.StartNexusOperationExecutionRequest', context)
+    : context;
+  {
+    const p = o.input;
+    if (p != null)
+      pending.push(
+        env.transformPayload(p, ctx).then((r) => {
+          o.input = r;
+        })
+      );
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+  {
+    const c = o.userMetadata;
+    if (c != null) walk_temporal_api_sdk_v1_UserMetadata(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_StartWorkflowExecutionRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IStartWorkflowExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.StartWorkflowExecutionRequest', context)
+    : context;
+  {
+    const c = o.input;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.memo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+  {
+    const c = o.header;
+    if (c != null) walk_temporal_api_common_v1_Header(c, env, ctx, pending);
+  }
+  {
+    const c = o.continuedFailure;
+    if (c != null) walk_temporal_api_failure_v1_Failure(c, env, ctx, pending);
+  }
+  {
+    const c = o.lastCompletionResult;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+  {
+    const c = o.userMetadata;
+    if (c != null) walk_temporal_api_sdk_v1_UserMetadata(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_StartWorkflowExecutionResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IStartWorkflowExecutionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.StartWorkflowExecutionResponse', context)
+    : context;
+  {
+    const c = o.eagerWorkflowTask;
+    if (c != null) walk_temporal_api_workflowservice_v1_PollWorkflowTaskQueueResponse(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_TerminateWorkflowExecutionRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.ITerminateWorkflowExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.TerminateWorkflowExecutionRequest', context)
+    : context;
+  {
+    const c = o.details;
+    if (c != null) walk_temporal_api_common_v1_Payloads(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_UpdateScheduleRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IUpdateScheduleRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.UpdateScheduleRequest', context)
+    : context;
+  {
+    const c = o.schedule;
+    if (c != null) walk_temporal_api_schedule_v1_Schedule(c, env, ctx, pending);
+  }
+  {
+    if (!env.skipSearchAttributes) {
+      const c = o.searchAttributes;
+      if (c != null) walk_temporal_api_common_v1_SearchAttributes(c, env, ctx, pending);
+    }
+  }
+  {
+    const c = o.memo;
+    if (c != null) walk_temporal_api_common_v1_Memo(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_UpdateWorkerDeploymentVersionComputeConfigRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IUpdateWorkerDeploymentVersionComputeConfigRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.UpdateWorkerDeploymentVersionComputeConfigRequest', context)
+    : context;
+  {
+    const m = o.computeConfigScalingGroups;
+    if (m)
+      for (const v of Object.values(m))
+        walk_temporal_api_compute_v1_ComputeConfigScalingGroupUpdate(v, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_UpdateWorkerDeploymentVersionMetadataRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IUpdateWorkerDeploymentVersionMetadataRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.UpdateWorkerDeploymentVersionMetadataRequest', context)
+    : context;
+  {
+    const m = o.upsertEntries;
+    if (m)
+      for (const [k, v] of Object.entries(m))
+        pending.push(
+          env.transformPayload(v, ctx).then((r) => {
+            m[k] = r;
+          })
+        );
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_UpdateWorkerDeploymentVersionMetadataResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IUpdateWorkerDeploymentVersionMetadataResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.UpdateWorkerDeploymentVersionMetadataResponse', context)
+    : context;
+  {
+    const c = o.metadata;
+    if (c != null) walk_temporal_api_deployment_v1_VersionMetadata(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_UpdateWorkflowExecutionRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IUpdateWorkflowExecutionRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.UpdateWorkflowExecutionRequest', context)
+    : context;
+  {
+    const c = o.request;
+    if (c != null) walk_temporal_api_update_v1_Request(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_UpdateWorkflowExecutionResponse<Ctx>(
+  o: temporal.api.workflowservice.v1.IUpdateWorkflowExecutionResponse,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(o, 'temporal.api.workflowservice.v1.UpdateWorkflowExecutionResponse', context)
+    : context;
+  {
+    const c = o.outcome;
+    if (c != null) walk_temporal_api_update_v1_Outcome(c, env, ctx, pending);
+  }
+}
+
+function walk_temporal_api_workflowservice_v1_ValidateWorkerDeploymentVersionComputeConfigRequest<Ctx>(
+  o: temporal.api.workflowservice.v1.IValidateWorkerDeploymentVersionComputeConfigRequest,
+  env: WalkEnv<Ctx>,
+  context: Ctx,
+  pending: Promise<unknown>[]
+): void {
+  const ctx = env.deriveContext
+    ? env.deriveContext(
+        o,
+        'temporal.api.workflowservice.v1.ValidateWorkerDeploymentVersionComputeConfigRequest',
+        context
+      )
+    : context;
+  {
+    const m = o.computeConfigScalingGroups;
+    if (m)
+      for (const v of Object.values(m))
+        walk_temporal_api_compute_v1_ComputeConfigScalingGroupUpdate(v, env, ctx, pending);
   }
 }

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -1,5 +1,5 @@
 // Utilities
-export { sleep, waitUntil, u8, approximatelyEqual } from './utilities';
+export { sleep, waitUntil, assertEventually, u8, approximatelyEqual } from './utilities';
 
 // Flags
 export {

--- a/packages/test-helpers/src/utilities.ts
+++ b/packages/test-helpers/src/utilities.ts
@@ -1,8 +1,42 @@
+import type { ExecutionContext } from 'ava';
+
 /**
  * Sleep for a given number of milliseconds
  */
 export async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Repeatedly run an assertion callback until it passes, or until a timeout elapses.
+ *
+ * Each attempt runs inside ava's `t.try()`, so failing intermediate attempts (including ones that
+ * throw, e.g. reading a metric line that isn't present yet) are discarded and do not fail the test.
+ * The final attempt is committed, so a genuine failure is reported with its normal assertion
+ * diagnostics and logs.
+ *
+ * Use this for state that only becomes true asynchronously (e.g. metrics that Core exports to its
+ * Prometheus endpoint on a delay). The check is written once, as the assertion, instead of being
+ * duplicated as both a `waitUntil` predicate and a separate assertion.
+ */
+export async function assertEventually<Context = unknown>(
+  t: ExecutionContext<Context>,
+  assertion: (t: ExecutionContext<Context>) => void | Promise<void>,
+  timeoutMs = 10000,
+  intervalMs = 100
+): Promise<void> {
+  const endTime = Date.now() + timeoutMs;
+  for (;;) {
+    const attempt = await t.try(async (tt) => {
+      await assertion(tt);
+    });
+    if (attempt.passed || Date.now() >= endTime) {
+      attempt.commit();
+      return;
+    }
+    attempt.discard();
+    await sleep(intervalMs);
+  }
 }
 
 /**

--- a/packages/test/src/helpers.ts
+++ b/packages/test/src/helpers.ts
@@ -18,6 +18,7 @@ import {
 export {
   sleep,
   waitUntil,
+  assertEventually,
   u8,
   approximatelyEqual,
   RUN_INTEGRATION_TESTS,

--- a/packages/test/src/test-extstore-visit.ts
+++ b/packages/test/src/test-extstore-visit.ts
@@ -7,16 +7,19 @@ import {
   extstoreRetrieveOptions,
   extstoreStoreOptions,
   isReferencePayload,
-  visitActivityTask,
-  visitActivityTaskCompletion,
-  visitNexusTask,
-  visitNexusTaskCompletion,
-  visitWorkflowActivation,
-  visitWorkflowActivationCompletion,
+  visit,
+  walkActivityTask,
+  walkActivityTaskCompletion,
+  walkNexusTask,
+  walkNexusTaskCompletion,
+  walkQueryWorkflowResponse,
+  walkStartWorkflowExecutionRequest,
+  walkWorkflowActivation,
+  walkWorkflowActivationCompletion,
 } from '@temporalio/common/lib/internal-non-workflow';
 import { encode } from '@temporalio/common/lib/encoding';
 import { METADATA_ENCODING_KEY } from '@temporalio/common/lib/converter/types';
-import type { coresdk } from '@temporalio/proto';
+import type { coresdk, temporal } from '@temporalio/proto';
 import { makeFakeDriver } from './extstore-fake-driver';
 
 /** Build a Payload whose proto-encoded size is at least `bodyBytes`, filled with `fill`. */
@@ -45,8 +48,9 @@ test('workflow store offloads a large payload and threads the target to the driv
     successful: { commands: [{ completeWorkflowExecution: { result: makePayload(256) } }] },
   };
 
-  await visitWorkflowActivationCompletion(
+  await visit(
     completion,
+    walkWorkflowActivationCompletion,
     extstoreStoreOptions(externalStorage, { initialTarget: WORKFLOW_TARGET })
   );
 
@@ -63,8 +67,9 @@ test('workflow store offloads only above-threshold payloads at a repeated site',
     successful: { commands: [{ scheduleActivity: { arguments: [makePayload(256), small] } }] },
   };
 
-  await visitWorkflowActivationCompletion(
+  await visit(
     completion,
+    walkWorkflowActivationCompletion,
     extstoreStoreOptions(externalStorage, { initialTarget: WORKFLOW_TARGET })
   );
 
@@ -85,8 +90,9 @@ test('workflow store applies a per-command derived target', async (t) => {
     },
   };
 
-  await visitWorkflowActivationCompletion(
+  await visit(
     completion,
+    walkWorkflowActivationCompletion,
     extstoreStoreOptions(externalStorage, {
       initialTarget: WORKFLOW_TARGET,
       // Stand-in for the worker's command→target mapping: the child command retargets its payloads.
@@ -107,8 +113,9 @@ test('workflow store then retrieve round-trips the original payload bytes', asyn
     successful: { commands: [{ completeWorkflowExecution: { result: original } }] },
   };
 
-  await visitWorkflowActivationCompletion(
+  await visit(
     completion,
+    walkWorkflowActivationCompletion,
     extstoreStoreOptions(externalStorage, { initialTarget: WORKFLOW_TARGET })
   );
   const reference = completion.successful!.commands![0]!.completeWorkflowExecution!.result!;
@@ -117,7 +124,7 @@ test('workflow store then retrieve round-trips the original payload bytes', asyn
   const activation: coresdk.workflow_activation.IWorkflowActivation = {
     jobs: [{ resolveActivity: { result: { completed: { result: reference } } } }],
   };
-  await visitWorkflowActivation(activation, extstoreRetrieveOptions(externalStorage));
+  await visit(activation, walkWorkflowActivation, extstoreRetrieveOptions(externalStorage));
 
   const retrieved = activation.jobs![0]!.resolveActivity!.result!.completed!.result!;
   t.false(isReferencePayload(retrieved));
@@ -131,7 +138,7 @@ test('activity task completion store offloads the result payload', async (t) => 
     result: { completed: { result: makePayload(256) } },
   };
 
-  await visitActivityTaskCompletion(completion, extstoreStoreOptions(externalStorage));
+  await visit(completion, walkActivityTaskCompletion, extstoreStoreOptions(externalStorage));
 
   t.true(isReferencePayload(completion.result!.completed!.result!));
   t.is(driver.storeCalls.length, 1);
@@ -144,7 +151,7 @@ test('activity task retrieve resolves the activity input', async (t) => {
     start: { input: [await toReference(externalStorage, input)] },
   };
 
-  await visitActivityTask(task, extstoreRetrieveOptions(externalStorage));
+  await visit(task, walkActivityTask, extstoreRetrieveOptions(externalStorage));
 
   t.deepEqual(task.start!.input![0], input);
 });
@@ -155,7 +162,7 @@ test('nexus task completion store offloads the sync result payload', async (t) =
     completed: { startOperation: { syncSuccess: { payload: makePayload(256) } } },
   };
 
-  await visitNexusTaskCompletion(completion, extstoreStoreOptions(externalStorage));
+  await visit(completion, walkNexusTaskCompletion, extstoreStoreOptions(externalStorage));
 
   t.true(isReferencePayload(completion.completed!.startOperation!.syncSuccess!.payload!));
 });
@@ -167,7 +174,35 @@ test('nexus task retrieve resolves the request payload', async (t) => {
     task: { request: { startOperation: { payload: await toReference(externalStorage, requestPayload) } } },
   };
 
-  await visitNexusTask(task, extstoreRetrieveOptions(externalStorage));
+  await visit(task, walkNexusTask, extstoreRetrieveOptions(externalStorage));
 
   t.deepEqual(task.task!.request!.startOperation!.payload, requestPayload);
+});
+
+test('client request store offloads the workflow input (via generic visit)', async (t) => {
+  const { externalStorage } = externalStorageWith();
+  const request: temporal.api.workflowservice.v1.IStartWorkflowExecutionRequest = {
+    workflowId: 'wf-1',
+    input: { payloads: [makePayload(256)] },
+  };
+
+  await visit(
+    request,
+    walkStartWorkflowExecutionRequest,
+    extstoreStoreOptions(externalStorage, { initialTarget: WORKFLOW_TARGET })
+  );
+
+  t.true(isReferencePayload(request.input!.payloads![0]!));
+});
+
+test('client response retrieve resolves the query result (via generic visit)', async (t) => {
+  const { externalStorage } = externalStorageWith();
+  const queryResult = makePayload(256, 9);
+  const response: temporal.api.workflowservice.v1.IQueryWorkflowResponse = {
+    queryResult: { payloads: [await toReference(externalStorage, queryResult)] },
+  };
+
+  await visit(response, walkQueryWorkflowResponse, extstoreRetrieveOptions(externalStorage));
+
+  t.deepEqual(response.queryResult!.payloads![0], queryResult);
 });

--- a/packages/test/src/test-extstore-visit.ts
+++ b/packages/test/src/test-extstore-visit.ts
@@ -1,0 +1,78 @@
+/* eslint @typescript-eslint/no-non-null-assertion: 0 */
+import test from 'ava';
+import type { Payload } from '@temporalio/common';
+import { ExternalStorage } from '@temporalio/common/lib/converter/extstore';
+import {
+  isReferencePayload,
+  retrieveWorkflowActivation,
+  storeWorkflowActivationCompletion,
+} from '@temporalio/common/lib/internal-non-workflow';
+import { encode } from '@temporalio/common/lib/encoding';
+import { METADATA_ENCODING_KEY } from '@temporalio/common/lib/converter/types';
+import { coresdk } from '@temporalio/proto';
+import { makeFakeDriver } from './extstore-fake-driver';
+
+/** Build a Payload whose proto-encoded size is at least `bodyBytes`, filled with `fill`. */
+function makePayload(bodyBytes: number, fill = 0): Payload {
+  return {
+    metadata: { [METADATA_ENCODING_KEY]: encode('binary/plain') },
+    data: new Uint8Array(bodyBytes).fill(fill),
+  };
+}
+
+function externalStorageWith(driver = makeFakeDriver({ name: 's3' }), payloadSizeThreshold = 96) {
+  return { driver, externalStorage: new ExternalStorage({ drivers: [driver], payloadSizeThreshold }) };
+}
+
+const WORKFLOW_TARGET = { kind: 'workflow', namespace: 'ns', id: 'wf-1', runId: 'run-1' } as const;
+
+test('store offloads a large payload at a singular site and threads the target to the driver', async (t) => {
+  const { driver, externalStorage } = externalStorageWith();
+  const completion: coresdk.workflow_completion.IWorkflowActivationCompletion = {
+    successful: { commands: [{ completeWorkflowExecution: { result: makePayload(256) } }] },
+  };
+
+  await storeWorkflowActivationCompletion(externalStorage, completion, { target: WORKFLOW_TARGET });
+
+  const result = completion.successful!.commands![0]!.completeWorkflowExecution!.result!;
+  t.true(isReferencePayload(result));
+  t.is(driver.storeCalls.length, 1);
+  t.deepEqual(driver.storeCalls[0]!.context.target, WORKFLOW_TARGET);
+});
+
+test('store offloads only above-threshold payloads at a repeated site', async (t) => {
+  const { externalStorage } = externalStorageWith();
+  const small = makePayload(0);
+  const completion: coresdk.workflow_completion.IWorkflowActivationCompletion = {
+    successful: { commands: [{ scheduleActivity: { arguments: [makePayload(256), small] } }] },
+  };
+
+  await storeWorkflowActivationCompletion(externalStorage, completion, { target: WORKFLOW_TARGET });
+
+  const args = completion.successful!.commands![0]!.scheduleActivity!.arguments!;
+  t.true(isReferencePayload(args[0]!));
+  t.deepEqual(args[1], small);
+});
+
+test('store then retrieve round-trips the original payload bytes through a worker message', async (t) => {
+  const { driver, externalStorage } = externalStorageWith();
+  const original = makePayload(256, 7);
+  const completion: coresdk.workflow_completion.IWorkflowActivationCompletion = {
+    successful: { commands: [{ completeWorkflowExecution: { result: original } }] },
+  };
+
+  await storeWorkflowActivationCompletion(externalStorage, completion, { target: WORKFLOW_TARGET });
+  const reference = completion.successful!.commands![0]!.completeWorkflowExecution!.result!;
+  t.true(isReferencePayload(reference));
+
+  // The reference produced on the outbound path arrives back on a later inbound activation.
+  const activation: coresdk.workflow_activation.IWorkflowActivation = {
+    jobs: [{ resolveActivity: { result: { completed: { result: reference } } } }],
+  };
+  await retrieveWorkflowActivation(externalStorage, activation);
+
+  const retrieved = activation.jobs![0]!.resolveActivity!.result!.completed!.result!;
+  t.false(isReferencePayload(retrieved));
+  t.deepEqual(retrieved, original);
+  t.is(driver.retrieveCalls.length, 1);
+});

--- a/packages/test/src/test-extstore-visit.ts
+++ b/packages/test/src/test-extstore-visit.ts
@@ -3,9 +3,16 @@ import test from 'ava';
 import type { Payload } from '@temporalio/common';
 import { ExternalStorage } from '@temporalio/common/lib/converter/extstore';
 import {
+  ExternalStorageRunner,
+  extstoreRetrieveOptions,
+  extstoreStoreOptions,
   isReferencePayload,
-  retrieveWorkflowActivation,
-  storeWorkflowActivationCompletion,
+  visitActivityTask,
+  visitActivityTaskCompletion,
+  visitNexusTask,
+  visitNexusTaskCompletion,
+  visitWorkflowActivation,
+  visitWorkflowActivationCompletion,
 } from '@temporalio/common/lib/internal-non-workflow';
 import { encode } from '@temporalio/common/lib/encoding';
 import { METADATA_ENCODING_KEY } from '@temporalio/common/lib/converter/types';
@@ -24,15 +31,24 @@ function externalStorageWith(driver = makeFakeDriver({ name: 's3' }), payloadSiz
   return { driver, externalStorage: new ExternalStorage({ drivers: [driver], payloadSizeThreshold }) };
 }
 
+/** Offload a payload through the runner and return the resulting reference payload. */
+async function toReference(externalStorage: ExternalStorage, payload: Payload): Promise<Payload> {
+  const [reference] = await new ExternalStorageRunner(externalStorage).store([payload]);
+  return reference!;
+}
+
 const WORKFLOW_TARGET = { kind: 'workflow', namespace: 'ns', id: 'wf-1', runId: 'run-1' } as const;
 
-test('store offloads a large payload at a singular site and threads the target to the driver', async (t) => {
+test('workflow store offloads a large payload and threads the target to the driver', async (t) => {
   const { driver, externalStorage } = externalStorageWith();
   const completion: coresdk.workflow_completion.IWorkflowActivationCompletion = {
     successful: { commands: [{ completeWorkflowExecution: { result: makePayload(256) } }] },
   };
 
-  await storeWorkflowActivationCompletion(externalStorage, completion, { target: WORKFLOW_TARGET });
+  await visitWorkflowActivationCompletion(
+    completion,
+    extstoreStoreOptions(externalStorage, { initialTarget: WORKFLOW_TARGET })
+  );
 
   const result = completion.successful!.commands![0]!.completeWorkflowExecution!.result!;
   t.true(isReferencePayload(result));
@@ -40,39 +56,118 @@ test('store offloads a large payload at a singular site and threads the target t
   t.deepEqual(driver.storeCalls[0]!.context.target, WORKFLOW_TARGET);
 });
 
-test('store offloads only above-threshold payloads at a repeated site', async (t) => {
+test('workflow store offloads only above-threshold payloads at a repeated site', async (t) => {
   const { externalStorage } = externalStorageWith();
   const small = makePayload(0);
   const completion: coresdk.workflow_completion.IWorkflowActivationCompletion = {
     successful: { commands: [{ scheduleActivity: { arguments: [makePayload(256), small] } }] },
   };
 
-  await storeWorkflowActivationCompletion(externalStorage, completion, { target: WORKFLOW_TARGET });
+  await visitWorkflowActivationCompletion(
+    completion,
+    extstoreStoreOptions(externalStorage, { initialTarget: WORKFLOW_TARGET })
+  );
 
   const args = completion.successful!.commands![0]!.scheduleActivity!.arguments!;
   t.true(isReferencePayload(args[0]!));
   t.deepEqual(args[1], small);
 });
 
-test('store then retrieve round-trips the original payload bytes through a worker message', async (t) => {
+test('workflow store applies a per-command derived target', async (t) => {
   const { driver, externalStorage } = externalStorageWith();
+  const childTarget = { kind: 'workflow', namespace: 'ns', id: 'child-1' } as const;
+  const completion: coresdk.workflow_completion.IWorkflowActivationCompletion = {
+    successful: {
+      commands: [
+        { completeWorkflowExecution: { result: makePayload(256, 1) } },
+        { startChildWorkflowExecution: { workflowId: 'child-1', input: [makePayload(256, 2)] } },
+      ],
+    },
+  };
+
+  await visitWorkflowActivationCompletion(
+    completion,
+    extstoreStoreOptions(externalStorage, {
+      initialTarget: WORKFLOW_TARGET,
+      // Stand-in for the worker's command→target mapping: the child command retargets its payloads.
+      deriveContext: (_message, typeName, context) =>
+        typeName === 'coresdk.workflow_commands.StartChildWorkflowExecution' ? childTarget : context,
+    })
+  );
+
+  const targets = driver.storeCalls.map((call) => call.context.target?.id);
+  t.true(targets.includes('wf-1'), 'workflow result stored against the workflow');
+  t.true(targets.includes('child-1'), 'child input stored against the child workflow');
+});
+
+test('workflow store then retrieve round-trips the original payload bytes', async (t) => {
+  const { externalStorage } = externalStorageWith();
   const original = makePayload(256, 7);
   const completion: coresdk.workflow_completion.IWorkflowActivationCompletion = {
     successful: { commands: [{ completeWorkflowExecution: { result: original } }] },
   };
 
-  await storeWorkflowActivationCompletion(externalStorage, completion, { target: WORKFLOW_TARGET });
+  await visitWorkflowActivationCompletion(
+    completion,
+    extstoreStoreOptions(externalStorage, { initialTarget: WORKFLOW_TARGET })
+  );
   const reference = completion.successful!.commands![0]!.completeWorkflowExecution!.result!;
   t.true(isReferencePayload(reference));
 
-  // The reference produced on the outbound path arrives back on a later inbound activation.
   const activation: coresdk.workflow_activation.IWorkflowActivation = {
     jobs: [{ resolveActivity: { result: { completed: { result: reference } } } }],
   };
-  await retrieveWorkflowActivation(externalStorage, activation);
+  await visitWorkflowActivation(activation, extstoreRetrieveOptions(externalStorage));
 
   const retrieved = activation.jobs![0]!.resolveActivity!.result!.completed!.result!;
   t.false(isReferencePayload(retrieved));
   t.deepEqual(retrieved, original);
-  t.is(driver.retrieveCalls.length, 1);
+});
+
+test('activity task completion store offloads the result payload', async (t) => {
+  const { driver, externalStorage } = externalStorageWith();
+  const completion: coresdk.IActivityTaskCompletion = {
+    taskToken: new Uint8Array([1]),
+    result: { completed: { result: makePayload(256) } },
+  };
+
+  await visitActivityTaskCompletion(completion, extstoreStoreOptions(externalStorage));
+
+  t.true(isReferencePayload(completion.result!.completed!.result!));
+  t.is(driver.storeCalls.length, 1);
+});
+
+test('activity task retrieve resolves the activity input', async (t) => {
+  const { externalStorage } = externalStorageWith();
+  const input = makePayload(256, 3);
+  const task: coresdk.activity_task.IActivityTask = {
+    start: { input: [await toReference(externalStorage, input)] },
+  };
+
+  await visitActivityTask(task, extstoreRetrieveOptions(externalStorage));
+
+  t.deepEqual(task.start!.input![0], input);
+});
+
+test('nexus task completion store offloads the sync result payload', async (t) => {
+  const { externalStorage } = externalStorageWith();
+  const completion: coresdk.nexus.INexusTaskCompletion = {
+    completed: { startOperation: { syncSuccess: { payload: makePayload(256) } } },
+  };
+
+  await visitNexusTaskCompletion(completion, extstoreStoreOptions(externalStorage));
+
+  t.true(isReferencePayload(completion.completed!.startOperation!.syncSuccess!.payload!));
+});
+
+test('nexus task retrieve resolves the request payload', async (t) => {
+  const { externalStorage } = externalStorageWith();
+  const requestPayload = makePayload(256, 5);
+  const task: coresdk.nexus.INexusTask = {
+    task: { request: { startOperation: { payload: await toReference(externalStorage, requestPayload) } } },
+  };
+
+  await visitNexusTask(task, extstoreRetrieveOptions(externalStorage));
+
+  t.deepEqual(task.task!.request!.startOperation!.payload, requestPayload);
 });

--- a/packages/test/src/test-extstore-visit.ts
+++ b/packages/test/src/test-extstore-visit.ts
@@ -9,7 +9,7 @@ import {
 } from '@temporalio/common/lib/internal-non-workflow';
 import { encode } from '@temporalio/common/lib/encoding';
 import { METADATA_ENCODING_KEY } from '@temporalio/common/lib/converter/types';
-import { coresdk } from '@temporalio/proto';
+import type { coresdk } from '@temporalio/proto';
 import { makeFakeDriver } from './extstore-fake-driver';
 
 /** Build a Payload whose proto-encoded size is at least `bodyBytes`, filled with `fill`. */

--- a/packages/test/src/test-extstore-visit.ts
+++ b/packages/test/src/test-extstore-visit.ts
@@ -8,6 +8,7 @@ import {
   extstoreStoreOptions,
   isReferencePayload,
   visit,
+  walkActivityHeartbeat,
   walkActivityTask,
   walkActivityTaskCompletion,
   walkNexusTask,
@@ -106,6 +107,34 @@ test('workflow store applies a per-command derived target', async (t) => {
   t.true(targets.includes('child-1'), 'child input stored against the child workflow');
 });
 
+test('workflow store leaves search attributes inline while offloading siblings', async (t) => {
+  const { externalStorage } = externalStorageWith();
+  const searchAttr = makePayload(256, 8);
+  const completion: coresdk.workflow_completion.IWorkflowActivationCompletion = {
+    successful: {
+      commands: [
+        {
+          startChildWorkflowExecution: {
+            workflowId: 'child-1',
+            input: [makePayload(256, 1)],
+            searchAttributes: { indexedFields: { CustomKey: searchAttr } },
+          },
+        },
+      ],
+    },
+  };
+
+  await visit(
+    completion,
+    walkWorkflowActivationCompletion,
+    extstoreStoreOptions(externalStorage, { initialTarget: WORKFLOW_TARGET })
+  );
+
+  const command = completion.successful!.commands![0]!.startChildWorkflowExecution!;
+  t.true(isReferencePayload(command.input![0]!), 'input is offloaded');
+  t.deepEqual(command.searchAttributes!.indexedFields!.CustomKey, searchAttr, 'search attribute left untouched');
+});
+
 test('workflow store then retrieve round-trips the original payload bytes', async (t) => {
   const { externalStorage } = externalStorageWith();
   const original = makePayload(256, 7);
@@ -142,6 +171,15 @@ test('activity task completion store offloads the result payload', async (t) => 
 
   t.true(isReferencePayload(completion.result!.completed!.result!));
   t.is(driver.storeCalls.length, 1);
+});
+
+test('activity heartbeat store offloads the details payload', async (t) => {
+  const { externalStorage } = externalStorageWith();
+  const heartbeat: coresdk.IActivityHeartbeat = { taskToken: new Uint8Array([1]), details: [makePayload(256)] };
+
+  await visit(heartbeat, walkActivityHeartbeat, extstoreStoreOptions(externalStorage));
+
+  t.true(isReferencePayload(heartbeat.details![0]!));
 });
 
 test('activity task retrieve resolves the activity input', async (t) => {

--- a/packages/test/src/test-metrics-custom.ts
+++ b/packages/test/src/test-metrics-custom.ts
@@ -6,7 +6,7 @@ import type { MetricTags } from '@temporalio/common';
 import { Context as ActivityContext, metricMeter as activityMetricMeter } from '@temporalio/activity';
 import type { Context as BaseContext } from './helpers-integration';
 import { helpers, makeTestFunction } from './helpers-integration';
-import { getRandomPort } from './helpers';
+import { getRandomPort, assertEventually } from './helpers';
 
 interface Context extends BaseContext {
   port: number;
@@ -38,12 +38,16 @@ const test = makeTestFunction<Context>({
 });
 
 async function assertMetricReported(t: ExecutionContext<Context>, regexp: RegExp) {
-  const resp = await fetch(`http://127.0.0.1:${t.context.port}/metrics`);
-  const text = await resp.text();
-  const matched = t.regex(text, regexp);
-  if (!matched) {
-    t.log(text);
-  }
+  // Metrics recorded by Core (in particular from workflows and activities) are pushed to the
+  // Prometheus exporter asynchronously, so the expected value may not be visible in the scrape
+  // immediately. Retry until it appears, otherwise these tests flake on slower runners.
+  await assertEventually(t, async (tt) => {
+    const text = await (await fetch(`http://127.0.0.1:${tt.context.port}/metrics`)).text();
+    const matched = tt.regex(text, regexp);
+    if (!matched) {
+      tt.log(text);
+    }
+  });
 }
 
 /**

--- a/packages/test/src/test-runtime-otel.ts
+++ b/packages/test/src/test-runtime-otel.ts
@@ -139,7 +139,7 @@ test.serial('Exporting OTEL metrics from Core works', async (t) => {
           });
           const req = await Promise.race([
             capturedRequest,
-            await new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 2000)),
+            new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 10000)),
           ]);
           t.truthy(req);
           t.is(req?.url, '/opentelemetry.proto.collector.metrics.v1.MetricsService/Export');
@@ -192,7 +192,7 @@ test.serial('Exporting OTEL metrics using OTLP/HTTP from Core works', async (t) 
           });
           const req = await Promise.race([
             capturedRequest,
-            await new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 2000)),
+            new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 10000)),
           ]);
           t.truthy(req);
           t.is(req?.url, '/v1/metrics');

--- a/packages/test/src/test-runtime-prometheus.ts
+++ b/packages/test/src/test-runtime-prometheus.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import test from 'ava';
 import { WorkflowClient } from '@temporalio/client';
 import { Runtime } from '@temporalio/worker';
-import { Worker, getRandomPort, TestWorkflowEnvironment } from './helpers';
+import { Worker, getRandomPort, TestWorkflowEnvironment, assertEventually } from './helpers';
 import * as workflows from './workflows';
 
 test.serial('Runtime.install() throws meaningful error when passed invalid metrics.prometheus.bindAddress', (t) => {
@@ -54,10 +54,12 @@ test.serial('Exporting Prometheus metrics from Core works', async (t) => {
         taskQueue: 'test-prometheus',
         workflowId: randomUUID(),
       });
-      const resp = await fetch(`http://127.0.0.1:${port}/metrics`);
-      // We're not concerned about exact details here, just that the metrics are present
-      const text = await resp.text();
-      t.assert(text.includes('myprefix_worker_task_slots_available'));
+      // Metrics are pushed to the Prometheus exporter asynchronously, so retry until present.
+      await assertEventually(t, async (tt) => {
+        const text = await (await fetch(`http://127.0.0.1:${port}/metrics`)).text();
+        // We're not concerned about exact details here, just that the metrics are present
+        tt.assert(text.includes('myprefix_worker_task_slots_available'), `Actual: \n-------\n${text}\n-------`);
+      });
     });
   } finally {
     await localEnv.teardown();
@@ -99,31 +101,35 @@ test.serial('Exporting Prometheus metrics from Core works with lots of options',
         workflowId: randomUUID(),
       });
 
-      const resp = await fetch(`http://127.0.0.1:${port}/metrics`);
-      const text = await resp.text();
+      // The metrics below are recorded by the worker's Core runtime and pushed to the Prometheus
+      // exporter asynchronously, so they may not be visible in the scrape immediately after the
+      // workflow completes. Retry until they appear, otherwise this test flakes on slower runners.
+      await assertEventually(t, async (tt) => {
+        const text = await (await fetch(`http://127.0.0.1:${port}/metrics`)).text();
 
-      // Verify use seconds & unit suffix
-      t.assert(
-        text.includes(
-          'temporal_workflow_task_execution_latency_seconds_bucket{namespace="default",' +
-            'service_name="temporal-core-sdk",task_queue="test-prometheus",' +
-            'workflow_type="successString",my_tag="my_value",le="31415"}'
-        ),
-        `Actual: \n-------\n${text}\n-------`
-      );
+        // Verify use seconds & unit suffix
+        tt.assert(
+          text.includes(
+            'temporal_workflow_task_execution_latency_seconds_bucket{namespace="default",' +
+              'service_name="temporal-core-sdk",task_queue="test-prometheus",' +
+              'workflow_type="successString",my_tag="my_value",le="31415"}'
+          ),
+          `Actual: \n-------\n${text}\n-------`
+        );
 
-      // Verify histogram overrides
-      t.assert(
-        text.match(/temporal_request_latency_seconds_bucket\{.*,le="31415"/),
-        `Actual: \n-------\n${text}\n-------`
-      );
-      t.assert(
-        text.match(/workflow_task_execution_latency_seconds_bucket\{.*,le="31415"/),
-        `Actual: \n-------\n${text}\n-------`
-      );
+        // Verify histogram overrides
+        tt.assert(
+          text.match(/temporal_request_latency_seconds_bucket\{.*,le="31415"/),
+          `Actual: \n-------\n${text}\n-------`
+        );
+        tt.assert(
+          text.match(/workflow_task_execution_latency_seconds_bucket\{.*,le="31415"/),
+          `Actual: \n-------\n${text}\n-------`
+        );
 
-      // Verify prefix exists on client request metrics
-      t.assert(text.includes('temporal_long_request{'), `Actual: \n-------\n${text}\n-------`);
+        // Verify prefix exists on client request metrics
+        tt.assert(text.includes('temporal_long_request{'), `Actual: \n-------\n${text}\n-------`);
+      });
     });
   } finally {
     await localEnv.teardown();

--- a/packages/test/src/test-worker-poller-autoscale.ts
+++ b/packages/test/src/test-worker-poller-autoscale.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
 import test from 'ava';
 import { Runtime, Worker } from '@temporalio/worker';
-import { getRandomPort, TestWorkflowEnvironment } from './helpers';
+import { getRandomPort, TestWorkflowEnvironment, assertEventually } from './helpers';
 import * as activities from './activities';
 import * as workflows from './workflows';
 
@@ -36,30 +36,30 @@ test.serial('Can run autoscaling polling worker', async (t) => {
     });
     const workerPromise = worker.run();
 
-    // Give pollers a beat to start
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    // Pollers start asynchronously and their counts are exported to the Prometheus endpoint on a
+    // delay, so retry the assertions until they hold rather than sleeping for a fixed duration and
+    // hoping the pollers have stabilized.
+    await assertEventually(t, async (tt) => {
+      const metricsText = await (await fetch(`http://127.0.0.1:${port}/metrics`)).text();
+      const matches = metricsText.split('\n').filter((l) => l.includes('temporal_num_pollers'));
+      const activity_pollers = matches.filter((l) => l.includes('activity_task'));
+      const workflow_pollers = matches.filter((l) => l.includes('workflow_task') && l.includes(taskQueue));
 
-    const resp = await fetch(`http://127.0.0.1:${port}/metrics`);
-    const metricsText = await resp.text();
-    const metricsLines = metricsText.split('\n');
+      tt.is(activity_pollers.length, 1, 'Should have exactly one activity poller metric');
+      tt.true(activity_pollers[0].endsWith('2'), 'Activity poller count should be 2');
+      tt.is(workflow_pollers.length, 2, 'Should have exactly two workflow poller metrics (sticky and non-sticky)');
 
-    const matches = metricsLines.filter((l) => l.includes('temporal_num_pollers'));
-    const activity_pollers = matches.filter((l) => l.includes('activity_task'));
-    t.is(activity_pollers.length, 1, 'Should have exactly one activity poller metric');
-    t.true(activity_pollers[0].endsWith('2'), 'Activity poller count should be 2');
-    const workflow_pollers = matches.filter((l) => l.includes('workflow_task') && l.includes(taskQueue));
-    t.is(workflow_pollers.length, 2, 'Should have exactly two workflow poller metrics (sticky and non-sticky)');
-
-    // There's sticky & non-sticky pollers, and they may have a count of 1 or 2 depending on
-    // initialization timing.
-    t.true(
-      workflow_pollers[0].endsWith('2') || workflow_pollers[0].endsWith('1'),
-      'First workflow poller count should be 1 or 2'
-    );
-    t.true(
-      workflow_pollers[1].endsWith('2') || workflow_pollers[1].endsWith('1'),
-      'Second workflow poller count should be 1 or 2'
-    );
+      // There's sticky & non-sticky pollers, and they may have a count of 1 or 2 depending on
+      // initialization timing.
+      tt.true(
+        workflow_pollers[0].endsWith('2') || workflow_pollers[0].endsWith('1'),
+        'First workflow poller count should be 1 or 2'
+      );
+      tt.true(
+        workflow_pollers[1].endsWith('2') || workflow_pollers[1].endsWith('1'),
+        'Second workflow poller count should be 1 or 2'
+      );
+    });
 
     const workflowPromises = Array(20)
       .fill(0)

--- a/packages/test/src/test-workflow-codec-runner.ts
+++ b/packages/test/src/test-workflow-codec-runner.ts
@@ -20,7 +20,10 @@ function failureWithDetail(label: string) {
   );
 }
 
-function decodeCompletion(bytes: Uint8Array): coresdk.workflow_completion.WorkflowActivationCompletion {
+function decodeCompletion(
+  completion: coresdk.workflow_completion.IWorkflowActivationCompletion
+): coresdk.workflow_completion.WorkflowActivationCompletion {
+  const bytes = coresdk.workflow_completion.WorkflowActivationCompletion.encodeDelimited(completion).finish();
   return coresdk.workflow_completion.WorkflowActivationCompletion.decodeDelimited(bytes);
 }
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -33,12 +33,13 @@ import {
   encodeToPayload,
   extstoreRetrieveOptions,
   extstoreStoreOptions,
-  visitActivityTask,
-  visitActivityTaskCompletion,
-  visitNexusTask,
-  visitNexusTaskCompletion,
-  visitWorkflowActivation,
-  visitWorkflowActivationCompletion,
+  visit,
+  walkActivityTask,
+  walkActivityTaskCompletion,
+  walkNexusTask,
+  walkNexusTaskCompletion,
+  walkWorkflowActivation,
+  walkWorkflowActivationCompletion,
 } from '@temporalio/common/lib/internal-non-workflow';
 import type { StorageDriverTargetInfo } from '@temporalio/common/lib/converter/extstore';
 import { historyFromJSON } from '@temporalio/common/lib/proto-utils';
@@ -1250,7 +1251,7 @@ export class Worker {
           mergeMap(async (rest) => {
             const { externalStorage } = this.options.loadedDataConverter;
             if (externalStorage) {
-              await visitActivityTaskCompletion(rest, extstoreStoreOptions(externalStorage));
+              await visit(rest, walkActivityTaskCompletion, extstoreStoreOptions(externalStorage));
             }
             return coresdk.ActivityTaskCompletion.encodeDelimited(rest).finish();
           }),
@@ -1312,7 +1313,7 @@ export class Worker {
       mergeMap(async (result) => {
         const { externalStorage } = this.options.loadedDataConverter;
         if (externalStorage) {
-          await visitNexusTaskCompletion(result, extstoreStoreOptions(externalStorage));
+          await visit(result, walkNexusTaskCompletion, extstoreStoreOptions(externalStorage));
         }
         return coresdk.nexus.NexusTaskCompletion.encodeDelimited(result).finish();
       })
@@ -1464,7 +1465,7 @@ export class Worker {
       }
       const { externalStorage } = this.options.loadedDataConverter;
       if (externalStorage) {
-        await visitWorkflowActivation(activation, extstoreRetrieveOptions(externalStorage));
+        await visit(activation, walkWorkflowActivation, extstoreRetrieveOptions(externalStorage));
       }
       const decodedActivation = await workflowCodecRunner.decodeActivation(activation);
 
@@ -1484,8 +1485,9 @@ export class Worker {
         const encodedCompletion = await workflowCodecRunner.encodeCompletion(unencodedCompletion);
         if (externalStorage) {
           const namespace = workflowCodecRunner.workflowContext.namespace;
-          await visitWorkflowActivationCompletion(
+          await visit(
             encodedCompletion,
+            walkWorkflowActivationCompletion,
             extstoreStoreOptions(externalStorage, {
               initialTarget: {
                 kind: 'workflow',
@@ -1919,7 +1921,7 @@ export class Worker {
       const task = coresdk.activity_task.ActivityTask.decode(new Uint8Array(buffer));
       const { externalStorage } = this.options.loadedDataConverter;
       if (externalStorage) {
-        await visitActivityTask(task, extstoreRetrieveOptions(externalStorage));
+        await visit(task, walkActivityTask, extstoreRetrieveOptions(externalStorage));
       }
       const { taskToken, ...rest } = task;
       const base64TaskToken = formatTaskToken(taskToken);
@@ -1972,7 +1974,7 @@ export class Worker {
       const task = coresdk.nexus.NexusTask.decode(new Uint8Array(buffer));
       const { externalStorage } = this.options.loadedDataConverter;
       if (externalStorage) {
-        await visitNexusTask(task, extstoreRetrieveOptions(externalStorage));
+        await visit(task, walkNexusTask, extstoreRetrieveOptions(externalStorage));
       }
       const taskToken = task.task?.taskToken || task.cancelTask?.taskToken;
       if (taskToken == null) {
@@ -2328,9 +2330,7 @@ function workflowCommandStoreTarget(
     switch (typeName) {
       case 'coresdk.workflow_commands.StartChildWorkflowExecution': {
         const command = message as coresdk.workflow_commands.IStartChildWorkflowExecution;
-        return command.workflowId
-          ? { kind: 'workflow', namespace: command.namespace || namespace, id: command.workflowId }
-          : context;
+        return { kind: 'workflow', namespace: command.namespace || namespace, id: command.workflowId ?? undefined };
       }
       case 'coresdk.workflow_commands.SignalExternalWorkflowExecution':
       case 'coresdk.workflow_commands.RequestCancelExternalWorkflowExecution': {
@@ -2338,10 +2338,10 @@ function workflowCommandStoreTarget(
           childWorkflowId?: string | null;
         };
         const workflowId = command.workflowExecution?.workflowId ?? command.childWorkflowId ?? undefined;
-        return workflowId
-          ? { kind: 'workflow', namespace: command.workflowExecution?.namespace || namespace, id: workflowId }
-          : context;
+        return { kind: 'workflow', namespace: command.workflowExecution?.namespace || namespace, id: workflowId };
       }
+      case 'coresdk.workflow_commands.ContinueAsNewWorkflowExecution':
+        return context ? { ...context, runId: undefined } : context;
       default:
         return context;
     }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -34,6 +34,7 @@ import {
   extstoreRetrieveOptions,
   extstoreStoreOptions,
   visit,
+  walkActivityHeartbeat,
   walkActivityTask,
   walkActivityTaskCompletion,
   walkNexusTask,
@@ -1827,10 +1828,12 @@ export class Worker {
                 onError();
                 return;
               }
-              const arr = coresdk.ActivityHeartbeat.encodeDelimited({
-                taskToken,
-                details: [payload],
-              }).finish();
+              const heartbeat: coresdk.IActivityHeartbeat = { taskToken, details: [payload] };
+              const { externalStorage } = this.options.loadedDataConverter;
+              if (externalStorage) {
+                await visit(heartbeat, walkActivityHeartbeat, extstoreStoreOptions(externalStorage));
+              }
+              const arr = coresdk.ActivityHeartbeat.encodeDelimited(heartbeat).finish();
               this.nativeWorker.recordActivityHeartbeat(byteArrayToBuffer(arr));
             } finally {
               this.activityHeartbeatSubject.next({

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -31,6 +31,8 @@ import {
   decodeFromPayloadsAtIndex,
   encodeErrorToFailure,
   encodeToPayload,
+  retrieveWorkflowActivation,
+  storeWorkflowActivationCompletion,
 } from '@temporalio/common/lib/internal-non-workflow';
 import { historyFromJSON } from '@temporalio/common/lib/proto-utils';
 import type { Duration } from '@temporalio/common/lib/time';
@@ -1441,6 +1443,10 @@ export class Worker {
           workflowId,
         });
       }
+      const { externalStorage } = this.options.loadedDataConverter;
+      if (externalStorage) {
+        await retrieveWorkflowActivation(externalStorage, activation);
+      }
       const decodedActivation = await workflowCodecRunner.decodeActivation(activation);
 
       if (workflow === undefined) {
@@ -1456,7 +1462,19 @@ export class Worker {
       let isFatalError = false;
       try {
         const unencodedCompletion = await workflow.workflow.activate(decodedActivation);
-        const completion = await workflowCodecRunner.encodeCompletion(unencodedCompletion);
+        const encodedCompletion = await workflowCodecRunner.encodeCompletion(unencodedCompletion);
+        if (externalStorage) {
+          await storeWorkflowActivationCompletion(externalStorage, encodedCompletion, {
+            target: {
+              kind: 'workflow',
+              namespace: workflowCodecRunner.workflowContext.namespace,
+              id: workflowCodecRunner.workflowContext.workflowId,
+              runId: activation.runId,
+            },
+          });
+        }
+        const completion =
+          coresdk.workflow_completion.WorkflowActivationCompletion.encodeDelimited(encodedCompletion).finish();
 
         return { state: workflow, output: { close, completion } };
       } catch (err) {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -31,9 +31,16 @@ import {
   decodeFromPayloadsAtIndex,
   encodeErrorToFailure,
   encodeToPayload,
-  retrieveWorkflowActivation,
-  storeWorkflowActivationCompletion,
+  extstoreRetrieveOptions,
+  extstoreStoreOptions,
+  visitActivityTask,
+  visitActivityTaskCompletion,
+  visitNexusTask,
+  visitNexusTaskCompletion,
+  visitWorkflowActivation,
+  visitWorkflowActivationCompletion,
 } from '@temporalio/common/lib/internal-non-workflow';
+import type { StorageDriverTargetInfo } from '@temporalio/common/lib/converter/extstore';
 import { historyFromJSON } from '@temporalio/common/lib/proto-utils';
 import type { Duration } from '@temporalio/common/lib/time';
 import {
@@ -1240,7 +1247,13 @@ export class Worker {
             return { taskToken, result };
           }),
           filter(<T>(result: T): result is Exclude<T, undefined> => result !== undefined),
-          map((rest) => coresdk.ActivityTaskCompletion.encodeDelimited(rest).finish()),
+          mergeMap(async (rest) => {
+            const { externalStorage } = this.options.loadedDataConverter;
+            if (externalStorage) {
+              await visitActivityTaskCompletion(rest, extstoreStoreOptions(externalStorage));
+            }
+            return coresdk.ActivityTaskCompletion.encodeDelimited(rest).finish();
+          }),
           tap({
             next: () => {
               group$.close();
@@ -1296,7 +1309,13 @@ export class Worker {
         }
       ),
       filter(<T>(result: T): result is Exclude<T, undefined> => result !== undefined),
-      map((result) => coresdk.nexus.NexusTaskCompletion.encodeDelimited(result).finish())
+      mergeMap(async (result) => {
+        const { externalStorage } = this.options.loadedDataConverter;
+        if (externalStorage) {
+          await visitNexusTaskCompletion(result, extstoreStoreOptions(externalStorage));
+        }
+        return coresdk.nexus.NexusTaskCompletion.encodeDelimited(result).finish();
+      })
     );
   }
 
@@ -1445,7 +1464,7 @@ export class Worker {
       }
       const { externalStorage } = this.options.loadedDataConverter;
       if (externalStorage) {
-        await retrieveWorkflowActivation(externalStorage, activation);
+        await visitWorkflowActivation(activation, extstoreRetrieveOptions(externalStorage));
       }
       const decodedActivation = await workflowCodecRunner.decodeActivation(activation);
 
@@ -1464,14 +1483,19 @@ export class Worker {
         const unencodedCompletion = await workflow.workflow.activate(decodedActivation);
         const encodedCompletion = await workflowCodecRunner.encodeCompletion(unencodedCompletion);
         if (externalStorage) {
-          await storeWorkflowActivationCompletion(externalStorage, encodedCompletion, {
-            target: {
-              kind: 'workflow',
-              namespace: workflowCodecRunner.workflowContext.namespace,
-              id: workflowCodecRunner.workflowContext.workflowId,
-              runId: activation.runId,
-            },
-          });
+          const namespace = workflowCodecRunner.workflowContext.namespace;
+          await visitWorkflowActivationCompletion(
+            encodedCompletion,
+            extstoreStoreOptions(externalStorage, {
+              initialTarget: {
+                kind: 'workflow',
+                namespace,
+                id: workflowCodecRunner.workflowContext.workflowId,
+                runId: activation.runId,
+              },
+              deriveContext: workflowCommandStoreTarget(namespace),
+            })
+          );
         }
         const completion =
           coresdk.workflow_completion.WorkflowActivationCompletion.encodeDelimited(encodedCompletion).finish();
@@ -1893,6 +1917,10 @@ export class Worker {
         this.hasOutstandingActivityPoll = false;
       }
       const task = coresdk.activity_task.ActivityTask.decode(new Uint8Array(buffer));
+      const { externalStorage } = this.options.loadedDataConverter;
+      if (externalStorage) {
+        await visitActivityTask(task, extstoreRetrieveOptions(externalStorage));
+      }
       const { taskToken, ...rest } = task;
       const base64TaskToken = formatTaskToken(taskToken);
       this.logger.trace('Got activity task', {
@@ -1942,6 +1970,10 @@ export class Worker {
         this.hasOutstandingNexusPoll = false;
       }
       const task = coresdk.nexus.NexusTask.decode(new Uint8Array(buffer));
+      const { externalStorage } = this.options.loadedDataConverter;
+      if (externalStorage) {
+        await visitNexusTask(task, extstoreRetrieveOptions(externalStorage));
+      }
       const taskToken = task.task?.taskToken || task.cancelTask?.taskToken;
       if (taskToken == null) {
         throw new TypeError('Got a Nexus task without a task token');
@@ -2282,6 +2314,37 @@ async function extractActivityInfo({
     namespace: start.workflowNamespace || activityNamespace,
     activityRunId: !inWorkflow ? start.runId : undefined,
     inWorkflow,
+  };
+}
+
+function workflowCommandStoreTarget(
+  namespace: string
+): (
+  message: object,
+  typeName: string,
+  context: StorageDriverTargetInfo | undefined
+) => StorageDriverTargetInfo | undefined {
+  return (message, typeName, context) => {
+    switch (typeName) {
+      case 'coresdk.workflow_commands.StartChildWorkflowExecution': {
+        const command = message as coresdk.workflow_commands.IStartChildWorkflowExecution;
+        return command.workflowId
+          ? { kind: 'workflow', namespace: command.namespace || namespace, id: command.workflowId }
+          : context;
+      }
+      case 'coresdk.workflow_commands.SignalExternalWorkflowExecution':
+      case 'coresdk.workflow_commands.RequestCancelExternalWorkflowExecution': {
+        const command = message as coresdk.workflow_commands.ISignalExternalWorkflowExecution & {
+          childWorkflowId?: string | null;
+        };
+        const workflowId = command.workflowExecution?.workflowId ?? command.childWorkflowId ?? undefined;
+        return workflowId
+          ? { kind: 'workflow', namespace: command.workflowExecution?.namespace || namespace, id: workflowId }
+          : context;
+      }
+      default:
+        return context;
+    }
   };
 }
 

--- a/packages/worker/src/workflow-codec-runner.ts
+++ b/packages/worker/src/workflow-codec-runner.ts
@@ -34,7 +34,7 @@ export class WorkflowCodecRunner {
 
   constructor(
     private readonly codecs: PayloadCodec[],
-    private readonly workflowContext: WorkflowSerializationContext
+    public readonly workflowContext: WorkflowSerializationContext
   ) {}
 
   private consumeContext<TContext extends SerializationContext>(
@@ -368,7 +368,7 @@ export class WorkflowCodecRunner {
    */
   public async encodeCompletion(
     completion: coresdk.workflow_completion.IWorkflowActivationCompletion
-  ): Promise<Uint8Array> {
+  ): Promise<Encoded<coresdk.workflow_completion.IWorkflowActivationCompletion>> {
     const encodedCompletion: Encoded<coresdk.workflow_completion.IWorkflowActivationCompletion> = {
       ...completion,
       failed: completion.failed
@@ -608,6 +608,6 @@ export class WorkflowCodecRunner {
         : null,
     };
 
-    return coresdk.workflow_completion.WorkflowActivationCompletion.encodeDelimited(encodedCompletion).finish();
+    return encodedCompletion;
   }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Wired extstore store + retrieve into the worker pipeline (workflow, activity, nexus boundaries) behind an internal `LoadedDataConverter.externalStorage` field, using the payload visitor

## Why?
Extstore pipeline integration sets us up for preview release.

## Checklist
Closes #2202