### PR TITLE
Remove experimental markers from user metadata fields

### DIFF
--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -82,16 +82,12 @@ export type WorkflowExecutionDescription = Replace<
   /**
    * General fixed details for this workflow execution that may appear in UI/CLI.
    * This can be in Temporal markdown format and can span multiple lines.
-   *
-   * @experimental User metadata is a new API and susceptible to change.
    */
   staticDetails: () => Promise<string | undefined>;
 
   /**
    * A single-line fixed summary for this workflow execution that may appear in the UI/CLI.
    * This can be in single-line Temporal markdown format.
-   *
-   * @experimental User metadata is a new API and susceptible to change.
    */
   staticSummary: () => Promise<string | undefined>;
 };

--- a/packages/common/src/activity-options.ts
+++ b/packages/common/src/activity-options.ts
@@ -183,8 +183,6 @@ export interface ActivityOptions {
   /**
    * A fixed, single-line summary for this workflow execution that may appear in the UI/CLI.
    * This can be in single-line Temporal markdown format.
-   *
-   * @experimental User metadata is a new API and susceptible to change.
    */
   summary?: string;
 
@@ -267,8 +265,6 @@ export interface LocalActivityOptions {
   /**
    * A fixed, single-line summary for this workflow execution that may appear in the UI/CLI.
    * This can be in single-line Temporal markdown format.
-   *
-   * @experimental User metadata is a new API and susceptible to change.
    */
   summary?: string;
 }

--- a/packages/common/src/user-metadata.ts
+++ b/packages/common/src/user-metadata.ts
@@ -7,9 +7,9 @@ import type { SerializationContext } from './converter/serialization-context';
  * User metadata that can be attached to workflow commands.
  */
 export interface UserMetadata {
-  /** @experimental A fixed, single line summary of the command's purpose */
+  /** A fixed, single line summary of the command's purpose */
   staticSummary?: string;
-  /** @experimental Fixed additional details about the command for longer-text description, can span multiple lines */
+  /** Fixed additional details about the command for longer-text description, can span multiple lines */
   staticDetails?: string;
 }
 

--- a/packages/common/src/workflow-options.ts
+++ b/packages/common/src/workflow-options.ts
@@ -196,15 +196,11 @@ export interface BaseWorkflowOptions {
   /**
    * General fixed details for this workflow execution that may appear in UI/CLI.
    * This can be in Temporal markdown format and can span multiple lines.
-   *
-   * @experimental User metadata is a new API and susceptible to change.
    */
   staticDetails?: string;
   /**
    * A single-line fixed summary for this workflow execution that may appear in the UI/CLI.
    * This can be in single-line Temporal markdown format.
-   *
-   * @experimental User metadata is a new API and susceptible to change.
    */
   staticSummary?: string;
 

--- a/packages/workflow/src/interceptors.ts
+++ b/packages/workflow/src/interceptors.ts
@@ -230,8 +230,6 @@ export interface TimerInput {
 export interface TimerOptions {
   /**
    * A fixed, single line summary of the command's purpose
-   *
-   * @experimental User metadata is a new API and susceptible to change.
    */
   readonly summary?: string;
 }
@@ -323,8 +321,6 @@ export interface StartNexusOperationOptions {
   /**
    * A fixed, single-line summary for this Nexus Operation that may appear in the UI/CLI.
    * This can be in single-line Temporal markdown format.
-   *
-   * @experimental User metadata is a new API and susceptible to change.
    */
   readonly summary?: string;
 }


### PR DESCRIPTION
## Summary
- Remove `@experimental User metadata is a new API and susceptible to change.` from user metadata fields: staticSummary, staticDetails, activity summary, timer summary
- These features are stable and shipping across all SDKs - graduating to GA API surface
- 5 files changed, 10 @experimental tags removed

## Test plan
- [ ] Verify no compilation errors
- [ ] Confirm other @experimental tags on non-user-metadata features are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)