### PR TITLE
tests: lowered timeout for otel test awaits and default timeout for assertEventually.

### DIFF
--- a/packages/test-helpers/src/utilities.ts
+++ b/packages/test-helpers/src/utilities.ts
@@ -22,7 +22,7 @@ export async function sleep(ms: number): Promise<void> {
 export async function assertEventually<Context = unknown>(
   t: ExecutionContext<Context>,
   assertion: (t: ExecutionContext<Context>) => void | Promise<void>,
-  timeoutMs = 10000,
+  timeoutMs = 3000,
   intervalMs = 100
 ): Promise<void> {
   const endTime = Date.now() + timeoutMs;

--- a/packages/test/src/test-runtime-otel.ts
+++ b/packages/test/src/test-runtime-otel.ts
@@ -139,7 +139,7 @@ test.serial('Exporting OTEL metrics from Core works', async (t) => {
           });
           const req = await Promise.race([
             capturedRequest,
-            new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 10000)),
+            new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 5000)),
           ]);
           t.truthy(req);
           t.is(req?.url, '/opentelemetry.proto.collector.metrics.v1.MetricsService/Export');
@@ -192,7 +192,7 @@ test.serial('Exporting OTEL metrics using OTLP/HTTP from Core works', async (t) 
           });
           const req = await Promise.race([
             capturedRequest,
-            new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 10000)),
+            new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 5000)),
           ]);
           t.truthy(req);
           t.is(req?.url, '/v1/metrics');


### PR DESCRIPTION

<!--- For ALL Contributors 👇 -->

## What was changed
- Adjust otel test await timeouts to `5s`
- Reduce default timeout of `assertEventually` from `10s` to `3s`

## Why?
- avoid issues where ava would hang test runner
