### PR TITLE
perf(langsmith): reuse test env + workflow bundle across cases

### DIFF
--- a/contrib/langsmith/src/__tests__/helpers.ts
+++ b/contrib/langsmith/src/__tests__/helpers.ts
@@ -5,10 +5,12 @@
  * @module
  */
 
+import { randomUUID } from 'crypto';
+import type { TestFn } from 'ava';
 import type { Client as LangSmithClient } from 'langsmith';
 import { Client } from '@temporalio/client';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
-import { Worker, type WorkerOptions } from '@temporalio/worker';
+import { Worker, bundleWorkflowCode, type WorkerOptions, type WorkflowBundle } from '@temporalio/worker';
 
 import { LangSmithPlugin, type LangSmithPluginOptions } from '../index';
 
@@ -168,25 +170,56 @@ export interface HarnessArgs<T> {
   body: (ctx: { client: Client; taskQueue: string; env: TestWorkflowEnvironment }) => Promise<T>;
 }
 
-/** Boot a local Temporal env with the plugin on both client and worker, run `body`, then tear down. */
+// One local Temporal server shared by all cases in a file
+let sharedEnv: TestWorkflowEnvironment | undefined;
+
+/** Register a per-file shared `TestWorkflowEnvironment`; `withTracingWorker` will reuse it. */
+export function useSharedEnv(test: TestFn<unknown>): void {
+  test.before(async () => {
+    sharedEnv = await TestWorkflowEnvironment.createLocal();
+  });
+  test.after.always(async () => {
+    await sharedEnv?.teardown();
+    sharedEnv = undefined;
+  });
+}
+
+const bundleCache = new Map<string, Promise<WorkflowBundle>>();
+
+function getBundle(plugin: LangSmithPlugin, workflowsPath: string, optionsKey: string): Promise<WorkflowBundle> {
+  const key = `${workflowsPath}\n${optionsKey}`;
+  let bundle = bundleCache.get(key);
+  if (!bundle) {
+    // Route through the plugin so the bundle carries its workflow interceptor
+    // module + baked config, exactly as Worker.create would have built it.
+    bundle = bundleWorkflowCode(plugin.configureBundler({ workflowsPath }));
+    bundleCache.set(key, bundle);
+  }
+  return bundle;
+}
+
 export async function withTracingWorker<T>(args: HarnessArgs<T>): Promise<T> {
-  const env = await TestWorkflowEnvironment.createLocal();
+  const privateEnv = sharedEnv ? undefined : await TestWorkflowEnvironment.createLocal();
+  const env = sharedEnv ?? privateEnv!;
   try {
-    const taskQueue = args.taskQueue ?? 'langsmith-test';
+    const taskQueue = args.taskQueue ?? `langsmith-test-${randomUUID()}`;
     const plugin = new LangSmithPlugin({ ...args.options, client: args.collector.asClient() });
+
+    const { workflowsPath = WORKFLOWS_PATH, ...restWorkerOpts } = args.workerOptions ?? {};
+    const workflowBundle = await getBundle(plugin, workflowsPath, JSON.stringify(args.options ?? {}));
 
     const worker = await Worker.create({
       connection: env.nativeConnection,
       namespace: env.namespace,
       taskQueue,
-      workflowsPath: WORKFLOWS_PATH,
+      workflowBundle,
       activities: args.activities,
       plugins: [plugin],
       // Avoid waiting for the default 10s sticky execution timeout on worker
       // transition: these short-lived per-case workers can otherwise stall a
       // full 10s on task redelivery and, on loaded CI, blow the 120s AVA cap.
       stickyQueueScheduleToStartTimeout: '1s',
-      ...args.workerOptions,
+      ...restWorkerOpts,
     });
 
     const client = new Client({
@@ -197,6 +230,6 @@ export async function withTracingWorker<T>(args: HarnessArgs<T>): Promise<T> {
 
     return await worker.runUntil(args.body({ client, taskQueue, env }));
   } finally {
-    await env.teardown();
+    if (privateEnv) await privateEnv.teardown();
   }
 }

--- a/contrib/langsmith/src/__tests__/test-continue-as-new.ts
+++ b/contrib/langsmith/src/__tests__/test-continue-as-new.ts
@@ -8,10 +8,12 @@
 import test from 'ava';
 
 import * as activities from './activities/langsmith';
-import { InMemoryRunCollector, dumpTraces, withTracingWorker } from './helpers';
+import { InMemoryRunCollector, dumpTraces, withTracingWorker, useSharedEnv } from './helpers';
 import * as workflows from './workflows/langsmith';
 
 process.env.LANGSMITH_TRACING = 'true';
+
+useSharedEnv(test);
 
 test('continue-as-new: keeps the successor on the same trace with a distinct run id', async (t) => {
   const collector = new InMemoryRunCollector();

--- a/contrib/langsmith/src/__tests__/test-env.ts
+++ b/contrib/langsmith/src/__tests__/test-env.ts
@@ -20,7 +20,7 @@
 import test from 'ava';
 
 import * as activities from './activities/langsmith';
-import { InMemoryRunCollector, withTracingWorker } from './helpers';
+import { InMemoryRunCollector, withTracingWorker, useSharedEnv } from './helpers';
 import * as workflows from './workflows/langsmith';
 
 const TRACING_ENV_VARS = ['LANGSMITH_TRACING', 'LANGSMITH_TRACING_V2', 'LANGCHAIN_TRACING_V2', 'LANGCHAIN_TRACING'];
@@ -58,6 +58,8 @@ async function runPlainWorkflow(collector: InMemoryRunCollector): Promise<void> 
     },
   });
 }
+
+useSharedEnv(test);
 
 test.serial('LANGSMITH_TRACING=false suppresses all emission', async (t) => {
   const snapshot = snapshotTracingEnv();

--- a/contrib/langsmith/src/__tests__/test-errors.ts
+++ b/contrib/langsmith/src/__tests__/test-errors.ts
@@ -8,7 +8,7 @@
 import test from 'ava';
 
 import * as activities from './activities/langsmith';
-import { InMemoryRunCollector, withTracingWorker } from './helpers';
+import { InMemoryRunCollector, withTracingWorker, useSharedEnv } from './helpers';
 import * as workflows from './workflows/langsmith';
 
 // Force the tracing gate on so activity-side runs emit deterministically regardless of ambient env.
@@ -18,6 +18,8 @@ const ACTIVITIES = {
   failingActivity: activities.failingActivity,
   benignFailingActivity: activities.benignFailingActivity,
 };
+
+useSharedEnv(test);
 
 test('error marking on activity runs: marks a non-benign activity failure as "<type>: <message>"', async (t) => {
   const collector = new InMemoryRunCollector();

--- a/contrib/langsmith/src/__tests__/test-parenting-edge-cases.ts
+++ b/contrib/langsmith/src/__tests__/test-parenting-edge-cases.ts
@@ -8,7 +8,7 @@
 import test from 'ava';
 
 import * as activities from './activities/langsmith';
-import { InMemoryRunCollector, SIMPLE_TREE, dumpTraces, withTracingWorker } from './helpers';
+import { InMemoryRunCollector, SIMPLE_TREE, dumpTraces, withTracingWorker, useSharedEnv } from './helpers';
 import * as workflows from './workflows/langsmith';
 
 process.env.LANGSMITH_TRACING = 'true';
@@ -19,6 +19,8 @@ const ALL_ACTIVITIES = {
 
 /** Root workflow-body `traceable`, no propagated parent — just the user run, no placeholder root. */
 const WORKFLOW_BODY_ROOT_TREE = ['workflow_inner_call'].join('\n');
+
+useSharedEnv(test);
 
 test('emits the basic SimpleWorkflow tree with no ambient (two roots)', async (t) => {
   const collector = new InMemoryRunCollector();

--- a/contrib/langsmith/src/__tests__/test-query-filter.ts
+++ b/contrib/langsmith/src/__tests__/test-query-filter.ts
@@ -12,10 +12,12 @@
 import test from 'ava';
 
 import * as activities from './activities/langsmith';
-import { InMemoryRunCollector, withTracingWorker } from './helpers';
+import { InMemoryRunCollector, withTracingWorker, useSharedEnv } from './helpers';
 import * as workflows from './workflows/langsmith';
 
 process.env.LANGSMITH_TRACING = 'true';
+
+useSharedEnv(test);
 
 test('internal-query filtering: traces user queries but not Temporal-internal queries', async (t) => {
   const collector = new InMemoryRunCollector();

--- a/contrib/langsmith/src/__tests__/test-readonly-determinism.ts
+++ b/contrib/langsmith/src/__tests__/test-readonly-determinism.ts
@@ -10,10 +10,12 @@ import test from 'ava';
 import { Worker } from '@temporalio/worker';
 
 import { LangSmithPlugin } from '../index';
-import { InMemoryRunCollector, WORKFLOWS_PATH, withTracingWorker } from './helpers';
+import { InMemoryRunCollector, WORKFLOWS_PATH, withTracingWorker, useSharedEnv } from './helpers';
 import * as workflows from './workflows/langsmith';
 
 process.env.LANGSMITH_TRACING = 'true';
+
+useSharedEnv(test);
 
 test('read-only handlers do not perturb the main random sequence', async (t) => {
   const collector = new InMemoryRunCollector();

--- a/contrib/langsmith/src/__tests__/test-replay-parenting.ts
+++ b/contrib/langsmith/src/__tests__/test-replay-parenting.ts
@@ -22,7 +22,7 @@ import test from 'ava';
 import { Worker } from '@temporalio/worker';
 
 import { LangSmithPlugin } from '../index';
-import { InMemoryRunCollector, WORKFLOWS_PATH, dumpTraces, withTracingWorker } from './helpers';
+import { InMemoryRunCollector, WORKFLOWS_PATH, dumpTraces, withTracingWorker, useSharedEnv } from './helpers';
 import {
   ConcurrentTraceableWorkflow,
   NestedTraceableWorkflow,
@@ -81,6 +81,8 @@ async function assertParentingStable(
     },
   });
 }
+
+useSharedEnv(test);
 
 test('nested traceable: child nests under its enclosing traceable, stable across replay', async (t) => {
   await assertParentingStable(t, NestedTraceableWorkflow, 'nested', ['parent', '  leaf'].join('\n'));

--- a/contrib/langsmith/src/__tests__/test-replay.ts
+++ b/contrib/langsmith/src/__tests__/test-replay.ts
@@ -15,10 +15,12 @@ import { Worker, type ReplayWorkerOptions } from '@temporalio/worker';
 
 import { LangSmithPlugin } from '../index';
 import * as activities from './activities/langsmith';
-import { InMemoryRunCollector, WORKFLOWS_PATH, withTracingWorker } from './helpers';
+import { InMemoryRunCollector, WORKFLOWS_PATH, withTracingWorker, useSharedEnv } from './helpers';
 import * as workflows from './workflows/langsmith';
 
 process.env.LANGSMITH_TRACING = 'true';
+
+useSharedEnv(test);
 
 test('replay safety: emits no runs when replaying recorded history', async (t) => {
   const live = new InMemoryRunCollector();

--- a/contrib/langsmith/src/__tests__/test-side-effects.ts
+++ b/contrib/langsmith/src/__tests__/test-side-effects.ts
@@ -8,10 +8,12 @@
 import test from 'ava';
 
 import * as activities from './activities/langsmith';
-import { InMemoryRunCollector, SIMPLE_TREE, dumpTraces, withTracingWorker } from './helpers';
+import { InMemoryRunCollector, SIMPLE_TREE, dumpTraces, withTracingWorker, useSharedEnv } from './helpers';
 import * as workflows from './workflows/langsmith';
 
 process.env.LANGSMITH_TRACING = 'true';
+
+useSharedEnv(test);
 
 test('replay side effects: emits each run exactly once even when the workflow is evicted and replayed', async (t) => {
   const collector = new InMemoryRunCollector();

--- a/contrib/langsmith/src/__tests__/test-signal-child.ts
+++ b/contrib/langsmith/src/__tests__/test-signal-child.ts
@@ -13,10 +13,12 @@
 import test from 'ava';
 
 import * as activities from './activities/langsmith';
-import { InMemoryRunCollector, withTracingWorker } from './helpers';
+import { InMemoryRunCollector, withTracingWorker, useSharedEnv } from './helpers';
 import * as workflows from './workflows/langsmith';
 
 process.env.LANGSMITH_TRACING = 'true';
+
+useSharedEnv(test);
 
 test('signal-child: emits a closed SignalChildWorkflow marker nested under the workflow run', async (t) => {
   const collector = new InMemoryRunCollector();

--- a/contrib/langsmith/src/__tests__/test-signal-start.ts
+++ b/contrib/langsmith/src/__tests__/test-signal-start.ts
@@ -12,11 +12,13 @@
 import test from 'ava';
 
 import * as activities from './activities/langsmith';
-import { InMemoryRunCollector, withTracingWorker } from './helpers';
+import { InMemoryRunCollector, withTracingWorker, useSharedEnv } from './helpers';
 import * as workflows from './workflows/langsmith';
 
 process.env.LANGSMITH_TRACING = 'true';
 process.env.LANGCHAIN_CALLBACKS_BACKGROUND = 'false';
+
+useSharedEnv(test);
 
 test.serial('signalWithStart: LangSmith signal interceptor preserves workflow ordering', async (t) => {
   const collector = new InMemoryRunCollector();


### PR DESCRIPTION
## What was changed
Added a new `useSharedEnv` helper for tests so langsmith tests won't recompile 3.5MB workflow bundles on the fly. 

## Why?
Was seeing test timeouts. While this wasn't the only reason, it was a contributing factor.
