### PR TITLE
fix(worker): fail activity task retryably on external storage driver errors

### DIFF
--- a/packages/test/src/activities/index.ts
+++ b/packages/test/src/activities/index.ts
@@ -87,6 +87,38 @@ export async function produceLargePayload(sizeBytes: number): Promise<Uint8Array
   return new Uint8Array(sizeBytes);
 }
 
+/**
+ * Returns a `Uint8Array` of the requested size filled with a recognizable byte pattern
+ * (`i % 256`). Used by external-storage tests to assert byte-exact round-trips.
+ */
+export async function producePatternedPayload(sizeBytes: number): Promise<Uint8Array> {
+  const buf = new Uint8Array(sizeBytes);
+  for (let i = 0; i < sizeBytes; i++) buf[i] = i % 256;
+  return buf;
+}
+
+/**
+ * Returns the length of the received payload. Used by external-storage tests to exercise
+ * offloading of activity *input* arguments (the argument is what gets offloaded/retrieved).
+ */
+export async function consumeLargePayload(payload: Uint8Array): Promise<number> {
+  return payload.length;
+}
+
+/**
+ * Until heartbeat details have been recovered from a previous attempt, heartbeats a large
+ * `Uint8Array` (large enough to be offloaded) and throws to force a retry. Once details are present,
+ * returns their length.
+ */
+export async function heartbeatThenReturnDetailsLength(sizeBytes: number): Promise<number> {
+  const details = activityInfo().heartbeatDetails as Uint8Array | undefined;
+  if (details === undefined) {
+    Context.current().heartbeat(new Uint8Array(sizeBytes));
+    throw new Error('retry to read heartbeat details on the next attempt');
+  }
+  return details.length;
+}
+
 export async function progressiveSleep(): Promise<void> {
   const cx = Context.current();
   // Use ms formatted string once to test this is supported

--- a/packages/test/src/extstore-fake-driver.ts
+++ b/packages/test/src/extstore-fake-driver.ts
@@ -2,7 +2,8 @@
  * Shared test double for {@link StorageDriver}. By default it stores and retrieves
  * payloads via an in-memory `Map`, so a store→retrieve round-trip yields the original
  * bytes. Tests that need failure or unusual-shape responses can override individual
- * operations via `onStore` / `onRetrieve`.
+ * operations via `onStore` / `onRetrieve`, or fail just the first store/retrieve (then recover) via
+ * `failFirstStore` / `failFirstRetrieve`.
  *
  * Every call is recorded on `storeCalls` / `retrieveCalls` (the recording happens
  * before the override runs, so an override can introspect its own call).
@@ -27,6 +28,10 @@ export interface FakeDriverOptions {
   onStore?: (payloads: Payload[]) => StorageDriverClaim[] | Promise<StorageDriverClaim[]>;
   /** Override default in-memory retrieve. */
   onRetrieve?: (claims: StorageDriverClaim[]) => Payload[] | Promise<Payload[]>;
+  /** Throw on the first `store` call (before storing), then behave normally. */
+  failFirstStore?: boolean;
+  /** Throw on the first `retrieve` call (before retrieving), then behave normally. */
+  failFirstRetrieve?: boolean;
 }
 
 export function makeFakeDriver(opts: FakeDriverOptions = {}): FakeDriver {
@@ -40,6 +45,7 @@ export function makeFakeDriver(opts: FakeDriverOptions = {}): FakeDriver {
     retrieveCalls: [],
     async store(context, payloads) {
       driver.storeCalls.push({ context, payloads });
+      if (opts.failFirstStore && driver.storeCalls.length === 1) throw new Error('transient store failure');
       if (opts.onStore) return opts.onStore(payloads);
       return payloads.map((p) => {
         const id = `${name}-${nextId++}`;
@@ -49,6 +55,7 @@ export function makeFakeDriver(opts: FakeDriverOptions = {}): FakeDriver {
     },
     async retrieve(context, claims) {
       driver.retrieveCalls.push({ context, claims });
+      if (opts.failFirstRetrieve && driver.retrieveCalls.length === 1) throw new Error('transient retrieve failure');
       if (opts.onRetrieve) return opts.onRetrieve(claims);
       return claims.map((c) => memory.get(c.claimData.id!)!);
     },

--- a/packages/test/src/test-integration-extstore.ts
+++ b/packages/test/src/test-integration-extstore.ts
@@ -1,52 +1,282 @@
 /**
  * Integration tests for the external storage feature.
  */
-import { ExternalStorage } from '@temporalio/common';
+import { ExternalStorage, type StorageDriverTargetInfo } from '@temporalio/common';
 import { decodeReferencePayload, isReferencePayload } from '@temporalio/common/lib/internal-non-workflow';
 import * as activities from './activities';
 import { makeFakeDriver } from './extstore-fake-driver';
 import { helpers, makeTestFunction } from './helpers-integration';
-import { externalStorageOffload } from './workflows';
+import {
+  externalStorageActivityInputOffload,
+  externalStorageByteFidelity,
+  externalStorageHeartbeatDetailsOffload,
+  externalStorageOffload,
+  externalStorageParentChildOffload,
+} from './workflows';
 
 const test = makeTestFunction({ workflowsPath: require.resolve('./workflows') });
+
+function requireDefined<T>(value: T | null | undefined, message: string): T {
+  if (value == null) throw new Error(message);
+  return value;
+}
 
 test('large activity result is offloaded to external storage and retrieved once', async (t) => {
   const { createWorker, startWorkflow } = helpers(t);
 
   const driver = makeFakeDriver();
-  // Small but non-zero threshold: small payloads (the activity's numeric arg and the
-  // workflow's numeric result) stay inline; only the large activity result is offloaded.
   const payloadSizeThreshold = 1024;
   const payloadSize = 4096;
   const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold });
 
-  const worker = await createWorker({
-    activities,
-    dataConverter: { externalStorage },
-  });
+  const worker = await createWorker({ activities, dataConverter: { externalStorage } });
 
   const handle = await startWorkflow(externalStorageOffload, { args: [payloadSize] });
   const len = await worker.runUntil(handle.result());
 
-  // Round-trip correctness: the offloaded payload was retrieved and reassembled intact.
   t.is(len, payloadSize);
-  // Exactly the one large activity result was offloaded, and it was retrieved exactly once
-  // when the worker decoded the activity result for the workflow.
   t.is(driver.storeCalls.length, 1);
   t.is(driver.retrieveCalls.length, 1);
 
-  // The activity result stored in workflow history is an external-storage reference.
   const { events } = await handle.fetchHistory();
   const completedEvent = events?.find((ev) => ev.activityTaskCompletedEventAttributes);
-  const resultPayload = completedEvent?.activityTaskCompletedEventAttributes?.result?.payloads?.[0];
-  // Narrow `resultPayload` to non-undefined so the checks below don't need non-null assertions.
-  if (resultPayload == null) throw new Error('expected an ActivityTaskCompleted event with a result payload');
+  const resultPayload = requireDefined(
+    completedEvent?.activityTaskCompletedEventAttributes?.result?.payloads?.[0],
+    'expected an ActivityTaskCompleted event with a result payload'
+  );
   t.true(isReferencePayload(resultPayload), 'activity result in history should be a reference payload');
 
-  // The reference points at the configured driver and records the original payload size (the encoded
-  // Payload wraps at least our `payloadSize` data bytes, plus metadata, and exceeds the threshold).
   const decoded = decodeReferencePayload(resultPayload);
   t.is(decoded.driverName, driver.name);
+  // sizeBytes is the encoded Payload size (data + metadata), so it only exceeds payloadSize.
   t.true(decoded.sizeBytes >= payloadSize);
   t.true(decoded.sizeBytes > payloadSizeThreshold);
+});
+
+test('large activity input argument is offloaded and retrieved', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+
+  const driver = makeFakeDriver();
+  const payloadSize = 4096;
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+  const worker = await createWorker({ activities, dataConverter: { externalStorage } });
+
+  const handle = await startWorkflow(externalStorageActivityInputOffload, { args: [payloadSize] });
+  const len = await worker.runUntil(handle.result());
+
+  t.is(len, payloadSize);
+  t.is(driver.storeCalls.length, 1);
+  t.is(driver.retrieveCalls.length, 1);
+
+  const { events } = await handle.fetchHistory();
+  const scheduled = events?.find((ev) => ev.activityTaskScheduledEventAttributes);
+  const inputPayload = requireDefined(
+    scheduled?.activityTaskScheduledEventAttributes?.input?.payloads?.[0],
+    'expected an ActivityTaskScheduled event with an input payload'
+  );
+  t.true(isReferencePayload(inputPayload), 'activity input in history should be a reference payload');
+});
+
+test('payloads at or below the threshold stay inline', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+
+  const driver = makeFakeDriver();
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 4096 });
+  const worker = await createWorker({ activities, dataConverter: { externalStorage } });
+
+  const smallSize = 1024;
+  const handle = await startWorkflow(externalStorageOffload, { args: [smallSize] });
+  const len = await worker.runUntil(handle.result());
+
+  t.is(len, smallSize);
+  t.is(driver.storeCalls.length, 0);
+  t.is(driver.retrieveCalls.length, 0);
+
+  const { events } = await handle.fetchHistory();
+  const completedEvent = events?.find((ev) => ev.activityTaskCompletedEventAttributes);
+  const resultPayload = requireDefined(
+    completedEvent?.activityTaskCompletedEventAttributes?.result?.payloads?.[0],
+    'expected an ActivityTaskCompleted event with a result payload'
+  );
+  t.false(isReferencePayload(resultPayload), 'below-threshold activity result should stay inline');
+});
+
+test('driverSelector routes offloaded payloads to the chosen driver', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+
+  const driverA = makeFakeDriver({ name: 'a' });
+  const driverB = makeFakeDriver({ name: 'b' });
+  const payloadSize = 4096;
+  let observedTarget: StorageDriverTargetInfo | undefined;
+  const externalStorage = new ExternalStorage({
+    drivers: [driverA, driverB],
+    // Route on the store target. produceLargePayload runs inside a workflow, so its result carries
+    // the owning workflow execution as the target.
+    driverSelector: (context) => {
+      observedTarget = context.target;
+      return context.target?.type === 'externalStorageOffload' ? driverB : driverA;
+    },
+    payloadSizeThreshold: 1024,
+  });
+  const worker = await createWorker({ activities, dataConverter: { externalStorage } });
+
+  const handle = await startWorkflow(externalStorageOffload, { args: [payloadSize] });
+  const len = await worker.runUntil(handle.result());
+
+  t.is(len, payloadSize);
+  t.is(observedTarget?.kind, 'workflow');
+  t.is(observedTarget?.type, 'externalStorageOffload');
+  t.is(driverA.storeCalls.length, 0);
+  t.is(driverB.storeCalls.length, 1);
+  t.is(driverB.retrieveCalls.length, 1);
+
+  const { events } = await handle.fetchHistory();
+  const completedEvent = events?.find((ev) => ev.activityTaskCompletedEventAttributes);
+  const resultPayload = requireDefined(
+    completedEvent?.activityTaskCompletedEventAttributes?.result?.payloads?.[0],
+    'expected an ActivityTaskCompleted event with a result payload'
+  );
+  t.is(decodeReferencePayload(resultPayload).driverName, 'b');
+});
+
+test('offloaded payload round-trips byte-for-byte', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+
+  const driver = makeFakeDriver();
+  const payloadSize = 4096;
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+  const worker = await createWorker({ activities, dataConverter: { externalStorage } });
+
+  const handle = await startWorkflow(externalStorageByteFidelity, { args: [payloadSize] });
+  const bytesMatch = await worker.runUntil(handle.result());
+
+  t.true(bytesMatch, 'retrieved bytes should exactly match the produced pattern');
+  t.is(driver.storeCalls.length, 1);
+  t.is(driver.retrieveCalls.length, 1);
+});
+
+test('large heartbeat details are offloaded and recovered on retry', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+
+  const driver = makeFakeDriver();
+  const payloadSize = 4096;
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+  const worker = await createWorker({ activities, dataConverter: { externalStorage } });
+
+  const handle = await startWorkflow(externalStorageHeartbeatDetailsOffload, { args: [payloadSize] });
+  const len = await worker.runUntil(handle.result());
+
+  t.is(len, payloadSize);
+  t.true(driver.storeCalls.length >= 1);
+  t.true(driver.retrieveCalls.length >= 1);
+});
+
+test('child workflow input and result are offloaded in both directions', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+
+  const driver = makeFakeDriver();
+  const payloadSize = 4096;
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+  const worker = await createWorker({ activities, dataConverter: { externalStorage } });
+
+  const handle = await startWorkflow(externalStorageParentChildOffload, { args: [payloadSize] });
+  const len = await worker.runUntil(handle.result());
+
+  t.is(len, payloadSize);
+  // Stores: child input (by parent) + child result (by child). Retrieves: each read once. The
+  // parent's final result is small and stays inline.
+  t.is(driver.storeCalls.length, 2);
+  t.is(driver.retrieveCalls.length, 2);
+});
+
+test('a transient workflow-completion store failure retries the workflow task and recovers', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+
+  // Activity input is offloaded on the workflow-task completion, so this covers the completion store.
+  const driver = makeFakeDriver({ failFirstStore: true });
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+  const worker = await createWorker({ activities, dataConverter: { externalStorage } });
+
+  const payloadSize = 4096;
+  const handle = await startWorkflow(externalStorageActivityInputOffload, { args: [payloadSize] });
+  const len = await worker.runUntil(handle.result());
+
+  t.is(len, payloadSize);
+  // Not exact: a workflow-task failure evicts and replays the workflow, so the retry count can vary.
+  t.true(driver.storeCalls.length >= 2);
+
+  // Only reliable because we fail exactly once: Temporal's transient-workflow-task optimization
+  // doesn't persist every consecutive WFT failure to history.
+  const { events } = await handle.fetchHistory();
+  const wftFailure = requireDefined(
+    events?.find((ev) => ev.workflowTaskFailedEventAttributes)?.workflowTaskFailedEventAttributes?.failure,
+    'expected a WorkflowTaskFailed event caused by the transient store failure'
+  );
+  t.true(
+    wftFailure.message?.includes('transient store failure') ?? false,
+    `WorkflowTaskFailed should reference the store failure, got: ${wftFailure.message}`
+  );
+});
+
+test('a transient workflow-activation retrieve failure retries the workflow task and recovers', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+
+  // Activity result is retrieved into the workflow activation, so this covers the activation retrieve.
+  const driver = makeFakeDriver({ failFirstRetrieve: true });
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+  const worker = await createWorker({ activities, dataConverter: { externalStorage } });
+
+  const payloadSize = 4096;
+  const handle = await startWorkflow(externalStorageOffload, { args: [payloadSize] });
+  const len = await worker.runUntil(handle.result());
+
+  t.is(len, payloadSize);
+  // Not exact: a workflow-task failure evicts and replays the workflow, so the retry count can vary.
+  t.true(driver.retrieveCalls.length >= 2);
+
+  const { events } = await handle.fetchHistory();
+  const wftFailure = requireDefined(
+    events?.find((ev) => ev.workflowTaskFailedEventAttributes)?.workflowTaskFailedEventAttributes?.failure,
+    'expected a WorkflowTaskFailed event caused by the transient retrieve failure'
+  );
+  t.true(
+    wftFailure.message?.includes('transient retrieve failure') ?? false,
+    `WorkflowTaskFailed should reference the retrieve failure, got: ${wftFailure.message}`
+  );
+});
+
+test('a transient activity result store failure retries the activity and recovers', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+
+  // The activity result is offloaded on the activity-task completion; failing the first store covers
+  // that path.
+  const driver = makeFakeDriver({ failFirstStore: true });
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+  const worker = await createWorker({ activities, dataConverter: { externalStorage } });
+
+  const payloadSize = 4096;
+  const handle = await startWorkflow(externalStorageOffload, { args: [payloadSize] });
+  const len = await worker.runUntil(handle.result());
+
+  t.is(len, payloadSize);
+  // Recovered activity attempts aren't recorded as history events, so the retry is observed via the
+  // driver call count rather than an ActivityTaskFailed event.
+  t.true(driver.storeCalls.length >= 2);
+});
+
+test('a transient activity input retrieve failure retries the activity and recovers', async (t) => {
+  const { createWorker, startWorkflow } = helpers(t);
+
+  // The activity input is offloaded, then retrieved when the worker delivers the activity task;
+  // failing the first retrieve covers that path.
+  const driver = makeFakeDriver({ failFirstRetrieve: true });
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+  const worker = await createWorker({ activities, dataConverter: { externalStorage } });
+
+  const payloadSize = 4096;
+  const handle = await startWorkflow(externalStorageActivityInputOffload, { args: [payloadSize] });
+  const len = await worker.runUntil(handle.result());
+
+  t.is(len, payloadSize);
+  t.true(driver.retrieveCalls.length >= 2);
 });

--- a/packages/test/src/workflows/external-storage-offload.ts
+++ b/packages/test/src/workflows/external-storage-offload.ts
@@ -1,8 +1,19 @@
-import { proxyActivities } from '@temporalio/workflow';
+import { executeChild, proxyActivities } from '@temporalio/workflow';
 import type * as activities from '../activities';
 
-const { produceLargePayload } = proxyActivities<typeof activities>({
-  startToCloseTimeout: '1 minute',
+// Allow a few attempts so the driver-failure tests can assert that a driver failure is
+// retried rather than being fatal; success-path tests all pass on the first attempt anyway.
+const { produceLargePayload, producePatternedPayload, consumeLargePayload } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '10s',
+  scheduleToCloseTimeout: '30s',
+  retry: { maximumAttempts: 3, initialInterval: '100ms' },
+});
+
+// Heartbeat-details recovery requires a retry; allow a little headroom in case the first attempt's
+// heartbeat isn't flushed before it fails.
+const { heartbeatThenReturnDetailsLength } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '10s',
+  retry: { maximumAttempts: 5, initialInterval: '100ms' },
 });
 
 /**
@@ -14,4 +25,53 @@ const { produceLargePayload } = proxyActivities<typeof activities>({
 export async function externalStorageOffload(sizeBytes: number): Promise<number> {
   const payload = await produceLargePayload(sizeBytes);
   return payload.length;
+}
+
+/**
+ * Generates a large payload in Workflow code and passes it as an *argument* to an activity,
+ * exercising offload of the activity input on the outbound command and retrieval on the
+ * inbound activity task. Returns the length the activity observed.
+ */
+export async function externalStorageActivityInputOffload(sizeBytes: number): Promise<number> {
+  return await consumeLargePayload(new Uint8Array(sizeBytes));
+}
+
+/**
+ * Retrieves a patterned payload from an activity and verifies every byte survived the
+ * store/retrieve round-trip intact. Returns `true` iff the bytes match `i % 256`.
+ */
+export async function externalStorageByteFidelity(sizeBytes: number): Promise<boolean> {
+  const payload = await producePatternedPayload(sizeBytes);
+  if (payload.length !== sizeBytes) return false;
+  for (let i = 0; i < payload.length; i++) {
+    if (payload[i] !== i % 256) return false;
+  }
+  return true;
+}
+
+/**
+ * Runs an activity that heartbeats a large details payload on its first attempt (offloaded),
+ * fails, and on retry reads the recovered heartbeat details (retrieved). Returns the length
+ * the retried attempt observed.
+ */
+export async function externalStorageHeartbeatDetailsOffload(sizeBytes: number): Promise<number> {
+  return await heartbeatThenReturnDetailsLength(sizeBytes);
+}
+
+/**
+ * Child workflow that echoes back the (large) payload it receives, so its input is offloaded on
+ * the parent's outbound command and its result is offloaded on the child's completion.
+ */
+export async function externalStorageChildEcho(payload: Uint8Array): Promise<Uint8Array> {
+  return payload;
+}
+
+/**
+ * Parent workflow that starts a child with a large argument and reads back the child's large
+ * result, exercising offload/retrieval in both directions between two Workflows on the same
+ * Worker. Returns the length of the payload round-tripped through the child.
+ */
+export async function externalStorageParentChildOffload(sizeBytes: number): Promise<number> {
+  const result = await executeChild(externalStorageChildEcho, { args: [new Uint8Array(sizeBytes)] });
+  return result.length;
 }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1086,6 +1086,12 @@ export class Worker {
                         `Got start event for an already running activity: ${base64TaskToken}`
                       );
                     }
+                    // Resolve external-storage references in the task payloads in place before anything
+                    // reads them: `extractActivityInfo` below decodes `start.heartbeatDetails` into `info`.
+                    const { externalStorage } = loadedDataConverter;
+                    if (externalStorage) {
+                      await visit(task, walkActivityTask, extstoreRetrieveOptions(externalStorage));
+                    }
                     info = await extractActivityInfo({
                       task,
                       dataConverter: loadedDataConverter,
@@ -1203,7 +1209,7 @@ export class Worker {
               return undefined;
             }
             if (output.type === 'result') {
-              return { taskToken, result: output.result };
+              return { taskToken, result: output.result, info: undefined };
             }
             const { base64TaskToken } = output.activity.info;
 
@@ -1255,15 +1261,58 @@ export class Worker {
               ...activityLogAttributes(output.activity.info),
               status,
             });
-            return { taskToken, result };
+            return { taskToken, result, info: output.activity.info };
           }),
           filter(<T>(result: T): result is Exclude<T, undefined> => result !== undefined),
-          mergeMap(async (rest) => {
+          mergeMap(async ({ taskToken, result, info }) => {
             const { externalStorage } = this.options.loadedDataConverter;
+            const completion = { taskToken, result };
             if (externalStorage) {
-              await visit(rest, walkActivityTaskCompletion, extstoreStoreOptions(externalStorage));
+              let initialTarget: StorageDriverTargetInfo | undefined;
+              if (info) {
+                if (info.inWorkflow) {
+                  initialTarget = {
+                    kind: 'workflow',
+                    namespace: info.namespace,
+                    id: info.workflowExecution?.workflowId,
+                    runId: info.workflowExecution?.runId,
+                    type: info.workflowType,
+                  };
+                } else {
+                  initialTarget = {
+                    kind: 'activity',
+                    namespace: info.namespace,
+                    id: info.activityId,
+                    type: info.activityType,
+                    runId: info.activityRunId,
+                  };
+                }
+              }
+              try {
+                await visit(
+                  completion,
+                  walkActivityTaskCompletion,
+                  extstoreStoreOptions(externalStorage, { initialTarget })
+                );
+              } catch (e) {
+                const error = ensureApplicationFailure(e);
+                // Offloading the activity result failed. Fail the activity task retryably (the encoded
+                // failure surfaces in history/to the workflow) instead of tearing down the Worker.
+                this.logger.error(
+                  `Error while offloading ActivityTask result to external storage: ${errorMessage(error)}`,
+                  {
+                    ...(info ? activityLogAttributes(info) : { taskToken: formatTaskToken(taskToken) }),
+                    error: e,
+                  }
+                );
+                completion.result = {
+                  failed: {
+                    failure: await encodeErrorToFailure(this.options.loadedDataConverter, error),
+                  },
+                };
+              }
             }
-            return coresdk.ActivityTaskCompletion.encodeDelimited(rest).finish();
+            return coresdk.ActivityTaskCompletion.encodeDelimited(completion).finish();
           }),
           tap({
             next: () => {
@@ -1931,10 +1980,6 @@ export class Worker {
         this.hasOutstandingActivityPoll = false;
       }
       const task = coresdk.activity_task.ActivityTask.decode(new Uint8Array(buffer));
-      const { externalStorage } = this.options.loadedDataConverter;
-      if (externalStorage) {
-        await visit(task, walkActivityTask, extstoreRetrieveOptions(externalStorage));
-      }
       const { taskToken, ...rest } = task;
       const base64TaskToken = formatTaskToken(taskToken);
       this.logger.trace('Got activity task', {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Fix worker to fail activity task retryably when storage driver faults
- Plumb through activity and workflow info targets for activity results.
- Add more integration tests for external storage.

## Why?

Fix known issues in external storage interaction. More tests to validate feature.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: More integration tests
1. Any docs updates needed? No