### PR TITLE
extstore/surface exstore errors in client

### DIFF
--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -15,6 +15,7 @@ import {
   convertDeploymentVersion,
   decodePriority,
   decompileRetryPolicy,
+  ExternalStorageError,
 } from '@temporalio/common';
 import type { Duration } from '@temporalio/common/lib/time';
 import { msOptionalToTs, msToNumber, optionalTsToDate, optionalTsToMs } from '@temporalio/common/lib/time';
@@ -482,7 +483,10 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       }
       throw new ServiceError(fallbackMessage, { cause: err });
     }
-    throw new ServiceError('Unexpected error while making gRPC request');
+    if (err instanceof ExternalStorageError) {
+      throw new ServiceError('External storage failed', { cause: err });
+    }
+    throw new ServiceError('Unexpected error while making gRPC request', { cause: err as Error });
   }
 }
 

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -17,6 +17,7 @@ import {
   convertDeploymentVersion,
   decodePriority,
   decompileRetryPolicy,
+  ExternalStorageError,
 } from '@temporalio/common';
 import type { Duration } from '@temporalio/common/lib/time';
 import { msOptionalToTs, msToNumber, optionalTsToDate, optionalTsToMs } from '@temporalio/common/lib/time';
@@ -525,7 +526,10 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       }
       throw new ServiceError(fallbackMessage, { cause: err });
     }
-    throw new ServiceError('Unexpected error while making gRPC request');
+    if (err instanceof ExternalStorageError) {
+      throw new ServiceError('External storage failed', { cause: err });
+    }
+    throw new ServiceError('Unexpected error while making gRPC request', { cause: err as Error });
   }
 }
 

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -1,6 +1,6 @@
 import { status as grpcStatus } from '@grpc/grpc-js';
 import type { ActivitySerializationContext, PayloadTypeInfo, StorageDriverTargetInfo } from '@temporalio/common';
-import { ensureTemporalFailure } from '@temporalio/common';
+import { ensureTemporalFailure, ExternalStorageError } from '@temporalio/common';
 import {
   encodeErrorToFailure,
   encodeToPayloadsWithContext,
@@ -177,8 +177,10 @@ export class AsyncCompletionClient extends BaseClient {
       }
 
       throw new ActivityCompletionError(err.details || err.message);
+    } else if (err instanceof ExternalStorageError) {
+      throw new ActivityCompletionError('External storage failed', { cause: err });
     }
-    throw new ActivityCompletionError('Unexpected failure');
+    throw new ActivityCompletionError('Unexpected failure', { cause: err });
   }
 
   /**

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -1,6 +1,6 @@
 import { status as grpcStatus } from '@grpc/grpc-js';
 import type { ActivitySerializationContext, StorageDriverTargetInfo } from '@temporalio/common';
-import { ensureTemporalFailure } from '@temporalio/common';
+import { ensureTemporalFailure, ExternalStorageError } from '@temporalio/common';
 import {
   encodeErrorToFailure,
   encodeToPayloadsWithContext,
@@ -163,8 +163,10 @@ export class AsyncCompletionClient extends BaseClient {
       }
 
       throw new ActivityCompletionError(err.details || err.message);
+    } else if (err instanceof ExternalStorageError) {
+      throw new ActivityCompletionError('External storage failed', { cause: err });
     }
-    throw new ActivityCompletionError('Unexpected failure');
+    throw new ActivityCompletionError('Unexpected failure', { cause: err });
   }
 
   /**

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -88,10 +88,18 @@ export class ActivityNotFoundError extends Error {}
 
 /**
  * Thrown by {@link AsyncCompletionClient} when trying to complete or heartbeat
- * an Activity for any reason apart from {@link ActivityNotFoundError}.
+ * an Activity for any reason apart from {@link ActivityNotFoundError}. If an
+ * underlying error exists, it will be stored in the `cause` property.
  */
 @SymbolBasedInstanceOfError('ActivityCompletionError')
-export class ActivityCompletionError extends Error {}
+export class ActivityCompletionError extends Error {
+  public readonly cause?: unknown;
+
+  constructor(message: string, opts?: { cause?: unknown }) {
+    super(message);
+    this.cause = opts?.cause;
+  }
+}
 
 /**
  * Thrown by {@link AsyncCompletionClient.heartbeat} when the Workflow has

--- a/packages/client/src/nexus-client.ts
+++ b/packages/client/src/nexus-client.ts
@@ -24,7 +24,7 @@ import {
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { msOptionalToTs, optionalTsToDate, optionalTsToMs } from '@temporalio/common/lib/time';
 import { temporal } from '@temporalio/proto';
-import type { LoadedDataConverter } from '@temporalio/common';
+import { ExternalStorageError, type LoadedDataConverter } from '@temporalio/common';
 import type { SearchAttributeType, TypedSearchAttributeValue } from '@temporalio/common/lib/search-attributes';
 import { decode } from '@temporalio/common/lib/encoding';
 import type { BaseClientOptions, LoadedWithDefaults, WithDefaults } from './base-client';
@@ -404,11 +404,11 @@ export class NexusClient extends BaseClient {
       userMetadata,
     };
     const externalStorage = this.dataConverter.externalStorage;
-    if (externalStorage) {
-      await visit(req, walkStartNexusOperationExecutionRequest, extstoreStoreOptions(externalStorage));
-    }
     let res: temporal.api.workflowservice.v1.IStartNexusOperationExecutionResponse;
     try {
+      if (externalStorage) {
+        await visit(req, walkStartNexusOperationExecutionRequest, extstoreStoreOptions(externalStorage));
+      }
       res = await this.connection.workflowService.startNexusOperationExecution(req);
     } catch (err: unknown) {
       this.rethrowGrpcError(err, 'Failed to start Nexus operation', input.id);
@@ -481,14 +481,13 @@ export class NexusClient extends BaseClient {
     };
     for (;;) {
       let res: temporal.api.workflowservice.v1.IPollNexusOperationExecutionResponse;
+      const externalStorage = this.dataConverter.externalStorage;
       try {
         res = await this.connection.workflowService.pollNexusOperationExecution(req);
+        await visit(res, walkPollNexusOperationExecutionResponse, extstoreInboundOptions(externalStorage));
       } catch (err: unknown) {
         this.rethrowGrpcError(err, 'Failed to poll Nexus operation result', input.operationId);
       }
-
-      const externalStorage = this.dataConverter.externalStorage;
-      await visit(res, walkPollNexusOperationExecutionResponse, extstoreInboundOptions(externalStorage));
 
       // The operation is closed if we have a result or failure
       if (res.result) {
@@ -511,13 +510,13 @@ export class NexusClient extends BaseClient {
       runId: input.runId ?? '',
     };
     let res: temporal.api.workflowservice.v1.IDescribeNexusOperationExecutionResponse;
+    const externalStorage = this.dataConverter.externalStorage;
     try {
       res = await this.connection.workflowService.describeNexusOperationExecution(req);
+      await visit(res, walkDescribeNexusOperationExecutionResponse, extstoreInboundOptions(externalStorage));
     } catch (err: unknown) {
       this.rethrowGrpcError(err, 'Failed to describe Nexus operation', input.operationId);
     }
-    const externalStorage = this.dataConverter.externalStorage;
-    await visit(res, walkDescribeNexusOperationExecutionResponse, extstoreInboundOptions(externalStorage));
     if (!res.info) {
       throw new ServiceError('Received invalid Nexus operation description from server: missing info');
     }
@@ -560,6 +559,7 @@ export class NexusClient extends BaseClient {
     let nextPageToken: Uint8Array | undefined = undefined;
     for (;;) {
       let response: temporal.api.workflowservice.v1.IListNexusOperationExecutionsResponse;
+      const externalStorage = this.dataConverter.externalStorage;
       try {
         response = await this.connection.workflowService.listNexusOperationExecutions({
           namespace: this.options.namespace,
@@ -567,11 +567,10 @@ export class NexusClient extends BaseClient {
           pageSize: input.pageSize,
           nextPageToken,
         });
+        await visit(response, walkListNexusOperationExecutionsResponse, extstoreInboundOptions(externalStorage));
       } catch (err: unknown) {
         this.rethrowGrpcError(err, 'Failed to list Nexus operations', undefined);
       }
-      const externalStorage = this.dataConverter.externalStorage;
-      await visit(response, walkListNexusOperationExecutionsResponse, extstoreInboundOptions(externalStorage));
       for (const raw of response.operations ?? []) {
         yield nexusOperationListInfoFromProto(raw);
       }
@@ -607,6 +606,9 @@ export class NexusClient extends BaseClient {
       throw new ServiceError(fallbackMessage, { cause: err });
     }
 
+    if (err instanceof ExternalStorageError) {
+      throw new ServiceError('External storage failed', { cause: err });
+    }
     throw new ServiceError('Unexpected error while making gRPC request', { cause: err as Error });
   }
 }

--- a/packages/client/src/nexus-client.ts
+++ b/packages/client/src/nexus-client.ts
@@ -25,6 +25,7 @@ import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow
 import { msOptionalToTs, optionalTsToDate, optionalTsToMs } from '@temporalio/common/lib/time';
 import { temporal } from '@temporalio/proto';
 import type { LoadedDataConverter, TypeInfo } from '@temporalio/common';
+import { ExternalStorageError } from '@temporalio/common';
 import type { SearchAttributeType, TypedSearchAttributeValue } from '@temporalio/common/lib/search-attributes';
 import { decode } from '@temporalio/common/lib/encoding';
 import type { BaseClientOptions, LoadedWithDefaults, WithDefaults } from './base-client';
@@ -413,11 +414,11 @@ export class NexusClient extends BaseClient {
       userMetadata,
     };
     const externalStorage = this.dataConverter.externalStorage;
-    if (externalStorage) {
-      await visit(req, walkStartNexusOperationExecutionRequest, extstoreStoreOptions(externalStorage));
-    }
     let res: temporal.api.workflowservice.v1.IStartNexusOperationExecutionResponse;
     try {
+      if (externalStorage) {
+        await visit(req, walkStartNexusOperationExecutionRequest, extstoreStoreOptions(externalStorage));
+      }
       res = await this.connection.workflowService.startNexusOperationExecution(req);
     } catch (err: unknown) {
       this.rethrowGrpcError(err, 'Failed to start Nexus operation', input.id);
@@ -496,14 +497,13 @@ export class NexusClient extends BaseClient {
     };
     for (;;) {
       let res: temporal.api.workflowservice.v1.IPollNexusOperationExecutionResponse;
+      const externalStorage = this.dataConverter.externalStorage;
       try {
         res = await this.connection.workflowService.pollNexusOperationExecution(req);
+        await visit(res, walkPollNexusOperationExecutionResponse, extstoreInboundOptions(externalStorage));
       } catch (err: unknown) {
         this.rethrowGrpcError(err, 'Failed to poll Nexus operation result', input.operationId);
       }
-
-      const externalStorage = this.dataConverter.externalStorage;
-      await visit(res, walkPollNexusOperationExecutionResponse, extstoreInboundOptions(externalStorage));
 
       // The operation is closed if we have a result or failure
       if (res.result) {
@@ -526,13 +526,13 @@ export class NexusClient extends BaseClient {
       runId: input.runId ?? '',
     };
     let res: temporal.api.workflowservice.v1.IDescribeNexusOperationExecutionResponse;
+    const externalStorage = this.dataConverter.externalStorage;
     try {
       res = await this.connection.workflowService.describeNexusOperationExecution(req);
+      await visit(res, walkDescribeNexusOperationExecutionResponse, extstoreInboundOptions(externalStorage));
     } catch (err: unknown) {
       this.rethrowGrpcError(err, 'Failed to describe Nexus operation', input.operationId);
     }
-    const externalStorage = this.dataConverter.externalStorage;
-    await visit(res, walkDescribeNexusOperationExecutionResponse, extstoreInboundOptions(externalStorage));
     if (!res.info) {
       throw new ServiceError('Received invalid Nexus operation description from server: missing info');
     }
@@ -575,6 +575,7 @@ export class NexusClient extends BaseClient {
     let nextPageToken: Uint8Array | undefined = undefined;
     for (;;) {
       let response: temporal.api.workflowservice.v1.IListNexusOperationExecutionsResponse;
+      const externalStorage = this.dataConverter.externalStorage;
       try {
         response = await this.connection.workflowService.listNexusOperationExecutions({
           namespace: this.options.namespace,
@@ -582,11 +583,10 @@ export class NexusClient extends BaseClient {
           pageSize: input.pageSize,
           nextPageToken,
         });
+        await visit(response, walkListNexusOperationExecutionsResponse, extstoreInboundOptions(externalStorage));
       } catch (err: unknown) {
         this.rethrowGrpcError(err, 'Failed to list Nexus operations', undefined);
       }
-      const externalStorage = this.dataConverter.externalStorage;
-      await visit(response, walkListNexusOperationExecutionsResponse, extstoreInboundOptions(externalStorage));
       for (const raw of response.operations ?? []) {
         yield nexusOperationListInfoFromProto(raw);
       }
@@ -622,6 +622,9 @@ export class NexusClient extends BaseClient {
       throw new ServiceError(fallbackMessage, { cause: err });
     }
 
+    if (err instanceof ExternalStorageError) {
+      throw new ServiceError('External storage failed', { cause: err });
+    }
     throw new ServiceError('Unexpected error while making gRPC request', { cause: err as Error });
   }
 }

--- a/packages/client/src/schedule-client.ts
+++ b/packages/client/src/schedule-client.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { status as grpcStatus } from '@grpc/grpc-js';
-import type { Workflow } from '@temporalio/common';
+import { ExternalStorageError, type Workflow } from '@temporalio/common';
 import {
   decodeSearchAttributes,
   decodeTypedSearchAttributes,
@@ -414,6 +414,7 @@ export class ScheduleClient extends BaseClient {
     let nextPageToken: Uint8Array | undefined = undefined;
     for (;;) {
       let response: temporal.api.workflowservice.v1.ListSchedulesResponse;
+      const externalStorage = this.dataConverter.externalStorage;
       try {
         response = await this.workflowService.listSchedules({
           nextPageToken,
@@ -421,12 +422,10 @@ export class ScheduleClient extends BaseClient {
           maximumPageSize: options?.pageSize,
           query: options?.query,
         });
+        await visit(response, walkListSchedulesResponse, extstoreInboundOptions(externalStorage));
       } catch (e) {
         this.rethrowGrpcError(e, 'Failed to list schedules', undefined);
       }
-
-      const externalStorage = this.dataConverter.externalStorage;
-      await visit(response, walkListSchedulesResponse, extstoreInboundOptions(externalStorage));
 
       for (const raw of response.schedules ?? []) {
         yield <ScheduleSummary>{
@@ -576,6 +575,9 @@ export class ScheduleClient extends BaseClient {
       }
 
       throw new ServiceError(fallbackMessage, { cause: err });
+    }
+    if (err instanceof ExternalStorageError) {
+      throw new ServiceError('External storage failed', { cause: err });
     }
     throw new ServiceError('Unexpected error while making gRPC request', { cause: err as Error });
   }

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -26,6 +26,7 @@ import {
   decodeRetryState,
   encodeWorkflowIdConflictPolicy,
   compilePriority,
+  ExternalStorageError,
 } from '@temporalio/common';
 import { encodeUserMetadata } from '@temporalio/common/lib/internal-non-workflow/codec-helpers';
 import { encodeUnifiedSearchAttributes } from '@temporalio/common/lib/converter/payload-search-attributes';
@@ -830,13 +831,13 @@ export class WorkflowClient extends BaseClient {
 
     for (;;) {
       let res: temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
+      const externalStorage = this.dataConverter.externalStorage;
       try {
         res = await this.workflowService.getWorkflowExecutionHistory(req);
+        await visit(res, walkGetWorkflowExecutionHistoryResponse, extstoreInboundOptions(externalStorage));
       } catch (err) {
         this.rethrowGrpcError(err, 'Failed to get Workflow execution history', { workflowId, runId });
       }
-      const externalStorage = this.dataConverter.externalStorage;
-      await visit(res, walkGetWorkflowExecutionHistoryResponse, extstoreInboundOptions(externalStorage));
       const events = res.history?.events;
 
       if (events == null || events.length === 0) {
@@ -960,6 +961,9 @@ export class WorkflowClient extends BaseClient {
 
       throw new ServiceError(fallbackMessage, { cause: err });
     }
+    if (err instanceof ExternalStorageError) {
+      throw new ServiceError('External storage failed', { cause: err });
+    }
     throw new ServiceError('Unexpected error while making gRPC request', { cause: err as Error });
   }
 
@@ -982,22 +986,23 @@ export class WorkflowClient extends BaseClient {
       },
     };
     const externalStorage = this.dataConverter.externalStorage;
-    if (externalStorage) {
-      await visit(
-        req,
-        walkQueryWorkflowRequest,
-        extstoreStoreOptions(externalStorage, {
-          initialTarget: {
-            kind: 'workflow',
-            namespace: this.options.namespace,
-            id: input.workflowExecution.workflowId ?? undefined,
-          },
-        })
-      );
-    }
     let response: temporal.api.workflowservice.v1.QueryWorkflowResponse;
     try {
+      if (externalStorage) {
+        await visit(
+          req,
+          walkQueryWorkflowRequest,
+          extstoreStoreOptions(externalStorage, {
+            initialTarget: {
+              kind: 'workflow',
+              namespace: this.options.namespace,
+              id: input.workflowExecution.workflowId ?? undefined,
+            },
+          })
+        );
+      }
       response = await this.workflowService.queryWorkflow(req);
+      await visit(response, walkQueryWorkflowResponse, extstoreInboundOptions(externalStorage));
     } catch (err) {
       if (isGrpcServiceError(err)) {
         rethrowKnownErrorTypes(err);
@@ -1007,7 +1012,6 @@ export class WorkflowClient extends BaseClient {
       }
       this.rethrowGrpcError(err, 'Failed to query Workflow', input.workflowExecution);
     }
-    await visit(response, walkQueryWorkflowResponse, extstoreInboundOptions(externalStorage));
     if (response.queryRejected) {
       if (response.queryRejected.status === undefined || response.queryRejected.status === null) {
         throw new TypeError('Received queryRejected from server with no status');
@@ -1069,34 +1073,34 @@ export class WorkflowClient extends BaseClient {
 
     const request = await this._createUpdateWorkflowRequest(waitForStageProto, input);
     const externalStorage = this.dataConverter.externalStorage;
-    if (externalStorage) {
-      await visit(
-        request,
-        walkUpdateWorkflowExecutionRequest,
-        extstoreStoreOptions(externalStorage, {
-          initialTarget: {
-            kind: 'workflow',
-            namespace: this.options.namespace,
-            id: input.workflowExecution.workflowId ?? undefined,
-          },
-        })
-      );
-    }
 
     // Repeatedly send UpdateWorkflowExecution until update is durable (if the server receives a request with
     // an update ID that already exists, it responds with information for the existing update). If the
     // requested wait stage is COMPLETED, further polling is done before returning the UpdateHandle.
     let response: temporal.api.workflowservice.v1.UpdateWorkflowExecutionResponse;
     try {
+      if (externalStorage) {
+        await visit(
+          request,
+          walkUpdateWorkflowExecutionRequest,
+          extstoreStoreOptions(externalStorage, {
+            initialTarget: {
+              kind: 'workflow',
+              namespace: this.options.namespace,
+              id: input.workflowExecution.workflowId ?? undefined,
+            },
+          })
+        );
+      }
       do {
         response = await this.workflowService.updateWorkflowExecution(request);
       } while (
         response.stage < UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED
       );
+      await visit(response, walkUpdateWorkflowExecutionResponse, extstoreInboundOptions(externalStorage));
     } catch (err) {
       this.rethrowUpdateGrpcError(err, 'Workflow Update failed', input.workflowExecution);
     }
-    await visit(response, walkUpdateWorkflowExecutionResponse, extstoreInboundOptions(externalStorage));
     return {
       updateId: request.request!.meta!.updateId!,
 
@@ -1759,6 +1763,7 @@ export class WorkflowClient extends BaseClient {
     let nextPageToken: Uint8Array = Buffer.alloc(0);
     for (;;) {
       let response: temporal.api.workflowservice.v1.ListWorkflowExecutionsResponse;
+      const externalStorage = this.dataConverter.externalStorage;
       try {
         response = await this.workflowService.listWorkflowExecutions({
           namespace: this.options.namespace,
@@ -1766,11 +1771,10 @@ export class WorkflowClient extends BaseClient {
           nextPageToken,
           pageSize: options?.pageSize,
         });
+        await visit(response, walkListWorkflowExecutionsResponse, extstoreInboundOptions(externalStorage));
       } catch (e) {
         this.rethrowGrpcError(e, 'Failed to list workflows', undefined);
       }
-      const externalStorage = this.dataConverter.externalStorage;
-      await visit(response, walkListWorkflowExecutionsResponse, extstoreInboundOptions(externalStorage));
       // Not decoding memo payloads concurrently even though we could have to keep the lazy nature of this iterator.
       // Decoding is done for `memo` fields which tend to be small.
       // We might decide to change that based on user feedback.

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -32,6 +32,7 @@ import {
   encodeWorkflowIdConflictPolicy,
   compilePriority,
   extractWorkflowTypeAndConfig,
+  ExternalStorageError,
 } from '@temporalio/common';
 import { encodeUserMetadata } from '@temporalio/common/lib/internal-non-workflow/codec-helpers';
 import { encodeUnifiedSearchAttributes } from '@temporalio/common/lib/converter/payload-search-attributes';
@@ -932,13 +933,13 @@ export class WorkflowClient extends BaseClient {
 
     for (;;) {
       let res: temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
+      const externalStorage = this.dataConverter.externalStorage;
       try {
         res = await this.workflowService.getWorkflowExecutionHistory(req);
+        await visit(res, walkGetWorkflowExecutionHistoryResponse, extstoreInboundOptions(externalStorage));
       } catch (err) {
         this.rethrowGrpcError(err, 'Failed to get Workflow execution history', { workflowId, runId });
       }
-      const externalStorage = this.dataConverter.externalStorage;
-      await visit(res, walkGetWorkflowExecutionHistoryResponse, extstoreInboundOptions(externalStorage));
       const events = res.history?.events;
 
       if (events == null || events.length === 0) {
@@ -1064,6 +1065,9 @@ export class WorkflowClient extends BaseClient {
 
       throw new ServiceError(fallbackMessage, { cause: err });
     }
+    if (err instanceof ExternalStorageError) {
+      throw new ServiceError('External storage failed', { cause: err });
+    }
     throw new ServiceError('Unexpected error while making gRPC request', { cause: err as Error });
   }
 
@@ -1089,22 +1093,23 @@ export class WorkflowClient extends BaseClient {
       },
     };
     const externalStorage = this.dataConverter.externalStorage;
-    if (externalStorage) {
-      await visit(
-        req,
-        walkQueryWorkflowRequest,
-        extstoreStoreOptions(externalStorage, {
-          initialTarget: {
-            kind: 'workflow',
-            namespace: this.options.namespace,
-            id: input.workflowExecution.workflowId ?? undefined,
-          },
-        })
-      );
-    }
     let response: temporal.api.workflowservice.v1.QueryWorkflowResponse;
     try {
+      if (externalStorage) {
+        await visit(
+          req,
+          walkQueryWorkflowRequest,
+          extstoreStoreOptions(externalStorage, {
+            initialTarget: {
+              kind: 'workflow',
+              namespace: this.options.namespace,
+              id: input.workflowExecution.workflowId ?? undefined,
+            },
+          })
+        );
+      }
       response = await this.workflowService.queryWorkflow(req);
+      await visit(response, walkQueryWorkflowResponse, extstoreInboundOptions(externalStorage));
     } catch (err) {
       if (isGrpcServiceError(err)) {
         rethrowKnownErrorTypes(err);
@@ -1114,7 +1119,6 @@ export class WorkflowClient extends BaseClient {
       }
       this.rethrowGrpcError(err, 'Failed to query Workflow', input.workflowExecution);
     }
-    await visit(response, walkQueryWorkflowResponse, extstoreInboundOptions(externalStorage));
     if (internalOptions != null) {
       // A Query writes nothing to history, so the server returns a link to the Workflow execution
       // that processed it rather than to an event. Captured before the rejection check below so a
@@ -1194,34 +1198,34 @@ export class WorkflowClient extends BaseClient {
 
     const request = await this._createUpdateWorkflowRequest(waitForStageProto, input);
     const externalStorage = this.dataConverter.externalStorage;
-    if (externalStorage) {
-      await visit(
-        request,
-        walkUpdateWorkflowExecutionRequest,
-        extstoreStoreOptions(externalStorage, {
-          initialTarget: {
-            kind: 'workflow',
-            namespace: this.options.namespace,
-            id: input.workflowExecution.workflowId ?? undefined,
-          },
-        })
-      );
-    }
 
     // Repeatedly send UpdateWorkflowExecution until update is durable (if the server receives a request with
     // an update ID that already exists, it responds with information for the existing update). If the
     // requested wait stage is COMPLETED, further polling is done before returning the UpdateHandle.
     let response: temporal.api.workflowservice.v1.UpdateWorkflowExecutionResponse;
     try {
+      if (externalStorage) {
+        await visit(
+          request,
+          walkUpdateWorkflowExecutionRequest,
+          extstoreStoreOptions(externalStorage, {
+            initialTarget: {
+              kind: 'workflow',
+              namespace: this.options.namespace,
+              id: input.workflowExecution.workflowId ?? undefined,
+            },
+          })
+        );
+      }
       do {
         response = await this.workflowService.updateWorkflowExecution(request);
       } while (
         response.stage < UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED
       );
+      await visit(response, walkUpdateWorkflowExecutionResponse, extstoreInboundOptions(externalStorage));
     } catch (err) {
       this.rethrowUpdateGrpcError(err, 'Workflow Update failed', input.workflowExecution);
     }
-    await visit(response, walkUpdateWorkflowExecutionResponse, extstoreInboundOptions(externalStorage));
     const internalOptions = (input.options as InternalWorkflowUpdateOptions)[InternalWorkflowUpdateOptionsSymbol];
     if (internalOptions != null) {
       // Capture the link the server attached to the Update response so the Nexus helper can add it
@@ -1982,6 +1986,7 @@ export class WorkflowClient extends BaseClient {
     let nextPageToken: Uint8Array = Buffer.alloc(0);
     for (;;) {
       let response: temporal.api.workflowservice.v1.ListWorkflowExecutionsResponse;
+      const externalStorage = this.dataConverter.externalStorage;
       try {
         response = await this.workflowService.listWorkflowExecutions({
           namespace: this.options.namespace,
@@ -1989,11 +1994,10 @@ export class WorkflowClient extends BaseClient {
           nextPageToken,
           pageSize: options?.pageSize,
         });
+        await visit(response, walkListWorkflowExecutionsResponse, extstoreInboundOptions(externalStorage));
       } catch (e) {
         this.rethrowGrpcError(e, 'Failed to list workflows', undefined);
       }
-      const externalStorage = this.dataConverter.externalStorage;
-      await visit(response, walkListWorkflowExecutionsResponse, extstoreInboundOptions(externalStorage));
       // Not decoding memo payloads concurrently even though we could have to keep the lazy nature of this iterator.
       // Decoding is done for `memo` fields which tend to be small.
       // We might decide to change that based on user feedback.

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -111,8 +111,8 @@ export class ExternalStorageDriverError extends ExternalStorageError {
 }
 
 /**
- * [TMPRL-1105] Thrown when external storage is asked to use a driver that is not registered 
- * on the configured `ExternalStorage`. 
+ * [TMPRL-1105] Thrown when external storage is asked to use a driver that is not registered
+ * on the configured `ExternalStorage`.
  *
  * @experimental
  */

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -75,14 +75,55 @@ export class NamespaceNotFoundError extends Error {
 export class CompleteAsyncError extends Error {}
 
 /**
+ * Base type for all external storage errors.
+ *
+ * @experimental
+ */
+@SymbolBasedInstanceOfError('ExternalStorageError')
+export abstract class ExternalStorageError extends Error {}
+
+/**
  * Thrown when an inbound payload is detected as an external-storage reference
  * but no `ExternalStorage` is configured to resolve it.
  *
  * @experimental
  */
 @SymbolBasedInstanceOfError('ExternalStorageNotConfiguredError')
-export class ExternalStorageNotConfiguredError extends Error {
+export class ExternalStorageNotConfiguredError extends ExternalStorageError {
   constructor(message = 'Detected externally stored payload(s) but external storage is not configured.') {
     super(`[TMPRL1105] ${message}`);
   }
 }
+
+/**
+ * Thrown when a storage driver's `store` or `retrieve` operation fails.
+ *
+ * @experimental
+ */
+@SymbolBasedInstanceOfError('ExternalStorageDriverError')
+export class ExternalStorageDriverError extends ExternalStorageError {
+  public readonly cause?: unknown;
+
+  constructor(message: string, opts?: { cause?: unknown }) {
+    super(message);
+    this.cause = opts?.cause;
+  }
+}
+
+/**
+ * [TMPRL-1105] Thrown when external storage is asked to use a driver that is not registered 
+ * on the configured `ExternalStorage`. 
+ *
+ * @experimental
+ */
+@SymbolBasedInstanceOfError('ExternalStorageUnregisteredDriverError')
+export class ExternalStorageUnregisteredDriverError extends ExternalStorageError {}
+
+/**
+ * Thrown when an external-storage reference is malformed, or a driver returns a result inconsistent
+ * with its input.
+ *
+ * @experimental
+ */
+@SymbolBasedInstanceOfError('ExternalStorageReferenceError')
+export class ExternalStorageReferenceError extends ExternalStorageError {}

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -83,7 +83,7 @@ export class CompleteAsyncError extends Error {}
 export abstract class ExternalStorageError extends Error {}
 
 /**
- * Thrown when an inbound payload is detected as an external-storage reference
+ * [TMPRL1105] Thrown when an inbound payload is detected as an external-storage reference
  * but no `ExternalStorage` is configured to resolve it.
  *
  * @experimental
@@ -111,7 +111,7 @@ export class ExternalStorageDriverError extends ExternalStorageError {
 }
 
 /**
- * [TMPRL-1105] Thrown when external storage is asked to use a driver that is not registered
+ * Thrown when external storage is asked to use a driver that is not registered
  * on the configured `ExternalStorage`.
  *
  * @experimental

--- a/packages/common/src/internal-non-workflow/external-storage-runner.ts
+++ b/packages/common/src/internal-non-workflow/external-storage-runner.ts
@@ -13,7 +13,11 @@ import type {
   StorageDriverStoreContext,
   StorageDriverTargetInfo,
 } from '../converter/extstore';
-import { ValueError } from '../errors';
+import {
+  ExternalStorageDriverError,
+  ExternalStorageReferenceError,
+  ExternalStorageUnregisteredDriverError,
+} from '../errors';
 import type { Payload } from '../interfaces';
 import { decodeReferencePayload, encodeReferencePayload, isReferencePayload } from './extstore-helpers';
 
@@ -68,7 +72,7 @@ export class ExternalStorageRunner {
       const selected = driverSelector(storeCtx, payload);
       if (selected === null) continue;
       if (this.externalStorage.getDriver(selected.name) !== selected) {
-        throw new ValueError(
+        throw new ExternalStorageUnregisteredDriverError(
           `Driver '${selected.name}' returned by driverSelector is not registered in ExternalStorage.drivers`
         );
       }
@@ -85,12 +89,19 @@ export class ExternalStorageRunner {
 
     const result = payloads.slice();
     await runWithAbortOnFirstError(batchController, [...driverGroups.values()], async (group) => {
-      const claims = await group.driver.store(
-        storeCtx,
-        group.items.map((it) => it.payload)
-      );
+      let claims: StorageDriverClaim[];
+      try {
+        claims = await group.driver.store(
+          storeCtx,
+          group.items.map((it) => it.payload)
+        );
+      } catch (cause) {
+        throw new ExternalStorageDriverError(`Storage driver '${group.driver.name}' failed to store payloads`, {
+          cause,
+        });
+      }
       if (claims.length !== group.items.length) {
-        throw new ValueError(
+        throw new ExternalStorageReferenceError(
           `Driver '${group.driver.name}' returned ${claims.length} claims for ${group.items.length} payloads`
         );
       }
@@ -125,10 +136,15 @@ export class ExternalStorageRunner {
 
     for (const [i, payload] of payloads.entries()) {
       if (!isReferencePayload(payload)) continue;
-      const decoded = decodeReferencePayload(payload);
+      let decoded: ReturnType<typeof decodeReferencePayload>;
+      try {
+        decoded = decodeReferencePayload(payload);
+      } catch (cause) {
+        throw new ExternalStorageReferenceError('Failed to decode external storage reference', { cause });
+      }
       const driver = this.externalStorage.getDriver(decoded.driverName);
       if (driver === null) {
-        throw new ValueError(`No driver registered with name '${decoded.driverName}'`);
+        throw new ExternalStorageUnregisteredDriverError(`No driver registered with name '${decoded.driverName}'`);
       }
       let group = driverGroups.get(decoded.driverName);
       if (group === undefined) {
@@ -142,12 +158,19 @@ export class ExternalStorageRunner {
 
     const result = payloads.slice();
     await runWithAbortOnFirstError(batchController, [...driverGroups.values()], async (group) => {
-      const retrieved = await group.driver.retrieve(
-        retrieveCtx,
-        group.items.map((it) => it.claim)
-      );
+      let retrieved: Payload[];
+      try {
+        retrieved = await group.driver.retrieve(
+          retrieveCtx,
+          group.items.map((it) => it.claim)
+        );
+      } catch (cause) {
+        throw new ExternalStorageDriverError(`Storage driver '${group.driver.name}' failed to retrieve payloads`, {
+          cause,
+        });
+      }
       if (retrieved.length !== group.items.length) {
-        throw new ValueError(
+        throw new ExternalStorageReferenceError(
           `Driver '${group.driver.name}' returned ${retrieved.length} payloads for ${group.items.length} claims`
         );
       }

--- a/packages/common/src/internal-non-workflow/external-storage-runner.ts
+++ b/packages/common/src/internal-non-workflow/external-storage-runner.ts
@@ -14,7 +14,11 @@ import type {
   StorageDriverStoreContext,
   StorageDriverTargetInfo,
 } from '../converter/extstore';
-import { ValueError } from '../errors';
+import {
+  ExternalStorageDriverError,
+  ExternalStorageReferenceError,
+  ExternalStorageUnregisteredDriverError,
+} from '../errors';
 import type { Payload } from '../interfaces';
 import { decodeReferencePayload, encodeReferencePayload, isReferencePayload } from './extstore-helpers';
 
@@ -70,7 +74,7 @@ export class ExternalStorageRunner {
       const selected = driverSelector(selectCtx, payload);
       if (selected === null) continue;
       if (this.externalStorage.getDriver(selected.name) !== selected) {
-        throw new ValueError(
+        throw new ExternalStorageUnregisteredDriverError(
           `Driver '${selected.name}' returned by driverSelector is not registered in ExternalStorage.drivers`
         );
       }
@@ -87,12 +91,19 @@ export class ExternalStorageRunner {
 
     const result = payloads.slice();
     await runWithAbortOnFirstError(batchController, [...driverGroups.values()], async (group) => {
-      const claims = await group.driver.store(
-        storeCtx,
-        group.items.map((it) => it.payload)
-      );
+      let claims: StorageDriverClaim[];
+      try {
+        claims = await group.driver.store(
+          storeCtx,
+          group.items.map((it) => it.payload)
+        );
+      } catch (cause) {
+        throw new ExternalStorageDriverError(`Storage driver '${group.driver.name}' failed to store payloads`, {
+          cause,
+        });
+      }
       if (claims.length !== group.items.length) {
-        throw new ValueError(
+        throw new ExternalStorageReferenceError(
           `Driver '${group.driver.name}' returned ${claims.length} claims for ${group.items.length} payloads`
         );
       }
@@ -127,10 +138,15 @@ export class ExternalStorageRunner {
 
     for (const [i, payload] of payloads.entries()) {
       if (!isReferencePayload(payload)) continue;
-      const decoded = decodeReferencePayload(payload);
+      let decoded: ReturnType<typeof decodeReferencePayload>;
+      try {
+        decoded = decodeReferencePayload(payload);
+      } catch (cause) {
+        throw new ExternalStorageReferenceError('Failed to decode external storage reference', { cause });
+      }
       const driver = this.externalStorage.getDriver(decoded.driverName);
       if (driver === null) {
-        throw new ValueError(`No driver registered with name '${decoded.driverName}'`);
+        throw new ExternalStorageUnregisteredDriverError(`No driver registered with name '${decoded.driverName}'`);
       }
       let group = driverGroups.get(decoded.driverName);
       if (group === undefined) {
@@ -144,12 +160,19 @@ export class ExternalStorageRunner {
 
     const result = payloads.slice();
     await runWithAbortOnFirstError(batchController, [...driverGroups.values()], async (group) => {
-      const retrieved = await group.driver.retrieve(
-        retrieveCtx,
-        group.items.map((it) => it.claim)
-      );
+      let retrieved: Payload[];
+      try {
+        retrieved = await group.driver.retrieve(
+          retrieveCtx,
+          group.items.map((it) => it.claim)
+        );
+      } catch (cause) {
+        throw new ExternalStorageDriverError(`Storage driver '${group.driver.name}' failed to retrieve payloads`, {
+          cause,
+        });
+      }
       if (retrieved.length !== group.items.length) {
-        throw new ValueError(
+        throw new ExternalStorageReferenceError(
           `Driver '${group.driver.name}' returned ${retrieved.length} payloads for ${group.items.length} claims`
         );
       }

--- a/packages/common/src/type-helpers.ts
+++ b/packages/common/src/type-helpers.ts
@@ -175,8 +175,7 @@ export function assertNever(msg: string, x: never): never {
   throw new TypeError(msg + ': ' + x);
 }
 
-export type Class<E extends Error> = {
-  new (...args: any[]): E;
+export type Class<E extends Error> = (abstract new (...args: any[]) => E) & {
   prototype: E;
 };
 

--- a/packages/common/src/type-helpers.ts
+++ b/packages/common/src/type-helpers.ts
@@ -192,8 +192,7 @@ export function assertNever(msg: string, x: never): never {
   throw new TypeError(msg + ': ' + x);
 }
 
-export type Class<E extends Error> = {
-  new (...args: any[]): E;
+export type Class<E extends Error> = (abstract new (...args: any[]) => E) & {
   prototype: E;
 };
 

--- a/packages/test/src/test-extstore-runner.ts
+++ b/packages/test/src/test-extstore-runner.ts
@@ -1,6 +1,11 @@
 /* eslint @typescript-eslint/no-non-null-assertion: 0 */
 import test from 'ava';
-import { ValueError, type Payload } from '@temporalio/common';
+import {
+  ExternalStorageDriverError,
+  ExternalStorageReferenceError,
+  ExternalStorageUnregisteredDriverError,
+  type Payload,
+} from '@temporalio/common';
 import { ExternalStorage } from '@temporalio/common/lib/converter/extstore';
 import { ExternalStorageRunner, isReferencePayload } from '@temporalio/common/lib/internal-non-workflow';
 import { encode } from '@temporalio/common/lib/encoding';
@@ -102,7 +107,7 @@ test('store selector returning null leaves the payload inline', async (t) => {
   t.deepEqual(result, [originalPayload]);
 });
 
-test('store throws ValueError when selector returns an unregistered driver', async (t) => {
+test('store throws ExternalStorageUnregisteredDriverError when selector returns an unregistered driver', async (t) => {
   const registeredDriver = makeFakeDriver({ name: 'a' });
   const strangerDriver = makeFakeDriver({ name: 'a' }); // same name, different identity
   const runner = new ExternalStorageRunner(
@@ -114,25 +119,27 @@ test('store throws ValueError when selector returns an unregistered driver', asy
   );
 
   await t.throwsAsync(() => runner.store([makePayload(1)]), {
-    instanceOf: ValueError,
+    instanceOf: ExternalStorageUnregisteredDriverError,
   });
 });
 
-test('store propagates driver errors unchanged', async (t) => {
+test('store wraps driver errors in ExternalStorageDriverError', async (t) => {
   const boom = new Error('disk full');
   const driver = makeFakeDriver({ name: 's3', onStore: () => Promise.reject(boom) });
   const runner = new ExternalStorageRunner(new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 0 }));
 
-  const err = await t.throwsAsync(() => runner.store([makePayload(1)]));
-  t.is(err, boom);
+  const err = await t.throwsAsync(() => runner.store([makePayload(1)]), {
+    instanceOf: ExternalStorageDriverError,
+  });
+  t.is(err?.cause, boom);
 });
 
-test('store raises ValueError on claim arity mismatch', async (t) => {
+test('store raises ExternalStorageReferenceError on claim arity mismatch', async (t) => {
   const driver = makeFakeDriver({ name: 's3', onStore: () => [] });
   const runner = new ExternalStorageRunner(new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 0 }));
 
   await t.throwsAsync(() => runner.store([makePayload(1)]), {
-    instanceOf: ValueError,
+    instanceOf: ExternalStorageReferenceError,
   });
 });
 
@@ -184,7 +191,7 @@ test('store/retrieve round-trip preserves order across drivers', async (t) => {
   t.deepEqual(retrievedPayloads, inputPayloads);
 });
 
-test('retrieve raises ValueError when the driver name is unknown', async (t) => {
+test('retrieve raises ExternalStorageUnregisteredDriverError when the driver name is unknown', async (t) => {
   const writerDriver = makeFakeDriver({ name: 'writer' });
   const writerRunner = new ExternalStorageRunner(
     new ExternalStorage({ drivers: [writerDriver], payloadSizeThreshold: 0 })
@@ -195,11 +202,11 @@ test('retrieve raises ValueError when the driver name is unknown', async (t) => 
   const readerRunner = new ExternalStorageRunner(new ExternalStorage({ drivers: [readerDriver] }));
 
   await t.throwsAsync(() => readerRunner.retrieve(storedPayloads), {
-    instanceOf: ValueError,
+    instanceOf: ExternalStorageUnregisteredDriverError,
   });
 });
 
-test('retrieve raises ValueError on payload arity mismatch', async (t) => {
+test('retrieve raises ExternalStorageReferenceError on payload arity mismatch', async (t) => {
   const payloadsToStore = [makePayload(1), makePayload(2)];
   const payloadsToRetrieve = [makePayload(1)];
 
@@ -215,11 +222,11 @@ test('retrieve raises ValueError on payload arity mismatch', async (t) => {
   );
 
   await t.throwsAsync(() => readerRunner.retrieve(storedPayloads), {
-    instanceOf: ValueError,
+    instanceOf: ExternalStorageReferenceError,
   });
 });
 
-test('retrieve propagates driver errors unchanged', async (t) => {
+test('retrieve wraps driver errors in ExternalStorageDriverError', async (t) => {
   const boom = new Error('object gone');
   const writerDriver = makeFakeDriver({ name: 's3' });
   const writerRunner = new ExternalStorageRunner(
@@ -232,8 +239,10 @@ test('retrieve propagates driver errors unchanged', async (t) => {
     new ExternalStorage({ drivers: [readerDriver], payloadSizeThreshold: 0 })
   );
 
-  const err = await t.throwsAsync(() => readerRunner.retrieve(storedPayloads));
-  t.is(err, boom);
+  const err = await t.throwsAsync(() => readerRunner.retrieve(storedPayloads), {
+    instanceOf: ExternalStorageDriverError,
+  });
+  t.is(err?.cause, boom);
 });
 
 test('retrieve only resolves reference payloads, passing others through', async (t) => {

--- a/packages/test/src/test-extstore-runner.ts
+++ b/packages/test/src/test-extstore-runner.ts
@@ -1,6 +1,11 @@
 /* eslint @typescript-eslint/no-non-null-assertion: 0 */
 import test from 'ava';
-import { ValueError, type Payload } from '@temporalio/common';
+import {
+  ExternalStorageDriverError,
+  ExternalStorageReferenceError,
+  ExternalStorageUnregisteredDriverError,
+  type Payload,
+} from '@temporalio/common';
 import { ExternalStorage } from '@temporalio/common/lib/converter/extstore';
 import type { StorageDriverSelectContext, StorageDriverTargetInfo } from '@temporalio/common/lib/converter/extstore';
 import { ExternalStorageRunner, isReferencePayload } from '@temporalio/common/lib/internal-non-workflow';
@@ -103,7 +108,7 @@ test('store selector returning null leaves the payload inline', async (t) => {
   t.deepEqual(result, [originalPayload]);
 });
 
-test('store throws ValueError when selector returns an unregistered driver', async (t) => {
+test('store throws ExternalStorageUnregisteredDriverError when selector returns an unregistered driver', async (t) => {
   const registeredDriver = makeFakeDriver({ name: 'a' });
   const strangerDriver = makeFakeDriver({ name: 'a' }); // same name, different identity
   const runner = new ExternalStorageRunner(
@@ -115,25 +120,27 @@ test('store throws ValueError when selector returns an unregistered driver', asy
   );
 
   await t.throwsAsync(() => runner.store([makePayload(1)]), {
-    instanceOf: ValueError,
+    instanceOf: ExternalStorageUnregisteredDriverError,
   });
 });
 
-test('store propagates driver errors unchanged', async (t) => {
+test('store wraps driver errors in ExternalStorageDriverError', async (t) => {
   const boom = new Error('disk full');
   const driver = makeFakeDriver({ name: 's3', onStore: () => Promise.reject(boom) });
   const runner = new ExternalStorageRunner(new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 0 }));
 
-  const err = await t.throwsAsync(() => runner.store([makePayload(1)]));
-  t.is(err, boom);
+  const err = await t.throwsAsync(() => runner.store([makePayload(1)]), {
+    instanceOf: ExternalStorageDriverError,
+  });
+  t.is(err?.cause, boom);
 });
 
-test('store raises ValueError on claim arity mismatch', async (t) => {
+test('store raises ExternalStorageReferenceError on claim arity mismatch', async (t) => {
   const driver = makeFakeDriver({ name: 's3', onStore: () => [] });
   const runner = new ExternalStorageRunner(new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 0 }));
 
   await t.throwsAsync(() => runner.store([makePayload(1)]), {
-    instanceOf: ValueError,
+    instanceOf: ExternalStorageReferenceError,
   });
 });
 
@@ -208,7 +215,7 @@ test('store/retrieve round-trip preserves order across drivers', async (t) => {
   t.deepEqual(retrievedPayloads, inputPayloads);
 });
 
-test('retrieve raises ValueError when the driver name is unknown', async (t) => {
+test('retrieve raises ExternalStorageUnregisteredDriverError when the driver name is unknown', async (t) => {
   const writerDriver = makeFakeDriver({ name: 'writer' });
   const writerRunner = new ExternalStorageRunner(
     new ExternalStorage({ drivers: [writerDriver], payloadSizeThreshold: 0 })
@@ -219,11 +226,11 @@ test('retrieve raises ValueError when the driver name is unknown', async (t) => 
   const readerRunner = new ExternalStorageRunner(new ExternalStorage({ drivers: [readerDriver] }));
 
   await t.throwsAsync(() => readerRunner.retrieve(storedPayloads), {
-    instanceOf: ValueError,
+    instanceOf: ExternalStorageUnregisteredDriverError,
   });
 });
 
-test('retrieve raises ValueError on payload arity mismatch', async (t) => {
+test('retrieve raises ExternalStorageReferenceError on payload arity mismatch', async (t) => {
   const payloadsToStore = [makePayload(1), makePayload(2)];
   const payloadsToRetrieve = [makePayload(1)];
 
@@ -239,11 +246,11 @@ test('retrieve raises ValueError on payload arity mismatch', async (t) => {
   );
 
   await t.throwsAsync(() => readerRunner.retrieve(storedPayloads), {
-    instanceOf: ValueError,
+    instanceOf: ExternalStorageReferenceError,
   });
 });
 
-test('retrieve propagates driver errors unchanged', async (t) => {
+test('retrieve wraps driver errors in ExternalStorageDriverError', async (t) => {
   const boom = new Error('object gone');
   const writerDriver = makeFakeDriver({ name: 's3' });
   const writerRunner = new ExternalStorageRunner(
@@ -256,8 +263,10 @@ test('retrieve propagates driver errors unchanged', async (t) => {
     new ExternalStorage({ drivers: [readerDriver], payloadSizeThreshold: 0 })
   );
 
-  const err = await t.throwsAsync(() => readerRunner.retrieve(storedPayloads));
-  t.is(err, boom);
+  const err = await t.throwsAsync(() => readerRunner.retrieve(storedPayloads), {
+    instanceOf: ExternalStorageDriverError,
+  });
+  t.is(err?.cause, boom);
 });
 
 test('retrieve only resolves reference payloads, passing others through', async (t) => {

--- a/packages/test/src/test-integration-extstore.ts
+++ b/packages/test/src/test-integration-extstore.ts
@@ -267,8 +267,8 @@ test('a transient workflow-completion store failure retries the workflow task an
     'expected a WorkflowTaskFailed event caused by the transient store failure'
   );
   t.true(
-    wftFailure.message?.includes('transient store failure') ?? false,
-    `WorkflowTaskFailed should reference the store failure, got: ${wftFailure.message}`
+    wftFailure.message?.includes('failed to store payloads') ?? false,
+    `WorkflowTaskFailed should reference the external storage failure, got: ${wftFailure.message}`
   );
 });
 
@@ -294,8 +294,8 @@ test('a transient workflow-activation retrieve failure retries the workflow task
     'expected a WorkflowTaskFailed event caused by the transient retrieve failure'
   );
   t.true(
-    wftFailure.message?.includes('transient retrieve failure') ?? false,
-    `WorkflowTaskFailed should reference the retrieve failure, got: ${wftFailure.message}`
+    wftFailure.message?.includes('failed to retrieve payloads') ?? false,
+    `WorkflowTaskFailed should reference the external storage failure, got: ${wftFailure.message}`
   );
 });
 

--- a/packages/test/src/test-integration-extstore.ts
+++ b/packages/test/src/test-integration-extstore.ts
@@ -271,8 +271,8 @@ test('a transient workflow-completion store failure retries the workflow task an
     'expected a WorkflowTaskFailed event caused by the transient store failure'
   );
   t.true(
-    wftFailure.message?.includes('transient store failure') ?? false,
-    `WorkflowTaskFailed should reference the store failure, got: ${wftFailure.message}`
+    wftFailure.message?.includes('failed to store payloads') ?? false,
+    `WorkflowTaskFailed should reference the external storage failure, got: ${wftFailure.message}`
   );
 });
 
@@ -298,8 +298,8 @@ test('a transient workflow-activation retrieve failure retries the workflow task
     'expected a WorkflowTaskFailed event caused by the transient retrieve failure'
   );
   t.true(
-    wftFailure.message?.includes('transient retrieve failure') ?? false,
-    `WorkflowTaskFailed should reference the retrieve failure, got: ${wftFailure.message}`
+    wftFailure.message?.includes('failed to retrieve payloads') ?? false,
+    `WorkflowTaskFailed should reference the external storage failure, got: ${wftFailure.message}`
   );
 });
 


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed

- Added new ExternalStorageError base type and a small set of high-level external storage errors
- Client surfaces that raise errors now properly handle extstore errors

## Why?

Previously, surfacing external storage errors from client logic meant that callers would see the new extstore error type which could break compatibility. This PR patches the error types that are thrown to include a `cause` where upstream errors can be put. This means we can move the extstore calls back inside the try/catch blocks, catch them meaningfully, and still throw consistent error types.

## Checklist
- Added tests