### PR TITLE
Make integration test task queues unique

### DIFF
--- a/packages/test-helpers/src/helpers.ts
+++ b/packages/test-helpers/src/helpers.ts
@@ -8,6 +8,8 @@ import type { TestWorkflowEnvironment } from './wrappers';
 import { Worker } from './wrappers';
 
 export const isBun = typeof (globalThis as any).Bun !== 'undefined';
+const TASK_QUEUE_NAME_MAX_LENGTH = 1_000;
+const TASK_QUEUE_NAME_UUID_LENGTH = 36;
 /** Union type for all supported test environment types */
 export type AnyTestWorkflowEnvironment = TestWorkflowEnvironment | RealTestWorkflowEnvironment;
 
@@ -50,6 +52,21 @@ export function defaultTaskQueueTransform(title: string): string {
     .replace(/^[-]?(.+?)[-]?$/, '$1');
 }
 
+function taskQueueNameForTest(title: string): string {
+  // Keep enough room for the separator and UUID, since task queue names are
+  // limited to 1,000 bytes by the server.
+  const maxPrefixLength = TASK_QUEUE_NAME_MAX_LENGTH - TASK_QUEUE_NAME_UUID_LENGTH - 1;
+  let prefix = '';
+  let prefixLength = 0;
+  for (const character of defaultTaskQueueTransform(title)) {
+    const characterLength = Buffer.byteLength(character);
+    if (prefixLength + characterLength > maxPrefixLength) break;
+    prefix += character;
+    prefixLength += characterLength;
+  }
+  return `${prefix}-${randomUUID()}`;
+}
+
 /**
  * Create helpers for a test.
  *
@@ -65,7 +82,7 @@ export function helpers<TEnv extends AnyTestWorkflowEnvironment = TestWorkflowEn
   env: AnyTestWorkflowEnvironment = t.context.env
 ): BaseHelpers {
   // createBaseHelpers(t.title, env, t.context.workflowBundle);
-  const taskQueue = defaultTaskQueueTransform(t.title);
+  const taskQueue = taskQueueNameForTest(t.title);
   const workflowBundle = t.context.workflowBundle;
 
   return {

--- a/packages/test-helpers/src/helpers.ts
+++ b/packages/test-helpers/src/helpers.ts
@@ -86,14 +86,15 @@ function taskQueueNameForTest(title: string, testContext: object, env: object): 
  *
  * @param t - The test execution context
  * @param env - Optional environment override (defaults to t.context.env)
+ * @param testIdentity - Optional stable identity used to reuse a task queue across helper wrappers
  * @returns BaseHelpers instance
  */
 export function helpers<TEnv extends AnyTestWorkflowEnvironment = TestWorkflowEnvironment>(
   t: ExecutionContext<BaseContext<TEnv>>,
-  env: AnyTestWorkflowEnvironment = t.context.env
+  env: AnyTestWorkflowEnvironment = t.context.env,
+  testIdentity: object = t
 ): BaseHelpers {
-  // createBaseHelpers(t.title, env, t.context.workflowBundle);
-  const taskQueue = taskQueueNameForTest(t.title, t, env);
+  const taskQueue = taskQueueNameForTest(t.title, testIdentity, env);
   const workflowBundle = t.context.workflowBundle;
 
   return {

--- a/packages/test-helpers/src/helpers.ts
+++ b/packages/test-helpers/src/helpers.ts
@@ -10,6 +10,7 @@ import { Worker } from './wrappers';
 export const isBun = typeof (globalThis as any).Bun !== 'undefined';
 const TASK_QUEUE_NAME_MAX_LENGTH = 1_000;
 const TASK_QUEUE_NAME_UUID_LENGTH = 36;
+const taskQueueNamesByTest = new WeakMap<object, WeakMap<object, string>>();
 /** Union type for all supported test environment types */
 export type AnyTestWorkflowEnvironment = TestWorkflowEnvironment | RealTestWorkflowEnvironment;
 
@@ -52,7 +53,15 @@ export function defaultTaskQueueTransform(title: string): string {
     .replace(/^[-]?(.+?)[-]?$/, '$1');
 }
 
-function taskQueueNameForTest(title: string): string {
+function taskQueueNameForTest(title: string, testContext: object, env: object): string {
+  let taskQueueNamesByEnvironment = taskQueueNamesByTest.get(testContext);
+  if (taskQueueNamesByEnvironment === undefined) {
+    taskQueueNamesByEnvironment = new WeakMap();
+    taskQueueNamesByTest.set(testContext, taskQueueNamesByEnvironment);
+  }
+  const existing = taskQueueNamesByEnvironment.get(env);
+  if (existing !== undefined) return existing;
+
   // Keep enough room for the separator and UUID, since task queue names are
   // limited to 1,000 bytes by the server.
   const maxPrefixLength = TASK_QUEUE_NAME_MAX_LENGTH - TASK_QUEUE_NAME_UUID_LENGTH - 1;
@@ -64,7 +73,9 @@ function taskQueueNameForTest(title: string): string {
     prefix += character;
     prefixLength += characterLength;
   }
-  return `${prefix}-${randomUUID()}`;
+  const taskQueue = `${prefix}-${randomUUID()}`;
+  taskQueueNamesByEnvironment.set(env, taskQueue);
+  return taskQueue;
 }
 
 /**
@@ -82,7 +93,7 @@ export function helpers<TEnv extends AnyTestWorkflowEnvironment = TestWorkflowEn
   env: AnyTestWorkflowEnvironment = t.context.env
 ): BaseHelpers {
   // createBaseHelpers(t.title, env, t.context.workflowBundle);
-  const taskQueue = taskQueueNameForTest(t.title);
+  const taskQueue = taskQueueNameForTest(t.title, t, env);
   const workflowBundle = t.context.workflowBundle;
 
   return {

--- a/packages/test/src/helpers-integration.ts
+++ b/packages/test/src/helpers-integration.ts
@@ -25,7 +25,6 @@ import type {
 } from '@temporalio/test-helpers';
 import {
   helpers as baseHelpers,
-  defaultTaskQueueTransform,
   createTestWorkflowBundle as createTestWorkflowBundleBase,
   createTestWorkflowEnvironment as createTestWorkflowEnvironmentBase,
   createLocalTestEnvironment,
@@ -169,7 +168,7 @@ export function helpers(t: ExecutionContext<Context>, env?: TestWorkflowEnvironm
   const testEnv = env ?? t.context.env;
   const { workflowBundle } = t.context;
   const base = baseHelpers(t, testEnv);
-  const taskQueue = defaultTaskQueueTransform(t.title);
+  const { taskQueue } = base;
 
   return {
     ...base,

--- a/packages/test/src/helpers-integration.ts
+++ b/packages/test/src/helpers-integration.ts
@@ -261,5 +261,9 @@ export function configurableHelpers<T>(
   workflowBundle: WorkflowBundle,
   testEnv: TestWorkflowEnvironment
 ): BaseHelpers {
-  return baseHelpers({ title: t.title, context: { env: testEnv, workflowBundle } } as ExecutionContext<Context>);
+  return baseHelpers(
+    { ...t, context: { ...t.context, workflowBundle } } as unknown as ExecutionContext<Context>,
+    testEnv,
+    t
+  );
 }

--- a/packages/test/src/helpers-integration.ts
+++ b/packages/test/src/helpers-integration.ts
@@ -262,7 +262,7 @@ export function configurableHelpers<T>(
   testEnv: TestWorkflowEnvironment
 ): BaseHelpers {
   return baseHelpers(
-    { ...t, context: { ...t.context, workflowBundle } } as unknown as ExecutionContext<Context>,
+    { title: t.title, context: { ...t.context, workflowBundle } } as unknown as ExecutionContext<Context>,
     testEnv,
     t
   );

--- a/packages/test/src/test-nexus-task-queue.ts
+++ b/packages/test/src/test-nexus-task-queue.ts
@@ -1,0 +1,47 @@
+import test from 'ava';
+import { helpers } from './helpers-integration';
+
+function testContext(
+  deleteNexusEndpoint: () => Promise<void>,
+  createNexusEndpoint: (name: string, taskQueue: string) => Promise<{ id: string; version: number }> = async () => ({
+    id: 'endpoint-id',
+    version: 1,
+  })
+): {
+  context: Parameters<typeof helpers>[0];
+  cleanup: () => Promise<void>;
+} {
+  let cleanup: (() => Promise<void>) | undefined;
+  const context = {
+    title: 'Nexus endpoint cleanup',
+    context: {
+      env: {
+        createNexusEndpoint,
+        deleteNexusEndpoint,
+      },
+      workflowBundle: {},
+    },
+    teardown(fn: () => Promise<void>) {
+      cleanup = fn;
+    },
+  } as any;
+  return {
+    context,
+    cleanup: async () => await cleanup!(),
+  };
+}
+
+test('Nexus endpoints route to the helper worker task queue', async (t) => {
+  let routedTaskQueue: string | undefined;
+  const { context } = testContext(
+    async () => undefined,
+    async (_name, taskQueue) => {
+      routedTaskQueue = taskQueue;
+      return { id: 'endpoint-id', version: 1 };
+    }
+  );
+
+  const helper = helpers(context);
+  await helper.registerNexusEndpoint();
+  t.is(routedTaskQueue, helper.taskQueue);
+});

--- a/packages/test/src/test-task-queue-helpers.ts
+++ b/packages/test/src/test-task-queue-helpers.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import type { ExecutionContext } from 'ava';
 import { helpers } from '@temporalio/test-helpers';
+import { configurableHelpers } from './helpers-integration';
 
 function taskQueueFor(title: string): string {
   return helpers({ title, context: { workflowBundle: {}, env: {} } } as ExecutionContext<any>).taskQueue;
@@ -30,6 +31,13 @@ test('shared helpers isolate task queues for different environments in the same 
   const secondEnv = {} as any;
 
   t.not(helpers(context, firstEnv).taskQueue, helpers(context, secondEnv).taskQueue);
+});
+
+test('configurable helpers reuse a task queue for the same test environment', (t) => {
+  const env = {} as any;
+  const context = { title: 'Configurable helper test', context: {} } as ExecutionContext<any>;
+
+  t.is(configurableHelpers(context, {} as any, env).taskQueue, configurableHelpers(context, {} as any, env).taskQueue);
 });
 
 test('shared helper task queues stay within the server length limit', (t) => {

--- a/packages/test/src/test-task-queue-helpers.ts
+++ b/packages/test/src/test-task-queue-helpers.ts
@@ -1,0 +1,30 @@
+import test from 'ava';
+import type { ExecutionContext } from 'ava';
+import { helpers } from '@temporalio/test-helpers';
+
+function taskQueueFor(title: string): string {
+  return helpers({ title, context: { workflowBundle: {}, env: {} } } as ExecutionContext<any>).taskQueue;
+}
+
+test('shared helpers create unique task queues with a readable title prefix', (t) => {
+  const first = taskQueueFor('My shared helper test');
+  const second = taskQueueFor('My shared helper test');
+
+  t.regex(first, /^my-shared-helper-test-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  t.not(first, second);
+});
+
+test('shared helper task queues stay within the server length limit', (t) => {
+  const taskQueue = taskQueueFor('a'.repeat(2_000));
+
+  t.is(Buffer.byteLength(taskQueue), 1_000);
+  t.regex(taskQueue, new RegExp(`^${'a'.repeat(963)}-[0-9a-f-]{36}$`));
+});
+
+test('shared helper task queues truncate on UTF-8 character boundaries', (t) => {
+  const taskQueue = taskQueueFor('😀'.repeat(1_000));
+
+  t.true(Buffer.byteLength(taskQueue) <= 1_000);
+  t.false(taskQueue.includes('\uFFFD'));
+  t.regex(taskQueue, /-[0-9a-f-]{36}$/);
+});

--- a/packages/test/src/test-task-queue-helpers.ts
+++ b/packages/test/src/test-task-queue-helpers.ts
@@ -35,7 +35,8 @@ test('shared helpers isolate task queues for different environments in the same 
 
 test('configurable helpers reuse a task queue for the same test environment', (t) => {
   const env = {} as any;
-  const context = { title: 'Configurable helper test', context: {} } as ExecutionContext<any>;
+  const context = { context: {} } as ExecutionContext<any>;
+  Object.defineProperty(context, 'title', { value: 'Configurable helper test' });
 
   t.is(configurableHelpers(context, {} as any, env).taskQueue, configurableHelpers(context, {} as any, env).taskQueue);
 });

--- a/packages/test/src/test-task-queue-helpers.ts
+++ b/packages/test/src/test-task-queue-helpers.ts
@@ -14,6 +14,24 @@ test('shared helpers create unique task queues with a readable title prefix', (t
   t.not(first, second);
 });
 
+test('shared helpers reuse a task queue for the same test environment', (t) => {
+  const env = {};
+  const context = { title: 'Stable helper test', context: { workflowBundle: {}, env } } as ExecutionContext<any>;
+
+  t.is(helpers(context).taskQueue, helpers(context).taskQueue);
+});
+
+test('shared helpers isolate task queues for different environments in the same test', (t) => {
+  const context = {
+    title: 'Multi-environment helper test',
+    context: { workflowBundle: {}, env: {} },
+  } as ExecutionContext<any>;
+  const firstEnv = {} as any;
+  const secondEnv = {} as any;
+
+  t.not(helpers(context, firstEnv).taskQueue, helpers(context, secondEnv).taskQueue);
+});
+
 test('shared helper task queues stay within the server length limit', (t) => {
   const taskQueue = taskQueueFor('a'.repeat(2_000));
 


### PR DESCRIPTION
The shared integration-test helper currently derives task queue names only from AVA test titles. That is safe with an ephemeral server, but concurrent CI runs against one persistent Cloud namespace can create workers on identical queues and consume each other's workflow tasks.

This change retains the readable normalized title prefix and appends a UUID whenever the shared helper creates a task queue. It truncates the prefix on UTF-8 character boundaries so the complete name stays within Temporal's 1,000-byte limit. Local tests keep the same naming shape with an added uniqueness suffix; workflow IDs remain independently randomized.

Focused coverage verifies uniqueness, readable prefixes, the server length limit, and multi-byte truncation. The seven combined Cloud-foundation AVA tests pass. The package TypeScript build reaches only the two pre-existing `ActivityExecutionStatus.PAUSED` errors on current main.

Part of temporalio/features#851.