### PR TITLE
fix(extstore): set workflow type in workflow-owned store targets

### DIFF
--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -1165,6 +1165,7 @@ export class WorkflowClient extends BaseClient {
               kind: 'workflow',
               namespace: this.options.namespace,
               id: input.workflowStartOptions.workflowId,
+              type: input.workflowType,
             },
           })
         );
@@ -1367,7 +1368,12 @@ export class WorkflowClient extends BaseClient {
           req,
           walkSignalWithStartWorkflowExecutionRequest,
           extstoreStoreOptions(externalStorage, {
-            initialTarget: { kind: 'workflow', namespace: this.options.namespace, id: req.workflowId ?? undefined },
+            initialTarget: {
+              kind: 'workflow',
+              namespace: this.options.namespace,
+              id: req.workflowId ?? undefined,
+              type: workflowType,
+            },
           })
         );
       }
@@ -1410,6 +1416,7 @@ export class WorkflowClient extends BaseClient {
               kind: 'workflow',
               namespace: req.namespace ?? this.options.namespace,
               id: req.workflowId ?? undefined,
+              type: workflowType,
             },
           })
         );

--- a/packages/test/src/test-integration-extstore.ts
+++ b/packages/test/src/test-integration-extstore.ts
@@ -197,15 +197,20 @@ test('child workflow input and result are offloaded in both directions', async (
   const len = await worker.runUntil(handle.result());
 
   t.is(len, payloadSize);
-  // [0] child input (parent's StartChildWorkflowExecution command), [1] child result (child's
-  // completion) — both keyed under the child's type. The parent's final result stays inline.
-  // The child's id/runId are runtime-generated, so only kind and type are asserted.
+  // [0] child input (parent's StartChildWorkflowExecution command), keyed under the child (its
+  // runtime-generated id isn't known here, so only kind/type are asserted). [1] child result
+  // (child's completion), keyed under the *parent* — a child's result is consumed by its parent.
+  // The parent's own final result stays inline.
   t.is(driver.storeCalls.length, 2);
   t.is(driver.retrieveCalls.length, 2);
   t.is(driver.storeCalls[0].context.target?.kind, 'workflow');
   t.is(driver.storeCalls[0].context.target?.type, 'externalStorageEcho');
-  t.is(driver.storeCalls[1].context.target?.kind, 'workflow');
-  t.is(driver.storeCalls[1].context.target?.type, 'externalStorageEcho');
+  t.deepEqual(driver.storeCalls[1].context.target, {
+    kind: 'workflow',
+    namespace: 'default',
+    id: handle.workflowId,
+    runId: handle.firstExecutionRunId,
+  });
 });
 
 test('continue-as-new offloads a large argument keyed under the target workflow type', async (t) => {

--- a/packages/test/src/test-integration-extstore.ts
+++ b/packages/test/src/test-integration-extstore.ts
@@ -13,6 +13,7 @@ import { helpers, makeTestFunction } from './helpers-integration';
 import {
   externalStorageActivityInputOffload,
   externalStorageByteFidelity,
+  externalStorageContinueAsNewSource,
   externalStorageEcho,
   externalStorageHeartbeatDetailsOffload,
   externalStorageOffload,
@@ -196,10 +197,45 @@ test('child workflow input and result are offloaded in both directions', async (
   const len = await worker.runUntil(handle.result());
 
   t.is(len, payloadSize);
-  // Stores: child input (by parent) + child result (by child). Retrieves: each read once. The
-  // parent's final result is small and stays inline.
+  // [0] child input (parent's StartChildWorkflowExecution command), [1] child result (child's
+  // completion) — both keyed under the child's type. The parent's final result stays inline.
+  // The child's id/runId are runtime-generated, so only kind and type are asserted.
   t.is(driver.storeCalls.length, 2);
   t.is(driver.retrieveCalls.length, 2);
+  t.is(driver.storeCalls[0].context.target?.kind, 'workflow');
+  t.is(driver.storeCalls[0].context.target?.type, 'externalStorageEcho');
+  t.is(driver.storeCalls[1].context.target?.kind, 'workflow');
+  t.is(driver.storeCalls[1].context.target?.type, 'externalStorageEcho');
+});
+
+test('continue-as-new offloads a large argument keyed under the target workflow type', async (t) => {
+  const { createWorker, taskQueue } = helpers(t);
+
+  const driver = makeFakeDriver();
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+  const sizeBytes = 4096;
+
+  const worker = await createWorker({ dataConverter: { externalStorage } });
+  const client = new Client({ connection: t.context.env.connection, dataConverter: { externalStorage } });
+
+  const workflowId = randomUUID();
+  const handle = await client.workflow.start(externalStorageContinueAsNewSource, {
+    taskQueue,
+    workflowId,
+    args: [sizeBytes],
+  });
+  const result = await worker.runUntil(handle.result());
+  t.is(result, sizeBytes, 'the continue-as-new target should observe the full offloaded argument');
+
+  // The ContinueAsNew argument, offloaded on the source's completion but keyed under the new run.
+  t.is(driver.storeCalls.length, 1);
+  t.deepEqual(driver.storeCalls[0].context.target, {
+    kind: 'workflow',
+    namespace: 'default',
+    id: workflowId,
+    runId: undefined,
+    type: 'externalStorageContinueAsNewTarget',
+  });
 });
 
 test('a transient workflow-completion store failure retries the workflow task and recovers', async (t) => {
@@ -321,6 +357,22 @@ test('client offloads a large start argument and retrieves a large result', asyn
     ?.workflowExecutionCompletedEventAttributes?.result?.payloads?.[0];
   if (resultPayload == null) throw new Error('expected a completed result payload');
   t.true(isReferencePayload(resultPayload), 'workflow result should be a reference before the client retrieves it');
+
+  // [0] client-side start argument, [1] Worker-side completion result.
+  t.is(driver.storeCalls.length, 2);
+  t.deepEqual(driver.storeCalls[0].context.target, {
+    kind: 'workflow',
+    namespace: 'default',
+    id: workflowId,
+    type: 'externalStorageEcho',
+  });
+  t.deepEqual(driver.storeCalls[1].context.target, {
+    kind: 'workflow',
+    namespace: 'default',
+    id: workflowId,
+    runId: handle.firstExecutionRunId,
+    type: 'externalStorageEcho',
+  });
 });
 
 test('client retrieves an offloaded query result', async (t) => {
@@ -417,6 +469,41 @@ test('AsyncCompletionClient.complete by ID targets the Activity for a Standalone
     namespace: 'default',
     id: 'act-2',
     runId: 'run-2',
+  });
+});
+
+test('signalWithStart offloads a large workflow argument and targets the workflow type', async (t) => {
+  const driver = makeFakeDriver();
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 1024 });
+
+  let req: temporal.api.workflowservice.v1.ISignalWithStartWorkflowExecutionRequest | undefined;
+  const connection = {
+    workflowService: {
+      signalWithStartWorkflowExecution: async (
+        r: temporal.api.workflowservice.v1.ISignalWithStartWorkflowExecutionRequest
+      ) => {
+        req = r;
+        return { runId: 'run-1' };
+      },
+    },
+    plugins: [],
+  } as unknown as ConnectionLike;
+  const client = new Client({ connection, dataConverter: { externalStorage } });
+
+  await client.workflow.signalWithStart('myWorkflow', {
+    workflowId: 'wf-1',
+    taskQueue: 'q',
+    args: [new Uint8Array(4096).fill(1)],
+    signal: 'mySignal',
+  });
+
+  t.is(driver.storeCalls.length, 1);
+  t.true(isReferencePayload(req!.input!.payloads![0]), 'the workflow argument should be offloaded before sending');
+  t.deepEqual(driver.storeCalls[0].context.target, {
+    kind: 'workflow',
+    namespace: 'default',
+    id: 'wf-1',
+    type: 'myWorkflow',
   });
 });
 

--- a/packages/test/src/workflows/external-storage-offload.ts
+++ b/packages/test/src/workflows/external-storage-offload.ts
@@ -1,4 +1,12 @@
-import { condition, defineQuery, defineSignal, executeChild, proxyActivities, setHandler } from '@temporalio/workflow';
+import {
+  condition,
+  defineQuery,
+  defineSignal,
+  executeChild,
+  makeContinueAsNewFunc,
+  proxyActivities,
+  setHandler,
+} from '@temporalio/workflow';
 import type * as activities from '../activities';
 
 // Allow a few attempts so the driver-failure tests can assert that a driver failure is
@@ -74,6 +82,24 @@ export async function externalStorageParentChildOffload(sizeBytes: number): Prom
  */
 export async function externalStorageEcho(data: Uint8Array): Promise<Uint8Array> {
   return data;
+}
+
+/**
+ * Continues-as-new into a *different* workflow type ({@link externalStorageContinueAsNewTarget}),
+ * passing a large argument. Exercises offload of the ContinueAsNew arguments on the source
+ * workflow's completion. Those arguments belong to the new run, so they must be keyed under the
+ * new workflow type (the command's `workflowType`), not the source's.
+ */
+export async function externalStorageContinueAsNewSource(sizeBytes: number): Promise<number> {
+  const continueAsTarget = makeContinueAsNewFunc<typeof externalStorageContinueAsNewTarget>({
+    workflowType: 'externalStorageContinueAsNewTarget',
+  });
+  return await continueAsTarget(new Uint8Array(sizeBytes).fill(4));
+}
+
+/** Target of {@link externalStorageContinueAsNewSource}'s continue-as-new; returns its argument's length. */
+export async function externalStorageContinueAsNewTarget(data: Uint8Array): Promise<number> {
+  return data.length;
 }
 
 export const getBlobQuery = defineQuery<Uint8Array>('getBlob');

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -178,6 +178,7 @@ interface WorkflowWithLogAttributes {
   workflow: Workflow;
   logAttributes: Record<string, unknown>;
   workflowCodecRunner: WorkflowCodecRunner;
+  workflowType: string;
 }
 
 function addBuildIdIfMissing(options: CompiledWorkerOptions, bundleCode?: string): CompiledWorkerOptionsWithBuildId {
@@ -1564,6 +1565,7 @@ export class Worker {
                 namespace,
                 id: workflowCodecRunner.workflowContext.workflowId,
                 runId: activation.runId,
+                type: workflow.workflowType,
               },
               deriveContext: workflowCommandStoreTarget(namespace),
             })
@@ -1714,7 +1716,7 @@ export class Worker {
     });
 
     this.numCachedWorkflowsSubject.next(this.numCachedWorkflowsSubject.value + 1);
-    return { workflow, logAttributes, workflowCodecRunner };
+    return { workflow, logAttributes, workflowCodecRunner, workflowType };
   }
 
   /**
@@ -2421,7 +2423,12 @@ function workflowCommandStoreTarget(
     switch (typeName) {
       case 'coresdk.workflow_commands.StartChildWorkflowExecution': {
         const command = message as coresdk.workflow_commands.IStartChildWorkflowExecution;
-        return { kind: 'workflow', namespace: command.namespace || namespace, id: command.workflowId ?? undefined };
+        return {
+          kind: 'workflow',
+          namespace: command.namespace || namespace,
+          id: command.workflowId ?? undefined,
+          type: command.workflowType ?? undefined,
+        };
       }
       case 'coresdk.workflow_commands.SignalExternalWorkflowExecution':
       case 'coresdk.workflow_commands.RequestCancelExternalWorkflowExecution': {
@@ -2431,8 +2438,11 @@ function workflowCommandStoreTarget(
         const workflowId = command.workflowExecution?.workflowId ?? command.childWorkflowId ?? undefined;
         return { kind: 'workflow', namespace: command.workflowExecution?.namespace || namespace, id: workflowId };
       }
-      case 'coresdk.workflow_commands.ContinueAsNewWorkflowExecution':
-        return context ? { ...context, runId: undefined } : context;
+      case 'coresdk.workflow_commands.ContinueAsNewWorkflowExecution': {
+        if (context == null) return context;
+        const command = message as coresdk.workflow_commands.IContinueAsNewWorkflowExecution;
+        return { ...context, runId: undefined, type: command.workflowType || context.type };
+      }
       default:
         return context;
     }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -178,7 +178,7 @@ interface WorkflowWithLogAttributes {
   workflow: Workflow;
   logAttributes: Record<string, unknown>;
   workflowCodecRunner: WorkflowCodecRunner;
-  workflowType: string;
+  info: WorkflowInfo;
 }
 
 function addBuildIdIfMissing(options: CompiledWorkerOptions, bundleCode?: string): CompiledWorkerOptionsWithBuildId {
@@ -1565,9 +1565,9 @@ export class Worker {
                 namespace,
                 id: workflowCodecRunner.workflowContext.workflowId,
                 runId: activation.runId,
-                type: workflow.workflowType,
+                type: workflow.info.workflowType,
               },
-              deriveContext: workflowCommandStoreTarget(namespace),
+              deriveContext: workflowCommandStoreTarget(namespace, workflow.info),
             })
           );
         }
@@ -1716,7 +1716,7 @@ export class Worker {
     });
 
     this.numCachedWorkflowsSubject.next(this.numCachedWorkflowsSubject.value + 1);
-    return { workflow, logAttributes, workflowCodecRunner, workflowType };
+    return { workflow, logAttributes, workflowCodecRunner, info: workflowInfo };
   }
 
   /**
@@ -2413,7 +2413,8 @@ async function extractActivityInfo({
 }
 
 function workflowCommandStoreTarget(
-  namespace: string
+  namespace: string,
+  info: WorkflowInfo
 ): (
   message: object,
   typeName: string,
@@ -2442,6 +2443,11 @@ function workflowCommandStoreTarget(
         if (context == null) return context;
         const command = message as coresdk.workflow_commands.IContinueAsNewWorkflowExecution;
         return { ...context, runId: undefined, type: command.workflowType || context.type };
+      }
+      case 'coresdk.workflow_commands.CompleteWorkflowExecution': {
+        const { parent } = info;
+        if (parent == null || info.continuedFromExecutionRunId != null) return context;
+        return { kind: 'workflow', namespace: parent.namespace || namespace, id: parent.workflowId, runId: parent.runId };
       }
       default:
         return context;

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -2447,7 +2447,12 @@ function workflowCommandStoreTarget(
       case 'coresdk.workflow_commands.CompleteWorkflowExecution': {
         const { parent } = info;
         if (parent == null || info.continuedFromExecutionRunId != null) return context;
-        return { kind: 'workflow', namespace: parent.namespace || namespace, id: parent.workflowId, runId: parent.runId };
+        return {
+          kind: 'workflow',
+          namespace: parent.namespace || namespace,
+          id: parent.workflowId,
+          runId: parent.runId,
+        };
       }
       default:
         return context;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Fixed store sites that weren't specifying the workflow type in the target info.
- Fixed child workflows to target result under parent workflow if not CaN'd.

## Why?

Make sure external storage provides as much information as possible to drivers when storing.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: More and updated integration tests

1. Any docs updates needed? No