### PR TITLE
feat(common): add TypeInfo converter hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ to docs, or any other relevant information.
 ### Added
 
 - **Experimental**: Added `TypeInfo` and `TransferTypeConverter` to `@temporalio/common` for converting
-  application values to and from serialization-friendly transfer types around payload conversion.
+  application values to and from serialization-friendly transfer types and supplying converter-specific hints.
 - Workers can now configure the number of activity slots reserved for eager execution per
   workflow task with `maxEagerActivityReservationsPerWorkflowTask`. Setting it to zero disables
   eager activity execution.

--- a/packages/common/src/__tests__/test-type-info.ts
+++ b/packages/common/src/__tests__/test-type-info.ts
@@ -5,6 +5,7 @@ import {
   CompositePayloadConverter,
   defaultPayloadConverter,
   JsonPayloadConverter,
+  type PayloadConverter,
 } from '../converter/payload-converter';
 import { ProtobufBinaryPayloadConverter } from '../converter/protobuf-payload-converters';
 import type { SerializationContext } from '../converter/serialization-context';
@@ -36,12 +37,11 @@ function toUserAccountData(account: UserAccount): UserAccountData {
   };
 }
 
-function fromUserAccountData(value: unknown): UserAccount {
-  const data = value as UserAccountData;
-  return new UserAccount(data.id, BigInt(data.balanceInCents));
+function fromUserAccountData(value: UserAccountData): UserAccount {
+  return new UserAccount(value.id, BigInt(value.balanceInCents));
 }
 
-const userAccountTypeInfo: TypeInfo<UserAccount> = {
+const userAccountTypeInfo: TypeInfo<UserAccount, UserAccountData> = {
   transferTypeConverter: {
     toTransferType: toUserAccountData,
     fromTransferType: fromUserAccountData,
@@ -88,6 +88,22 @@ class HintedProtobufBinaryPayloadConverter extends ProtobufBinaryPayloadConverte
     return hint.messageType.decode(payload.data) as T;
   }
 }
+
+function checkPayloadConverterHintTypes(
+  converter: PayloadConverter,
+  payload: Payload,
+  valueHint: ProtobufJsConverterHint<{ value: string }>,
+  countHint: ProtobufJsConverterHint<{ count: number }>
+): void {
+  converter.toPayload({ value: '123' }, undefined, valueHint);
+  converter.toPayload({ count: 123 }, undefined, countHint);
+  converter.fromPayload<{ value: string }>(payload, undefined, valueHint);
+  converter.fromPayload<{ count: number }>(payload, undefined, countHint);
+
+  // @ts-expect-error 2345 Converter hint value type must match the converted value type.
+  converter.fromPayload<{ value: string }>(payload, undefined, countHint);
+}
+void checkPayloadConverterHintTypes;
 
 test('converts an application class to a transfer type around JSON payload conversion', async (t) => {
   const account = new UserAccount('account-123', 123n);

--- a/packages/common/src/__tests__/test-type-info.ts
+++ b/packages/common/src/__tests__/test-type-info.ts
@@ -107,7 +107,7 @@ test('uses a converter hint to serialize and deserialize a protobuf message', as
     converter: 'protobufjs',
     messageType,
   } satisfies ProtobufJsConverterHint<{ value: string }>;
-  const typeInfo: TypeInfo<{ value: string }, { value: string }> = { hint };
+  const typeInfo: TypeInfo<{ value: string }, { value: string }> = { converterHint: hint };
   const converter = {
     ...defaultDataConverter,
     payloadConverter: new CompositePayloadConverter(

--- a/packages/common/src/__tests__/test-type-info.ts
+++ b/packages/common/src/__tests__/test-type-info.ts
@@ -10,8 +10,11 @@ import { ProtobufBinaryPayloadConverter } from '../converter/protobuf-payload-co
 import type { SerializationContext } from '../converter/serialization-context';
 import { PayloadConverterError, ValueError } from '../errors';
 import type { Payload } from '../interfaces';
-import { decodeArrayFromPayloads, encodeToPayloadsWithContext } from '../internal-non-workflow/codec-helpers';
-import { isRecord } from '../type-helpers';
+import {
+  decodeArrayFromPayloads,
+  decodeFromPayloadsAtIndex,
+  encodeToPayloadsWithContext,
+} from '../internal-non-workflow/codec-helpers';
 import type { ConverterHint, TypeInfo } from '../type-info';
 
 class UserAccount {
@@ -63,12 +66,12 @@ class HintedProtobufBinaryPayloadConverter extends ProtobufBinaryPayloadConverte
     if (hint === undefined) {
       return super.toPayload(value);
     }
-    if (!this.validateConverterHint(hint) || !isRecord(value)) {
+    if (!this.validateConverterHint(hint)) {
       return undefined;
     }
     return this.constructPayload({
       messageTypeName: hint.messageType.fullName,
-      message: hint.messageType.encode(hint.messageType.create(value)).finish(),
+      message: hint.messageType.encode(Object.assign(hint.messageType.create(), value)).finish(),
     });
   }
 
@@ -117,11 +120,7 @@ test('uses a converter hint to serialize and deserialize a protobuf message', as
   };
 
   const payloads = await encodeToPayloadsWithContext(converter, undefined, [{ value: '123' }], [typeInfo]);
-  const [result] = await decodeArrayFromPayloads(converter, payloads, undefined, [typeInfo]);
+  const result = await decodeFromPayloadsAtIndex(converter, 0, payloads, undefined, typeInfo);
 
-  if (!isRecord(result)) {
-    t.fail('Expected a protobuf object');
-    return;
-  }
   t.is(result.value, '123');
 });

--- a/packages/common/src/__tests__/test-type-info.ts
+++ b/packages/common/src/__tests__/test-type-info.ts
@@ -110,7 +110,7 @@ test('uses a converter hint to serialize and deserialize a protobuf message', as
     converter: 'protobufjs',
     messageType,
   } satisfies ProtobufJsConverterHint<{ value: string }>;
-  const typeInfo: TypeInfo<{ value: string }, { value: string }> = { converterHint: hint };
+  const typeInfo: TypeInfo<{ value: string }, { value: string }> = { payloadConverterHint: hint };
   const converter = {
     ...defaultDataConverter,
     payloadConverter: new CompositePayloadConverter(

--- a/packages/common/src/__tests__/test-type-info.ts
+++ b/packages/common/src/__tests__/test-type-info.ts
@@ -1,8 +1,18 @@
 import test from 'ava';
+import { Field, Type } from 'protobufjs';
 import { defaultDataConverter } from '../converter/data-converter';
-import { defaultPayloadConverter } from '../converter/payload-converter';
+import {
+  CompositePayloadConverter,
+  defaultPayloadConverter,
+  JsonPayloadConverter,
+} from '../converter/payload-converter';
+import { ProtobufBinaryPayloadConverter } from '../converter/protobuf-payload-converters';
+import type { SerializationContext } from '../converter/serialization-context';
+import { PayloadConverterError, ValueError } from '../errors';
+import type { Payload } from '../interfaces';
 import { decodeArrayFromPayloads, encodeToPayloadsWithContext } from '../internal-non-workflow/codec-helpers';
-import type { TypeInfo } from '../type-info';
+import { isRecord } from '../type-helpers';
+import type { ConverterHint, TypeInfo } from '../type-info';
 
 class UserAccount {
   constructor(
@@ -35,6 +45,47 @@ const userAccountTypeInfo: TypeInfo<UserAccount> = {
   },
 };
 
+interface ProtobufJsConverterHint<T = unknown> extends ConverterHint<T> {
+  converter: 'protobufjs';
+  messageType: Type;
+}
+
+function isProtobufJsConverterHint(hint: ConverterHint): hint is ProtobufJsConverterHint {
+  return hint.converter === 'protobufjs' && 'messageType' in hint && hint.messageType instanceof Type;
+}
+
+class HintedProtobufBinaryPayloadConverter extends ProtobufBinaryPayloadConverter {
+  validateConverterHint(hint: ConverterHint): hint is ProtobufJsConverterHint {
+    return isProtobufJsConverterHint(hint);
+  }
+
+  override toPayload(value: unknown, _context?: SerializationContext, hint?: ConverterHint): Payload | undefined {
+    if (hint === undefined) {
+      return super.toPayload(value);
+    }
+    if (!this.validateConverterHint(hint) || !isRecord(value)) {
+      return undefined;
+    }
+    return this.constructPayload({
+      messageTypeName: hint.messageType.fullName,
+      message: hint.messageType.encode(hint.messageType.create(value)).finish(),
+    });
+  }
+
+  override fromPayload<T>(payload: Payload, _context?: SerializationContext, hint?: ConverterHint): T {
+    if (hint === undefined) {
+      return super.fromPayload(payload);
+    }
+    if (!this.validateConverterHint(hint)) {
+      throw new PayloadConverterError('Invalid protobufjs converter hint');
+    }
+    if (payload.data == null) {
+      throw new ValueError('Got payload with no data');
+    }
+    return hint.messageType.decode(payload.data) as T;
+  }
+}
+
 test('converts an application class to a transfer type around JSON payload conversion', async (t) => {
   const account = new UserAccount('account-123', 123n);
   const payloads = await encodeToPayloadsWithContext(defaultDataConverter, undefined, [account], [userAccountTypeInfo]);
@@ -48,4 +99,29 @@ test('converts an application class to a transfer type around JSON payload conve
   }
   t.is(result.id, account.id);
   t.is(result.balanceInCents, account.balanceInCents);
+});
+
+test('uses a converter hint to serialize and deserialize a protobuf message', async (t) => {
+  const messageType = new Type('HintedValue').add(new Field('value', 1, 'string'));
+  const hint = {
+    converter: 'protobufjs',
+    messageType,
+  } satisfies ProtobufJsConverterHint<{ value: string }>;
+  const typeInfo: TypeInfo<{ value: string }, { value: string }> = { hint };
+  const converter = {
+    ...defaultDataConverter,
+    payloadConverter: new CompositePayloadConverter(
+      new JsonPayloadConverter(),
+      new HintedProtobufBinaryPayloadConverter()
+    ),
+  };
+
+  const payloads = await encodeToPayloadsWithContext(converter, undefined, [{ value: '123' }], [typeInfo]);
+  const [result] = await decodeArrayFromPayloads(converter, payloads, undefined, [typeInfo]);
+
+  if (!isRecord(result)) {
+    t.fail('Expected a protobuf object');
+    return;
+  }
+  t.is(result.value, '123');
 });

--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -50,7 +50,7 @@ export function toPayloadWithTypeInfo<T>(
   typeInfo: TypeInfo<T, unknown> | undefined
 ): Payload {
   const transferValue = typeInfo?.transferTypeConverter ? typeInfo.transferTypeConverter.toTransferType(value) : value;
-  return converter.toPayload(transferValue, context, typeInfo?.hint);
+  return converter.toPayload(transferValue, context, typeInfo?.converterHint);
 }
 
 /**
@@ -64,7 +64,7 @@ export function fromPayloadWithTypeInfo<T>(
   context: SerializationContext | undefined,
   typeInfo: TypeInfo<T, unknown> | undefined
 ): T {
-  const transferValue = converter.fromPayload<unknown>(payload, context, typeInfo?.hint);
+  const transferValue = converter.fromPayload<unknown>(payload, context, typeInfo?.converterHint);
   return typeInfo?.transferTypeConverter
     ? typeInfo.transferTypeConverter.fromTransferType(transferValue)
     : (transferValue as T);

--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -1,7 +1,7 @@
 import { decode, encode } from '../encoding';
 import { PayloadConverterError, ValueError } from '../errors';
 import type { Payload } from '../interfaces';
-import type { TypeInfo } from '../type-info';
+import type { ConverterHint, TypeInfo } from '../type-info';
 import type { SerializationContext } from './serialization-context';
 import { encodingKeys, encodingTypes, METADATA_ENCODING_KEY } from './types';
 
@@ -21,12 +21,21 @@ export interface PayloadConverter {
    *
    * Should throw {@link ValueError} if unable to convert.
    */
-  toPayload<T>(value: T, context?: SerializationContext): Payload;
+  toPayload<T>(value: T, context?: SerializationContext, hint?: ConverterHint): Payload;
 
   /**
    * Converts a {@link Payload} back to a value.
    */
-  fromPayload<T>(payload: Payload, context?: SerializationContext): T;
+  fromPayload<T>(payload: Payload, context?: SerializationContext, hint?: ConverterHint): T;
+
+  /**
+   * Return whether this converter can handle the supplied converter hint.
+   *
+   * Implementations may also use this method to validate hints within {@link toPayload} and {@link fromPayload}.
+   *
+   * @experimental
+   */
+  validateConverterHint?: (hint: ConverterHint) => boolean;
 }
 
 /**
@@ -38,10 +47,10 @@ export function toPayloadWithTypeInfo<T>(
   converter: PayloadConverter,
   value: T,
   context: SerializationContext | undefined,
-  typeInfo: TypeInfo<T> | undefined
+  typeInfo: TypeInfo<T, unknown> | undefined
 ): Payload {
   const transferValue = typeInfo?.transferTypeConverter ? typeInfo.transferTypeConverter.toTransferType(value) : value;
-  return converter.toPayload(transferValue, context);
+  return converter.toPayload(transferValue, context, typeInfo?.hint);
 }
 
 /**
@@ -53,9 +62,9 @@ export function fromPayloadWithTypeInfo<T>(
   converter: PayloadConverter,
   payload: Payload,
   context: SerializationContext | undefined,
-  typeInfo: TypeInfo<T> | undefined
+  typeInfo: TypeInfo<T, unknown> | undefined
 ): T {
-  const transferValue = converter.fromPayload<unknown>(payload, context);
+  const transferValue = converter.fromPayload<unknown>(payload, context, typeInfo?.hint);
   return typeInfo?.transferTypeConverter
     ? typeInfo.transferTypeConverter.fromTransferType(transferValue)
     : (transferValue as T);
@@ -210,14 +219,23 @@ export interface PayloadConverterWithEncoding {
    * @param value The value to convert. Example values include the Workflow args sent from the Client and the values returned by a Workflow or Activity.
    * @returns The {@link Payload}, or `undefined` if unable to convert.
    */
-  toPayload<T>(value: T, context?: SerializationContext): Payload | undefined;
+  toPayload<T>(value: T, context?: SerializationContext, hint?: ConverterHint): Payload | undefined;
 
   /**
    * Converts a {@link Payload} back to a value.
    */
-  fromPayload<T>(payload: Payload, context?: SerializationContext): T;
+  fromPayload<T>(payload: Payload, context?: SerializationContext, hint?: ConverterHint): T;
 
   readonly encodingType: string;
+
+  /**
+   * Return whether this converter can handle the supplied converter hint.
+   *
+   * Implementations may also use this method to validate hints within {@link toPayload} and {@link fromPayload}.
+   *
+   * @experimental
+   */
+  validateConverterHint?: (hint: ConverterHint) => boolean;
 }
 
 /**
@@ -245,24 +263,30 @@ export class CompositePayloadConverter implements PayloadConverter {
    * Tries to run `.toPayload(value)` on each converter in the order provided at construction.
    * Returns the first successful result, throws {@link ValueError} if there is no converter that can handle the value.
    */
-  public toPayload<T>(value: T, context?: SerializationContext): Payload {
+  public toPayload<T>(value: T, context?: SerializationContext, hint?: ConverterHint): Payload {
     if (value instanceof RawValue) {
       return value.payload;
     }
     for (const converter of this.converters) {
-      const result = converter.toPayload(value, context);
+      if (hint !== undefined && !converter.validateConverterHint?.(hint)) {
+        continue;
+      }
+      const result = converter.toPayload(value, context, hint);
       if (result !== undefined) {
         return result;
       }
     }
 
+    if (hint !== undefined) {
+      throw new ValueError(`No payload converter supports converter hint '${hint.converter}'`);
+    }
     throw new ValueError(`Unable to convert ${value} to payload`);
   }
 
   /**
    * Run {@link PayloadConverterWithEncoding.fromPayload} based on the `encoding` metadata of the {@link Payload}.
    */
-  public fromPayload<T>(payload: Payload, context?: SerializationContext): T {
+  public fromPayload<T>(payload: Payload, context?: SerializationContext, hint?: ConverterHint): T {
     if (payload.metadata === undefined || payload.metadata === null) {
       throw new ValueError('Missing payload metadata');
     }
@@ -272,7 +296,12 @@ export class CompositePayloadConverter implements PayloadConverter {
     if (converter === undefined) {
       throw new ValueError(`Unknown encoding: ${encoding}`);
     }
-    return converter.fromPayload(payload, context);
+    if (hint !== undefined && !converter.validateConverterHint?.(hint)) {
+      throw new PayloadConverterError(
+        `Payload encoding '${encoding}' does not support converter hint '${hint.converter}'`
+      );
+    }
+    return converter.fromPayload(payload, context, hint);
   }
 }
 

--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -21,12 +21,12 @@ export interface PayloadConverter {
    *
    * Should throw {@link ValueError} if unable to convert.
    */
-  toPayload<T>(value: T, context?: SerializationContext, hint?: ConverterHint): Payload;
+  toPayload<T>(value: T, context?: SerializationContext, hint?: ConverterHint<T>): Payload;
 
   /**
    * Converts a {@link Payload} back to a value.
    */
-  fromPayload<T>(payload: Payload, context?: SerializationContext, hint?: ConverterHint): T;
+  fromPayload<T>(payload: Payload, context?: SerializationContext, hint?: ConverterHint<T>): T;
 
   /**
    * Return whether this converter can handle the supplied converter hint.
@@ -43,11 +43,11 @@ export interface PayloadConverter {
  *
  * @experimental
  */
-export function toPayloadWithTypeInfo<T>(
+export function toPayloadWithTypeInfo<T, D = T>(
   converter: PayloadConverter,
   value: T,
   context: SerializationContext | undefined,
-  typeInfo: TypeInfo<T, unknown> | undefined
+  typeInfo: TypeInfo<T, D> | undefined
 ): Payload {
   const transferValue = typeInfo?.transferTypeConverter ? typeInfo.transferTypeConverter.toTransferType(value) : value;
   return converter.toPayload(transferValue, context, typeInfo?.payloadConverterHint);
@@ -58,16 +58,16 @@ export function toPayloadWithTypeInfo<T>(
  *
  * @experimental
  */
-export function fromPayloadWithTypeInfo<T>(
+export function fromPayloadWithTypeInfo<T, D = T>(
   converter: PayloadConverter,
   payload: Payload,
   context: SerializationContext | undefined,
-  typeInfo: TypeInfo<T, unknown> | undefined
+  typeInfo: TypeInfo<T, D> | undefined
 ): T {
-  const transferValue = converter.fromPayload<unknown>(payload, context, typeInfo?.payloadConverterHint);
+  const transferValue = converter.fromPayload<D>(payload, context, typeInfo?.payloadConverterHint);
   return typeInfo?.transferTypeConverter
     ? typeInfo.transferTypeConverter.fromTransferType(transferValue)
-    : (transferValue as T);
+    : (transferValue as unknown as T);
 }
 
 /**
@@ -140,12 +140,12 @@ export function mapToPayloads<K extends string, T = any>(
  * @throws {@link PayloadConverterError} if conversion of the data passed as parameter failed for any
  *     reason.
  */
-export function fromPayloadsAtIndex<T>(
+export function fromPayloadsAtIndex<T, D = T>(
   converter: PayloadConverter,
   index: number,
   payloads?: Payload[] | null,
   context?: SerializationContext,
-  typeInfo?: TypeInfo<T>
+  typeInfo?: TypeInfo<T, D>
 ): T {
   // To make adding arguments a backwards compatible change
   if (payloads === undefined || payloads === null || index >= payloads.length) {
@@ -219,12 +219,12 @@ export interface PayloadConverterWithEncoding {
    * @param value The value to convert. Example values include the Workflow args sent from the Client and the values returned by a Workflow or Activity.
    * @returns The {@link Payload}, or `undefined` if unable to convert.
    */
-  toPayload<T>(value: T, context?: SerializationContext, hint?: ConverterHint): Payload | undefined;
+  toPayload<T>(value: T, context?: SerializationContext, hint?: ConverterHint<T>): Payload | undefined;
 
   /**
    * Converts a {@link Payload} back to a value.
    */
-  fromPayload<T>(payload: Payload, context?: SerializationContext, hint?: ConverterHint): T;
+  fromPayload<T>(payload: Payload, context?: SerializationContext, hint?: ConverterHint<T>): T;
 
   readonly encodingType: string;
 
@@ -263,7 +263,7 @@ export class CompositePayloadConverter implements PayloadConverter {
    * Tries to run `.toPayload(value)` on each converter in the order provided at construction.
    * Returns the first successful result, throws {@link ValueError} if there is no converter that can handle the value.
    */
-  public toPayload<T>(value: T, context?: SerializationContext, hint?: ConverterHint): Payload {
+  public toPayload<T>(value: T, context?: SerializationContext, hint?: ConverterHint<T>): Payload {
     if (value instanceof RawValue) {
       return value.payload;
     }
@@ -286,7 +286,7 @@ export class CompositePayloadConverter implements PayloadConverter {
   /**
    * Run {@link PayloadConverterWithEncoding.fromPayload} based on the `encoding` metadata of the {@link Payload}.
    */
-  public fromPayload<T>(payload: Payload, context?: SerializationContext, hint?: ConverterHint): T {
+  public fromPayload<T>(payload: Payload, context?: SerializationContext, hint?: ConverterHint<T>): T {
     if (payload.metadata === undefined || payload.metadata === null) {
       throw new ValueError('Missing payload metadata');
     }

--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -50,7 +50,7 @@ export function toPayloadWithTypeInfo<T>(
   typeInfo: TypeInfo<T, unknown> | undefined
 ): Payload {
   const transferValue = typeInfo?.transferTypeConverter ? typeInfo.transferTypeConverter.toTransferType(value) : value;
-  return converter.toPayload(transferValue, context, typeInfo?.converterHint);
+  return converter.toPayload(transferValue, context, typeInfo?.payloadConverterHint);
 }
 
 /**
@@ -64,7 +64,7 @@ export function fromPayloadWithTypeInfo<T>(
   context: SerializationContext | undefined,
   typeInfo: TypeInfo<T, unknown> | undefined
 ): T {
-  const transferValue = converter.fromPayload<unknown>(payload, context, typeInfo?.converterHint);
+  const transferValue = converter.fromPayload<unknown>(payload, context, typeInfo?.payloadConverterHint);
   return typeInfo?.transferTypeConverter
     ? typeInfo.transferTypeConverter.fromTransferType(transferValue)
     : (transferValue as T);

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -31,7 +31,7 @@ export * from './priority';
 export * from './metrics';
 export * from './retry-policy';
 export type { Timestamp, Duration, StringValue } from './time';
-export type { ConverterHint, TransferTypeConverter, TypeInfo, valueTypeBrand } from './type-info';
+export type { ConverterHint, TransferTypeConverter, TypeInfo } from './type-info';
 export * from './worker-deployments';
 export * from './workflow-definition-options';
 export * from './workflow-handle';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -31,7 +31,7 @@ export * from './priority';
 export * from './metrics';
 export * from './retry-policy';
 export type { Timestamp, Duration, StringValue } from './time';
-export type { TransferTypeConverter, TypeInfo } from './type-info';
+export type { ConverterHint, TransferTypeConverter, TypeInfo, valueTypeBrand } from './type-info';
 export * from './worker-deployments';
 export * from './workflow-definition-options';
 export * from './workflow-handle';

--- a/packages/common/src/internal-non-workflow/codec-helpers.ts
+++ b/packages/common/src/internal-non-workflow/codec-helpers.ts
@@ -141,12 +141,12 @@ export async function decodeArrayFromPayloads(
 /**
  * Decode `payloads` and then return {@link fromPayloadsAtIndex}.
  */
-export async function decodeFromPayloadsAtIndex<T>(
+export async function decodeFromPayloadsAtIndex<T, D = T>(
   converter: LoadedDataConverter,
   index: number,
   payloads?: Payload[] | null,
   context?: SerializationContext,
-  typeInfo?: TypeInfo<T>
+  typeInfo?: TypeInfo<T, D>
 ): Promise<T> {
   const { payloadConverter, payloadCodecs } = converter;
   return await fromPayloadsAtIndex(

--- a/packages/common/src/type-info.ts
+++ b/packages/common/src/type-info.ts
@@ -1,26 +1,54 @@
 /**
- * Type information used to convert an application value to a transfer type appropriate for serialization and
- * optionally provide converter-specific metadata.
+ * Describes how SDK conversion helpers adapt an application value of type `T` for payload conversion.
  *
- * Transfer type conversion and converter hints are applied by SDK conversion helpers when `TypeInfo` is supplied.
- * Calling a `PayloadConverter` directly does not apply it.
+ * {@link transferTypeConverter} performs an application-defined, payload-converter-independent transformation.
+ * For example, it can convert a class instance into a plain object before JSON serialization.
+ *
+ * {@link converterHint} carries metadata for a specific payload converter and describes its value type `D`.
+ * For example, a Protobuf converter hint can identify the message type required to deserialize bytes.
+ *
+ * On encoding, transfer type conversion runs before payload conversion. On decoding, payload conversion runs before
+ * transfer type conversion. Either mechanism may be used independently or they may be combined.
+ *
+ * SDK conversion helpers apply this information when supplied. Calling a {@link PayloadConverter} directly does not.
  *
  * @experimental
  */
 export interface TypeInfo<T = unknown, D = T> {
+  /**
+   * Converts between the application value and a representation suitable for payload conversion.
+   *
+   * This transformation runs outside the payload converter and should not depend on its serialization format.
+   */
   transferTypeConverter?: TransferTypeConverter<T>;
-  hint?: ConverterHint<D>;
+
+  /**
+   * Metadata forwarded unchanged to the payload converter.
+   *
+   * Use this when conversion requires format-specific runtime information, such as a Protobuf message type.
+   */
+  converterHint?: ConverterHint<D>;
 }
 
-/** @experimental */
+/**
+ * Converts between an application value and its payload-converter-independent transfer representation.
+ *
+ * @experimental
+ */
 export interface TransferTypeConverter<T> {
   fromTransferType(value: unknown): T;
   toTransferType(value: T): unknown;
 }
 
-export declare const valueTypeBrand: unique symbol;
+declare const valueTypeBrand: unique symbol;
 
-/** @experimental */
+/**
+ * Identifies converter-specific metadata and associates it with the value type `T` handled by that converter.
+ *
+ * Extend this interface to define metadata for a payload converter.
+ *
+ * @experimental
+ */
 export interface ConverterHint<T = unknown> {
   converter: string;
   [valueTypeBrand]?: T;

--- a/packages/common/src/type-info.ts
+++ b/packages/common/src/type-info.ts
@@ -1,17 +1,27 @@
 /**
- * Type information used to convert an application value to a transfer type appropriate for serialization.
+ * Type information used to convert an application value to a transfer type appropriate for serialization and
+ * optionally provide converter-specific metadata.
  *
- * Transfer type conversion is applied by SDK conversion helpers when `TypeInfo` is supplied. Calling a
- * `PayloadConverter` directly does not apply it.
+ * Transfer type conversion and converter hints are applied by SDK conversion helpers when `TypeInfo` is supplied.
+ * Calling a `PayloadConverter` directly does not apply it.
  *
  * @experimental
  */
-export interface TypeInfo<T = unknown> {
+export interface TypeInfo<T = unknown, D = T> {
   transferTypeConverter?: TransferTypeConverter<T>;
+  hint?: ConverterHint<D>;
 }
 
 /** @experimental */
 export interface TransferTypeConverter<T> {
   fromTransferType(value: unknown): T;
   toTransferType(value: T): unknown;
+}
+
+export declare const valueTypeBrand: unique symbol;
+
+/** @experimental */
+export interface ConverterHint<T = unknown> {
+  converter: string;
+  [valueTypeBrand]?: T;
 }

--- a/packages/common/src/type-info.ts
+++ b/packages/common/src/type-info.ts
@@ -4,7 +4,7 @@
  * {@link transferTypeConverter} performs an application-defined, payload-converter-independent transformation.
  * For example, it can convert a class instance into a plain object before JSON serialization.
  *
- * {@link converterHint} carries metadata for a specific payload converter and describes its value type `D`.
+ * {@link payloadConverterHint} carries metadata for a specific payload converter and describes its value type `D`.
  * For example, a Protobuf converter hint can identify the message type required to deserialize bytes.
  *
  * On encoding, transfer type conversion runs before payload conversion. On decoding, payload conversion runs before
@@ -27,7 +27,7 @@ export interface TypeInfo<T = unknown, D = T> {
    *
    * Use this when conversion requires format-specific runtime information, such as a Protobuf message type.
    */
-  converterHint?: ConverterHint<D>;
+  payloadConverterHint?: ConverterHint<D>;
 }
 
 /**

--- a/packages/common/src/type-info.ts
+++ b/packages/common/src/type-info.ts
@@ -10,6 +10,8 @@
  * On encoding, transfer type conversion runs before payload conversion. On decoding, payload conversion runs before
  * transfer type conversion. Either mechanism may be used independently or they may be combined.
  *
+ * When {@link transferTypeConverter} is unspecified, `D` should be the same type as `T`.
+ *
  * SDK conversion helpers apply this information when supplied. Calling a {@link PayloadConverter} directly does not.
  *
  * @experimental
@@ -20,7 +22,7 @@ export interface TypeInfo<T = unknown, D = T> {
    *
    * This transformation runs outside the payload converter and should not depend on its serialization format.
    */
-  transferTypeConverter?: TransferTypeConverter<T>;
+  transferTypeConverter?: TransferTypeConverter<T, D>;
 
   /**
    * Metadata forwarded unchanged to the payload converter.
@@ -31,19 +33,21 @@ export interface TypeInfo<T = unknown, D = T> {
 }
 
 /**
- * Converts between an application value and its payload-converter-independent transfer representation.
+ * Converts between an application value of type `T` and its payload-converter-independent representation of type `D`.
  *
  * @experimental
  */
-export interface TransferTypeConverter<T> {
-  fromTransferType(value: unknown): T;
-  toTransferType(value: T): unknown;
+export interface TransferTypeConverter<T, D = unknown> {
+  fromTransferType(value: D): T;
+  toTransferType(value: T): D;
 }
 
 declare const valueTypeBrand: unique symbol;
 
 /**
  * Identifies converter-specific metadata and associates it with the value type `T` handled by that converter.
+ *
+ * The association applies to an individual payload conversion; it does not bind a payload converter instance to `T`.
  *
  * Extend this interface to define metadata for a payload converter.
  *


### PR DESCRIPTION
## What was changed

Extended `TypeInfo<T, D>` with an optional `ConverterHint<D>` and added optional hint parameters to payload-converter serialization methods. Payload converters may expose the experimental `validateConverterHint` method, and `CompositePayloadConverter` uses it to select or validate the converter that receives a hint.

The TypeInfo conversion helpers now forward hints after applying transfer conversion. This is PR 2 of the stack and depends on #2250; Nexus operation integration follows separately.

## Why?

Transfer conversion is sufficient for formats such as JSON, but some payload converters require format-specific runtime information. Protobuf deserialization, for example, needs the message type in addition to the decoded bytes.

Conversions without a hint retain their existing best-effort behavior. This API is experimental and requires no rollout or manual steps.

## Checklist

1. Closes: N/A

2. How was this tested: Common build and all 38 Common tests; focused JSON transfer conversion and Protobuf converter-hint coverage; ESLint; Prettier; and `ts-prune`.

3. Any docs updates needed? No; documentation will accompany the completed experimental API.
