### PR TITLE
feat(exstore): add tmprl1105 error handling for when reference payloads are encountered without extstore configured.

### DIFF
--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -30,7 +30,7 @@ import {
   decodeOptionalFailureToOptionalError,
   encodeToPayloads,
   encodeUserMetadata,
-  extstoreRetrieveOptions,
+  extstoreInboundOptions,
   extstoreStoreOptions,
   visit,
   walkDescribeActivityExecutionResponse,
@@ -350,9 +350,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       try {
         const resp = await this.workflowService.pollActivityExecution(req);
         const externalStorage = this.dataConverter.externalStorage;
-        if (externalStorage) {
-          await visit(resp, walkPollActivityExecutionResponse, extstoreRetrieveOptions(externalStorage));
-        }
+        await visit(resp, walkPollActivityExecutionResponse, extstoreInboundOptions(externalStorage));
         if (resp.outcome?.result) {
           const [result] = await decodeArrayFromPayloads(this.dataConverter, resp.outcome.result.payloads ?? []);
           return result;
@@ -388,9 +386,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
         runId: input.activityRunId || undefined,
       });
       const externalStorage = this.dataConverter.externalStorage;
-      if (externalStorage) {
-        await visit(resp, walkDescribeActivityExecutionResponse, extstoreRetrieveOptions(externalStorage));
-      }
+      await visit(resp, walkDescribeActivityExecutionResponse, extstoreInboundOptions(externalStorage));
       return buildActivityDescription(resp.info!, this.dataConverter);
     } catch (err) {
       this.rethrowGrpcError(err, 'Failed to describe activity');
@@ -447,9 +443,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
           });
 
         const externalStorage = this.dataConverter.externalStorage;
-        if (externalStorage) {
-          await visit(resp, walkListActivityExecutionsResponse, extstoreRetrieveOptions(externalStorage));
-        }
+        await visit(resp, walkListActivityExecutionsResponse, extstoreInboundOptions(externalStorage));
 
         for (const info of resp.executions ?? []) {
           yield buildActivityExecutionInfo(info);

--- a/packages/client/src/nexus-client.ts
+++ b/packages/client/src/nexus-client.ts
@@ -13,7 +13,7 @@ import {
   decodeOptionalFailureToOptionalError,
   decodeOptionalSinglePayload,
   encodeToPayload,
-  extstoreRetrieveOptions,
+  extstoreInboundOptions,
   extstoreStoreOptions,
   visit,
   walkDescribeNexusOperationExecutionResponse,
@@ -488,9 +488,7 @@ export class NexusClient extends BaseClient {
       }
 
       const externalStorage = this.dataConverter.externalStorage;
-      if (externalStorage) {
-        await visit(res, walkPollNexusOperationExecutionResponse, extstoreRetrieveOptions(externalStorage));
-      }
+      await visit(res, walkPollNexusOperationExecutionResponse, extstoreInboundOptions(externalStorage));
 
       // The operation is closed if we have a result or failure
       if (res.result) {
@@ -519,9 +517,7 @@ export class NexusClient extends BaseClient {
       this.rethrowGrpcError(err, 'Failed to describe Nexus operation', input.operationId);
     }
     const externalStorage = this.dataConverter.externalStorage;
-    if (externalStorage) {
-      await visit(res, walkDescribeNexusOperationExecutionResponse, extstoreRetrieveOptions(externalStorage));
-    }
+    await visit(res, walkDescribeNexusOperationExecutionResponse, extstoreInboundOptions(externalStorage));
     if (!res.info) {
       throw new ServiceError('Received invalid Nexus operation description from server: missing info');
     }
@@ -575,9 +571,7 @@ export class NexusClient extends BaseClient {
         this.rethrowGrpcError(err, 'Failed to list Nexus operations', undefined);
       }
       const externalStorage = this.dataConverter.externalStorage;
-      if (externalStorage) {
-        await visit(response, walkListNexusOperationExecutionsResponse, extstoreRetrieveOptions(externalStorage));
-      }
+      await visit(response, walkListNexusOperationExecutionsResponse, extstoreInboundOptions(externalStorage));
       for (const raw of response.operations ?? []) {
         yield nexusOperationListInfoFromProto(raw);
       }

--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -11,7 +11,7 @@ import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import {
   encodeMapToPayloads,
   decodeMapFromPayloads,
-  extstoreRetrieveOptions,
+  extstoreInboundOptions,
   extstoreStoreOptions,
   visit,
   walkCreateScheduleRequest,
@@ -301,9 +301,7 @@ export class ScheduleClient extends BaseClient {
         scheduleId,
       });
       const externalStorage = this.dataConverter.externalStorage;
-      if (externalStorage) {
-        await visit(response, walkDescribeScheduleResponse, extstoreRetrieveOptions(externalStorage));
-      }
+      await visit(response, walkDescribeScheduleResponse, extstoreInboundOptions(externalStorage));
       return response;
     } catch (err: any) {
       this.rethrowGrpcError(err, 'Failed to describe schedule', scheduleId);
@@ -428,9 +426,7 @@ export class ScheduleClient extends BaseClient {
       }
 
       const externalStorage = this.dataConverter.externalStorage;
-      if (externalStorage) {
-        await visit(response, walkListSchedulesResponse, extstoreRetrieveOptions(externalStorage));
-      }
+      await visit(response, walkListSchedulesResponse, extstoreInboundOptions(externalStorage));
 
       for (const raw of response.schedules ?? []) {
         yield <ScheduleSummary>{

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -1556,9 +1556,7 @@ export class WorkflowClient extends BaseClient {
         execution: input.workflowExecution,
       });
       const externalStorage = this.dataConverter.externalStorage;
-      if (externalStorage) {
-        await visit(response, walkDescribeWorkflowExecutionResponse, extstoreRetrieveOptions(externalStorage));
-      }
+      await visit(response, walkDescribeWorkflowExecutionResponse, extstoreInboundOptions(externalStorage));
       return response;
     } catch (err) {
       this.rethrowGrpcError(err, 'Failed to describe workflow', input.workflowExecution);
@@ -1765,9 +1763,7 @@ export class WorkflowClient extends BaseClient {
         this.rethrowGrpcError(e, 'Failed to list workflows', undefined);
       }
       const externalStorage = this.dataConverter.externalStorage;
-      if (externalStorage) {
-        await visit(response, walkListWorkflowExecutionsResponse, extstoreRetrieveOptions(externalStorage));
-      }
+      await visit(response, walkListWorkflowExecutionsResponse, extstoreInboundOptions(externalStorage));
       // Not decoding memo payloads concurrently even though we could have to keep the lazy nature of this iterator.
       // Decoding is done for `memo` fields which tend to be small.
       // We might decide to change that based on user feedback.

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -39,7 +39,7 @@ import {
   decodeOptionalSinglePayload,
   encodeMapToPayloads,
   encodeToPayloadsWithContext,
-  extstoreRetrieveOptions,
+  extstoreInboundOptions,
   extstoreStoreOptions,
   visit,
   walkDescribeWorkflowExecutionResponse,
@@ -836,9 +836,7 @@ export class WorkflowClient extends BaseClient {
         this.rethrowGrpcError(err, 'Failed to get Workflow execution history', { workflowId, runId });
       }
       const externalStorage = this.dataConverter.externalStorage;
-      if (externalStorage) {
-        await visit(res, walkGetWorkflowExecutionHistoryResponse, extstoreRetrieveOptions(externalStorage));
-      }
+      await visit(res, walkGetWorkflowExecutionHistoryResponse, extstoreInboundOptions(externalStorage));
       const events = res.history?.events;
 
       if (events == null || events.length === 0) {
@@ -1009,9 +1007,7 @@ export class WorkflowClient extends BaseClient {
       }
       this.rethrowGrpcError(err, 'Failed to query Workflow', input.workflowExecution);
     }
-    if (externalStorage) {
-      await visit(response, walkQueryWorkflowResponse, extstoreRetrieveOptions(externalStorage));
-    }
+    await visit(response, walkQueryWorkflowResponse, extstoreInboundOptions(externalStorage));
     if (response.queryRejected) {
       if (response.queryRejected.status === undefined || response.queryRejected.status === null) {
         throw new TypeError('Received queryRejected from server with no status');
@@ -1100,9 +1096,7 @@ export class WorkflowClient extends BaseClient {
     } catch (err) {
       this.rethrowUpdateGrpcError(err, 'Workflow Update failed', input.workflowExecution);
     }
-    if (externalStorage) {
-      await visit(response, walkUpdateWorkflowExecutionResponse, extstoreRetrieveOptions(externalStorage));
-    }
+    await visit(response, walkUpdateWorkflowExecutionResponse, extstoreInboundOptions(externalStorage));
     return {
       updateId: request.request!.meta!.updateId!,
 
@@ -1177,9 +1171,7 @@ export class WorkflowClient extends BaseClient {
       }
       do {
         multiOpResp = await this.workflowService.executeMultiOperation(multiOpReq);
-        if (externalStorage) {
-          await visit(multiOpResp, walkExecuteMultiOperationResponse, extstoreRetrieveOptions(externalStorage));
-        }
+        await visit(multiOpResp, walkExecuteMultiOperationResponse, extstoreInboundOptions(externalStorage));
         startResp = multiOpResp.responses?.[0]
           ?.startWorkflow as temporal.api.workflowservice.v1.IStartWorkflowExecutionResponse;
         if (!seenStart) {
@@ -1266,9 +1258,7 @@ export class WorkflowClient extends BaseClient {
       try {
         const response = await this.workflowService.pollWorkflowExecutionUpdate(req);
         const externalStorage = this.dataConverter.externalStorage;
-        if (externalStorage) {
-          await visit(response, walkPollWorkflowExecutionUpdateResponse, extstoreRetrieveOptions(externalStorage));
-        }
+        await visit(response, walkPollWorkflowExecutionUpdateResponse, extstoreInboundOptions(externalStorage));
         if (response.outcome) {
           return response.outcome;
         }

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -73,3 +73,16 @@ export class NamespaceNotFoundError extends Error {
  */
 @SymbolBasedInstanceOfError('CompleteAsyncError')
 export class CompleteAsyncError extends Error {}
+
+/**
+ * Thrown when an inbound payload is detected as an external-storage reference
+ * but no `ExternalStorage` is configured to resolve it.
+ *
+ * @experimental
+ */
+@SymbolBasedInstanceOfError('ExternalStorageNotConfiguredError')
+export class ExternalStorageNotConfiguredError extends Error {
+  constructor(message = 'Detected externally stored payload(s) but external storage is not configured.') {
+    super(`[TMPRL1105] ${message}`);
+  }
+}

--- a/packages/common/src/internal-non-workflow/external-storage-visitor.ts
+++ b/packages/common/src/internal-non-workflow/external-storage-visitor.ts
@@ -53,11 +53,7 @@ export function extstoreStoreOptions(
   };
 }
 
-/**
- * @internal
- * @experimental
- */
-export function extstoreRetrieveOptions(
+function extstoreRetrieveOptions(
   externalStorage: ExternalStorage,
   { limit, abortSignal }: { limit?: ConcurrencyLimit; abortSignal?: AbortSignal } = {}
 ): VisitOptions<void> {
@@ -73,14 +69,11 @@ export function extstoreRetrieveOptions(
 }
 
 /**
- * Options for a detection-only inbound walk used when no {@link ExternalStorage} is configured.
- * The walk leaves every payload untouched but throws {@link ExternalStorageNotConfiguredError}
- * on the first reference payload it encounters.
- *
- * @internal
- * @experimental
+ * Detection-only inbound walk used when no {@link ExternalStorage} is configured: leaves every
+ * payload untouched but throws {@link ExternalStorageNotConfiguredError} on the first reference
+ * payload.
  */
-export function extstoreDetectReferencesOptions(): VisitOptions<void> {
+function extstoreDetectReferencesOptions(): VisitOptions<void> {
   const assertNoReference = (payloads: Payload[]): Payload[] => {
     if (payloads.some(isReferencePayload)) {
       throw new ExternalStorageNotConfiguredError();

--- a/packages/common/src/internal-non-workflow/external-storage-visitor.ts
+++ b/packages/common/src/internal-non-workflow/external-storage-visitor.ts
@@ -6,7 +6,10 @@
  */
 import type { ConcurrencyLimit } from '../concurrency/limit';
 import type { ExternalStorage, StorageDriverTargetInfo } from '../converter/extstore';
+import { ExternalStorageNotConfiguredError } from '../errors';
+import type { Payload } from '../interfaces';
 import { ExternalStorageRunner } from './external-storage-runner';
+import { isReferencePayload } from './extstore-helpers';
 import type { ContextDeriver, VisitOptions } from './payload-visitor';
 
 /**
@@ -67,4 +70,38 @@ export function extstoreRetrieveOptions(
     limit,
     abortSignal,
   };
+}
+
+/**
+ * Options for a detection-only inbound walk used when no {@link ExternalStorage} is configured.
+ * The walk leaves every payload untouched but throws {@link ExternalStorageNotConfiguredError}
+ * on the first reference payload it encounters.
+ *
+ * @internal
+ * @experimental
+ */
+export function extstoreDetectReferencesOptions(): VisitOptions<void> {
+  const assertNoReference = (payloads: Payload[]): Payload[] => {
+    if (payloads.some(isReferencePayload)) {
+      throw new ExternalStorageNotConfiguredError();
+    }
+    return payloads;
+  };
+  return {
+    transformPayloads: (payloads) => Promise.resolve(assertNoReference(payloads)),
+    transformPayload: (payload) => Promise.resolve(assertNoReference([payload])[0]!),
+    skipSearchAttributes: true,
+  };
+}
+
+/**
+ * The inbound External Storage pass for a worker/client boundary: resolve reference payloads when
+ * {@link ExternalStorage} is configured, otherwise fail loudly (via {@link extstoreDetectReferencesOptions})
+ * because nothing can resolve them.
+ *
+ * @internal
+ * @experimental
+ */
+export function extstoreInboundOptions(externalStorage: ExternalStorage | undefined): VisitOptions<void> {
+  return externalStorage ? extstoreRetrieveOptions(externalStorage) : extstoreDetectReferencesOptions();
 }

--- a/packages/test/src/test-extstore-visit.ts
+++ b/packages/test/src/test-extstore-visit.ts
@@ -5,9 +5,7 @@ import { ExternalStorageNotConfiguredError } from '@temporalio/common';
 import { ExternalStorage } from '@temporalio/common/lib/converter/extstore';
 import {
   ExternalStorageRunner,
-  extstoreDetectReferencesOptions,
   extstoreInboundOptions,
-  extstoreRetrieveOptions,
   extstoreStoreOptions,
   isReferencePayload,
   visit,
@@ -156,7 +154,7 @@ test('workflow store then retrieve round-trips the original payload bytes', asyn
   const activation: coresdk.workflow_activation.IWorkflowActivation = {
     jobs: [{ resolveActivity: { result: { completed: { result: reference } } } }],
   };
-  await visit(activation, walkWorkflowActivation, extstoreRetrieveOptions(externalStorage));
+  await visit(activation, walkWorkflowActivation, extstoreInboundOptions(externalStorage));
 
   const retrieved = activation.jobs![0]!.resolveActivity!.result!.completed!.result!;
   t.false(isReferencePayload(retrieved));
@@ -192,7 +190,7 @@ test('activity task retrieve resolves the activity input', async (t) => {
     start: { input: [await toReference(externalStorage, input)] },
   };
 
-  await visit(task, walkActivityTask, extstoreRetrieveOptions(externalStorage));
+  await visit(task, walkActivityTask, extstoreInboundOptions(externalStorage));
 
   t.deepEqual(task.start!.input![0], input);
 });
@@ -215,7 +213,7 @@ test('nexus task retrieve resolves the request payload', async (t) => {
     task: { request: { startOperation: { payload: await toReference(externalStorage, requestPayload) } } },
   };
 
-  await visit(task, walkNexusTask, extstoreRetrieveOptions(externalStorage));
+  await visit(task, walkNexusTask, extstoreInboundOptions(externalStorage));
 
   t.deepEqual(task.task!.request!.startOperation!.payload, requestPayload);
 });
@@ -243,44 +241,12 @@ test('client response retrieve resolves the query result (via generic visit)', a
     queryResult: { payloads: [await toReference(externalStorage, queryResult)] },
   };
 
-  await visit(response, walkQueryWorkflowResponse, extstoreRetrieveOptions(externalStorage));
+  await visit(response, walkQueryWorkflowResponse, extstoreInboundOptions(externalStorage));
 
   t.deepEqual(response.queryResult!.payloads![0], queryResult);
 });
 
-test('detect pass raises ExternalStorageNotConfiguredError on an inbound reference', async (t) => {
-  const { externalStorage } = externalStorageWith();
-  const task: coresdk.activity_task.IActivityTask = {
-    start: { input: [await toReference(externalStorage, makePayload(256, 3))] },
-  };
-
-  const err = await t.throwsAsync(() => visit(task, walkActivityTask, extstoreDetectReferencesOptions()), {
-    instanceOf: ExternalStorageNotConfiguredError,
-  });
-  t.regex(err!.message, /TMPRL1105/);
-});
-
-test('detect pass leaves a reference-free message untouched', async (t) => {
-  const input = makePayload(256, 3);
-  const task: coresdk.activity_task.IActivityTask = { start: { input: [input] } };
-
-  await t.notThrowsAsync(() => visit(task, walkActivityTask, extstoreDetectReferencesOptions()));
-  t.deepEqual(task.start!.input![0], input, 'payload passes through unchanged');
-});
-
-test('inbound options retrieve when storage is configured', async (t) => {
-  const { externalStorage } = externalStorageWith();
-  const input = makePayload(256, 3);
-  const task: coresdk.activity_task.IActivityTask = {
-    start: { input: [await toReference(externalStorage, input)] },
-  };
-
-  await visit(task, walkActivityTask, extstoreInboundOptions(externalStorage));
-
-  t.deepEqual(task.start!.input![0], input, 'reference resolved back to the original payload');
-});
-
-test('inbound options raise TMPRL1105 when storage is not configured', async (t) => {
+test('inbound options raise TMPRL1105 on a reference when storage is not configured', async (t) => {
   const { externalStorage } = externalStorageWith();
   const task: coresdk.activity_task.IActivityTask = {
     start: { input: [await toReference(externalStorage, makePayload(256, 3))] },
@@ -290,4 +256,12 @@ test('inbound options raise TMPRL1105 when storage is not configured', async (t)
     instanceOf: ExternalStorageNotConfiguredError,
   });
   t.regex(err!.message, /TMPRL1105/);
+});
+
+test('inbound options leave a reference-free message untouched when storage is not configured', async (t) => {
+  const input = makePayload(256, 3);
+  const task: coresdk.activity_task.IActivityTask = { start: { input: [input] } };
+
+  await t.notThrowsAsync(() => visit(task, walkActivityTask, extstoreInboundOptions(undefined)));
+  t.deepEqual(task.start!.input![0], input, 'payload passes through unchanged');
 });

--- a/packages/test/src/test-extstore-visit.ts
+++ b/packages/test/src/test-extstore-visit.ts
@@ -1,9 +1,12 @@
 /* eslint @typescript-eslint/no-non-null-assertion: 0 */
 import test from 'ava';
 import type { Payload } from '@temporalio/common';
+import { ExternalStorageNotConfiguredError } from '@temporalio/common';
 import { ExternalStorage } from '@temporalio/common/lib/converter/extstore';
 import {
   ExternalStorageRunner,
+  extstoreDetectReferencesOptions,
+  extstoreInboundOptions,
   extstoreRetrieveOptions,
   extstoreStoreOptions,
   isReferencePayload,
@@ -243,4 +246,48 @@ test('client response retrieve resolves the query result (via generic visit)', a
   await visit(response, walkQueryWorkflowResponse, extstoreRetrieveOptions(externalStorage));
 
   t.deepEqual(response.queryResult!.payloads![0], queryResult);
+});
+
+test('detect pass raises ExternalStorageNotConfiguredError on an inbound reference', async (t) => {
+  const { externalStorage } = externalStorageWith();
+  const task: coresdk.activity_task.IActivityTask = {
+    start: { input: [await toReference(externalStorage, makePayload(256, 3))] },
+  };
+
+  const err = await t.throwsAsync(() => visit(task, walkActivityTask, extstoreDetectReferencesOptions()), {
+    instanceOf: ExternalStorageNotConfiguredError,
+  });
+  t.regex(err!.message, /TMPRL1105/);
+});
+
+test('detect pass leaves a reference-free message untouched', async (t) => {
+  const input = makePayload(256, 3);
+  const task: coresdk.activity_task.IActivityTask = { start: { input: [input] } };
+
+  await t.notThrowsAsync(() => visit(task, walkActivityTask, extstoreDetectReferencesOptions()));
+  t.deepEqual(task.start!.input![0], input, 'payload passes through unchanged');
+});
+
+test('inbound options retrieve when storage is configured', async (t) => {
+  const { externalStorage } = externalStorageWith();
+  const input = makePayload(256, 3);
+  const task: coresdk.activity_task.IActivityTask = {
+    start: { input: [await toReference(externalStorage, input)] },
+  };
+
+  await visit(task, walkActivityTask, extstoreInboundOptions(externalStorage));
+
+  t.deepEqual(task.start!.input![0], input, 'reference resolved back to the original payload');
+});
+
+test('inbound options raise TMPRL1105 when storage is not configured', async (t) => {
+  const { externalStorage } = externalStorageWith();
+  const task: coresdk.activity_task.IActivityTask = {
+    start: { input: [await toReference(externalStorage, makePayload(256, 3))] },
+  };
+
+  const err = await t.throwsAsync(() => visit(task, walkActivityTask, extstoreInboundOptions(undefined)), {
+    instanceOf: ExternalStorageNotConfiguredError,
+  });
+  t.regex(err!.message, /TMPRL1105/);
 });

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1398,7 +1398,10 @@ export class Worker {
     protobufEncodedTask: ArrayBuffer,
     requestDeadline: Date | undefined
   ) {
-    const task = nexusTask.task!; // Caller guarantees the 'task' variant is populated.
+    const task = nexusTask.task;
+    if (task == null) {
+      throw new nexus.HandlerError('INTERNAL', 'Nexus task missing task request');
+    }
     const { taskToken } = task;
     if (taskToken == null) {
       throw new nexus.HandlerError('INTERNAL', 'Task missing request task token');

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1321,28 +1321,27 @@ export class Worker {
               if (task.task == null) {
                 throw new IllegalStateError(`Got empty task for task variant with token: ${base64TaskToken}`);
               }
-              const { externalStorage } = this.options.loadedDataConverter;
-              if (externalStorage) {
-                try {
-                  await visit(task, walkNexusTask, extstoreRetrieveOptions(externalStorage));
-                } catch (e) {
-                  this.logger.error(
-                    `Error while retrieving Nexus task payloads from external storage: ${errorMessage(e)}`,
-                    { taskToken: base64TaskToken, error: e }
-                  );
-                  // Core requires a NexusHandlerFailureInfo on a Nexus failure completion, so wrap the
-                  // driver error in a retryable handler error.
-                  return {
-                    taskToken: task.task.taskToken,
-                    failure: await handlerErrorToProto(
-                      this.options.loadedDataConverter,
-                      new nexus.HandlerError('INTERNAL', errorMessage(e), { cause: e, retryableOverride: true })
-                    ),
-                  };
-                }
+              try {
+                await visit(
+                  task,
+                  walkNexusTask,
+                  extstoreInboundOptions(this.options.loadedDataConverter.externalStorage)
+                );
+              } catch (e) {
+                this.logger.error(
+                  `Error while retrieving Nexus task payloads from external storage: ${errorMessage(e)}`,
+                  { taskToken: base64TaskToken, error: e }
+                );
+                return {
+                  taskToken: task.task.taskToken,
+                  failure: await handlerErrorToProto(
+                    this.options.loadedDataConverter,
+                    new nexus.HandlerError('INTERNAL', errorMessage(e), { cause: e, retryableOverride: true })
+                  ),
+                };
               }
               const requestDeadline = task.requestDeadline != null ? tsToDate(task.requestDeadline) : undefined;
-              return await this.handleNexusRunTask(task, base64TaskToken, protobufEncodedTask, requestDeadline);
+              return await this.handleNexusRunTask(task.task, base64TaskToken, protobufEncodedTask, requestDeadline);
             }
             case 'cancelTask': {
               const nexusHandler = this.taskTokenToNexusHandler.get(base64TaskToken);
@@ -1393,15 +1392,11 @@ export class Worker {
   }
 
   private async handleNexusRunTask(
-    nexusTask: coresdk.nexus.INexusTask,
+    task: temporal.api.workflowservice.v1.IPollNexusTaskQueueResponse,
     base64TaskToken: string,
     protobufEncodedTask: ArrayBuffer,
     requestDeadline: Date | undefined
   ) {
-    const task = nexusTask.task;
-    if (task == null) {
-      throw new nexus.HandlerError('INTERNAL', 'Nexus task missing task request');
-    }
     const { taskToken } = task;
     if (taskToken == null) {
       throw new nexus.HandlerError('INTERNAL', 'Task missing request task token');
@@ -1409,7 +1404,6 @@ export class Worker {
 
     let nexusHandler: NexusHandler | undefined = undefined;
     try {
-      await visit(nexusTask, walkNexusTask, extstoreInboundOptions(this.options.loadedDataConverter.externalStorage));
       const abortController = new AbortController();
 
       nexusHandler = new NexusHandler(

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -31,7 +31,7 @@ import {
   decodeFromPayloadsAtIndex,
   encodeErrorToFailure,
   encodeToPayload,
-  extstoreRetrieveOptions,
+  extstoreInboundOptions,
   extstoreStoreOptions,
   visit,
   walkActivityHeartbeat,
@@ -1086,12 +1086,7 @@ export class Worker {
                         `Got start event for an already running activity: ${base64TaskToken}`
                       );
                     }
-                    // Resolve external-storage references in the task payloads in place before anything
-                    // reads them: `extractActivityInfo` below decodes `start.heartbeatDetails` into `info`.
-                    const { externalStorage } = loadedDataConverter;
-                    if (externalStorage) {
-                      await visit(task, walkActivityTask, extstoreRetrieveOptions(externalStorage));
-                    }
+                    await visit(task, walkActivityTask, extstoreInboundOptions(loadedDataConverter.externalStorage));
                     info = await extractActivityInfo({
                       task,
                       dataConverter: loadedDataConverter,
@@ -1347,7 +1342,7 @@ export class Worker {
                 }
               }
               const requestDeadline = task.requestDeadline != null ? tsToDate(task.requestDeadline) : undefined;
-              return await this.handleNexusRunTask(task.task, base64TaskToken, protobufEncodedTask, requestDeadline);
+              return await this.handleNexusRunTask(task, base64TaskToken, protobufEncodedTask, requestDeadline);
             }
             case 'cancelTask': {
               const nexusHandler = this.taskTokenToNexusHandler.get(base64TaskToken);
@@ -1398,11 +1393,12 @@ export class Worker {
   }
 
   private async handleNexusRunTask(
-    task: temporal.api.workflowservice.v1.IPollNexusTaskQueueResponse,
+    nexusTask: coresdk.nexus.INexusTask,
     base64TaskToken: string,
     protobufEncodedTask: ArrayBuffer,
     requestDeadline: Date | undefined
   ) {
+    const task = nexusTask.task!; // Caller guarantees the 'task' variant is populated.
     const { taskToken } = task;
     if (taskToken == null) {
       throw new nexus.HandlerError('INTERNAL', 'Task missing request task token');
@@ -1410,6 +1406,7 @@ export class Worker {
 
     let nexusHandler: NexusHandler | undefined = undefined;
     try {
+      await visit(nexusTask, walkNexusTask, extstoreInboundOptions(this.options.loadedDataConverter.externalStorage));
       const abortController = new AbortController();
 
       nexusHandler = new NexusHandler(
@@ -1541,9 +1538,7 @@ export class Worker {
         });
       }
       const { externalStorage } = this.options.loadedDataConverter;
-      if (externalStorage) {
-        await visit(activation, walkWorkflowActivation, extstoreRetrieveOptions(externalStorage));
-      }
+      await visit(activation, walkWorkflowActivation, extstoreInboundOptions(externalStorage));
       const decodedActivation = await workflowCodecRunner.decodeActivation(activation);
 
       if (workflow === undefined) {
@@ -2052,9 +2047,6 @@ export class Worker {
         this.hasOutstandingNexusPoll = false;
       }
       const task = coresdk.nexus.NexusTask.decode(new Uint8Array(buffer));
-      // NOTE: external-storage retrieval of the request payload happens in `nexusOperator`'s `task`
-      // handling, so a driver failure fails the Nexus task retryably instead of tearing down the poll
-      // loop (and the Worker).
       const taskToken = task.task?.taskToken || task.cancelTask?.taskToken;
       if (taskToken == null) {
         throw new TypeError('Got a Nexus task without a task token');


### PR DESCRIPTION
## What was changed

When an inbound payload is an external-storage reference but no ExternalStorage is configured to resolve it, we now fail with `ExternalStorageNotConfiguredError` (TMPRL1105).

- New `ExternalStorageNotConfiguredError` (common/src/errors.ts).
- New extstoreInboundOptions(externalStorage?): the single inbound decision point
- Wired unconditionally at every inbound boundary: worker (workflow / activity / nexus tasks) and client (getHistory / query / update / multi-op / poll-update).
- Moved the activity/nexus inbound pass out of the poll loops into the task handlers, so a throw fails the task instead of crashing the poller.

## Why

- Trade-off: the inbound walk runs even when extstore is off (a read-only pass over an already-decoded message), in exchange for failing loudly instead of mis-decoding a reference.

## Checklist

- Testing: 46 extstore unit tests pass, incl. inbound retrieve-vs-throw dispatch; build + lint clean.