### PR TITLE
fix: clean up orphaned childWorkflowComplete entries on start failure [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -731,6 +731,7 @@ export class Activator implements ActivationHandler {
       if (!(activation.seq && activation.failed.workflowId && activation.failed.workflowType)) {
         throw new TypeError('Missing attributes in activation job');
       }
+      this.completions.childWorkflowComplete.delete(getSeq(activation));
       reject(
         new WorkflowExecutionAlreadyStartedError(
           'Workflow execution already started',
@@ -742,6 +743,7 @@ export class Activator implements ActivationHandler {
       if (!activation.cancelled.failure) {
         throw new TypeError('Got no failure in cancelled variant');
       }
+      this.completions.childWorkflowComplete.delete(getSeq(activation));
       reject(this.failureConverter.failureToError(activation.cancelled.failure, this.payloadConverter, context));
     } else {
       throw new TypeError('Got ResolveChildWorkflowExecutionStart with no status');


### PR DESCRIPTION
## Description

When `resolveChildWorkflowExecutionStart` receives a failed or cancelled result, the `childWorkflowComplete` completion map still holds an entry for that sequence number. Since the child workflow never started, it will never complete, so this entry is orphaned and constitutes a memory leak for the duration of the workflow execution.

## Fix

Added `this.completions.childWorkflowComplete.delete(getSeq(activation))` in both the `activation.failed` and `activation.cancelled` branches of `resolveChildWorkflowExecutionStart` to clean up the orphaned completion entry.

## Testing

- [x] Verified the fix compiles and is logically consistent with the existing code pattern
- [x] The `consumeCompletion` method on line 721 already consumes the `childWorkflowStart` entry; the missing piece was cleaning up the corresponding `childWorkflowComplete` entry that was registered in `workflow.ts` line 476

Fixes #2000