### PR TITLE
fix(langsmith): de-flake test harness sticky timeout

### DIFF
--- a/contrib/langsmith/src/__tests__/helpers.ts
+++ b/contrib/langsmith/src/__tests__/helpers.ts
@@ -182,6 +182,10 @@ export async function withTracingWorker<T>(args: HarnessArgs<T>): Promise<T> {
       workflowsPath: WORKFLOWS_PATH,
       activities: args.activities,
       plugins: [plugin],
+      // Avoid waiting for the default 10s sticky execution timeout on worker
+      // transition: these short-lived per-case workers can otherwise stall a
+      // full 10s on task redelivery and, on loaded CI, blow the 120s AVA cap.
+      stickyQueueScheduleToStartTimeout: '1s',
       ...args.workerOptions,
     });
 


### PR DESCRIPTION
## What was changed
- Set `stickyQueueScheduleToStartTimeout: '1s'` in the langsmith test harness (`withTracingWorker`).

## Why?
The default 10s sticky timeout intermittently stalls these short-lived per-case workers on task redelivery, blowing the 120s AVA timeout (observed hanging `test-signal-child` in CI). Matches the existing convention in the main integration suite (`test-sinks`, `test-signal-query-patch`).

## Checklist
No linked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)