### PR TITLE
chore(external-storage): mark driver packages as publishable

### DIFF
--- a/contrib/external-storage-gcs-google-sdk/package.json
+++ b/contrib/external-storage-gcs-google-sdk/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@temporalio/external-storage-gcs-google-sdk",
   "version": "1.20.0",
-  "private": true,
   "description": "@google-cloud/storage client for the Temporal GCS external storage driver",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",

--- a/contrib/external-storage-gcs/package.json
+++ b/contrib/external-storage-gcs/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@temporalio/external-storage-gcs",
   "version": "1.20.0",
-  "private": true,
   "description": "Google Cloud Storage external storage driver for the Temporal TypeScript SDK",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",

--- a/contrib/external-storage-s3-aws-sdk/package.json
+++ b/contrib/external-storage-s3-aws-sdk/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@temporalio/external-storage-s3-aws-sdk",
   "version": "1.20.0",
-  "private": true,
   "description": "AWS SDK (@aws-sdk/client-s3) client for the Temporal S3 external storage driver",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",

--- a/contrib/external-storage-s3/package.json
+++ b/contrib/external-storage-s3/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@temporalio/external-storage-s3",
   "version": "1.20.0",
-  "private": true,
   "description": "Amazon S3 external storage driver for the Temporal TypeScript SDK",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Mark S3 and GCS driver packages as publishable.

## Why?

Start publishing these packages in next release.