### PR TITLE
Make eager activity reservation limit configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ to docs, or any other relevant information.
 ### Added
 
 - Workers can now configure the number of activity slots reserved for eager execution per
-  workflow task with `maxEagerActivityReservationsPerWorkflowTask`.
+  workflow task with `maxEagerActivityReservationsPerWorkflowTask`. Setting it to zero disables
+  eager activity execution.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 
+### Added
+
+- Workers can now limit concurrent eager activity executions with
+  `maxConcurrentEagerActivityExecutionSize`.
+
 ### Fixed
 
 - strands: Declare `zod` as a peer dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ to docs, or any other relevant information.
 
 ### Added
 
-- Workers can now limit concurrent eager activity executions with
-  `maxConcurrentEagerActivityExecutionSize`.
+- Workers can now configure the number of activity slots reserved for eager execution per
+  workflow task with `maxEagerActivityReservationsPerWorkflowTask`.
 
 ### Fixed
 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -357,6 +357,7 @@ export const ActivityExecutionStatus = {
   CANCELED: 'CANCELED',
   TERMINATED: 'TERMINATED',
   TIMED_OUT: 'TIMED_OUT',
+  PAUSED: 'PAUSED',
 } as const;
 /**
  * @experimental Standalone Activities are experimental. APIs may be subject to change.
@@ -379,6 +380,7 @@ export const [encodeActivityExecutionStatus, decodeActivityExecutionStatus] = ma
     [ActivityExecutionStatus.CANCELED]: 4,
     [ActivityExecutionStatus.TERMINATED]: 5,
     [ActivityExecutionStatus.TIMED_OUT]: 6,
+    [ActivityExecutionStatus.PAUSED]: 7,
     UNSPECIFIED: 0,
   } as const,
   'ACTIVITY_EXECUTION_STATUS_'

--- a/packages/core-bridge/Cargo.lock
+++ b/packages/core-bridge/Cargo.lock
@@ -124,14 +124,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "backon"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
- "getrandom 0.2.17",
- "instant",
- "rand 0.8.6",
+ "fastrand",
 ]
 
 [[package]]
@@ -414,7 +412,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -508,7 +506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1039,15 +1037,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "inventory"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,7 +1370,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1527,7 +1516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1923,22 +1912,11 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -1955,31 +1933,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2179,7 +2138,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2238,7 +2197,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2546,7 +2505,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2582,7 +2541,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "backoff",
+ "backon",
  "base64",
  "bon",
  "bytes",
@@ -2708,7 +2667,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "backoff",
+ "backon",
  "bon",
  "crossbeam-channel",
  "crossbeam-utils",
@@ -3422,7 +3381,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/packages/core-bridge/src/worker.rs
+++ b/packages/core-bridge/src/worker.rs
@@ -546,6 +546,7 @@ mod config {
         default_heartbeat_throttle_interval: Duration,
         max_activities_per_second: Option<f64>,
         max_task_queue_activities_per_second: Option<f64>,
+        max_concurrent_eager_activity_execution_size: usize,
         shutdown_grace_time: Option<Duration>,
         plugins: Vec<String>,
         storage_drivers: Vec<String>,
@@ -639,6 +640,9 @@ mod config {
                     self.max_task_queue_activities_per_second,
                 )
                 .maybe_max_worker_activities_per_second(self.max_activities_per_second)
+                .max_concurrent_eager_activity_execution_size(
+                    self.max_concurrent_eager_activity_execution_size,
+                )
                 .maybe_graceful_shutdown_period(self.shutdown_grace_time)
                 .plugins(
                     self.plugins

--- a/packages/core-bridge/src/worker.rs
+++ b/packages/core-bridge/src/worker.rs
@@ -546,7 +546,7 @@ mod config {
         default_heartbeat_throttle_interval: Duration,
         max_activities_per_second: Option<f64>,
         max_task_queue_activities_per_second: Option<f64>,
-        max_concurrent_eager_activity_execution_size: usize,
+        max_eager_activity_reservations_per_workflow_task: usize,
         shutdown_grace_time: Option<Duration>,
         plugins: Vec<String>,
         storage_drivers: Vec<String>,
@@ -640,8 +640,8 @@ mod config {
                     self.max_task_queue_activities_per_second,
                 )
                 .maybe_max_worker_activities_per_second(self.max_activities_per_second)
-                .max_concurrent_eager_activity_execution_size(
-                    self.max_concurrent_eager_activity_execution_size,
+                .max_eager_activity_reservations_per_workflow_task(
+                    self.max_eager_activity_reservations_per_workflow_task,
                 )
                 .maybe_graceful_shutdown_period(self.shutdown_grace_time)
                 .plugins(

--- a/packages/core-bridge/ts/native.ts
+++ b/packages/core-bridge/ts/native.ts
@@ -262,7 +262,7 @@ export interface WorkerOptions {
   defaultHeartbeatThrottleInterval: number;
   maxTaskQueueActivitiesPerSecond: Option<number>;
   maxActivitiesPerSecond: Option<number>;
-  maxConcurrentEagerActivityExecutionSize: number;
+  maxEagerActivityReservationsPerWorkflowTask: number;
   shutdownGraceTime: number;
   plugins: string[];
   storageDrivers: string[];

--- a/packages/core-bridge/ts/native.ts
+++ b/packages/core-bridge/ts/native.ts
@@ -262,6 +262,7 @@ export interface WorkerOptions {
   defaultHeartbeatThrottleInterval: number;
   maxTaskQueueActivitiesPerSecond: Option<number>;
   maxActivitiesPerSecond: Option<number>;
+  maxConcurrentEagerActivityExecutionSize: number;
   shutdownGraceTime: number;
   plugins: string[];
   storageDrivers: string[];

--- a/packages/test/src/test-bridge.ts
+++ b/packages/test/src/test-bridge.ts
@@ -316,6 +316,7 @@ const GenericConfigs = {
       defaultHeartbeatThrottleInterval: 1000,
       maxTaskQueueActivitiesPerSecond: null,
       maxActivitiesPerSecond: null,
+      maxConcurrentEagerActivityExecutionSize: 0,
       shutdownGraceTime: 1000,
       plugins: [],
       storageDrivers: [],

--- a/packages/test/src/test-bridge.ts
+++ b/packages/test/src/test-bridge.ts
@@ -316,7 +316,7 @@ const GenericConfigs = {
       defaultHeartbeatThrottleInterval: 1000,
       maxTaskQueueActivitiesPerSecond: null,
       maxActivitiesPerSecond: null,
-      maxConcurrentEagerActivityExecutionSize: 0,
+      maxEagerActivityReservationsPerWorkflowTask: 3,
       shutdownGraceTime: 1000,
       plugins: [],
       storageDrivers: [],

--- a/packages/test/src/test-worker-options.ts
+++ b/packages/test/src/test-worker-options.ts
@@ -3,13 +3,13 @@ import { Runtime } from '@temporalio/worker';
 import { compileWorkerOptions, toNativeWorkerOptions } from '@temporalio/worker/lib/worker-options';
 import { defaultOptions } from './mock-native-worker';
 
-test('forwards the eager activity execution limit to Core', (t) => {
+test('forwards the eager activity reservation limit to Core', (t) => {
   const runtime = Runtime.instance();
   const compiled = compileWorkerOptions(
-    { ...defaultOptions, maxConcurrentEagerActivityExecutionSize: 7 },
+    { ...defaultOptions, maxEagerActivityReservationsPerWorkflowTask: 7 },
     runtime.logger,
     runtime.metricMeter
   );
 
-  t.is(toNativeWorkerOptions({ ...compiled, buildId: 'test-build-id' }).maxConcurrentEagerActivityExecutionSize, 7);
+  t.is(toNativeWorkerOptions({ ...compiled, buildId: 'test-build-id' }).maxEagerActivityReservationsPerWorkflowTask, 7);
 });

--- a/packages/test/src/test-worker-options.ts
+++ b/packages/test/src/test-worker-options.ts
@@ -13,3 +13,32 @@ test('forwards the eager activity reservation limit to Core', (t) => {
 
   t.is(toNativeWorkerOptions({ ...compiled, buildId: 'test-build-id' }).maxEagerActivityReservationsPerWorkflowTask, 7);
 });
+
+test('allows zero eager activity reservations to disable eager execution', (t) => {
+  const runtime = Runtime.instance();
+  const compiled = compileWorkerOptions(
+    { ...defaultOptions, maxEagerActivityReservationsPerWorkflowTask: 0 },
+    runtime.logger,
+    runtime.metricMeter
+  );
+
+  t.is(toNativeWorkerOptions({ ...compiled, buildId: 'test-build-id' }).maxEagerActivityReservationsPerWorkflowTask, 0);
+});
+
+for (const value of [-1, 1.5, Number.NaN]) {
+  test(`rejects invalid eager activity reservation limit ${value}`, (t) => {
+    const runtime = Runtime.instance();
+    t.throws(
+      () =>
+        compileWorkerOptions(
+          { ...defaultOptions, maxEagerActivityReservationsPerWorkflowTask: value },
+          runtime.logger,
+          runtime.metricMeter
+        ),
+      {
+        instanceOf: TypeError,
+        message: 'maxEagerActivityReservationsPerWorkflowTask must be a non-negative integer',
+      }
+    );
+  });
+}

--- a/packages/test/src/test-worker-options.ts
+++ b/packages/test/src/test-worker-options.ts
@@ -1,0 +1,15 @@
+import test from 'ava';
+import { Runtime } from '@temporalio/worker';
+import { compileWorkerOptions, toNativeWorkerOptions } from '@temporalio/worker/lib/worker-options';
+import { defaultOptions } from './mock-native-worker';
+
+test('forwards the eager activity execution limit to Core', (t) => {
+  const runtime = Runtime.instance();
+  const compiled = compileWorkerOptions(
+    { ...defaultOptions, maxConcurrentEagerActivityExecutionSize: 7 },
+    runtime.logger,
+    runtime.metricMeter
+  );
+
+  t.is(toNativeWorkerOptions({ ...compiled, buildId: 'test-build-id' }).maxConcurrentEagerActivityExecutionSize, 7);
+});

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -270,13 +270,13 @@ export interface WorkerOptions {
   maxTaskQueueActivitiesPerSecond?: number;
 
   /**
-   * Maximum number of eager Activities that can be reserved and executed concurrently by this Worker.
+   * Maximum number of Activity slots that may be reserved for eager execution when completing a Workflow Task.
    *
-   * A value of `0` or an unset value means there is no limit.
+   * Setting this to `0` disables eager Activity execution.
    *
-   * @default 0
+   * @default 3
    */
-  maxConcurrentEagerActivityExecutionSize?: number;
+  maxEagerActivityReservationsPerWorkflowTask?: number;
 
   /**
    * Maximum number of Workflow Tasks to execute concurrently.
@@ -768,7 +768,7 @@ export interface ReplayWorkerOptions
     | 'enableNonLocalActivities'
     | 'maxActivitiesPerSecond'
     | 'maxTaskQueueActivitiesPerSecond'
-    | 'maxConcurrentEagerActivityExecutionSize'
+    | 'maxEagerActivityReservationsPerWorkflowTask'
     | 'stickyQueueScheduleToStartTimeout'
     | 'maxCachedWorkflows'
     | 'useVersioning'
@@ -1222,7 +1222,7 @@ export function toNativeWorkerOptions(opts: CompiledWorkerOptionsWithBuildId): n
     defaultHeartbeatThrottleInterval: msToNumber(opts.defaultHeartbeatThrottleInterval),
     maxTaskQueueActivitiesPerSecond: opts.maxTaskQueueActivitiesPerSecond ?? null,
     maxActivitiesPerSecond: opts.maxActivitiesPerSecond ?? null,
-    maxConcurrentEagerActivityExecutionSize: opts.maxConcurrentEagerActivityExecutionSize ?? 0,
+    maxEagerActivityReservationsPerWorkflowTask: opts.maxEagerActivityReservationsPerWorkflowTask ?? 3,
     shutdownGraceTime: msToNumber(opts.shutdownGraceTime),
     plugins: opts.plugins?.map((p) => p.name) ?? [],
     storageDrivers: [...new Set((opts.loadedDataConverter.externalStorage?.drivers ?? []).map((d) => d.type))],

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -270,6 +270,15 @@ export interface WorkerOptions {
   maxTaskQueueActivitiesPerSecond?: number;
 
   /**
+   * Maximum number of eager Activities that can be reserved and executed concurrently by this Worker.
+   *
+   * A value of `0` or an unset value means there is no limit.
+   *
+   * @default 0
+   */
+  maxConcurrentEagerActivityExecutionSize?: number;
+
+  /**
    * Maximum number of Workflow Tasks to execute concurrently.
    *
    * In general, a Workflow Worker's performance is mostly network bound (due to communication latency with the
@@ -759,6 +768,7 @@ export interface ReplayWorkerOptions
     | 'enableNonLocalActivities'
     | 'maxActivitiesPerSecond'
     | 'maxTaskQueueActivitiesPerSecond'
+    | 'maxConcurrentEagerActivityExecutionSize'
     | 'stickyQueueScheduleToStartTimeout'
     | 'maxCachedWorkflows'
     | 'useVersioning'
@@ -1212,6 +1222,7 @@ export function toNativeWorkerOptions(opts: CompiledWorkerOptionsWithBuildId): n
     defaultHeartbeatThrottleInterval: msToNumber(opts.defaultHeartbeatThrottleInterval),
     maxTaskQueueActivitiesPerSecond: opts.maxTaskQueueActivitiesPerSecond ?? null,
     maxActivitiesPerSecond: opts.maxActivitiesPerSecond ?? null,
+    maxConcurrentEagerActivityExecutionSize: opts.maxConcurrentEagerActivityExecutionSize ?? 0,
     shutdownGraceTime: msToNumber(opts.shutdownGraceTime),
     plugins: opts.plugins?.map((p) => p.name) ?? [],
     storageDrivers: [...new Set((opts.loadedDataConverter.externalStorage?.drivers ?? []).map((d) => d.type))],

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -272,7 +272,7 @@ export interface WorkerOptions {
   /**
    * Maximum number of Activity slots that may be reserved for eager execution when completing a Workflow Task.
    *
-   * Setting this to `0` disables eager Activity execution.
+   * Must be a non-negative integer. Setting this to `0` disables eager Activity execution.
    *
    * @default 3
    */
@@ -1114,6 +1114,13 @@ export function compileWorkerOptions(
   }
 
   const opts = addDefaultWorkerOptions(rawOpts, logger, metricMeter);
+  if (
+    opts.maxEagerActivityReservationsPerWorkflowTask !== undefined &&
+    (!Number.isSafeInteger(opts.maxEagerActivityReservationsPerWorkflowTask) ||
+      opts.maxEagerActivityReservationsPerWorkflowTask < 0)
+  ) {
+    throw new TypeError('maxEagerActivityReservationsPerWorkflowTask must be a non-negative integer');
+  }
   if (opts.maxCachedWorkflows !== 0 && opts.maxCachedWorkflows < 2) {
     logger.warn('maxCachedWorkflows must be either 0 (ie. cache is disabled) or greater than 1. Defaulting to 2.');
     opts.maxCachedWorkflows = 2;


### PR DESCRIPTION
## What changed

- Add `maxEagerActivityReservationsPerWorkflowTask` to `WorkerOptions`.
- Forward the configured value through the native bridge into Core.
- Preserve the existing default of three; zero disables eager activity reservations.
- Reject negative, fractional, and otherwise non-integer values.
- Update the Core submodule to the merged configurable-limit implementation.

## Why

Core already caps the number of slots it attempts to reserve for eager activities while completing a workflow task. This exposes that existing cap to TypeScript users without introducing a separate execution-lifetime limit.

## Validation

- `pnpm --filter @temporalio/core-bridge run build`
- `pnpm --filter @temporalio/core-bridge run lint:check`
- `pnpm -C packages/test run build:ts`
- `pnpm -C packages/test exec ava lib/test-worker-options.js`
- Focused ESLint and Prettier checks

The broad lint check additionally requires unrelated workspace packages to be built. No breaking changes; the default remains three.
