### PR TITLE
fix(workflow-streams): re-derive log offset after parking in onPoll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ to docs, or any other relevant information.
 ### Fixed
 
 - strands: Declare `zod` as a peer dependency.
+- workflow-streams: `WorkflowStream.onPoll` no longer serves a stale log index for a poll that
+  was parked across a `truncate()` call, which could silently skip events.
 
 ## [1.21.1] - 2026-07-23
 

--- a/contrib/workflow-streams/src/__tests__/test-workflow-streams.ts
+++ b/contrib/workflow-streams/src/__tests__/test-workflow-streams.ts
@@ -19,6 +19,7 @@ import {
 } from '../client';
 import {
   type WorkflowStreamState,
+  decodePayloadWire,
   encodePayloadWire,
   workflowStreamOffsetQuery,
   workflowStreamPublishSignal,
@@ -39,6 +40,7 @@ import {
   forceFlushWorkflow,
   publisherSequencesQuery,
   truncateUpdate,
+  truncateWhileParkedWorkflow,
   truncateWorkflow,
   ttlTestWorkflow,
   workflowSidePublishWorkflow,
@@ -247,6 +249,40 @@ test('poll_truncated_offset_returns_application_failure', async (t) => {
     const after = await collectItems(handle, undefined, 3, 2);
     t.is(after.length, 2);
     t.is(after[0]!.offset, 3);
+
+    await handle.signal('close');
+  });
+});
+
+test('poll_parked_across_truncate_sees_all_events', async (t) => {
+  // Regression for #2263: a poll parked on from_offset=1 must not miss 'B'
+  // when the workflow publishes 'B', truncates, and publishes 'C' in a
+  // single task while the poll is parked.
+  const { createWorker, startWorkflow } = helpers(t);
+  const { env } = t.context;
+  const worker = await createWorker();
+  await worker.runUntil(async () => {
+    const handle = await startWorkflow(truncateWhileParkedWorkflow, { args: [] });
+    const rawHandle = env.client.workflow.getHandle(handle.workflowId);
+
+    // Consume 'A' so the next poll starts from_offset=1.
+    const first = await rawHandle.executeUpdate<PollResult, [PollInput]>(workflowStreamPollUpdate, {
+      args: [{ topics: [], from_offset: 0 }],
+    });
+    t.is(first.items.length, 1);
+    t.is(payloadString(decodePayloadWire(first.items[0]!.data)), 'A');
+
+    // Park from_offset=1, then trigger the publish/truncate/publish race.
+    const parkedPoll = rawHandle.executeUpdate<PollResult, [PollInput]>(workflowStreamPollUpdate, {
+      args: [{ topics: [], from_offset: 1 }],
+    });
+    await handle.signal('triggerContinue');
+
+    const result = await parkedPoll;
+    t.deepEqual(
+      result.items.map((i) => payloadString(decodePayloadWire(i.data))),
+      ['B', 'C']
+    );
 
     await handle.signal('close');
   });

--- a/contrib/workflow-streams/src/__tests__/test-workflow-streams.ts
+++ b/contrib/workflow-streams/src/__tests__/test-workflow-streams.ts
@@ -272,13 +272,18 @@ test('poll_parked_across_truncate_sees_all_events', async (t) => {
     t.is(first.items.length, 1);
     t.is(payloadString(decodePayloadWire(first.items[0]!.data)), 'A');
 
-    // Park from_offset=1, then trigger the publish/truncate/publish race.
-    const parkedPoll = rawHandle.executeUpdate<PollResult, [PollInput]>(workflowStreamPollUpdate, {
+    // Park from_offset=1. waitForStage: 'ACCEPTED' ensures the update has
+    // actually been admitted into the workflow (and is therefore blocked
+    // on condition()) before we trigger the race below — otherwise the
+    // signal could land first and the poll would just observe post-truncate
+    // state without ever having been parked.
+    const parkedUpdate = await rawHandle.startUpdate<PollResult, [PollInput]>(workflowStreamPollUpdate, {
       args: [{ topics: [], from_offset: 1 }],
+      waitForStage: 'ACCEPTED',
     });
     await handle.signal('triggerContinue');
 
-    const result = await parkedPoll;
+    const result = await parkedUpdate.result();
     t.deepEqual(
       result.items.map((i) => payloadString(decodePayloadWire(i.data))),
       ['B', 'C']

--- a/contrib/workflow-streams/src/__tests__/workflows/workflow-streams.ts
+++ b/contrib/workflow-streams/src/__tests__/workflows/workflow-streams.ts
@@ -93,6 +93,23 @@ export async function binaryPublishWorkflow(count: number): Promise<void> {
   await condition(() => closed);
 }
 
+/** Publishes 'A', then on signal synchronously publishes 'B', truncates, publishes 'C' (regression: #2263). */
+export async function truncateWhileParkedWorkflow(): Promise<void> {
+  const stream = new WorkflowStream();
+  const events = stream.topic<string>('events');
+  let closed = false;
+  setHandler(closeSignal, () => {
+    closed = true;
+  });
+  setHandler(triggerContinueSignal, () => {
+    events.publish('B');
+    stream.truncate(1);
+    events.publish('C');
+  });
+  events.publish('A');
+  await condition(() => closed);
+}
+
 /** Workflow that accepts a truncate update (explicit completion). */
 export async function truncateWorkflow(): Promise<void> {
   const stream = new WorkflowStream();

--- a/contrib/workflow-streams/src/workflow.ts
+++ b/contrib/workflow-streams/src/workflow.ts
@@ -319,25 +319,29 @@ export class WorkflowStream {
   }
 
   private async onPoll(input: PollInput): Promise<PollResult> {
+    const truncatedFailure = () =>
+      ApplicationFailure.create({
+        message:
+          `Requested offset ${input.from_offset} has been truncated. ` + `Current base offset is ${this.baseOffset}.`,
+        type: 'TruncatedOffset',
+        nonRetryable: true,
+      });
+    if (input.from_offset !== 0 && input.from_offset - this.baseOffset < 0) {
+      throw truncatedFailure();
+    }
+    // Re-derive logOffset after the wait: truncate() can advance baseOffset
+    // while this poll is parked, so a value captured before condition()
+    // would be stale.
+    await condition(() => this.log.length > Math.max(input.from_offset - this.baseOffset, 0) || this.draining);
     let logOffset = input.from_offset - this.baseOffset;
     if (logOffset < 0) {
       if (input.from_offset === 0) {
         // "From the beginning" — start at whatever is available.
         logOffset = 0;
       } else {
-        // Subscriber had a specific position that's been truncated.
-        // ApplicationFailure fails this update (client gets the error)
-        // without crashing the workflow task — avoids a poison pill
-        // during replay.
-        throw ApplicationFailure.create({
-          message:
-            `Requested offset ${input.from_offset} has been truncated. ` + `Current base offset is ${this.baseOffset}.`,
-          type: 'TruncatedOffset',
-          nonRetryable: true,
-        });
+        throw truncatedFailure();
       }
     }
-    await condition(() => this.log.length > logOffset || this.draining);
     const allNew = this.log.slice(logOffset);
 
     // Build [globalOffset, entry] candidates, filtering by topic if requested.

--- a/contrib/workflow-streams/src/workflow.ts
+++ b/contrib/workflow-streams/src/workflow.ts
@@ -331,8 +331,16 @@ export class WorkflowStream {
     }
     // Re-derive logOffset after the wait: truncate() can advance baseOffset
     // while this poll is parked, so a value captured before condition()
-    // would be stale.
-    await condition(() => this.log.length > Math.max(input.from_offset - this.baseOffset, 0) || this.draining);
+    // would be stale. The predicate also wakes on a truncation that moves
+    // baseOffset past from_offset, even if that leaves the log empty —
+    // otherwise such a truncate() would never satisfy `log.length > ...`
+    // and the poll would hang instead of failing with TruncatedOffset.
+    await condition(
+      () =>
+        this.draining ||
+        (input.from_offset !== 0 && input.from_offset - this.baseOffset < 0) ||
+        this.log.length > Math.max(input.from_offset - this.baseOffset, 0)
+    );
     let logOffset = input.from_offset - this.baseOffset;
     if (logOffset < 0) {
       if (input.from_offset === 0) {


### PR DESCRIPTION
onPoll captured logOffset from baseOffset before awaiting condition(...). If truncate() ran while the poll was parked, the log was shifted and baseOffset advanced, but the parked handler continued using the stale offset and silently skipped events.

This change re-derives the log offset after the wait and re-validates truncation so that a poll either:
- reads from the correct position after truncate(), or
- fails with TruncatedOffset if the requested position was removed while waiting.

Fixes #2263

## What was changed

- Changed WorkflowStream.onPoll() to calculate the effective log index after the poll wait instead of relying on the value captured before condition().
- Added re-validation after waiting to handle truncation races.
- Added a regression test covering the case where a poll is parked while publish → truncate → publish happens.

## Why?

A parked poll could wake up after truncate() and use a stale log index. This caused events to be silently skipped because the underlying log array had shifted while the poll was waiting.

## Checklist

1. Closes #2263

2. How was this tested:
- Added a regression test reproducing the parked onPoll + truncate interleaving.
- Verified TypeScript checks introduce no new errors compared to baseline.
- Verified ESLint passes.
- Integration test requires Temporal test server binary via TestWorkflowEnvironment.createLocal(); this could not be downloaded in the current environment, but the scenario was validated through the standalone reproduction.

3. Any docs updates needed?
No docs updates needed.