### PR TITLE
AI-338: drive langsmith workflow tracing from the SDK-provided AsyncLocalStorage

### DIFF
--- a/contrib/langsmith/README.md
+++ b/contrib/langsmith/README.md
@@ -171,23 +171,19 @@ below. Each row is exercised by the plugin's test suite.
 | Inside a **Workflow** body                       | ✅     | Replay-safe: deterministic IDs, emitted out-of-isolate, suppressed on replay. Works whether or not a parent trace is propagated in.                                |
 | Inside **signal / query / update** handlers      | ✅     | Handler-body `traceable` runs nest under the handler's run (workflow-body semantics). Temporal-internal queries (`__temporal*`, `__stack_trace`) are never traced. |
 
-**Concurrency caveat (workflow body only).** Inside a Workflow, parent
-resolution uses a synchronous context stack rather than `node:async_hooks`
-(which is unavailable in the workflow isolate). Sequential `await inner(...)`
-nesting is exact. Under `Promise.all(...)` fan-out, or for `traceable` calls
-made _after_ an `await` in the same scope, parenting falls back to the workflow
-run. This affects only the visual shape of the trace, never workflow history or
-control flow. Activity-body and client-side `traceable` use LangSmith's real
-async context and are unaffected.
+Inside a Workflow, parent resolution rides the SDK-provided `AsyncLocalStorage`
+the worker injects onto the workflow-sandbox global, so context propagates
+across `await` boundaries and `Promise.all(...)` fan-out exactly as it does
+outside the isolate — the same deterministic run tree replays identically.
 
 ## Process-wide effects to be aware of
 
 - **Workflow context provider.** Loading the plugin's workflow interceptor
   module installs a global LangSmith async-context provider inside the workflow
-  isolate (via `AsyncLocalStorageProviderSingleton.initializeGlobalInstance`).
-  This is what lets unchanged `traceable` calls find their parent inside a
-  Workflow. It is scoped to the workflow bundle and does not affect your
-  client/worker process context.
+  isolate (via `AsyncLocalStorageProviderSingleton.initializeGlobalInstance`),
+  backed by the SDK-provided `AsyncLocalStorage`. This is what lets unchanged
+  `traceable` calls find their parent inside a Workflow. It is scoped to the
+  workflow bundle and does not affect your client/worker process context.
 
 ## Composing with other plugins
 

--- a/contrib/langsmith/src/__tests__/test-replay-parenting.ts
+++ b/contrib/langsmith/src/__tests__/test-replay-parenting.ts
@@ -1,0 +1,95 @@
+/**
+ * Replay determinism of `traceable` parenting under the SDK-provided
+ * `AsyncLocalStorage`. Trace context inside the workflow isolate now rides the
+ * runtime-injected real ALS instead of a synchronous stack, so the risk is that
+ * async-context propagation resolves a different parent on replay. These cases
+ * exercise the three shapes most sensitive to that — nested `traceable`,
+ * `Promise.all` fan-out, and an async-generator (LangSmith's
+ * `AsyncLocalStorage.snapshot()` path) — and assert the emitted run hierarchy
+ * (parent links) is stable across replay.
+ *
+ * Determinism is proven two ways:
+ *  1. `maxCachedWorkflows: 0` evicts after every task, forcing the workflow body
+ *     to re-execute from history on each task. A divergent parent resolution on
+ *     replay would surface as a different tree or a duplicate `createRun`.
+ *  2. A true `Worker.runReplayHistory` pass must emit nothing (recorded history
+ *     re-emits no runs).
+ *
+ * @module
+ */
+
+import test from 'ava';
+import { Worker } from '@temporalio/worker';
+
+import { LangSmithPlugin } from '../index';
+import { InMemoryRunCollector, WORKFLOWS_PATH, dumpTraces, withTracingWorker } from './helpers';
+import {
+  ConcurrentTraceableWorkflow,
+  NestedTraceableWorkflow,
+  StreamingTraceableWorkflow,
+} from './workflows/langsmith';
+
+process.env.LANGSMITH_TRACING = 'true';
+// Keep langsmith callbacks synchronous so a stray/duplicate run fails fast.
+process.env.LANGCHAIN_CALLBACKS_BACKGROUND = 'false';
+
+/**
+ * Run `workflow` under forced eviction (every task after the first replays the
+ * body from history), then replay the recorded history. Asserts:
+ *  - the live tree matches `expectedTree`;
+ *  - every run was created exactly once (no duplicate from a divergent replay);
+ *  - a pure history replay re-emits nothing.
+ */
+async function assertParentingStable(
+  t: import('ava').ExecutionContext,
+  workflow: typeof NestedTraceableWorkflow | typeof ConcurrentTraceableWorkflow | typeof StreamingTraceableWorkflow,
+  workflowId: string,
+  expectedTree: string
+): Promise<void> {
+  const collector = new InMemoryRunCollector();
+  let rawCreate = 0;
+  const inner = collector.createRun;
+  collector.createRun = async (run: Record<string, unknown>): Promise<void> => {
+    rawCreate += 1;
+    return inner(run);
+  };
+
+  await withTracingWorker({
+    collector,
+    options: { addTemporalRuns: false },
+    activities: {},
+    // Evict after every task so each subsequent task replays the body from history.
+    workerOptions: { maxCachedWorkflows: 0 },
+    body: async ({ client, taskQueue }) => {
+      const handle = await client.workflow.start(workflow, {
+        taskQueue,
+        workflowId: `${workflowId}-${Date.now()}`,
+        args: ['x'],
+      });
+      await handle.result();
+      const history = await handle.fetchHistory();
+
+      t.is(dumpTraces(collector.records), expectedTree, 'live tree matches expected parenting');
+      t.is(rawCreate, collector.createOrder.length, 'each run created exactly once across evict-and-replay');
+
+      // Replay before teardown so the live Runtime singleton is reused (replaying after
+      // it shuts down races native finalization).
+      const replay = new InMemoryRunCollector();
+      const plugin = new LangSmithPlugin({ client: replay.asClient(), addTemporalRuns: false });
+      await Worker.runReplayHistory({ workflowsPath: WORKFLOWS_PATH, plugins: [plugin] }, history);
+      t.deepEqual(replay.records, [], 'pure history replay re-emits nothing');
+    },
+  });
+}
+
+test('nested traceable: child nests under its enclosing traceable, stable across replay', async (t) => {
+  await assertParentingStable(t, NestedTraceableWorkflow, 'nested', ['parent', '  leaf'].join('\n'));
+});
+
+test('Promise.all fan-out: each concurrent traceable parents under the workflow run, stable across replay', async (t) => {
+  await assertParentingStable(t, ConcurrentTraceableWorkflow, 'concurrent', ['fanout', 'fanout', 'fanout'].join('\n'));
+});
+
+test('async-generator traceable: streaming run parents deterministically, stable across replay', async (t) => {
+  await assertParentingStable(t, StreamingTraceableWorkflow, 'streaming', 'streaming');
+});

--- a/contrib/langsmith/src/__tests__/workflows/langsmith.ts
+++ b/contrib/langsmith/src/__tests__/workflows/langsmith.ts
@@ -14,6 +14,7 @@ import {
   defineUpdate,
   proxyActivities,
   setHandler,
+  sleep,
   startChild,
   uuid4,
   workflowInfo,
@@ -40,6 +41,63 @@ export async function SimpleWorkflow(input: string): Promise<string> {
 /** Calls native `traceable` directly in the workflow body. */
 export async function WorkflowBodyTraceableWorkflow(input: string): Promise<string> {
   return workflowInnerCall(input);
+}
+
+/** Leaf `traceable` invoked by {@link parentTraceable} (nested-parenting fixture). */
+const leafTraceable = traceable(async (input: string): Promise<string> => `leaf:${input}`, { name: 'leaf' });
+
+/**
+ * Awaits, THEN calls {@link leafTraceable} — so the child is created after the
+ * parent's synchronous frame has unwound. Real async context still resolves the
+ * parent; a synchronous context stack would have lost it and parented `leaf`
+ * under the workflow run instead.
+ */
+const parentTraceable = traceable(
+  async (input: string): Promise<string> => {
+    await sleep(1);
+    return leafTraceable(input);
+  },
+  { name: 'parent' }
+);
+
+/** A `traceable` awaiting another after an `await`: asserts nested-parenting via real async context. */
+export async function NestedTraceableWorkflow(input: string): Promise<string> {
+  return parentTraceable(input);
+}
+
+/** A `traceable` fanned out under {@link ConcurrentTraceableWorkflow}; awaits so branches interleave. */
+const fanoutTraceable = traceable(
+  async (input: string): Promise<string> => {
+    await sleep(1);
+    return `fan:${input}`;
+  },
+  { name: 'fanout' }
+);
+
+/** `Promise.all` fan-out of `traceable` calls: each concurrent branch parents under the workflow run. */
+export async function ConcurrentTraceableWorkflow(input: string): Promise<string[]> {
+  return Promise.all([fanoutTraceable(`${input}-a`), fanoutTraceable(`${input}-b`), fanoutTraceable(`${input}-c`)]);
+}
+
+/** An async-generator `traceable`: exercises LangSmith's `AsyncLocalStorage.snapshot()` streaming path. */
+const streamingTraceable = traceable(
+  async function* streaming(input: string): AsyncGenerator<string> {
+    await sleep(1);
+    yield `${input}-1`;
+    await sleep(1);
+    yield `${input}-2`;
+    yield `${input}-3`;
+  },
+  { name: 'streaming' }
+);
+
+/** Drives an async-generator `traceable` to completion; the run must parent under the workflow run. */
+export async function StreamingTraceableWorkflow(input: string): Promise<string[]> {
+  const chunks: string[] = [];
+  for await (const chunk of streamingTraceable(input)) {
+    chunks.push(chunk);
+  }
+  return chunks;
 }
 
 /** No `traceable` anywhere. */

--- a/contrib/langsmith/src/async-hooks-shim.ts
+++ b/contrib/langsmith/src/async-hooks-shim.ts
@@ -1,0 +1,16 @@
+/**
+ * Bundle-time stand-in for `node:async_hooks` inside the workflow isolate, where
+ * that builtin is unavailable. The plugin's bundler aliases `node:async_hooks`
+ * to this module (see {@link bundleRewritesPlugin} in `plugin.ts`) so LangSmith's
+ * `import { AsyncLocalStorage } from "node:async_hooks"` — including its
+ * `new AsyncLocalStorage()` and static `AsyncLocalStorage.snapshot()` — resolves
+ * to the real, async-context-tracking `AsyncLocalStorage` the SDK worker injects
+ * onto the workflow-sandbox global.
+ *
+ * @module
+ * @internal
+ */
+
+declare const globalThis: { AsyncLocalStorage: typeof import('node:async_hooks').AsyncLocalStorage };
+
+export const AsyncLocalStorage = globalThis.AsyncLocalStorage;

--- a/contrib/langsmith/src/plugin.ts
+++ b/contrib/langsmith/src/plugin.ts
@@ -91,8 +91,10 @@ export class LangSmithPlugin extends SimplePlugin {
   private readonly client: Client;
   private readonly emitter: EmitterConfig;
   private readonly workflowConfig: WorkflowLangSmithConfig;
-  // Absolute path so the workflow bundler resolves it under strict pnpm.
+  // Absolute paths so the workflow bundler resolves them under strict pnpm.
   private readonly workflowInterceptorModule = require.resolve('./workflow-interceptors');
+  // Target of the `node:async_hooks` rewrite; re-exports the runtime-injected ALS.
+  private readonly asyncHooksShimModule = require.resolve('./async-hooks-shim');
 
   constructor(options: LangSmithPluginOptions = {}) {
     // super() reads options.name immediately
@@ -172,7 +174,7 @@ export class LangSmithPlugin extends SimplePlugin {
       // Double-encode so the injected token is a string literal in the bundle.
       const definitions = { [CONFIG_GLOBAL]: JSON.stringify(JSON.stringify(this.workflowConfig)) };
       const plugins = [...(merged.plugins ?? [])];
-      plugins.push(bundleRewritesPlugin(this.workflowInterceptorModule, definitions) as (typeof plugins)[number]);
+      plugins.push(bundleRewritesPlugin(this.asyncHooksShimModule, definitions) as (typeof plugins)[number]);
       return { ...merged, plugins };
     };
     return { ...base, workflowInterceptorModules, ignoreModules, webpackConfigHook };
@@ -228,13 +230,15 @@ interface WebpackCompiler {
 /**
  * A webpack plugin that installs the three Workflow-bundle rewrites LangSmith needs:
  *
- *  - redirect `node:async_hooks` to the isolate-safe workflow-interceptor shim.
+ *  - redirect `node:async_hooks` to the shim module that re-exports the
+ *    runtime-injected `AsyncLocalStorage`, so LangSmith's `new AsyncLocalStorage()`
+ *    and `AsyncLocalStorage.snapshot()` resolve to the real SDK-provided ALS.
  *    webpack routes `node:` requests through a scheme handler before alias
  *    resolution, so `resolve.alias` can't do this; `NormalModuleReplacementPlugin`
  *    rewrites the request in `beforeResolve`. Paired with the `ignoreModules`
  *    whitelist (see {@link LangSmithPlugin.configureBundler}). The rewrite target
- *    is the resolved absolute module path so webpack dedupes to one isolate
- *    instance regardless of issuer.
+ *    is the resolved absolute module path so webpack dedupes to one instance
+ *    regardless of issuer.
  *  - redirect langsmith's node-only `utils/{fs,worker_threads}.cjs` to their
  *    `.browser.cjs` siblings so node builtins stay out of the isolate. Scoped to
  *    langsmith so a user's own `fs.cjs` is never rewritten.
@@ -246,14 +250,14 @@ interface WebpackCompiler {
  * installers (e.g. pnpm with `hoist=false`). Using the compiler's own webpack
  * also guarantees the exact instance running the bundle — never a second copy.
  */
-function bundleRewritesPlugin(workflowInterceptorModule: string, definitions: Record<string, string>): WebpackPlugin {
+function bundleRewritesPlugin(asyncHooksShimModule: string, definitions: Record<string, string>): WebpackPlugin {
   const swap = (s: string): string => s.replace(/\.cjs$/, '.browser.cjs');
   return {
     apply(compiler) {
       const { NormalModuleReplacementPlugin, DefinePlugin } = compiler.webpack;
 
       new NormalModuleReplacementPlugin(/^node:async_hooks$/, (resource) => {
-        resource.request = workflowInterceptorModule;
+        resource.request = asyncHooksShimModule;
       }).apply(compiler);
 
       new NormalModuleReplacementPlugin(/[/\\]utils[/\\](?:fs|worker_threads)\.cjs$/, (resource) => {

--- a/contrib/langsmith/src/workflow-interceptors.ts
+++ b/contrib/langsmith/src/workflow-interceptors.ts
@@ -1,12 +1,10 @@
 /**
- * Workflow-isolate interceptors and the deterministic LangSmith context
- * provider. Loaded into the workflow bundle (via the plugin's `workflowModules`)
- * and runs entirely inside the V8 isolate, where `node:async_hooks` is
- * unavailable so a synchronous stack-based context provider stands in for
- * LangSmith's async-context store.
- *
- * Internal: the worker loads this module by specifier and the bundler aliases
- * `node:async_hooks` to it — it is not a hand-import API.
+ * Workflow-isolate interceptors and the LangSmith context provider. Loaded into
+ * the workflow bundle (via the plugin's `workflowModules`) and runs entirely
+ * inside the V8 isolate. Trace context propagates through the real,
+ * async-context-tracking `AsyncLocalStorage` the SDK worker injects onto the
+ * workflow-sandbox global; the plugin and LangSmith's own load-time init
+ * converge on one shared store (see {@link sharedStore}).
  *
  * @module
  * @internal
@@ -94,101 +92,26 @@ function readConfig(): WorkflowLangSmithConfig {
   return { addTemporalRuns: false };
 }
 
-/**
- * Synchronous, isolate-safe replacement for LangSmith's async-context store,
- * shared by the installed provider, the {@link AsyncLocalStorage} shim, and
- * every interceptor so they all read and write one store. `workflowAmbient`
- * persists across `await` boundaries; `stack` tracks synchronous `traceable`
- * nesting. Under `Promise.all` fan-out parenting falls back to the ambient —
- * trace-shape-only non-determinism, never workflow history.
- */
-class WorkflowContextManager {
-  private workflowAmbient: RunTree | undefined;
-  private readonly stack: (RunTree | undefined)[] = [];
-
-  getStore(): RunTree | undefined {
-    return this.stack.length > 0 ? this.stack[this.stack.length - 1] : this.workflowAmbient;
-  }
-
-  /**
-   * Push `context`, run `fn`, pop in `finally`, and return `fn`'s result — the
-   * `AsyncLocalStorage.run` contract langsmith relies on.
-   */
-  run<T>(context: RunTree | undefined, fn: () => T): T {
-    this.stack.push(context);
-    try {
-      return fn();
-    } finally {
-      this.stack.pop();
-    }
-  }
-
-  /** The ambient run an outbound interceptor should propagate / parent under. */
-  ambient(): RunTree | undefined {
-    return this.getStore();
-  }
-
-  /** Run an async scope with a dedicated ambient (workflow execute / handler). */
-  async withAmbient<T>(run: RunTree | undefined, fn: () => Promise<T>): Promise<T> {
-    const prev = this.workflowAmbient;
-    this.workflowAmbient = run;
-    try {
-      return await fn();
-    } finally {
-      this.workflowAmbient = prev;
-    }
-  }
+/** The `getStore`/`run` slice of `AsyncLocalStorage` the interceptors and LangSmith share. */
+interface RunTreeStore {
+  getStore(): RunTree | undefined;
+  run<T>(store: RunTree | undefined, fn: () => T): T;
 }
 
-let providerInstalled = false;
-function ensureProviderInstalled(manager: WorkflowContextManager): void {
-  if (providerInstalled) {
-    return;
-  }
-  providerInstalled = true;
-  // LangSmith's `AsyncLocalStorageInterface` requires exactly two members,
-  // `getStore` and `run` (it never calls `enterWith`), so we provide only those.
-  // The cast bridges the generic `run<T>` signature to the interface's
-  // `run: (ctx, () => void) => void`.
-  AsyncLocalStorageProviderSingleton.initializeGlobalInstance({
-    getStore: () => manager.getStore(),
-    run: <T>(context: RunTree | undefined, fn: () => T): T => manager.run(context as RunTree | undefined, fn),
-  } as Parameters<typeof AsyncLocalStorageProviderSingleton.initializeGlobalInstance>[0]);
-}
-
-const sharedManager = new WorkflowContextManager();
-ensureProviderInstalled(sharedManager);
-
-/**
- * Isolate-safe stand-in for Node's `AsyncLocalStorage`. The plugin's bundler
- * aliases `node:async_hooks` (absent in the isolate) to this module so
- * LangSmith's `import { AsyncLocalStorage } from "node:async_hooks"` resolves
- * here. Every instance delegates to {@link sharedManager}.
- *
- * @internal
- */
-export class AsyncLocalStorage<T = unknown> {
-  getStore(): T | undefined {
-    return sharedManager.getStore() as unknown as T | undefined;
-  }
-
-  run<R>(store: T, fn: (...args: never[]) => R): R {
-    return sharedManager.run(store as unknown as RunTree | undefined, fn as () => R);
-  }
-
-  enterWith(_store: T): void {
-    /* no-op: parenting inside the isolate is stack-scoped via run() */
-  }
-
-  /**
-   * Best-effort equivalent of `AsyncLocalStorage.snapshot()` (used only by
-   * LangSmith's async-generator streaming paths). Runs the callback in the
-   * current synchronous scope; the isolate has no async context to capture.
-   */
-  static snapshot(): (fn: (...args: unknown[]) => unknown, ...args: unknown[]) => unknown {
-    return (fn, ...args) => fn(...args);
-  }
-}
+// The SDK worker injects a real, async-context-tracking `AsyncLocalStorage` onto
+// the workflow-sandbox global before the bundle evaluates. Bundler aliases (see
+// plugin.ts) also route LangSmith's `new AsyncLocalStorage()` there, so both the
+// plugin and LangSmith's load-time `initializeGlobalInstance` compete for one
+// global slot (first writer wins). Install our instance, then read back whichever
+// won so interceptors and `traceable` read/write the same store regardless of
+// load order.
+declare const globalThis: { AsyncLocalStorage: new () => RunTreeStore };
+AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
+  new globalThis.AsyncLocalStorage() as Parameters<
+    typeof AsyncLocalStorageProviderSingleton.initializeGlobalInstance
+  >[0]
+);
+const sharedStore = AsyncLocalStorageProviderSingleton.getInstance() as RunTreeStore;
 
 /** Reconstruct the propagated parent run from a Payload-keyed header map. */
 function reconstructParent(headers: Record<string, unknown> | undefined): RunTree | undefined {
@@ -269,10 +192,7 @@ function buildReplaySafeRunTree(
 }
 
 class LangSmithWorkflowInbound implements WorkflowInboundCallsInterceptor {
-  constructor(
-    private readonly ctx: WorkflowContextManager,
-    private readonly config: WorkflowLangSmithConfig
-  ) {}
+  constructor(private readonly config: WorkflowLangSmithConfig) {}
 
   async execute(input: WorkflowExecuteInput, next: Next<WorkflowInboundCallsInterceptor, 'execute'>): Promise<unknown> {
     const parent = reconstructParent(input.headers);
@@ -287,13 +207,8 @@ class LangSmithWorkflowInbound implements WorkflowInboundCallsInterceptor {
 
   async handleSignal(input: SignalInput, next: Next<WorkflowInboundCallsInterceptor, 'handleSignal'>): Promise<void> {
     const parent = reconstructParent(input.headers);
-    await this.runInbound(
-      handleSignalRunName(input.signalName),
-      RUN_TYPE.CHAIN,
-      parent,
-      { args: input.args },
-      () => next(input),
-      true
+    await this.runInbound(handleSignalRunName(input.signalName), RUN_TYPE.CHAIN, parent, { args: input.args }, () =>
+      next(input)
     );
   }
 
@@ -308,7 +223,6 @@ class LangSmithWorkflowInbound implements WorkflowInboundCallsInterceptor {
       parent,
       { args: input.args },
       () => next(input),
-      true,
       // Read-only: mint run ids from the nondeterministic unsafe random source so the
       // handler never draws from the Workflow main PRNG (which a clean replay would not advance).
       workflowInfo().unsafe.random.uuid4
@@ -320,13 +234,8 @@ class LangSmithWorkflowInbound implements WorkflowInboundCallsInterceptor {
     next: Next<WorkflowInboundCallsInterceptor, 'handleUpdate'>
   ): Promise<unknown> {
     const parent = reconstructParent(input.headers);
-    return this.runInbound(
-      handleUpdateRunName(input.name),
-      RUN_TYPE.CHAIN,
-      parent,
-      { args: input.args },
-      () => next(input),
-      true
+    return this.runInbound(handleUpdateRunName(input.name), RUN_TYPE.CHAIN, parent, { args: input.args }, () =>
+      next(input)
     );
   }
 
@@ -338,11 +247,10 @@ class LangSmithWorkflowInbound implements WorkflowInboundCallsInterceptor {
       // Propagation only: install the reconstructed parent (or a placeholder parent
       // when none was propagated, to keep a validator-body `traceable` off the
       // no-parent `crypto` path) so the validator body nests under the update's
-      // trace. Validators are synchronous, so install via the stack-based `run`,
-      // not the async `withAmbient`.
+      // trace.
       const ambient =
         asReplaySafeParent(reconstructParent(input.headers), generateNewUuid4) ?? placeholderRoot(generateNewUuid4);
-      this.ctx.run(ambient, () => next(input));
+      sharedStore.run(ambient, () => next(input));
       return;
     }
     const run = buildReplaySafeRunTree(this.config, {
@@ -353,11 +261,11 @@ class LangSmithWorkflowInbound implements WorkflowInboundCallsInterceptor {
       generateNewUuid4,
     });
     // Validators are synchronous and must not be made async; emit start/end
-    // around the synchronous call, with the run installed on the stack so a
-    // `traceable` in the validator body nests under it.
+    // around the synchronous call, with the run installed as the active store so
+    // a `traceable` in the validator body nests under it.
     void run.postRun();
     try {
-      this.ctx.run(run, () => next(input));
+      sharedStore.run(run, () => next(input));
       void run.end({});
     } catch (err) {
       void run.end(undefined, describeError(err));
@@ -368,12 +276,10 @@ class LangSmithWorkflowInbound implements WorkflowInboundCallsInterceptor {
   }
 
   /**
-   * Open the inbound run, install it as the active run for `next`, and close it.
-   *
-   * `scoped` handlers install the run on the synchronous stack so a handler running
-   * concurrently with the workflow body cannot leak its run into the body's ambient;
-   * `execute` (scoped: false) installs a persistent ambient that survives the body's
-   * awaits.
+   * Open the inbound run, install it as the active run for the whole `next`
+   * async scope, and close it. The real ALS scopes the run to this branch, so a
+   * handler running concurrently with the workflow body never leaks its run into
+   * the body's context.
    */
   private async runInbound(
     name: string,
@@ -381,7 +287,6 @@ class LangSmithWorkflowInbound implements WorkflowInboundCallsInterceptor {
     parent: RunTree | undefined,
     inputs: Record<string, unknown>,
     next: () => Promise<unknown>,
-    scoped = false,
     generateNewUuid4?: () => string
   ): Promise<unknown> {
     if (!this.config.addTemporalRuns) {
@@ -392,7 +297,7 @@ class LangSmithWorkflowInbound implements WorkflowInboundCallsInterceptor {
       // `createChild` branch (deterministic id) rather than the no-parent branch
       // that mints a uuid via `crypto`, which the isolate lacks.
       const ambient = asReplaySafeParent(parent, generateNewUuid4) ?? placeholderRoot(generateNewUuid4);
-      return scoped ? this.ctx.run(ambient, next) : this.ctx.withAmbient(ambient, next);
+      return sharedStore.run(ambient, next);
     }
     const run = buildReplaySafeRunTree(this.config, {
       name,
@@ -414,15 +319,12 @@ class LangSmithWorkflowInbound implements WorkflowInboundCallsInterceptor {
         throw err;
       }
     };
-    return scoped ? this.ctx.run(run, body) : this.ctx.withAmbient(run, body);
+    return sharedStore.run(run, body);
   }
 }
 
 class LangSmithWorkflowOutbound implements WorkflowOutboundCallsInterceptor {
-  constructor(
-    private readonly ctx: WorkflowContextManager,
-    private readonly config: WorkflowLangSmithConfig
-  ) {}
+  constructor(private readonly config: WorkflowLangSmithConfig) {}
 
   async scheduleActivity(
     input: ActivityInput,
@@ -457,7 +359,7 @@ class LangSmithWorkflowOutbound implements WorkflowOutboundCallsInterceptor {
   ): Promise<never> {
     // Don't propagate a placeholder root: it is never emitted, so the successor's
     // runs would dangle under a nonexistent parent. Let it install its own.
-    const ambient = this.ctx.ambient();
+    const ambient = sharedStore.getStore();
     const context = ambient instanceof _RootReplaySafeRunTreeFactory ? undefined : runHeaders(ambient);
     const headers = withContextHeader(input.headers, context);
     return next({ ...input, headers });
@@ -478,7 +380,7 @@ class LangSmithWorkflowOutbound implements WorkflowOutboundCallsInterceptor {
     input: StartNexusOperationInput,
     next: Next<WorkflowOutboundCallsInterceptor, 'startNexusOperation'>
   ): Promise<StartNexusOperationOutput> {
-    const ambient = this.ctx.ambient();
+    const ambient = sharedStore.getStore();
     if (this.config.addTemporalRuns && ambient instanceof ReplaySafeRunTree) {
       await emitMarker(ambient, startNexusOperationRunName(input.service, input.operation), {});
     }
@@ -493,7 +395,7 @@ class LangSmithWorkflowOutbound implements WorkflowOutboundCallsInterceptor {
     input: { headers: Headers; args?: unknown[] },
     next: (headers: Headers) => Promise<R>
   ): Promise<R> {
-    const ambient = this.ctx.ambient();
+    const ambient = sharedStore.getStore();
     if (this.config.addTemporalRuns && ambient instanceof ReplaySafeRunTree) {
       await emitMarker(ambient, name, { args: input.args ?? [] });
     }
@@ -507,7 +409,7 @@ class LangSmithWorkflowOutbound implements WorkflowOutboundCallsInterceptor {
     input: { headers: Headers; args?: unknown[] },
     next: (headers: Headers) => Promise<R>
   ): Promise<R> {
-    const ambient = this.ctx.ambient();
+    const ambient = sharedStore.getStore();
     let propagate: RunTree | undefined = ambient;
     if (this.config.addTemporalRuns && ambient instanceof ReplaySafeRunTree) {
       propagate = await emitMarker(ambient, name, { args: input.args ?? [] });
@@ -526,7 +428,7 @@ class LangSmithWorkflowOutbound implements WorkflowOutboundCallsInterceptor {
 export function interceptors(): WorkflowInterceptors {
   const config = readConfig();
   return {
-    inbound: [new LangSmithWorkflowInbound(sharedManager, config)],
-    outbound: [new LangSmithWorkflowOutbound(sharedManager, config)],
+    inbound: [new LangSmithWorkflowInbound(config)],
+    outbound: [new LangSmithWorkflowOutbound(config)],
   };
 }


### PR DESCRIPTION
Replaces the hand-rolled synchronous context provider in the LangSmith workflow interceptor with the AsyncLocalStorage the worker injects onto the workflow-sandbox global, so trace context propagates across awaits and Promise.all fan-out and stays deterministic under replay. The node:async_hooks bundle rewrite now targets a small shim that re-exports that global.