### PR TITLE
Add changelog entry for user metadata + changelog CI gate

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,33 @@
+name: Changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changelog-check:
+    name: Changelog checkpoint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a CHANGELOG.md update or override label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$LABELS" | grep -q '"skip-changelog"'; then
+            echo "Found 'skip-changelog' label; no CHANGELOG.md entry required."
+            exit 0
+          fi
+          if gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' \
+            | grep -Eq '(^|/)CHANGELOG\.md$'; then
+            echo "A CHANGELOG.md was updated."
+            exit 0
+          fi
+          echo "::error::This PR does not update a CHANGELOG.md. If it includes a user-facing change, add an entry under [Unreleased] in CHANGELOG.md. If no changelog entry is needed, a maintainer can apply the 'skip-changelog' label."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ to docs, or any other relevant information.
   alters the size of payloads (e.g. compression, encryption, external storage), it is advised that
   you disable size enforcement by setting `disablePayloadErrorLimit: true` on the worker.
 
+### Changed
+
+- User metadata fields (staticSummary, staticDetails, currentDetails, activity summary, timer
+  summary) are no longer marked as experimental.
+
 ## [1.20.3] - 2026-07-13
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Add missing changelog entry for user metadata experimental marker removal (merged in #2226)
- Add a `changelog.yml` CI workflow that requires either a CHANGELOG.md update or a `skip-changelog` label on PRs, matching the pattern used by sdk-go

## Test plan
- [ ] Verify the changelog CI check passes on this PR (it touches CHANGELOG.md)
- [ ] Verify future PRs without CHANGELOG.md changes get flagged unless `skip-changelog` label is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)