### PR TITLE
fix(worker): set external storage target for activity heartbeats

### DIFF
--- a/packages/test/src/test-integration-extstore.ts
+++ b/packages/test/src/test-integration-extstore.ts
@@ -169,6 +169,11 @@ test('large heartbeat details are offloaded and recovered on retry', async (t) =
   t.is(len, payloadSize);
   t.true(driver.storeCalls.length >= 1);
   t.true(driver.retrieveCalls.length >= 1);
+
+  // The heartbeat store carried the owning workflow as its target (the activity is workflow-bound).
+  const target = requireDefined(driver.storeCalls[0], 'expected a heartbeat store call').context.target;
+  t.is(target?.kind, 'workflow');
+  t.is(target?.type, 'externalStorageHeartbeatDetailsOffload');
 });
 
 test('child workflow input and result are offloaded in both directions', async (t) => {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1268,26 +1268,7 @@ export class Worker {
             const { externalStorage } = this.options.loadedDataConverter;
             const completion = { taskToken, result };
             if (externalStorage) {
-              let initialTarget: StorageDriverTargetInfo | undefined;
-              if (info) {
-                if (info.inWorkflow) {
-                  initialTarget = {
-                    kind: 'workflow',
-                    namespace: info.namespace,
-                    id: info.workflowExecution?.workflowId,
-                    runId: info.workflowExecution?.runId,
-                    type: info.workflowType,
-                  };
-                } else {
-                  initialTarget = {
-                    kind: 'activity',
-                    namespace: info.namespace,
-                    id: info.activityId,
-                    type: info.activityType,
-                    runId: info.activityRunId,
-                  };
-                }
-              }
+              const initialTarget = info ? activityStorageTarget(info) : undefined;
               try {
                 await visit(
                   completion,
@@ -1890,7 +1871,11 @@ export class Worker {
               const heartbeat: coresdk.IActivityHeartbeat = { taskToken, details: [payload] };
               const { externalStorage } = this.options.loadedDataConverter;
               if (externalStorage) {
-                await visit(heartbeat, walkActivityHeartbeat, extstoreStoreOptions(externalStorage));
+                await visit(
+                  heartbeat,
+                  walkActivityHeartbeat,
+                  extstoreStoreOptions(externalStorage, { initialTarget: activityStorageTarget(info) })
+                );
               }
               const arr = coresdk.ActivityHeartbeat.encodeDelimited(heartbeat).finish();
               this.nativeWorker.recordActivityHeartbeat(byteArrayToBuffer(arr));
@@ -2315,6 +2300,29 @@ function extractSourceMap(code: string): [string, string] {
   }
 
   throw new Error("Can't extract inlined source map from the provided Workflow Bundle");
+}
+
+/**
+ * External-storage target for payloads produced by an activity, matching the Go SDK: a
+ * workflow-bound activity targets its owning workflow execution; a standalone activity targets
+ * itself. Used for both the activity result and its heartbeat details.
+ */
+function activityStorageTarget(info: ActivityInfo): StorageDriverTargetInfo {
+  return info.inWorkflow
+    ? {
+        kind: 'workflow',
+        namespace: info.namespace,
+        id: info.workflowExecution?.workflowId,
+        runId: info.workflowExecution?.runId,
+        type: info.workflowType,
+      }
+    : {
+        kind: 'activity',
+        namespace: info.namespace,
+        id: info.activityId,
+        type: info.activityType,
+        runId: info.activityRunId,
+      };
 }
 
 /**


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Fix activity heartbeat external storage to provide storage target info.

## Why?

Allow storage drivers to get correct target information.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: Integration test

1. Any docs updates needed? No