### PR TITLE
fix(strands): declare zod as a peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,15 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 
+### Fixed
+
+- strands: Declare `zod` as a peer dependency.
+
 ## [1.21.1] - 2026-07-23
 
 ### Fixed
 
-- strands: add `@aws-sdk/client-s3` to the workflow bundler ignore list, fixing bundler errors when
+- strands: Add `@aws-sdk/client-s3` to the workflow bundler ignore list, fixing bundler errors when
   using the S3-backed `context-offloader` vended plugin. The package is dynamically imported
   worker-side and is never reached from workflow code.
 

--- a/contrib/strands/package.json
+++ b/contrib/strands/package.json
@@ -35,7 +35,8 @@
     "web-streams-polyfill": "^4.2.0"
   },
   "peerDependencies": {
-    "@strands-agents/sdk": "^1.3.0"
+    "@strands-agents/sdk": "^1.3.0",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",


### PR DESCRIPTION
## Problem

`@temporalio/strands-agents` imports `zod` as a **runtime value** in `contrib/strands/src/json-schema.ts`:

```ts
import { z } from 'zod';
// ...
return schema instanceof z.ZodType ? (z.toJSONSchema(schema) as JSONSchema) : schema;
```

That compiles to a real `require('zod')` in `lib/json-schema.js`, executed at module load. But `zod` was declared only in `devDependencies`, which are stripped from the published package. As a result, the published `@temporalio/strands-agents@1.21.1` throws a module-not-found for consumers who don't already have `zod` installed.

## Fix

Declare `zod` as a **peer dependency** (kept in `devDependencies` for in-workspace build/test).

Peer rather than a plain dependency: the `schema instanceof z.ZodType` check runs against schemas the *user* built with *their* `zod`. A duplicate copy pulled in as a direct dependency could make `instanceof` silently return `false`, causing a user's zod schema to be passed through untouched as a literal JSON Schema — a silent correctness bug. A peer dep guarantees a single shared instance, matching how `@strands-agents/sdk` is already declared. Range is `^4.0.0` since `z.toJSONSchema` is a zod-4 API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)