### PR TITLE
Propagate nexus.HandlerError from payload converter and codec in Nexus handler

### DIFF
--- a/packages/test/src/failing-handler-error-payload-converter.ts
+++ b/packages/test/src/failing-handler-error-payload-converter.ts
@@ -1,0 +1,15 @@
+import * as nexus from 'nexus-rpc';
+import type { Payload } from '@temporalio/common';
+import { defaultPayloadConverter } from '@temporalio/common';
+import type { PayloadConverter } from '@temporalio/common/lib/converter/payload-converter';
+
+export const payloadConverter: PayloadConverter = {
+  toPayload<T>(value: T): Payload {
+    return defaultPayloadConverter.toPayload(value);
+  },
+  fromPayload<T>(_payload: Payload): T {
+    throw new nexus.HandlerError('NOT_FOUND', 'Intentional payload converter HandlerError for testing', {
+      retryableOverride: false,
+    });
+  },
+};

--- a/packages/test/src/test-nexus-codec-converter-errors.ts
+++ b/packages/test/src/test-nexus-codec-converter-errors.ts
@@ -116,3 +116,104 @@ test('Nexus operation converter failure is not retried', async (t) => {
     t.regex(converterError.message, /Intentional payload converter failure for testing/);
   });
 });
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+test('Nexus operation codec HandlerError is propagated as-is', async (t) => {
+  const { createWorker, registerNexusEndpoint, taskQueue } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+
+  // Only fail when decoding the Nexus operation input ('hello'), so that the caller workflow's
+  // own activation payloads still decode successfully and the operation is actually reached.
+  const handlerErrorCodec: PayloadCodec = {
+    async encode(payloads: Payload[]): Promise<Payload[]> {
+      return payloads;
+    },
+    async decode(payloads: Payload[]): Promise<Payload[]> {
+      for (const payload of payloads) {
+        if (payload.data != null && Buffer.from(payload.data).toString() === '"hello"') {
+          throw new nexus.HandlerError('NOT_FOUND', 'Intentional codec HandlerError for testing', {
+            retryableOverride: false,
+          });
+        }
+      }
+      return payloads;
+    },
+  };
+
+  const worker = await createWorker({
+    dataConverter: { payloadCodecs: [handlerErrorCodec] },
+    nexusServices: [
+      nexus.serviceHandler(testService, {
+        async echoOp(_ctx, input) {
+          return input;
+        },
+      }),
+    ],
+  });
+
+  const customClient = new Client({
+    connection: t.context.env.connection,
+    dataConverter: { payloadCodecs: [handlerErrorCodec] },
+  });
+
+  await worker.runUntil(async () => {
+    const err = await t.throwsAsync(
+      () =>
+        customClient.workflow.execute(nexusEchoCaller, {
+          taskQueue,
+          workflowId: randomUUID(),
+          args: [endpointName],
+        }),
+      {
+        instanceOf: WorkflowFailedError,
+      }
+    );
+    t.true(err!.cause instanceof NexusOperationFailure);
+    const nexusFailure = err!.cause as NexusOperationFailure;
+    t.true(nexusFailure.cause instanceof nexus.HandlerError);
+    const handlerError = innermostHandlerError(nexusFailure.cause as nexus.HandlerError);
+    t.is(handlerError.type, 'NOT_FOUND');
+    t.false(handlerError.retryable);
+    t.regex(handlerError.message, /Intentional codec HandlerError for testing/);
+  });
+});
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+test('Nexus operation converter HandlerError is propagated as-is', async (t) => {
+  const { createWorker, registerNexusEndpoint, taskQueue } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+
+  const worker = await createWorker({
+    dataConverter: { payloadConverterPath: require.resolve('./failing-handler-error-payload-converter') },
+    nexusServices: [
+      nexus.serviceHandler(testService, {
+        async echoOp(_ctx, input) {
+          return input;
+        },
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const err = await t.throwsAsync(
+      () =>
+        t.context.env.client.workflow.execute(nexusEchoCaller, {
+          taskQueue,
+          workflowId: randomUUID(),
+          args: [endpointName],
+        }),
+      {
+        instanceOf: WorkflowFailedError,
+      }
+    );
+    t.true(err!.cause instanceof NexusOperationFailure);
+    const nexusFailure = err!.cause as NexusOperationFailure;
+    t.true(nexusFailure.cause instanceof nexus.HandlerError);
+    const handlerError = innermostHandlerError(nexusFailure.cause as nexus.HandlerError);
+    t.is(handlerError.type, 'NOT_FOUND');
+    t.false(handlerError.retryable);
+    t.regex(handlerError.message, /Intentional payload converter HandlerError for testing/);
+  });
+});

--- a/packages/worker/src/nexus/conversions.ts
+++ b/packages/worker/src/nexus/conversions.ts
@@ -18,7 +18,7 @@ export async function decodePayload(
   try {
     decoded = await decodeOptionalSingle(dataConverter.payloadCodecs, payload);
   } catch (err) {
-    if (err instanceof ApplicationFailure) {
+    if (err instanceof ApplicationFailure || err instanceof nexus.HandlerError) {
       throw err;
     }
     throw new nexus.HandlerError('INTERNAL', `Payload codec failed to decode Nexus operation input`, { cause: err });
@@ -31,7 +31,7 @@ export async function decodePayload(
   try {
     return dataConverter.payloadConverter.fromPayload(decoded);
   } catch (err) {
-    if (err instanceof ApplicationFailure) {
+    if (err instanceof ApplicationFailure || err instanceof nexus.HandlerError) {
       throw err;
     }
     throw new nexus.HandlerError('BAD_REQUEST', `Payload converter failed to decode Nexus operation input`, {


### PR DESCRIPTION
When the payload codec or converter fails while decoding a Nexus operation input, we already propagate ApplicationFailure as-is instead of wrapping it in a generic HandlerError. Do the same for nexus.HandlerError so that a codec or converter can surface a specific handler error type (e.g. NOT_FOUND) and control retryability directly.

This is consistent with the Python SDK and is more intuitive behavior: an error type the handler deliberately raised should reach the caller unchanged rather than being re-wrapped as INTERNAL/BAD_REQUEST.

Adds test coverage for both the codec and converter paths in test-nexus-codec-converter-errors.ts.
