### PR TITLE
extstore/replay and heartbeat metadata

### DIFF
--- a/contrib/langsmith/src/__tests__/test-comprehensive.ts
+++ b/contrib/langsmith/src/__tests__/test-comprehensive.ts
@@ -1,6 +1,12 @@
 /**
- * Line-for-line trace-tree E2E: drives one `ComprehensiveWorkflow` touching every
- * instrumented boundary and asserts the EXACT run hierarchy with `deepEqual`.
+ * Trace-tree E2E: drives one `ComprehensiveWorkflow` touching every instrumented boundary and
+ * asserts the EXACT run hierarchy (each run's full root-to-node parent chain).
+ *
+ * The hierarchy is compared as a multiset of root-to-node paths rather than a positional line
+ * dump. Some runs are emitted by workflows that execute concurrently (notably the receiver child's
+ * `RunWorkflow` span races the parent's `SignalChildWorkflow` marker), so the `createRun` arrival
+ * order of such siblings is non-deterministic. Their relative order carries no meaning; the parent
+ * chain of every run does, and that is what we assert.
  *
  * @module
  */
@@ -181,12 +187,29 @@ const EXPECTED_FALSE: string[] = [
   '    update_inner_call',
 ];
 
+/**
+ * Convert an indented (two-space-per-depth) trace dump into a sorted multiset of root-to-node
+ * paths, e.g. `'user_pipeline > RunWorkflow:X > HandleSignal:signal'`. Sorting drops sibling order
+ * (non-deterministic for concurrent runs) while preserving each node's full parent chain.
+ */
+function toPaths(lines: string[]): string[] {
+  const stack: string[] = [];
+  const paths: string[] = [];
+  for (const line of lines) {
+    const depth = (line.length - line.trimStart().length) / 2;
+    stack.length = depth;
+    stack.push(line.trim());
+    paths.push(stack.join(' > '));
+  }
+  return paths.sort();
+}
+
 test.serial('comprehensive trace tree: addTemporalRuns=true', async (t) => {
   const collector = await runComprehensive(true);
-  t.deepEqual(dumpTraces(collector.records).split('\n'), EXPECTED_TRUE);
+  t.deepEqual(toPaths(dumpTraces(collector.records).split('\n')), toPaths(EXPECTED_TRUE));
 });
 
 test.serial('comprehensive trace tree: addTemporalRuns=false', async (t) => {
   const collector = await runComprehensive(false);
-  t.deepEqual(dumpTraces(collector.records).split('\n'), EXPECTED_FALSE);
+  t.deepEqual(toPaths(dumpTraces(collector.records).split('\n')), toPaths(EXPECTED_FALSE));
 });

--- a/packages/core-bridge/src/worker.rs
+++ b/packages/core-bridge/src/worker.rs
@@ -499,7 +499,7 @@ impl MutableFinalize for HistoryForReplayTunnelHandle {}
 mod config {
     use std::collections::{HashMap, HashSet};
     use std::{sync::Arc, time::Duration};
-    use temporalio_common::protos::temporal::api::worker::v1::PluginInfo;
+    use temporalio_common::protos::temporal::api::worker::v1::{PluginInfo, StorageDriverInfo};
     use temporalio_common::worker::{
         VersioningBehavior as CoreVersioningBehavior,
         WorkerDeploymentOptions as CoreWorkerDeploymentOptions,
@@ -548,6 +548,7 @@ mod config {
         max_task_queue_activities_per_second: Option<f64>,
         shutdown_grace_time: Option<Duration>,
         plugins: Vec<String>,
+        storage_drivers: Vec<String>,
         workflow_failure_errors: HashSet<WorkflowErrorType>,
         workflow_types_to_failure_errors: HashMap<String, HashSet<WorkflowErrorType>>,
         disable_payload_error_limit: bool,
@@ -646,6 +647,12 @@ mod config {
                             name,
                             version: String::new(),
                         })
+                        .collect::<HashSet<_>>(),
+                )
+                .storage_drivers(
+                    self.storage_drivers
+                        .into_iter()
+                        .map(|r#type| StorageDriverInfo { r#type })
                         .collect::<HashSet<_>>(),
                 )
                 .workflow_failure_errors(into_core_workflow_error_set(self.workflow_failure_errors))

--- a/packages/core-bridge/ts/native.ts
+++ b/packages/core-bridge/ts/native.ts
@@ -264,6 +264,7 @@ export interface WorkerOptions {
   maxActivitiesPerSecond: Option<number>;
   shutdownGraceTime: number;
   plugins: string[];
+  storageDrivers: string[];
   workflowFailureErrors: WorkflowErrorType[];
   workflowTypesToFailureErrors: Record<string, WorkflowErrorType[]>;
   disablePayloadErrorLimit: boolean;

--- a/packages/test/src/test-bridge.ts
+++ b/packages/test/src/test-bridge.ts
@@ -318,6 +318,7 @@ const GenericConfigs = {
       maxActivitiesPerSecond: null,
       shutdownGraceTime: 1000,
       plugins: [],
+      storageDrivers: [],
       workflowFailureErrors: [],
       workflowTypesToFailureErrors: {},
       disablePayloadErrorLimit: false,

--- a/packages/test/src/test-extstore-worker-options.ts
+++ b/packages/test/src/test-extstore-worker-options.ts
@@ -1,0 +1,42 @@
+import test from 'ava';
+import { Runtime } from '@temporalio/worker';
+import { compileWorkerOptions, toNativeWorkerOptions } from '@temporalio/worker/lib/worker-options';
+import { ExternalStorage, type StorageDriver } from '@temporalio/common/lib/converter/extstore';
+import { defaultOptions } from './mock-native-worker';
+
+/** Minimal driver whose reported `type` is independent of its (unique) `name`. */
+function driver(name: string, type: string): StorageDriver {
+  return { name, type, store: async () => [], retrieve: async () => [] };
+}
+
+/** Distinct storage driver types the native worker config would report via the worker heartbeat. */
+function reportedDriverTypes(externalStorage?: ExternalStorage): string[] {
+  const runtime = Runtime.instance();
+  const compiled = compileWorkerOptions(defaultOptions, runtime.logger, runtime.metricMeter);
+  const native = toNativeWorkerOptions({
+    ...compiled,
+    buildId: 'test-build-id',
+    loadedDataConverter: { ...compiled.loadedDataConverter, externalStorage },
+  });
+  return native.storageDrivers;
+}
+
+test('reports no storage drivers when external storage is unset', (t) => {
+  t.deepEqual(reportedDriverTypes(undefined), []);
+});
+
+test('reports each configured driver type', (t) => {
+  const externalStorage = new ExternalStorage({
+    drivers: [driver('primary', 'aws.s3driver'), driver('backup', 'gcp.gcsdriver')],
+    driverSelector: () => null,
+  });
+  t.deepEqual(reportedDriverTypes(externalStorage).sort(), ['aws.s3driver', 'gcp.gcsdriver']);
+});
+
+test('dedups repeated driver types across distinct drivers', (t) => {
+  const externalStorage = new ExternalStorage({
+    drivers: [driver('east', 'aws.s3driver'), driver('west', 'aws.s3driver')],
+    driverSelector: () => null,
+  });
+  t.deepEqual(reportedDriverTypes(externalStorage), ['aws.s3driver']);
+});

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -1214,6 +1214,7 @@ export function toNativeWorkerOptions(opts: CompiledWorkerOptionsWithBuildId): n
     maxActivitiesPerSecond: opts.maxActivitiesPerSecond ?? null,
     shutdownGraceTime: msToNumber(opts.shutdownGraceTime),
     plugins: opts.plugins?.map((p) => p.name) ?? [],
+    storageDrivers: [...new Set((opts.loadedDataConverter.externalStorage?.drivers ?? []).map((d) => d.type))],
     workflowFailureErrors,
     workflowTypesToFailureErrors,
     disablePayloadErrorLimit: opts.disablePayloadErrorLimit ?? false,

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1493,7 +1493,8 @@ export class Worker {
       try {
         const unencodedCompletion = await workflow.workflow.activate(decodedActivation);
         const encodedCompletion = await workflowCodecRunner.encodeCompletion(unencodedCompletion);
-        if (externalStorage) {
+        // Skip extstore.store on replay: the completion is discarded and its payloads were already offloaded on the original run.
+        if (externalStorage && !this.isReplayWorker) {
           const namespace = workflowCodecRunner.workflowContext.namespace;
           await visit(
             encodedCompletion,


### PR DESCRIPTION

## What was changed
- enable safe worker replay (no extstore.store)
- add driver types to worker heartbeat

## Why?
- external storage release

## Checklist
