### PR TITLE
feat(common): add TypeInfo-aware payload conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 
+### Added
+
+- **Experimental**: Added `TypeInfo` and `TransferTypeConverter` to `@temporalio/common` for converting
+  application values to and from serialization-friendly transfer types around payload conversion.
+
 ### Fixed
 
 - strands: Declare `zod` as a peer dependency.

--- a/packages/common/src/__tests__/test-type-info.ts
+++ b/packages/common/src/__tests__/test-type-info.ts
@@ -1,0 +1,51 @@
+import test from 'ava';
+import { defaultDataConverter } from '../converter/data-converter';
+import { defaultPayloadConverter } from '../converter/payload-converter';
+import { decodeArrayFromPayloads, encodeToPayloadsWithContext } from '../internal-non-workflow/codec-helpers';
+import type { TypeInfo } from '../type-info';
+
+class UserAccount {
+  constructor(
+    readonly id: string,
+    readonly balanceInCents: bigint
+  ) {}
+}
+
+interface UserAccountData {
+  id: string;
+  balanceInCents: string;
+}
+
+function toUserAccountData(account: UserAccount): UserAccountData {
+  return {
+    id: account.id,
+    balanceInCents: account.balanceInCents.toString(),
+  };
+}
+
+function fromUserAccountData(value: unknown): UserAccount {
+  const data = value as UserAccountData;
+  return new UserAccount(data.id, BigInt(data.balanceInCents));
+}
+
+const userAccountTypeInfo: TypeInfo<UserAccount> = {
+  transferTypeConverter: {
+    toTransferType: toUserAccountData,
+    fromTransferType: fromUserAccountData,
+  },
+};
+
+test('converts an application class to a transfer type around JSON payload conversion', async (t) => {
+  const account = new UserAccount('account-123', 123n);
+  const payloads = await encodeToPayloadsWithContext(defaultDataConverter, undefined, [account], [userAccountTypeInfo]);
+
+  t.deepEqual(payloads, [defaultPayloadConverter.toPayload(toUserAccountData(account))]);
+
+  const [result] = await decodeArrayFromPayloads(defaultDataConverter, payloads, undefined, [userAccountTypeInfo]);
+  if (!(result instanceof UserAccount)) {
+    t.fail('Expected a UserAccount');
+    return;
+  }
+  t.is(result.id, account.id);
+  t.is(result.balanceInCents, account.balanceInCents);
+});

--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -1,6 +1,7 @@
 import { decode, encode } from '../encoding';
 import { PayloadConverterError, ValueError } from '../errors';
 import type { Payload } from '../interfaces';
+import type { TypeInfo } from '../type-info';
 import type { SerializationContext } from './serialization-context';
 import { encodingKeys, encodingTypes, METADATA_ENCODING_KEY } from './types';
 
@@ -29,6 +30,38 @@ export interface PayloadConverter {
 }
 
 /**
+ * Apply TypeInfo transfer conversion before converting a value to a Payload.
+ *
+ * @experimental
+ */
+export function toPayloadWithTypeInfo<T>(
+  converter: PayloadConverter,
+  value: T,
+  context: SerializationContext | undefined,
+  typeInfo: TypeInfo<T> | undefined
+): Payload {
+  const transferValue = typeInfo?.transferTypeConverter ? typeInfo.transferTypeConverter.toTransferType(value) : value;
+  return converter.toPayload(transferValue, context);
+}
+
+/**
+ * Convert a Payload and then apply TypeInfo transfer conversion to the result.
+ *
+ * @experimental
+ */
+export function fromPayloadWithTypeInfo<T>(
+  converter: PayloadConverter,
+  payload: Payload,
+  context: SerializationContext | undefined,
+  typeInfo: TypeInfo<T> | undefined
+): T {
+  const transferValue = converter.fromPayload<unknown>(payload, context);
+  return typeInfo?.transferTypeConverter
+    ? typeInfo.transferTypeConverter.fromTransferType(transferValue)
+    : (transferValue as T);
+}
+
+/**
  * Implements conversion of a list of values.
  *
  * @param converter
@@ -49,13 +82,14 @@ export function toPayloads(converter: PayloadConverter, ...values: unknown[]): P
 export function toPayloadsWithContext(
   converter: PayloadConverter,
   context: SerializationContext | undefined,
-  values: unknown[]
+  values: unknown[],
+  typeInfo?: readonly TypeInfo[]
 ): Payload[] | undefined {
   if (values.length === 0) {
     return undefined;
   }
 
-  return values.map((value) => converter.toPayload(value, context));
+  return values.map((value, index) => toPayloadWithTypeInfo(converter, value, context, typeInfo?.[index]));
 }
 
 /**
@@ -101,7 +135,8 @@ export function fromPayloadsAtIndex<T>(
   converter: PayloadConverter,
   index: number,
   payloads?: Payload[] | null,
-  context?: SerializationContext
+  context?: SerializationContext,
+  typeInfo?: TypeInfo<T>
 ): T {
   // To make adding arguments a backwards compatible change
   if (payloads === undefined || payloads === null || index >= payloads.length) {
@@ -111,7 +146,7 @@ export function fromPayloadsAtIndex<T>(
   if (!payload) {
     return undefined as any;
   }
-  return converter.fromPayload(payload, context);
+  return fromPayloadWithTypeInfo(converter, payload, context, typeInfo);
 }
 
 /**
@@ -120,12 +155,15 @@ export function fromPayloadsAtIndex<T>(
 export function arrayFromPayloads(
   converter: PayloadConverter,
   payloads?: Payload[] | null,
-  context?: SerializationContext
+  context?: SerializationContext,
+  typeInfo?: readonly TypeInfo[]
 ): unknown[] {
   if (!payloads) {
     return [];
   }
-  return payloads.map((payload: Payload) => converter.fromPayload(payload, context));
+  return payloads.map((payload: Payload, index) =>
+    fromPayloadWithTypeInfo(converter, payload, context, typeInfo?.[index])
+  );
 }
 
 export function mapFromPayloads<K extends string, T = unknown>(

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -31,7 +31,7 @@ export * from './priority';
 export * from './metrics';
 export * from './retry-policy';
 export type { Timestamp, Duration, StringValue } from './time';
-export { TransferTypeConverter, TypeInfo } from './type-info';
+export type { TransferTypeConverter, TypeInfo } from './type-info';
 export * from './worker-deployments';
 export * from './workflow-definition-options';
 export * from './workflow-handle';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -31,6 +31,7 @@ export * from './priority';
 export * from './metrics';
 export * from './retry-policy';
 export type { Timestamp, Duration, StringValue } from './time';
+export { TransferTypeConverter, TypeInfo } from './type-info';
 export * from './worker-deployments';
 export * from './workflow-definition-options';
 export * from './workflow-handle';

--- a/packages/common/src/internal-non-workflow/codec-helpers.ts
+++ b/packages/common/src/internal-non-workflow/codec-helpers.ts
@@ -11,6 +11,7 @@ import type { PayloadCodec } from '../converter/payload-codec';
 import type { ProtoFailure } from '../failure';
 import type { LoadedDataConverter } from '../converter/data-converter';
 import type { UserMetadata } from '../user-metadata';
+import type { TypeInfo } from '../type-info';
 import type { SerializationContext } from '../converter/serialization-context';
 import type { DecodedPayload, DecodedProtoFailure, EncodedPayload, EncodedProtoFailure } from './codec-types';
 
@@ -130,10 +131,11 @@ export async function encodeToPayload(
 export async function decodeArrayFromPayloads(
   converter: LoadedDataConverter,
   payloads?: Payload[] | null,
-  context?: SerializationContext
+  context?: SerializationContext,
+  typeInfo?: readonly TypeInfo[]
 ): Promise<unknown[]> {
   const { payloadConverter, payloadCodecs } = converter;
-  return arrayFromPayloads(payloadConverter, await decodeOptional(payloadCodecs, payloads, context), context);
+  return arrayFromPayloads(payloadConverter, await decodeOptional(payloadCodecs, payloads, context), context, typeInfo);
 }
 
 /**
@@ -143,14 +145,16 @@ export async function decodeFromPayloadsAtIndex<T>(
   converter: LoadedDataConverter,
   index: number,
   payloads?: Payload[] | null,
-  context?: SerializationContext
+  context?: SerializationContext,
+  typeInfo?: TypeInfo<T>
 ): Promise<T> {
   const { payloadConverter, payloadCodecs } = converter;
   return await fromPayloadsAtIndex(
     payloadConverter,
     index,
     await decodeOptional(payloadCodecs, payloads, context),
-    context
+    context,
+    typeInfo
   );
 }
 
@@ -195,13 +199,14 @@ export async function encodeToPayloads(
 export async function encodeToPayloadsWithContext(
   converter: LoadedDataConverter,
   context: SerializationContext | undefined,
-  values: unknown[]
+  values: unknown[],
+  typeInfo?: readonly TypeInfo[]
 ): Promise<Payload[] | undefined> {
   const { payloadConverter, payloadCodecs } = converter;
   if (values.length === 0) {
     return undefined;
   }
-  const payloads = toPayloadsWithContext(payloadConverter, context, values);
+  const payloads = toPayloadsWithContext(payloadConverter, context, values, typeInfo);
   return payloads ? await encode(payloadCodecs, payloads, context) : undefined;
 }
 

--- a/packages/common/src/type-info.ts
+++ b/packages/common/src/type-info.ts
@@ -1,0 +1,17 @@
+/**
+ * Type information used to convert an application value to a transfer type appropriate for serialization.
+ *
+ * Transfer type conversion is applied by SDK conversion helpers when `TypeInfo` is supplied. Calling a
+ * `PayloadConverter` directly does not apply it.
+ *
+ * @experimental
+ */
+export interface TypeInfo<T = unknown> {
+  transferTypeConverter?: TransferTypeConverter<T>;
+}
+
+/** @experimental */
+export interface TransferTypeConverter<T> {
+  fromTransferType(value: unknown): T;
+  toTransferType(value: T): unknown;
+}


### PR DESCRIPTION
## What was changed

Added the experimental `TypeInfo` and `TransferTypeConverter` APIs so applications can map domain objects to serialization-friendly transfer values.

The new `toPayloadWithTypeInfo` and `fromPayloadWithTypeInfo` helpers apply transfer conversion around the configured `PayloadConverter`. Existing positional payload and codec helpers accept optional TypeInfo and apply it by argument position.

## Why?

Application-to-transfer conversion is independent of the payload format. Keeping it outside payload converters allows JSON and other general-purpose converters to remain unaware of application classes while giving SDK boundaries one shared implementation of the conversion order.

Existing calls without TypeInfo are unchanged. This API is experimental and requires no rollout or manual steps.

## Checklist

1. Closes: N/A

2. How was this tested: Common build and test suite; focused JSON transfer conversion coverage; ESLint; Prettier; and `ts-prune`.

3. Any docs updates needed? No; documentation will accompany the completed experimental API.
