### PR TITLE
Fix schedule catchup window default

### DIFF
--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -437,7 +437,7 @@ export class ScheduleClient extends BaseClient {
           policies: {
             // 'overlap' should never be missing on describe, as the server will replace UNSPECIFIED by an actual value
             overlap: decodeScheduleOverlapPolicy(raw.schedule.policies?.overlapPolicy) ?? ScheduleOverlapPolicy.SKIP,
-            catchupWindow: optionalTsToMs(raw.schedule.policies?.catchupWindow) ?? 60_000,
+            catchupWindow: optionalTsToMs(raw.schedule.policies?.catchupWindow) ?? 365 * 24 * 60 * 60 * 1000,
             pauseOnFailure: raw.schedule.policies?.pauseOnFailure === true,
           },
           state: {

--- a/packages/client/src/schedule-types.ts
+++ b/packages/client/src/schedule-types.ts
@@ -45,11 +45,11 @@ export interface ScheduleOptions<A extends ScheduleOptionsAction = ScheduleOptio
     /**
      * The Temporal Server might be down or unavailable at the time when a Schedule should take an Action. When the Server
      * comes back up, `catchupWindow` controls which missed Actions should be taken at that point. The default is one
-     * minute, which means that the Schedule attempts to take any Actions that wouldn't be more than one minute late. It
+     * year, which means that the Schedule attempts to take any Actions that wouldn't be more than one year late. It
      * takes those Actions according to the {@link ScheduleOverlapPolicy}. An outage that lasts longer than the Catchup
      * Window could lead to missed Actions. (But you can always {@link ScheduleHandle.backfill}.)
      *
-     * @default 1 year
+     * When unset, this field is omitted so the Temporal Server applies its default (currently one year).
      * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
      */
     catchupWindow?: Duration;

--- a/packages/test/src/test-schedules.ts
+++ b/packages/test/src/test-schedules.ts
@@ -69,6 +69,7 @@ if (RUN_INTEGRATION_TESTS) {
       t.deepEqual(describedSchedule.spec.calendars, [
         { ...calendarSpecDescriptionDefaults, hour: [{ start: 2, end: 7, step: 1 }] },
       ]);
+      t.is(describedSchedule.policies.catchupWindow, 365 * 24 * 60 * 60 * 1000);
     } finally {
       await handle.delete();
     }


### PR DESCRIPTION
## What changed
- Correct catch-up-window documentation from one minute to one year.
- Correct the fallback used when decoding a server response without the field.
- Add server-backed describe coverage for the one-year default.

## Why
Requests already omitted an unspecified value, but the documentation and defensive response fallback still used the historical one-minute default.

## Breaking changes
None.