### PR TITLE
feat(extstore): add extstore to client pipelines. add integration tests.

### DIFF
--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -267,7 +267,18 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       const req = await this.buildStartActivityExecutionRequest(input);
       const externalStorage = this.dataConverter.externalStorage;
       if (externalStorage) {
-        await visit(req, walkStartActivityExecutionRequest, extstoreStoreOptions(externalStorage));
+        await visit(
+          req,
+          walkStartActivityExecutionRequest,
+          extstoreStoreOptions(externalStorage, {
+            initialTarget: {
+              kind: 'activity',
+              namespace: this.options.namespace,
+              id: input.options.id,
+              type: input.activityType,
+            },
+          })
+        );
       }
       const resp = await this.workflowService.startActivityExecution(req);
       return this.createHandle(input.options.id, resp.runId);

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -30,6 +30,13 @@ import {
   decodeOptionalFailureToOptionalError,
   encodeToPayloads,
   encodeUserMetadata,
+  extstoreRetrieveOptions,
+  extstoreStoreOptions,
+  visit,
+  walkDescribeActivityExecutionResponse,
+  walkListActivityExecutionsResponse,
+  walkPollActivityExecutionResponse,
+  walkStartActivityExecutionRequest,
 } from '@temporalio/common/lib/internal-non-workflow';
 import { temporal } from '@temporalio/proto';
 import type { Replace } from '@temporalio/common/lib/type-helpers';
@@ -257,9 +264,12 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
     validateActivityOptions(input.options);
 
     try {
-      const resp = await this.workflowService.startActivityExecution(
-        await this.buildStartActivityExecutionRequest(input)
-      );
+      const req = await this.buildStartActivityExecutionRequest(input);
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(req, walkStartActivityExecutionRequest, extstoreStoreOptions(externalStorage));
+      }
+      const resp = await this.workflowService.startActivityExecution(req);
       return this.createHandle(input.options.id, resp.runId);
     } catch (err) {
       if (isGrpcServiceError(err) && err.code === grpcStatus.ALREADY_EXISTS) {
@@ -328,6 +338,10 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
 
       try {
         const resp = await this.workflowService.pollActivityExecution(req);
+        const externalStorage = this.dataConverter.externalStorage;
+        if (externalStorage) {
+          await visit(resp, walkPollActivityExecutionResponse, extstoreRetrieveOptions(externalStorage));
+        }
         if (resp.outcome?.result) {
           const [result] = await decodeArrayFromPayloads(this.dataConverter, resp.outcome.result.payloads ?? []);
           return result;
@@ -362,6 +376,10 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
         activityId: input.activityId,
         runId: input.activityRunId || undefined,
       });
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(resp, walkDescribeActivityExecutionResponse, extstoreRetrieveOptions(externalStorage));
+      }
       return buildActivityDescription(resp.info!, this.dataConverter);
     } catch (err) {
       this.rethrowGrpcError(err, 'Failed to describe activity');
@@ -416,6 +434,11 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
             query: input.query,
             nextPageToken,
           });
+
+        const externalStorage = this.dataConverter.externalStorage;
+        if (externalStorage) {
+          await visit(resp, walkListActivityExecutionsResponse, extstoreRetrieveOptions(externalStorage));
+        }
 
         for (const info of resp.executions ?? []) {
           yield buildActivityExecutionInfo(info);

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -488,7 +488,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       }
       throw new ServiceError(fallbackMessage, { cause: err });
     }
-    throw new ServiceError('Unexpected error while making gRPC request');
+    throw err;
   }
 }
 

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -488,7 +488,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       }
       throw new ServiceError(fallbackMessage, { cause: err });
     }
-    throw err;
+    throw new ServiceError('Unexpected error while making gRPC request');
   }
 }
 

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -1,5 +1,5 @@
 import { status as grpcStatus } from '@grpc/grpc-js';
-import type { ActivitySerializationContext } from '@temporalio/common';
+import type { ActivitySerializationContext, StorageDriverActivityInfo } from '@temporalio/common';
 import { ensureTemporalFailure } from '@temporalio/common';
 import {
   encodeErrorToFailure,
@@ -135,6 +135,17 @@ export class AsyncCompletionClient extends BaseClient {
   }
 
   /**
+   * Storage target for offloaded payloads. By-ID operations carry the Activity ID; by-token operations
+   * only know the namespace (the token is opaque), so the target is namespace-scoped and the driver falls
+   * back to content-addressed naming.
+   */
+  protected storageTargetFor(taskTokenOrFullActivityId: Uint8Array | FullActivityId): StorageDriverActivityInfo {
+    return taskTokenOrFullActivityId instanceof Uint8Array
+      ? { kind: 'activity', namespace: this.options.namespace }
+      : { kind: 'activity', namespace: this.options.namespace, id: taskTokenOrFullActivityId.activityId };
+  }
+
+  /**
    * Transforms grpc errors into well defined TS errors.
    */
   protected handleError(err: unknown): never {
@@ -170,6 +181,7 @@ export class AsyncCompletionClient extends BaseClient {
       [result]
     );
     const externalStorage = this.dataConverter.externalStorage;
+    const target = this.storageTargetFor(taskTokenOrFullActivityId);
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
         const req: temporal.api.workflowservice.v1.IRespondActivityTaskCompletedRequest = {
@@ -179,7 +191,11 @@ export class AsyncCompletionClient extends BaseClient {
           result: { payloads },
         };
         if (externalStorage) {
-          await visit(req, walkRespondActivityTaskCompletedRequest, extstoreStoreOptions(externalStorage));
+          await visit(
+            req,
+            walkRespondActivityTaskCompletedRequest,
+            extstoreStoreOptions(externalStorage, { initialTarget: target })
+          );
         }
         await this.workflowService.respondActivityTaskCompleted(req);
       } else {
@@ -190,7 +206,11 @@ export class AsyncCompletionClient extends BaseClient {
           result: { payloads },
         };
         if (externalStorage) {
-          await visit(req, walkRespondActivityTaskCompletedByIdRequest, extstoreStoreOptions(externalStorage));
+          await visit(
+            req,
+            walkRespondActivityTaskCompletedByIdRequest,
+            extstoreStoreOptions(externalStorage, { initialTarget: target })
+          );
         }
         await this.workflowService.respondActivityTaskCompletedById(req);
       }
@@ -219,6 +239,7 @@ export class AsyncCompletionClient extends BaseClient {
       this.serializationContextFor(taskTokenOrFullActivityId, options)
     );
     const externalStorage = this.dataConverter.externalStorage;
+    const target = this.storageTargetFor(taskTokenOrFullActivityId);
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
         const req: temporal.api.workflowservice.v1.IRespondActivityTaskFailedRequest = {
@@ -228,7 +249,11 @@ export class AsyncCompletionClient extends BaseClient {
           failure,
         };
         if (externalStorage) {
-          await visit(req, walkRespondActivityTaskFailedRequest, extstoreStoreOptions(externalStorage));
+          await visit(
+            req,
+            walkRespondActivityTaskFailedRequest,
+            extstoreStoreOptions(externalStorage, { initialTarget: target })
+          );
         }
         await this.workflowService.respondActivityTaskFailed(req);
       } else {
@@ -239,7 +264,11 @@ export class AsyncCompletionClient extends BaseClient {
           failure,
         };
         if (externalStorage) {
-          await visit(req, walkRespondActivityTaskFailedByIdRequest, extstoreStoreOptions(externalStorage));
+          await visit(
+            req,
+            walkRespondActivityTaskFailedByIdRequest,
+            extstoreStoreOptions(externalStorage, { initialTarget: target })
+          );
         }
         await this.workflowService.respondActivityTaskFailedById(req);
       }
@@ -272,6 +301,7 @@ export class AsyncCompletionClient extends BaseClient {
       [details]
     );
     const externalStorage = this.dataConverter.externalStorage;
+    const target = this.storageTargetFor(taskTokenOrFullActivityId);
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
         const req: temporal.api.workflowservice.v1.IRespondActivityTaskCanceledRequest = {
@@ -281,7 +311,11 @@ export class AsyncCompletionClient extends BaseClient {
           details: { payloads },
         };
         if (externalStorage) {
-          await visit(req, walkRespondActivityTaskCanceledRequest, extstoreStoreOptions(externalStorage));
+          await visit(
+            req,
+            walkRespondActivityTaskCanceledRequest,
+            extstoreStoreOptions(externalStorage, { initialTarget: target })
+          );
         }
         await this.workflowService.respondActivityTaskCanceled(req);
       } else {
@@ -292,7 +326,11 @@ export class AsyncCompletionClient extends BaseClient {
           details: { payloads },
         };
         if (externalStorage) {
-          await visit(req, walkRespondActivityTaskCanceledByIdRequest, extstoreStoreOptions(externalStorage));
+          await visit(
+            req,
+            walkRespondActivityTaskCanceledByIdRequest,
+            extstoreStoreOptions(externalStorage, { initialTarget: target })
+          );
         }
         await this.workflowService.respondActivityTaskCanceledById(req);
       }
@@ -324,6 +362,7 @@ export class AsyncCompletionClient extends BaseClient {
     let paused = false;
     let reset = false;
     const externalStorage = this.dataConverter.externalStorage;
+    const target = this.storageTargetFor(taskTokenOrFullActivityId);
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
         const req: temporal.api.workflowservice.v1.IRecordActivityTaskHeartbeatRequest = {
@@ -333,7 +372,11 @@ export class AsyncCompletionClient extends BaseClient {
           details: { payloads },
         };
         if (externalStorage) {
-          await visit(req, walkRecordActivityTaskHeartbeatRequest, extstoreStoreOptions(externalStorage));
+          await visit(
+            req,
+            walkRecordActivityTaskHeartbeatRequest,
+            extstoreStoreOptions(externalStorage, { initialTarget: target })
+          );
         }
         const response = await this.workflowService.recordActivityTaskHeartbeat(req);
         cancelRequested = !!response.cancelRequested;
@@ -347,7 +390,11 @@ export class AsyncCompletionClient extends BaseClient {
           details: { payloads },
         };
         if (externalStorage) {
-          await visit(req, walkRecordActivityTaskHeartbeatByIdRequest, extstoreStoreOptions(externalStorage));
+          await visit(
+            req,
+            walkRecordActivityTaskHeartbeatByIdRequest,
+            extstoreStoreOptions(externalStorage, { initialTarget: target })
+          );
         }
         const response = await this.workflowService.recordActivityTaskHeartbeatById(req);
         cancelRequested = !!response.cancelRequested;

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -1,5 +1,5 @@
 import { status as grpcStatus } from '@grpc/grpc-js';
-import type { ActivitySerializationContext, StorageDriverActivityInfo } from '@temporalio/common';
+import type { ActivitySerializationContext, StorageDriverTargetInfo } from '@temporalio/common';
 import { ensureTemporalFailure } from '@temporalio/common';
 import {
   encodeErrorToFailure,
@@ -139,10 +139,16 @@ export class AsyncCompletionClient extends BaseClient {
    * only know the namespace (the token is opaque), so the target is namespace-scoped and the driver falls
    * back to content-addressed naming.
    */
-  protected storageTargetFor(taskTokenOrFullActivityId: Uint8Array | FullActivityId): StorageDriverActivityInfo {
-    return taskTokenOrFullActivityId instanceof Uint8Array
-      ? { kind: 'activity', namespace: this.options.namespace }
-      : { kind: 'activity', namespace: this.options.namespace, id: taskTokenOrFullActivityId.activityId };
+  protected storageTargetFor(taskTokenOrFullActivityId: Uint8Array | FullActivityId): StorageDriverTargetInfo {
+    const namespace = this.options.namespace;
+    if (taskTokenOrFullActivityId instanceof Uint8Array) {
+      return { kind: 'workflow', namespace };
+    }
+    const { workflowId, runId, activityId } = taskTokenOrFullActivityId;
+    if (workflowId != null) {
+      return { kind: 'workflow', namespace, id: workflowId, ...(runId != null ? { runId } : {}) };
+    }
+    return { kind: 'activity', namespace, id: activityId, ...(runId != null ? { runId } : {}) };
   }
 
   /**

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -158,7 +158,7 @@ export class AsyncCompletionClient extends BaseClient {
 
       throw new ActivityCompletionError(err.details || err.message);
     }
-    throw new ActivityCompletionError('Unexpected failure');
+    throw err;
   }
 
   /**
@@ -181,7 +181,6 @@ export class AsyncCompletionClient extends BaseClient {
       [result]
     );
     const externalStorage = this.dataConverter.externalStorage;
-    const target = this.storageTargetFor(taskTokenOrFullActivityId);
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
         const req: temporal.api.workflowservice.v1.IRespondActivityTaskCompletedRequest = {
@@ -194,7 +193,7 @@ export class AsyncCompletionClient extends BaseClient {
           await visit(
             req,
             walkRespondActivityTaskCompletedRequest,
-            extstoreStoreOptions(externalStorage, { initialTarget: target })
+            extstoreStoreOptions(externalStorage, { initialTarget: this.storageTargetFor(taskTokenOrFullActivityId) })
           );
         }
         await this.workflowService.respondActivityTaskCompleted(req);
@@ -209,7 +208,7 @@ export class AsyncCompletionClient extends BaseClient {
           await visit(
             req,
             walkRespondActivityTaskCompletedByIdRequest,
-            extstoreStoreOptions(externalStorage, { initialTarget: target })
+            extstoreStoreOptions(externalStorage, { initialTarget: this.storageTargetFor(taskTokenOrFullActivityId) })
           );
         }
         await this.workflowService.respondActivityTaskCompletedById(req);
@@ -239,7 +238,6 @@ export class AsyncCompletionClient extends BaseClient {
       this.serializationContextFor(taskTokenOrFullActivityId, options)
     );
     const externalStorage = this.dataConverter.externalStorage;
-    const target = this.storageTargetFor(taskTokenOrFullActivityId);
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
         const req: temporal.api.workflowservice.v1.IRespondActivityTaskFailedRequest = {
@@ -252,7 +250,7 @@ export class AsyncCompletionClient extends BaseClient {
           await visit(
             req,
             walkRespondActivityTaskFailedRequest,
-            extstoreStoreOptions(externalStorage, { initialTarget: target })
+            extstoreStoreOptions(externalStorage, { initialTarget: this.storageTargetFor(taskTokenOrFullActivityId) })
           );
         }
         await this.workflowService.respondActivityTaskFailed(req);
@@ -267,7 +265,7 @@ export class AsyncCompletionClient extends BaseClient {
           await visit(
             req,
             walkRespondActivityTaskFailedByIdRequest,
-            extstoreStoreOptions(externalStorage, { initialTarget: target })
+            extstoreStoreOptions(externalStorage, { initialTarget: this.storageTargetFor(taskTokenOrFullActivityId) })
           );
         }
         await this.workflowService.respondActivityTaskFailedById(req);
@@ -301,7 +299,6 @@ export class AsyncCompletionClient extends BaseClient {
       [details]
     );
     const externalStorage = this.dataConverter.externalStorage;
-    const target = this.storageTargetFor(taskTokenOrFullActivityId);
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
         const req: temporal.api.workflowservice.v1.IRespondActivityTaskCanceledRequest = {
@@ -314,7 +311,7 @@ export class AsyncCompletionClient extends BaseClient {
           await visit(
             req,
             walkRespondActivityTaskCanceledRequest,
-            extstoreStoreOptions(externalStorage, { initialTarget: target })
+            extstoreStoreOptions(externalStorage, { initialTarget: this.storageTargetFor(taskTokenOrFullActivityId) })
           );
         }
         await this.workflowService.respondActivityTaskCanceled(req);
@@ -329,7 +326,7 @@ export class AsyncCompletionClient extends BaseClient {
           await visit(
             req,
             walkRespondActivityTaskCanceledByIdRequest,
-            extstoreStoreOptions(externalStorage, { initialTarget: target })
+            extstoreStoreOptions(externalStorage, { initialTarget: this.storageTargetFor(taskTokenOrFullActivityId) })
           );
         }
         await this.workflowService.respondActivityTaskCanceledById(req);
@@ -362,7 +359,6 @@ export class AsyncCompletionClient extends BaseClient {
     let paused = false;
     let reset = false;
     const externalStorage = this.dataConverter.externalStorage;
-    const target = this.storageTargetFor(taskTokenOrFullActivityId);
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
         const req: temporal.api.workflowservice.v1.IRecordActivityTaskHeartbeatRequest = {
@@ -375,7 +371,7 @@ export class AsyncCompletionClient extends BaseClient {
           await visit(
             req,
             walkRecordActivityTaskHeartbeatRequest,
-            extstoreStoreOptions(externalStorage, { initialTarget: target })
+            extstoreStoreOptions(externalStorage, { initialTarget: this.storageTargetFor(taskTokenOrFullActivityId) })
           );
         }
         const response = await this.workflowService.recordActivityTaskHeartbeat(req);
@@ -393,7 +389,7 @@ export class AsyncCompletionClient extends BaseClient {
           await visit(
             req,
             walkRecordActivityTaskHeartbeatByIdRequest,
-            extstoreStoreOptions(externalStorage, { initialTarget: target })
+            extstoreStoreOptions(externalStorage, { initialTarget: this.storageTargetFor(taskTokenOrFullActivityId) })
           );
         }
         const response = await this.workflowService.recordActivityTaskHeartbeatById(req);

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -1,8 +1,22 @@
 import { status as grpcStatus } from '@grpc/grpc-js';
 import type { ActivitySerializationContext } from '@temporalio/common';
 import { ensureTemporalFailure } from '@temporalio/common';
-import { encodeErrorToFailure, encodeToPayloadsWithContext } from '@temporalio/common/lib/internal-non-workflow';
+import {
+  encodeErrorToFailure,
+  encodeToPayloadsWithContext,
+  extstoreStoreOptions,
+  visit,
+  walkRecordActivityTaskHeartbeatByIdRequest,
+  walkRecordActivityTaskHeartbeatRequest,
+  walkRespondActivityTaskCanceledByIdRequest,
+  walkRespondActivityTaskCanceledRequest,
+  walkRespondActivityTaskCompletedByIdRequest,
+  walkRespondActivityTaskCompletedRequest,
+  walkRespondActivityTaskFailedByIdRequest,
+  walkRespondActivityTaskFailedRequest,
+} from '@temporalio/common/lib/internal-non-workflow';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
+import type { temporal } from '@temporalio/proto';
 import type { BaseClientOptions, LoadedWithDefaults, WithDefaults } from './base-client';
 import { BaseClient, defaultBaseClientOptions } from './base-client';
 import {
@@ -155,21 +169,30 @@ export class AsyncCompletionClient extends BaseClient {
       this.serializationContextFor(taskTokenOrFullActivityId, options),
       [result]
     );
+    const externalStorage = this.dataConverter.externalStorage;
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
-        await this.workflowService.respondActivityTaskCompleted({
+        const req: temporal.api.workflowservice.v1.IRespondActivityTaskCompletedRequest = {
           identity: this.options.identity,
           namespace: this.options.namespace,
           taskToken: taskTokenOrFullActivityId,
           result: { payloads },
-        });
+        };
+        if (externalStorage) {
+          await visit(req, walkRespondActivityTaskCompletedRequest, extstoreStoreOptions(externalStorage));
+        }
+        await this.workflowService.respondActivityTaskCompleted(req);
       } else {
-        await this.workflowService.respondActivityTaskCompletedById({
+        const req: temporal.api.workflowservice.v1.IRespondActivityTaskCompletedByIdRequest = {
           identity: this.options.identity,
           namespace: this.options.namespace,
           ...taskTokenOrFullActivityId,
           result: { payloads },
-        });
+        };
+        if (externalStorage) {
+          await visit(req, walkRespondActivityTaskCompletedByIdRequest, extstoreStoreOptions(externalStorage));
+        }
+        await this.workflowService.respondActivityTaskCompletedById(req);
       }
     } catch (err) {
       this.handleError(err);
@@ -195,21 +218,30 @@ export class AsyncCompletionClient extends BaseClient {
       ensureTemporalFailure(err),
       this.serializationContextFor(taskTokenOrFullActivityId, options)
     );
+    const externalStorage = this.dataConverter.externalStorage;
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
-        await this.workflowService.respondActivityTaskFailed({
+        const req: temporal.api.workflowservice.v1.IRespondActivityTaskFailedRequest = {
           identity: this.options.identity,
           namespace: this.options.namespace,
           taskToken: taskTokenOrFullActivityId,
           failure,
-        });
+        };
+        if (externalStorage) {
+          await visit(req, walkRespondActivityTaskFailedRequest, extstoreStoreOptions(externalStorage));
+        }
+        await this.workflowService.respondActivityTaskFailed(req);
       } else {
-        await this.workflowService.respondActivityTaskFailedById({
+        const req: temporal.api.workflowservice.v1.IRespondActivityTaskFailedByIdRequest = {
           identity: this.options.identity,
           namespace: this.options.namespace,
           ...taskTokenOrFullActivityId,
           failure,
-        });
+        };
+        if (externalStorage) {
+          await visit(req, walkRespondActivityTaskFailedByIdRequest, extstoreStoreOptions(externalStorage));
+        }
+        await this.workflowService.respondActivityTaskFailedById(req);
       }
     } catch (err) {
       this.handleError(err);
@@ -239,21 +271,30 @@ export class AsyncCompletionClient extends BaseClient {
       this.serializationContextFor(taskTokenOrFullActivityId, options),
       [details]
     );
+    const externalStorage = this.dataConverter.externalStorage;
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
-        await this.workflowService.respondActivityTaskCanceled({
+        const req: temporal.api.workflowservice.v1.IRespondActivityTaskCanceledRequest = {
           identity: this.options.identity,
           namespace: this.options.namespace,
           taskToken: taskTokenOrFullActivityId,
           details: { payloads },
-        });
+        };
+        if (externalStorage) {
+          await visit(req, walkRespondActivityTaskCanceledRequest, extstoreStoreOptions(externalStorage));
+        }
+        await this.workflowService.respondActivityTaskCanceled(req);
       } else {
-        await this.workflowService.respondActivityTaskCanceledById({
+        const req: temporal.api.workflowservice.v1.IRespondActivityTaskCanceledByIdRequest = {
           identity: this.options.identity,
           namespace: this.options.namespace,
           ...taskTokenOrFullActivityId,
           details: { payloads },
-        });
+        };
+        if (externalStorage) {
+          await visit(req, walkRespondActivityTaskCanceledByIdRequest, extstoreStoreOptions(externalStorage));
+        }
+        await this.workflowService.respondActivityTaskCanceledById(req);
       }
     } catch (err) {
       this.handleError(err);
@@ -282,24 +323,33 @@ export class AsyncCompletionClient extends BaseClient {
     let cancelRequested = false;
     let paused = false;
     let reset = false;
+    const externalStorage = this.dataConverter.externalStorage;
     try {
       if (taskTokenOrFullActivityId instanceof Uint8Array) {
-        const response = await this.workflowService.recordActivityTaskHeartbeat({
+        const req: temporal.api.workflowservice.v1.IRecordActivityTaskHeartbeatRequest = {
           identity: this.options.identity,
           namespace: this.options.namespace,
           taskToken: taskTokenOrFullActivityId,
           details: { payloads },
-        });
+        };
+        if (externalStorage) {
+          await visit(req, walkRecordActivityTaskHeartbeatRequest, extstoreStoreOptions(externalStorage));
+        }
+        const response = await this.workflowService.recordActivityTaskHeartbeat(req);
         cancelRequested = !!response.cancelRequested;
         paused = !!response.activityPaused;
         reset = !!response.activityReset;
       } else {
-        const response = await this.workflowService.recordActivityTaskHeartbeatById({
+        const req: temporal.api.workflowservice.v1.IRecordActivityTaskHeartbeatByIdRequest = {
           identity: this.options.identity,
           namespace: this.options.namespace,
           ...taskTokenOrFullActivityId,
           details: { payloads },
-        });
+        };
+        if (externalStorage) {
+          await visit(req, walkRecordActivityTaskHeartbeatByIdRequest, extstoreStoreOptions(externalStorage));
+        }
+        const response = await this.workflowService.recordActivityTaskHeartbeatById(req);
         cancelRequested = !!response.cancelRequested;
         paused = !!response.activityPaused;
         reset = !!response.activityReset;

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -164,7 +164,7 @@ export class AsyncCompletionClient extends BaseClient {
 
       throw new ActivityCompletionError(err.details || err.message);
     }
-    throw err;
+    throw new ActivityCompletionError('Unexpected failure');
   }
 
   /**

--- a/packages/client/src/nexus-client.ts
+++ b/packages/client/src/nexus-client.ts
@@ -13,6 +13,13 @@ import {
   decodeOptionalFailureToOptionalError,
   decodeOptionalSinglePayload,
   encodeToPayload,
+  extstoreRetrieveOptions,
+  extstoreStoreOptions,
+  visit,
+  walkDescribeNexusOperationExecutionResponse,
+  walkListNexusOperationExecutionsResponse,
+  walkPollNexusOperationExecutionResponse,
+  walkStartNexusOperationExecutionRequest,
 } from '@temporalio/common/lib/internal-non-workflow';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { msOptionalToTs, optionalTsToDate, optionalTsToMs } from '@temporalio/common/lib/time';
@@ -396,6 +403,10 @@ export class NexusClient extends BaseClient {
       nexusHeader: input.headers ?? {},
       userMetadata,
     };
+    const externalStorage = this.dataConverter.externalStorage;
+    if (externalStorage) {
+      await visit(req, walkStartNexusOperationExecutionRequest, extstoreStoreOptions(externalStorage));
+    }
     let res: temporal.api.workflowservice.v1.IStartNexusOperationExecutionResponse;
     try {
       res = await this.connection.workflowService.startNexusOperationExecution(req);
@@ -476,6 +487,11 @@ export class NexusClient extends BaseClient {
         this.rethrowGrpcError(err, 'Failed to poll Nexus operation result', input.operationId);
       }
 
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(res, walkPollNexusOperationExecutionResponse, extstoreRetrieveOptions(externalStorage));
+      }
+
       // The operation is closed if we have a result or failure
       if (res.result) {
         return await decodeFromPayloadsAtIndex(this.dataConverter, 0, [res.result]);
@@ -501,6 +517,10 @@ export class NexusClient extends BaseClient {
       res = await this.connection.workflowService.describeNexusOperationExecution(req);
     } catch (err: unknown) {
       this.rethrowGrpcError(err, 'Failed to describe Nexus operation', input.operationId);
+    }
+    const externalStorage = this.dataConverter.externalStorage;
+    if (externalStorage) {
+      await visit(res, walkDescribeNexusOperationExecutionResponse, extstoreRetrieveOptions(externalStorage));
     }
     if (!res.info) {
       throw new ServiceError('Received invalid Nexus operation description from server: missing info');
@@ -553,6 +573,10 @@ export class NexusClient extends BaseClient {
         });
       } catch (err: unknown) {
         this.rethrowGrpcError(err, 'Failed to list Nexus operations', undefined);
+      }
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(response, walkListNexusOperationExecutionsResponse, extstoreRetrieveOptions(externalStorage));
       }
       for (const raw of response.operations ?? []) {
         yield nexusOperationListInfoFromProto(raw);

--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -581,7 +581,7 @@ export class ScheduleClient extends BaseClient {
 
       throw new ServiceError(fallbackMessage, { cause: err });
     }
-    throw err;
+    throw new ServiceError('Unexpected error while making gRPC request', { cause: err as Error });
   }
 }
 

--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -265,7 +265,19 @@ export class ScheduleClient extends BaseClient {
     try {
       const externalStorage = this.dataConverter.externalStorage;
       if (externalStorage) {
-        await visit(req, walkCreateScheduleRequest, extstoreStoreOptions(externalStorage));
+        const startWorkflow = req.schedule?.action?.startWorkflow;
+        await visit(
+          req,
+          walkCreateScheduleRequest,
+          extstoreStoreOptions(externalStorage, {
+            initialTarget: {
+              kind: 'workflow',
+              namespace: this.options.namespace,
+              id: startWorkflow?.workflowId ?? undefined,
+              type: startWorkflow?.workflowType?.name ?? undefined,
+            },
+          })
+        );
       }
       const res = await this.workflowService.createSchedule(req);
       return { conflictToken: res.conflictToken };
@@ -327,7 +339,19 @@ export class ScheduleClient extends BaseClient {
     try {
       const externalStorage = this.dataConverter.externalStorage;
       if (externalStorage) {
-        await visit(req, walkUpdateScheduleRequest, extstoreStoreOptions(externalStorage));
+        const startWorkflow = req.schedule?.action?.startWorkflow;
+        await visit(
+          req,
+          walkUpdateScheduleRequest,
+          extstoreStoreOptions(externalStorage, {
+            initialTarget: {
+              kind: 'workflow',
+              namespace: this.options.namespace,
+              id: startWorkflow?.workflowId ?? undefined,
+              type: startWorkflow?.workflowType?.name ?? undefined,
+            },
+          })
+        );
       }
       return await this.workflowService.updateSchedule(req);
     } catch (err: any) {

--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -8,7 +8,17 @@ import {
 } from '@temporalio/common/lib/converter/payload-search-attributes';
 import type { Headers } from '@temporalio/common/lib/interceptors';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
-import { encodeMapToPayloads, decodeMapFromPayloads } from '@temporalio/common/lib/internal-non-workflow';
+import {
+  encodeMapToPayloads,
+  decodeMapFromPayloads,
+  extstoreRetrieveOptions,
+  extstoreStoreOptions,
+  visit,
+  walkCreateScheduleRequest,
+  walkDescribeScheduleResponse,
+  walkListSchedulesResponse,
+  walkUpdateScheduleRequest,
+} from '@temporalio/common/lib/internal-non-workflow';
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { temporal } from '@temporalio/proto';
 import {
@@ -253,6 +263,10 @@ export class ScheduleClient extends BaseClient {
       },
     };
     try {
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(req, walkCreateScheduleRequest, extstoreStoreOptions(externalStorage));
+      }
       const res = await this.workflowService.createSchedule(req);
       return { conflictToken: res.conflictToken };
     } catch (err: any) {
@@ -270,10 +284,15 @@ export class ScheduleClient extends BaseClient {
     scheduleId: string
   ): Promise<temporal.api.workflowservice.v1.IDescribeScheduleResponse> {
     try {
-      return await this.workflowService.describeSchedule({
+      const response = await this.workflowService.describeSchedule({
         namespace: this.options.namespace,
         scheduleId,
       });
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(response, walkDescribeScheduleResponse, extstoreRetrieveOptions(externalStorage));
+      }
+      return response;
     } catch (err: any) {
       this.rethrowGrpcError(err, 'Failed to describe schedule', scheduleId);
     }
@@ -287,7 +306,7 @@ export class ScheduleClient extends BaseClient {
     opts: CompiledScheduleUpdateOptions,
     header: Headers
   ): Promise<temporal.api.workflowservice.v1.IUpdateScheduleResponse> {
-    const req = {
+    const req: temporal.api.workflowservice.v1.IUpdateScheduleRequest = {
       namespace: this.options.namespace,
       scheduleId,
       schedule: {
@@ -306,6 +325,10 @@ export class ScheduleClient extends BaseClient {
           : undefined,
     };
     try {
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(req, walkUpdateScheduleRequest, extstoreStoreOptions(externalStorage));
+      }
       return await this.workflowService.updateSchedule(req);
     } catch (err: any) {
       this.rethrowGrpcError(err, 'Failed to update schedule', scheduleId);
@@ -378,6 +401,11 @@ export class ScheduleClient extends BaseClient {
         });
       } catch (e) {
         this.rethrowGrpcError(e, 'Failed to list schedules', undefined);
+      }
+
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(response, walkListSchedulesResponse, extstoreRetrieveOptions(externalStorage));
       }
 
       for (const raw of response.schedules ?? []) {

--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -581,7 +581,7 @@ export class ScheduleClient extends BaseClient {
 
       throw new ServiceError(fallbackMessage, { cause: err });
     }
-    throw new ServiceError('Unexpected error while making gRPC request', { cause: err as Error });
+    throw err;
   }
 }
 

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -42,9 +42,11 @@ import {
   extstoreRetrieveOptions,
   extstoreStoreOptions,
   visit,
+  walkDescribeWorkflowExecutionResponse,
   walkExecuteMultiOperationRequest,
   walkExecuteMultiOperationResponse,
   walkGetWorkflowExecutionHistoryResponse,
+  walkListWorkflowExecutionsResponse,
   walkPollWorkflowExecutionUpdateResponse,
   walkQueryWorkflowRequest,
   walkQueryWorkflowResponse,
@@ -1559,10 +1561,15 @@ export class WorkflowClient extends BaseClient {
    */
   protected async _describeWorkflowHandler(input: WorkflowDescribeInput): Promise<DescribeWorkflowExecutionResponse> {
     try {
-      return await this.workflowService.describeWorkflowExecution({
+      const response = await this.workflowService.describeWorkflowExecution({
         namespace: this.options.namespace,
         execution: input.workflowExecution,
       });
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(response, walkDescribeWorkflowExecutionResponse, extstoreRetrieveOptions(externalStorage));
+      }
+      return response;
     } catch (err) {
       this.rethrowGrpcError(err, 'Failed to describe workflow', input.workflowExecution);
     }
@@ -1766,6 +1773,10 @@ export class WorkflowClient extends BaseClient {
         });
       } catch (e) {
         this.rethrowGrpcError(e, 'Failed to list workflows', undefined);
+      }
+      const externalStorage = this.dataConverter.externalStorage;
+      if (externalStorage) {
+        await visit(response, walkListWorkflowExecutionsResponse, extstoreRetrieveOptions(externalStorage));
       }
       // Not decoding memo payloads concurrently even though we could have to keep the lazy nature of this iterator.
       // Decoding is done for `memo` fields which tend to be small.

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -1672,10 +1672,6 @@ export class WorkflowClient extends BaseClient {
               namespace: this.client.options.namespace,
               execution: { workflowId, runId },
             });
-          const externalStorage = this.client.dataConverter.externalStorage;
-          if (externalStorage) {
-            await visit(response, walkGetWorkflowExecutionHistoryResponse, extstoreRetrieveOptions(externalStorage));
-          }
           events.push(...(response.history?.events ?? []));
           nextPageToken = response.nextPageToken;
           if (nextPageToken == null || nextPageToken.length === 0) break;

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -1672,6 +1672,10 @@ export class WorkflowClient extends BaseClient {
               namespace: this.client.options.namespace,
               execution: { workflowId, runId },
             });
+          const externalStorage = this.client.dataConverter.externalStorage;
+          if (externalStorage) {
+            await visit(response, walkGetWorkflowExecutionHistoryResponse, extstoreRetrieveOptions(externalStorage));
+          }
           events.push(...(response.history?.events ?? []));
           nextPageToken = response.nextPageToken;
           if (nextPageToken == null || nextPageToken.length === 0) break;

--- a/packages/test/src/test-integration-extstore.ts
+++ b/packages/test/src/test-integration-extstore.ts
@@ -374,6 +374,58 @@ test('AsyncCompletionClient.complete offloads a large result', async (t) => {
   const decoded = decodeReferencePayload(payload);
   t.is(decoded.driverName, driver.name);
   t.true(decoded.sizeBytes >= 4096);
+  // By-token completion knows only the namespace (the task token is opaque).
+  t.deepEqual(driver.storeCalls[0].context.target, { kind: 'activity', namespace: 'default' });
+});
+
+test('AsyncCompletionClient.complete by ID targets the activity', async (t) => {
+  const driver = makeFakeDriver();
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+
+  const connection = {
+    workflowService: { respondActivityTaskCompletedById: async () => ({}) },
+    plugins: [],
+  } as unknown as ConnectionLike;
+  const client = new Client({ connection, dataConverter: { externalStorage } });
+
+  await client.activity.complete({ workflowId: 'wf-1', activityId: 'act-1' }, new Uint8Array(4096).fill(9));
+
+  t.is(driver.storeCalls.length, 1);
+  t.deepEqual(driver.storeCalls[0].context.target, { kind: 'activity', namespace: 'default', id: 'act-1' });
+});
+
+test('activity-client start offloads a large input and targets the activity', async (t) => {
+  const driver = makeFakeDriver();
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+
+  let startReq: temporal.api.workflowservice.v1.IStartActivityExecutionRequest | undefined;
+  const connection = {
+    workflowService: {
+      startActivityExecution: async (req: temporal.api.workflowservice.v1.IStartActivityExecutionRequest) => {
+        startReq = req;
+        return { runId: 'run-1' };
+      },
+    },
+    plugins: [],
+  } as unknown as ConnectionLike;
+  const client = new Client({ connection, dataConverter: { externalStorage } });
+
+  await client.activity.start('myActivity', {
+    id: 'act-1',
+    taskQueue: 'q',
+    args: [new Uint8Array(4096).fill(8)],
+    scheduleToCloseTimeout: '1 minute',
+    retry: { maximumAttempts: 1 },
+  });
+
+  t.is(driver.storeCalls.length, 1);
+  t.true(isReferencePayload(startReq!.input!.payloads![0]), 'the activity input should be offloaded before sending');
+  t.deepEqual(driver.storeCalls[0].context.target, {
+    kind: 'activity',
+    namespace: 'default',
+    id: 'act-1',
+    type: 'myActivity',
+  });
 });
 
 test('client offloads a large workflow memo and retrieves it via describe', async (t) => {
@@ -440,6 +492,11 @@ test('schedule create offloads a large memo and describe retrieves it', async (t
   // Store: the memo exceeded the threshold and was offloaded on create.
   t.is(driver.storeCalls.length, 1);
   t.true(isReferencePayload(createReq!.memo!.fields!.blob), 'schedule memo should be offloaded on create');
+  // The store target is the workflow the schedule action will start.
+  const target = driver.storeCalls[0].context.target;
+  t.is(target?.kind, 'workflow');
+  t.is(target?.namespace, 'default');
+  t.is(target?.kind === 'workflow' ? target.type : undefined, 'w');
 
   // Retrieve: describe converts the reference back to the original bytes.
   const description = await handle.describe();

--- a/packages/test/src/test-integration-extstore.ts
+++ b/packages/test/src/test-integration-extstore.ts
@@ -306,12 +306,11 @@ test('client offloads a large start argument and retrieves a large result', asyn
 
   const workflowId = randomUUID();
   const handle = await client.workflow.start(externalStorageEcho, { taskQueue, workflowId, args: [data] });
-  // Round-trip proves both directions: the client stored the arg (so the worker could run) and the
-  // client retrieved the offloaded result.
   const result = await worker.runUntil(handle.result());
   t.deepEqual(result, data);
 
-  // Inspect raw history via a converter without external storage, so references are not retrieved away.
+  // Raw history is fetched through a converter without external storage; otherwise the references
+  // below would be retrieved away before we can assert on them.
   const { events } = await t.context.env.client.workflow.getHandle(workflowId).fetchHistory();
   const startArg = events?.find((e) => e.workflowExecutionStartedEventAttributes)
     ?.workflowExecutionStartedEventAttributes?.input?.payloads?.[0];
@@ -340,7 +339,6 @@ test('client retrieves an offloaded query result', async (t) => {
     const handle = await client.workflow.start(externalStorageQueryable, { taskQueue, workflowId, args: [sizeBytes] });
     const retrievesBefore = driver.retrieveCalls.length;
     const blob = await handle.query(getBlobQuery);
-    // The worker offloads the large query result; only a client-side retrieve yields the original bytes.
     t.deepEqual(blob, expected);
     t.true(driver.retrieveCalls.length > retrievesBefore, 'client should retrieve the offloaded query result');
     await handle.signal(finishSignal);
@@ -374,11 +372,10 @@ test('AsyncCompletionClient.complete offloads a large result', async (t) => {
   const decoded = decodeReferencePayload(payload);
   t.is(decoded.driverName, driver.name);
   t.true(decoded.sizeBytes >= 4096);
-  // By-token completion knows only the namespace (the task token is opaque).
-  t.deepEqual(driver.storeCalls[0].context.target, { kind: 'activity', namespace: 'default' });
+  t.deepEqual(driver.storeCalls[0].context.target, { kind: 'workflow', namespace: 'default' });
 });
 
-test('AsyncCompletionClient.complete by ID targets the activity', async (t) => {
+test('AsyncCompletionClient.complete by ID targets the Workflow for a Workflow Activity', async (t) => {
   const driver = makeFakeDriver();
   const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
 
@@ -388,10 +385,39 @@ test('AsyncCompletionClient.complete by ID targets the activity', async (t) => {
   } as unknown as ConnectionLike;
   const client = new Client({ connection, dataConverter: { externalStorage } });
 
-  await client.activity.complete({ workflowId: 'wf-1', activityId: 'act-1' }, new Uint8Array(4096).fill(9));
+  await client.activity.complete(
+    { workflowId: 'wf-1', runId: 'run-1', activityId: 'act-1' },
+    new Uint8Array(4096).fill(9)
+  );
 
   t.is(driver.storeCalls.length, 1);
-  t.deepEqual(driver.storeCalls[0].context.target, { kind: 'activity', namespace: 'default', id: 'act-1' });
+  t.deepEqual(driver.storeCalls[0].context.target, {
+    kind: 'workflow',
+    namespace: 'default',
+    id: 'wf-1',
+    runId: 'run-1',
+  });
+});
+
+test('AsyncCompletionClient.complete by ID targets the Activity for a Standalone Activity', async (t) => {
+  const driver = makeFakeDriver();
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+
+  const connection = {
+    workflowService: { respondActivityTaskCompletedById: async () => ({}) },
+    plugins: [],
+  } as unknown as ConnectionLike;
+  const client = new Client({ connection, dataConverter: { externalStorage } });
+
+  await client.activity.complete({ runId: 'run-2', activityId: 'act-2' }, new Uint8Array(4096).fill(9));
+
+  t.is(driver.storeCalls.length, 1);
+  t.deepEqual(driver.storeCalls[0].context.target, {
+    kind: 'activity',
+    namespace: 'default',
+    id: 'act-2',
+    runId: 'run-2',
+  });
 });
 
 test('activity-client start offloads a large input and targets the activity', async (t) => {
@@ -447,15 +473,13 @@ test('client offloads a large workflow memo and retrieves it via describe', asyn
   });
   await worker.runUntil(handle.result());
 
-  // The memo exceeds the threshold, so the client offloads it on start; describe must retrieve it back.
   t.true(driver.storeCalls.length >= 1, 'the large memo should have been offloaded on start');
   const description = await handle.describe();
   t.deepEqual(description.memo?.blob, memoBlob);
 });
 
-// Driven through a mock connection rather than the ephemeral server: describing a just-created
-// schedule against `TestWorkflowEnvironment` times out on slower CI runners (schedules need the
-// real server, see test-schedules.ts). The mock keeps store+retrieve fully deterministic.
+// Mocked rather than run against the ephemeral server: describing a just-created schedule there
+// times out on slower CI runners (test-schedules.ts covers schedules against a real server).
 test('schedule create offloads a large memo and describe retrieves it', async (t) => {
   const driver = makeFakeDriver();
   const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
@@ -468,7 +492,6 @@ test('schedule create offloads a large memo and describe retrieves it', async (t
         createReq = req;
         return {};
       },
-      // Echo the reference the client offloaded on create, so describe must retrieve it back.
       describeSchedule: async () => ({
         schedule: {
           spec: {},
@@ -489,16 +512,13 @@ test('schedule create offloads a large memo and describe retrieves it', async (t
     memo: { blob: memoBlob },
   });
 
-  // Store: the memo exceeded the threshold and was offloaded on create.
   t.is(driver.storeCalls.length, 1);
   t.true(isReferencePayload(createReq!.memo!.fields!.blob), 'schedule memo should be offloaded on create');
-  // The store target is the workflow the schedule action will start.
   const target = driver.storeCalls[0].context.target;
   t.is(target?.kind, 'workflow');
   t.is(target?.namespace, 'default');
   t.is(target?.kind === 'workflow' ? target.type : undefined, 'w');
 
-  // Retrieve: describe converts the reference back to the original bytes.
   const description = await handle.describe();
   t.deepEqual(description.memo?.blob, memoBlob);
 });

--- a/packages/test/src/test-integration-extstore.ts
+++ b/packages/test/src/test-integration-extstore.ts
@@ -401,28 +401,47 @@ test('client offloads a large workflow memo and retrieves it via describe', asyn
   t.deepEqual(description.memo?.blob, memoBlob);
 });
 
-test('client offloads a large schedule memo and retrieves it via describe', async (t) => {
-  const { taskQueue } = helpers(t);
-
+// Driven through a mock connection rather than the ephemeral server: describing a just-created
+// schedule against `TestWorkflowEnvironment` times out on slower CI runners (schedules need the
+// real server, see test-schedules.ts). The mock keeps store+retrieve fully deterministic.
+test('schedule create offloads a large memo and describe retrieves it', async (t) => {
   const driver = makeFakeDriver();
   const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
   const memoBlob = new Uint8Array(4096).fill(6);
 
-  const client = new Client({ connection: t.context.env.connection, dataConverter: { externalStorage } });
+  let createReq: temporal.api.workflowservice.v1.ICreateScheduleRequest | undefined;
+  const connection = {
+    workflowService: {
+      createSchedule: async (req: temporal.api.workflowservice.v1.ICreateScheduleRequest) => {
+        createReq = req;
+        return {};
+      },
+      // Echo the reference the client offloaded on create, so describe must retrieve it back.
+      describeSchedule: async () => ({
+        schedule: {
+          spec: {},
+          action: { startWorkflow: { workflowType: { name: 'w' }, taskQueue: { name: 'q' } } },
+        },
+        info: { createTime: { seconds: 0, nanos: 0 } },
+        memo: { fields: { blob: createReq!.memo!.fields!.blob } },
+      }),
+    },
+    plugins: [],
+  } as unknown as ConnectionLike;
+  const client = new Client({ connection, dataConverter: { externalStorage } });
 
-  const scheduleId = randomUUID();
-  // `spec: {}` never fires, so no worker is needed; the action is inert.
   const handle = await client.schedule.create({
-    scheduleId,
+    scheduleId: 'sched-1',
     spec: {},
-    action: { type: 'startWorkflow', workflowType: 'externalStorageEcho', taskQueue },
+    action: { type: 'startWorkflow', workflowType: 'w', taskQueue: 'q' },
     memo: { blob: memoBlob },
   });
-  try {
-    t.true(driver.storeCalls.length >= 1, 'the large schedule memo should have been offloaded on create');
-    const description = await handle.describe();
-    t.deepEqual(description.memo?.blob, memoBlob);
-  } finally {
-    await handle.delete();
-  }
+
+  // Store: the memo exceeded the threshold and was offloaded on create.
+  t.is(driver.storeCalls.length, 1);
+  t.true(isReferencePayload(createReq!.memo!.fields!.blob), 'schedule memo should be offloaded on create');
+
+  // Retrieve: describe converts the reference back to the original bytes.
+  const description = await handle.describe();
+  t.deepEqual(description.memo?.blob, memoBlob);
 });

--- a/packages/test/src/test-integration-extstore.ts
+++ b/packages/test/src/test-integration-extstore.ts
@@ -1,17 +1,25 @@
 /**
  * Integration tests for the external storage feature.
  */
+import { randomUUID } from 'node:crypto';
+import type { ConnectionLike } from '@temporalio/client';
+import { Client } from '@temporalio/client';
 import { ExternalStorage, type StorageDriverTargetInfo } from '@temporalio/common';
 import { decodeReferencePayload, isReferencePayload } from '@temporalio/common/lib/internal-non-workflow';
+import type { temporal } from '@temporalio/proto';
 import * as activities from './activities';
 import { makeFakeDriver } from './extstore-fake-driver';
 import { helpers, makeTestFunction } from './helpers-integration';
 import {
   externalStorageActivityInputOffload,
   externalStorageByteFidelity,
+  externalStorageEcho,
   externalStorageHeartbeatDetailsOffload,
   externalStorageOffload,
   externalStorageParentChildOffload,
+  externalStorageQueryable,
+  finishSignal,
+  getBlobQuery,
 } from './workflows';
 
 const test = makeTestFunction({ workflowsPath: require.resolve('./workflows') });
@@ -284,4 +292,137 @@ test('a transient activity input retrieve failure retries the activity and recov
 
   t.is(len, payloadSize);
   t.true(driver.retrieveCalls.length >= 2);
+});
+
+test('client offloads a large start argument and retrieves a large result', async (t) => {
+  const { createWorker, taskQueue } = helpers(t);
+
+  const driver = makeFakeDriver();
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+  const data = new Uint8Array(4096).fill(3);
+
+  const worker = await createWorker({ dataConverter: { externalStorage } });
+  const client = new Client({ connection: t.context.env.connection, dataConverter: { externalStorage } });
+
+  const workflowId = randomUUID();
+  const handle = await client.workflow.start(externalStorageEcho, { taskQueue, workflowId, args: [data] });
+  // Round-trip proves both directions: the client stored the arg (so the worker could run) and the
+  // client retrieved the offloaded result.
+  const result = await worker.runUntil(handle.result());
+  t.deepEqual(result, data);
+
+  // Inspect raw history via a converter without external storage, so references are not retrieved away.
+  const { events } = await t.context.env.client.workflow.getHandle(workflowId).fetchHistory();
+  const startArg = events?.find((e) => e.workflowExecutionStartedEventAttributes)
+    ?.workflowExecutionStartedEventAttributes?.input?.payloads?.[0];
+  if (startArg == null) throw new Error('expected a start input payload');
+  t.true(isReferencePayload(startArg), 'start argument should be offloaded by the client');
+
+  const resultPayload = events?.find((e) => e.workflowExecutionCompletedEventAttributes)
+    ?.workflowExecutionCompletedEventAttributes?.result?.payloads?.[0];
+  if (resultPayload == null) throw new Error('expected a completed result payload');
+  t.true(isReferencePayload(resultPayload), 'workflow result should be a reference before the client retrieves it');
+});
+
+test('client retrieves an offloaded query result', async (t) => {
+  const { createWorker, taskQueue } = helpers(t);
+
+  const driver = makeFakeDriver();
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+  const sizeBytes = 4096;
+  const expected = new Uint8Array(sizeBytes).fill(7);
+
+  const worker = await createWorker({ dataConverter: { externalStorage } });
+  const client = new Client({ connection: t.context.env.connection, dataConverter: { externalStorage } });
+
+  const workflowId = randomUUID();
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(externalStorageQueryable, { taskQueue, workflowId, args: [sizeBytes] });
+    const retrievesBefore = driver.retrieveCalls.length;
+    const blob = await handle.query(getBlobQuery);
+    // The worker offloads the large query result; only a client-side retrieve yields the original bytes.
+    t.deepEqual(blob, expected);
+    t.true(driver.retrieveCalls.length > retrievesBefore, 'client should retrieve the offloaded query result');
+    await handle.signal(finishSignal);
+    await handle.result();
+  });
+});
+
+test('AsyncCompletionClient.complete offloads a large result', async (t) => {
+  const driver = makeFakeDriver();
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+
+  let recorded: temporal.api.workflowservice.v1.IRespondActivityTaskCompletedRequest | undefined;
+  const connection = {
+    workflowService: {
+      respondActivityTaskCompleted: async (
+        req: temporal.api.workflowservice.v1.IRespondActivityTaskCompletedRequest
+      ) => {
+        recorded = req;
+      },
+    },
+    plugins: [],
+  } as unknown as ConnectionLike;
+  const client = new Client({ connection, dataConverter: { externalStorage } });
+
+  await client.activity.complete(new Uint8Array([1]), new Uint8Array(4096).fill(9));
+
+  t.is(driver.storeCalls.length, 1);
+  const payload = recorded?.result?.payloads?.[0];
+  if (payload == null) throw new Error('expected a result payload');
+  t.true(isReferencePayload(payload), 'the async completion result should be offloaded before sending');
+  const decoded = decodeReferencePayload(payload);
+  t.is(decoded.driverName, driver.name);
+  t.true(decoded.sizeBytes >= 4096);
+});
+
+test('client offloads a large workflow memo and retrieves it via describe', async (t) => {
+  const { createWorker, taskQueue } = helpers(t);
+
+  const driver = makeFakeDriver();
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+  const memoBlob = new Uint8Array(4096).fill(5);
+
+  const worker = await createWorker({ dataConverter: { externalStorage } });
+  const client = new Client({ connection: t.context.env.connection, dataConverter: { externalStorage } });
+
+  const workflowId = randomUUID();
+  const handle = await client.workflow.start(externalStorageEcho, {
+    taskQueue,
+    workflowId,
+    args: [new Uint8Array(1)],
+    memo: { blob: memoBlob },
+  });
+  await worker.runUntil(handle.result());
+
+  // The memo exceeds the threshold, so the client offloads it on start; describe must retrieve it back.
+  t.true(driver.storeCalls.length >= 1, 'the large memo should have been offloaded on start');
+  const description = await handle.describe();
+  t.deepEqual(description.memo?.blob, memoBlob);
+});
+
+test('client offloads a large schedule memo and retrieves it via describe', async (t) => {
+  const { taskQueue } = helpers(t);
+
+  const driver = makeFakeDriver();
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+  const memoBlob = new Uint8Array(4096).fill(6);
+
+  const client = new Client({ connection: t.context.env.connection, dataConverter: { externalStorage } });
+
+  const scheduleId = randomUUID();
+  // `spec: {}` never fires, so no worker is needed; the action is inert.
+  const handle = await client.schedule.create({
+    scheduleId,
+    spec: {},
+    action: { type: 'startWorkflow', workflowType: 'externalStorageEcho', taskQueue },
+    memo: { blob: memoBlob },
+  });
+  try {
+    t.true(driver.storeCalls.length >= 1, 'the large schedule memo should have been offloaded on create');
+    const description = await handle.describe();
+    t.deepEqual(description.memo?.blob, memoBlob);
+  } finally {
+    await handle.delete();
+  }
 });

--- a/packages/test/src/workflows/external-storage-offload.ts
+++ b/packages/test/src/workflows/external-storage-offload.ts
@@ -59,24 +59,19 @@ export async function externalStorageHeartbeatDetailsOffload(sizeBytes: number):
 }
 
 /**
- * Child workflow that echoes back the (large) payload it receives, so its input is offloaded on
- * the parent's outbound command and its result is offloaded on the child's completion.
- */
-export async function externalStorageChildEcho(payload: Uint8Array): Promise<Uint8Array> {
-  return payload;
-}
-
-/**
  * Parent workflow that starts a child with a large argument and reads back the child's large
  * result, exercising offload/retrieval in both directions between two Workflows on the same
  * Worker. Returns the length of the payload round-tripped through the child.
  */
 export async function externalStorageParentChildOffload(sizeBytes: number): Promise<number> {
-  const result = await executeChild(externalStorageChildEcho, { args: [new Uint8Array(sizeBytes)] });
+  const result = await executeChild(externalStorageEcho, { args: [new Uint8Array(sizeBytes)] });
   return result.length;
 }
 
-/** Returns its argument unchanged, so a large arg/result round-trips through the client boundary. */
+/**
+ * Returns its argument unchanged. Used directly (a large arg/result round-trips through the client
+ * boundary) and as the child in {@link externalStorageParentChildOffload}.
+ */
 export async function externalStorageEcho(data: Uint8Array): Promise<Uint8Array> {
   return data;
 }

--- a/packages/test/src/workflows/external-storage-offload.ts
+++ b/packages/test/src/workflows/external-storage-offload.ts
@@ -1,4 +1,4 @@
-import { executeChild, proxyActivities } from '@temporalio/workflow';
+import { condition, defineQuery, defineSignal, executeChild, proxyActivities, setHandler } from '@temporalio/workflow';
 import type * as activities from '../activities';
 
 // Allow a few attempts so the driver-failure tests can assert that a driver failure is
@@ -74,4 +74,26 @@ export async function externalStorageChildEcho(payload: Uint8Array): Promise<Uin
 export async function externalStorageParentChildOffload(sizeBytes: number): Promise<number> {
   const result = await executeChild(externalStorageChildEcho, { args: [new Uint8Array(sizeBytes)] });
   return result.length;
+}
+
+/** Returns its argument unchanged, so a large arg/result round-trips through the client boundary. */
+export async function externalStorageEcho(data: Uint8Array): Promise<Uint8Array> {
+  return data;
+}
+
+export const getBlobQuery = defineQuery<Uint8Array>('getBlob');
+export const finishSignal = defineSignal('finish');
+
+/**
+ * Serves a large blob (built from the given size) via a query, and stays open until signalled.
+ * Lets a client exercise the query retrieve path against an offloaded query result.
+ */
+export async function externalStorageQueryable(sizeBytes: number): Promise<void> {
+  const blob = new Uint8Array(sizeBytes).fill(7);
+  setHandler(getBlobQuery, () => blob);
+  let finished = false;
+  setHandler(finishSignal, () => {
+    finished = true;
+  });
+  await condition(() => finished);
 }


### PR DESCRIPTION

<!--- For ALL Contributors 👇 -->

## What was changed
Integrate external storage into the remaining client paths. 

- **workflow-client**: retrieve on `describe`, `list`
- **schedule-client**: store on `create`/`update`; retrieve on `describe`/`list`
- **async-completion-client**: store on `complete`/`fail`/`reportCancellation`/`heartbeat` (token + by-id)
- **activity-client**: store on `start`; retrieve on `poll`/`describe`/`list`
- **nexus-client**: store on `start`; retrieve on `poll`/`describe`/`list`

The rest (`start`, `signalWithStart`, etc are already in main).

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
- Integration round-trips against dev server: workflow start-arg + result, query result, workflow/schedule memo via describe, and async-completion store.
