### PR TITLE
fix: stale artifact causing build failure

### DIFF
--- a/packages/common/src/__tests__/test-payload-visitor.ts
+++ b/packages/common/src/__tests__/test-payload-visitor.ts
@@ -100,7 +100,7 @@ test('a transform still waiting on the concurrency limit is skipped once a sibli
   };
 
   const error = await t.throwsAsync(
-    visitWorkflowActivation(activation, {
+    visit(activation, walkWorkflowActivation, {
       transformPayload: async (p) => {
         const tag = read(p);
         started.push(tag);


### PR DESCRIPTION
## What was changed
Stale artifact causing build failure from weird merge: 

## Why?
https://github.com/temporalio/sdk-typescript/pull/2218 using `visitWorkflowActivation` instead of `visit`, causing build failure.

2. How was this tested:
Existing CI

3. Any docs updates needed?
No
