### PR TITLE
Mark privileged integration tests local-only

### DIFF
--- a/packages/test-helpers/src/ava-helpers.ts
+++ b/packages/test-helpers/src/ava-helpers.ts
@@ -1,6 +1,7 @@
-import type { TestFn } from 'ava';
+import type { AfterFn, AlwaysInterface, FailingFn, OnlyFn, SerialFn, TestFn } from 'ava';
 import ava from 'ava';
 import { inWorkflowContext } from '@temporalio/workflow';
+import { isSet } from './flags';
 
 function noopTest(): void {
   // eslint: this function body is empty and it's okay.
@@ -19,5 +20,72 @@ noopTest.skip = () => noopTest;
  * (Mostly complete) helper to allow mixing workflow and non-workflow code in the same test file.
  */
 export const test: TestFn<unknown> = inWorkflowContext() ? (noopTest as any) : ava;
+
+function assertReason(reason: string): void {
+  if (typeof reason !== 'string' || reason.trim() === '') {
+    throw new TypeError('A non-empty reason is required for a local-server-only test');
+  }
+}
+
+function localServerSkipTitle(title: string, reason: string): string {
+  return `${title} (requires local server: ${reason})`;
+}
+
+/**
+ * Return a test function which skips its tests and hooks when the integration suite is configured to use envconfig.
+ *
+ * Local-server requirements must always include a reason so Cloud output makes the excluded capability explicit.
+ */
+export function requiresLocalServer<Context = unknown>(reason: string, baseTest?: TestFn<Context>): TestFn<Context> {
+  assertReason(reason);
+  const source = (baseTest ?? test) as TestFn<Context>;
+  if (!isSet(process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER, false)) {
+    return source;
+  }
+
+  const skip = ((titleOrMacro: any, implementation?: any, ...args: any[]) => {
+    if (typeof titleOrMacro === 'string') {
+      source.skip(localServerSkipTitle(titleOrMacro, reason), implementation, ...args);
+    } else {
+      // AVA macros generate their own title, so they cannot be decorated without changing their public contract.
+      if (implementation === undefined) source.skip(titleOrMacro, ...args);
+      else source.skip(titleOrMacro, implementation, ...args);
+    }
+  }) as TestFn<Context>['skip'];
+
+  // Skip hooks as well as tests: suite setup must not create a local server in envconfig mode.
+  const noopHook = (() => undefined) as any;
+  const before = (source.before.skip ?? noopHook) as TestFn<Context>['before'];
+  const after = (source.after.skip ?? noopHook) as AfterFn<Context>;
+  after.always = ((source.after as any).always?.skip ?? noopHook) as AlwaysInterface<Context>;
+  const beforeEach = (source.beforeEach.skip ?? noopHook) as TestFn<Context>['beforeEach'];
+  const afterEach = (source.afterEach.skip ?? noopHook) as AfterFn<Context>;
+  afterEach.always = ((source.afterEach as any).always?.skip ?? noopHook) as AlwaysInterface<Context>;
+  const serial = skip as SerialFn<Context>;
+  serial.before = before;
+  serial.after = after;
+  serial.beforeEach = beforeEach;
+  serial.afterEach = afterEach;
+  serial.failing = skip as FailingFn<Context>;
+  serial.only = skip as OnlyFn<Context>;
+  serial.skip = skip;
+  serial.todo = source.todo;
+  const failing = skip as FailingFn<Context>;
+  failing.only = skip as OnlyFn<Context>;
+  failing.skip = skip;
+  const skipped = skip as TestFn<Context>;
+  skipped.before = before;
+  skipped.after = after;
+  skipped.beforeEach = beforeEach;
+  skipped.afterEach = afterEach;
+  skipped.serial = serial;
+  skipped.failing = failing;
+  skipped.only = skip as OnlyFn<Context>;
+  skipped.skip = skip;
+  skipped.todo = source.todo;
+  skipped.macro = source.macro;
+  skipped.meta = source.meta;
+  return skipped;
+}
 
 export { noopTest };

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -27,7 +27,7 @@ export { baseBundlerIgnoreModules, createBaseBundlerOptions } from './bundler';
 export { ByteSkewerPayloadCodec } from './codecs';
 
 // AVA helpers
-export { test, noopTest } from './ava-helpers';
+export { test, noopTest, requiresLocalServer } from './ava-helpers';
 
 // Wrappers
 export { Worker, TestWorkflowEnvironment } from './wrappers';

--- a/packages/test/src/helpers-integration.ts
+++ b/packages/test/src/helpers-integration.ts
@@ -30,6 +30,8 @@ import {
   createTestWorkflowEnvironment as createTestWorkflowEnvironmentBase,
   createLocalTestEnvironment,
   defaultSAKeys,
+  isSet,
+  requiresLocalServer,
   test as anyTest,
   Worker,
 } from '@temporalio/test-helpers';
@@ -89,8 +91,12 @@ export function makeConfigurableEnvironmentTestFn<T>(opts: {
   createTestContext: (t: ExecutionContext) => Promise<T>;
   teardown: (t: T) => Promise<void>;
   runtimeOpts?: Partial<RuntimeOptions> | (() => Promise<[Partial<RuntimeOptions>, Partial<T>]>) | undefined;
+  requiresLocalServer?: string;
 }): TestFn<T> {
-  const test = anyTest as TestFn<T>;
+  const test =
+    opts.requiresLocalServer !== undefined
+      ? requiresLocalServer<T>(opts.requiresLocalServer, anyTest as TestFn<T>)
+      : (anyTest as TestFn<T>);
   test.before(async (t) => {
     const [runtimeOpts, extraContext] =
       typeof opts.runtimeOpts === 'function' ? await opts.runtimeOpts() : [opts.runtimeOpts, {}];
@@ -105,6 +111,8 @@ export function makeConfigurableEnvironmentTestFn<T>(opts: {
 
 export interface TestFunctionOptions<C extends Context = Context> {
   workflowsPath: string;
+  /** Why this suite needs an ephemeral/local Temporal server rather than an envconfig-selected server. */
+  requiresLocalServer?: string;
   workflowEnvironmentOpts?: LocalTestWorkflowEnvironmentOptions;
   workflowInterceptorModules?: string[];
   recordedLogs?: { [workflowId: string]: LogEntry[] };
@@ -115,6 +123,7 @@ export function makeTestFunction<C extends Context = Context>(opts: TestFunction
   return makeConfigurableEnvironmentTestFn<C>({
     recordedLogs: opts.recordedLogs,
     runtimeOpts: opts.runtimeOpts,
+    requiresLocalServer: opts.requiresLocalServer,
     createTestContext: makeDefaultTestContextFunction(opts) as (t: ExecutionContext) => Promise<C>,
     teardown: async (c: Context) => {
       if (c.env) {
@@ -143,6 +152,11 @@ export function makeDefaultTestContextFunction(opts: TestFunctionOptions): (t: E
 export async function createTestWorkflowEnvironment(
   opts?: LocalTestWorkflowEnvironmentOptions
 ): Promise<TestWorkflowEnvironment> {
+  if (isSet(process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER, false) && opts?.server) {
+    throw new Error(
+      'workflowEnvironmentOpts.server cannot be used when TEMPORAL_TEST_ENV_CONFIG_SERVER is enabled; mark the suite requiresLocalServer instead'
+    );
+  }
   return createTestWorkflowEnvironmentBase(opts);
 }
 

--- a/packages/test/src/test-integration-extstore-nexus.ts
+++ b/packages/test/src/test-integration-extstore-nexus.ts
@@ -11,7 +11,10 @@ import * as workflow from '@temporalio/workflow';
 import { makeFakeDriver } from './extstore-fake-driver';
 import { helpers, makeTestFunction } from './helpers-integration';
 
-const test = makeTestFunction({ workflowsPath: __filename });
+const test = makeTestFunction({
+  workflowsPath: __filename,
+  requiresLocalServer: 'Current Cloud credentials cannot manage Nexus endpoints (temporalio/features#851).',
+});
 
 const nexusSizeService = nexus.service('extstoreNexusSizeService', {
   // Takes a payload and returns its length, so a large input can be offloaded and the handler's

--- a/packages/test/src/test-local-server-annotation.ts
+++ b/packages/test/src/test-local-server-annotation.ts
@@ -1,0 +1,92 @@
+import test from 'ava';
+import type { TestFn } from 'ava';
+import { requiresLocalServer } from '@temporalio/test-helpers';
+import { makeDefaultTestContextFunction } from './helpers-integration';
+
+function makeFakeTest(registrations: string[], hooks: string[]): TestFn<unknown> {
+  const register = ((title: string) => registrations.push(title)) as any;
+  register.skip = ((title: string) => registrations.push(`skip:${title}`)) as any;
+
+  const before = (() => hooks.push('before')) as any;
+  before.skip = (() => hooks.push('before.skip')) as any;
+  const beforeEach = (() => hooks.push('beforeEach')) as any;
+  beforeEach.skip = (() => hooks.push('beforeEach.skip')) as any;
+  const after = (() => hooks.push('after')) as any;
+  after.skip = (() => hooks.push('after.skip')) as any;
+  after.always = (() => hooks.push('after.always')) as any;
+  after.always.skip = (() => hooks.push('after.always.skip')) as any;
+  const afterEach = (() => hooks.push('afterEach')) as any;
+  afterEach.skip = (() => hooks.push('afterEach.skip')) as any;
+  afterEach.always = (() => hooks.push('afterEach.always')) as any;
+  afterEach.always.skip = (() => hooks.push('afterEach.always.skip')) as any;
+
+  register.before = before;
+  register.after = after;
+  register.beforeEach = beforeEach;
+  register.afterEach = afterEach;
+  register.serial = register;
+  register.failing = register;
+  register.only = register;
+  register.todo = () => undefined;
+  register.macro = () => undefined;
+  register.meta = {};
+  return register;
+}
+
+test.serial('requiresLocalServer passes through when envconfig is disabled', (t) => {
+  const previous = process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+  t.teardown(() => {
+    if (previous === undefined) delete process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+    else process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER = previous;
+  });
+  delete process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+
+  const base = makeFakeTest([], []);
+  t.is(requiresLocalServer('starts an ephemeral server', base), base);
+});
+
+test.serial('requiresLocalServer skips tests and hooks in envconfig mode', (t) => {
+  const previous = process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+  t.teardown(() => {
+    if (previous === undefined) delete process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+    else process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER = previous;
+  });
+  process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER = 'true';
+
+  const registrations: string[] = [];
+  const hooks: string[] = [];
+  const localOnly = requiresLocalServer('starts an ephemeral server', makeFakeTest(registrations, hooks));
+  localOnly('regular test', () => undefined);
+  localOnly.serial('serial test', () => undefined);
+  localOnly.before(() => undefined);
+  localOnly.after.always(() => undefined);
+
+  t.deepEqual(registrations, [
+    'skip:regular test (requires local server: starts an ephemeral server)',
+    'skip:serial test (requires local server: starts an ephemeral server)',
+  ]);
+  t.deepEqual(hooks, ['before.skip', 'after.always.skip']);
+});
+
+test.serial('requiresLocalServer requires a reason', (t) => {
+  t.throws(() => requiresLocalServer(''), {
+    instanceOf: TypeError,
+    message: 'A non-empty reason is required for a local-server-only test',
+  });
+});
+
+test.serial('envconfig rejects local server options before creating an environment', async (t) => {
+  const previous = process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+  t.teardown(() => {
+    if (previous === undefined) delete process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+    else process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER = previous;
+  });
+  process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER = 'true';
+
+  const createContext = makeDefaultTestContextFunction({
+    workflowsPath: __filename,
+    workflowEnvironmentOpts: { server: { extraArgs: ['--dynamic-config-value', 'test.value=true'] } },
+  });
+  const error = await t.throwsAsync(createContext({} as any));
+  t.regex(error!.message, /workflowEnvironmentOpts\.server cannot be used/);
+});

--- a/packages/test/src/test-nexus-codec-converter-errors.ts
+++ b/packages/test/src/test-nexus-codec-converter-errors.ts
@@ -11,6 +11,7 @@ import { innermostHandlerError } from './helpers-nexus';
 const test = makeTestFunction({
   workflowsPath: __filename,
   workflowInterceptorModules: [__filename],
+  requiresLocalServer: 'Current Cloud credentials cannot manage Nexus endpoints (temporalio/features#851).',
 });
 
 const testService = nexus.service('codec-converter-test', {

--- a/packages/test/src/test-nexus-handler.ts
+++ b/packages/test/src/test-nexus-handler.ts
@@ -19,6 +19,7 @@ import {
 } from '@temporalio/common';
 import { ServiceError } from '@temporalio/client';
 import { coerceToHandlerError, operationErrorToProto } from '@temporalio/worker/lib/nexus/conversions';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 
 export interface Context {
   taskQueue: string;
@@ -27,7 +28,10 @@ export interface Context {
   logEntries: LogEntry[];
 }
 
-const test = anyTest as TestFn<Context>;
+const test = requiresLocalServer<Context>(
+  'Current Cloud credentials cannot manage Nexus endpoints (temporalio/features#851).',
+  anyTest as TestFn<Context>
+);
 
 test.before(async (t) => {
   const logEntries = new Array<LogEntry>();

--- a/packages/test/src/test-nexus-operation-timeouts.ts
+++ b/packages/test/src/test-nexus-operation-timeouts.ts
@@ -4,7 +4,10 @@ import { WorkflowFailedError } from '@temporalio/client';
 import * as workflow from '@temporalio/workflow';
 import { helpers, makeTestFunction } from './helpers-integration';
 
-const test = makeTestFunction({ workflowsPath: __filename });
+const test = makeTestFunction({
+  workflowsPath: __filename,
+  requiresLocalServer: 'Current Cloud credentials cannot manage Nexus endpoints (temporalio/features#851).',
+});
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // NEXUS OPERATION SCHEDULE-TO-START TIMEOUT TEST

--- a/packages/test/src/test-nexus-signal-linking.ts
+++ b/packages/test/src/test-nexus-signal-linking.ts
@@ -31,6 +31,7 @@ const { EventType } = temporal.api.enums.v1;
 
 const test = makeTestFunction({
   workflowsPath: __filename,
+  requiresLocalServer: 'Current Cloud credentials cannot manage Nexus endpoints (temporalio/features#851).',
   workflowEnvironmentOpts: {
     server: {
       extraArgs: [

--- a/packages/test/src/test-nexus-standalone.ts
+++ b/packages/test/src/test-nexus-standalone.ts
@@ -30,6 +30,7 @@ const { EventType } = temporal.api.enums.v1;
 
 const test = makeTestFunction({
   workflowsPath: __filename,
+  requiresLocalServer: 'Current Cloud credentials cannot manage Nexus endpoints (temporalio/features#851).',
   workflowEnvironmentOpts: {
     server: {
       extraArgs: [

--- a/packages/test/src/test-nexus-temporal-operation.ts
+++ b/packages/test/src/test-nexus-temporal-operation.ts
@@ -17,6 +17,7 @@ import { waitUntil } from './helpers';
 
 const test = makeTestFunction({
   workflowsPath: __filename,
+  requiresLocalServer: 'Current Cloud credentials cannot manage Nexus endpoints (temporalio/features#851).',
   workflowEnvironmentOpts: {
     server: {
       extraArgs: [

--- a/packages/test/src/test-nexus-update-operation.ts
+++ b/packages/test/src/test-nexus-update-operation.ts
@@ -29,6 +29,7 @@ function causeChainMessages(err: unknown): string {
 
 const test = makeTestFunction({
   workflowsPath: __filename,
+  requiresLocalServer: 'Current Cloud credentials cannot manage Nexus endpoints (temporalio/features#851).',
   workflowEnvironmentOpts: {
     server: {
       // The default dev server (Temporal 1.31.2) does not deliver Workflow Update completion

--- a/packages/test/src/test-nexus-workflow-caller.ts
+++ b/packages/test/src/test-nexus-workflow-caller.ts
@@ -12,7 +12,11 @@ import { unwrapHandlerErrorCause, innermostHandlerError } from './helpers-nexus'
 import { waitUntil } from './helpers';
 
 const recordedLogs: { [key: string]: LogEntry[] } = {};
-const test = makeTestFunction({ workflowsPath: __filename, recordedLogs });
+const test = makeTestFunction({
+  workflowsPath: __filename,
+  recordedLogs,
+  requiresLocalServer: 'Current Cloud credentials cannot manage Nexus endpoints (temporalio/features#851).',
+});
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Service definitions

--- a/packages/test/src/test-schedules.ts
+++ b/packages/test/src/test-schedules.ts
@@ -14,6 +14,7 @@ import { defaultPayloadConverter, Client, Connection } from '@temporalio/client'
 import { msToNumber } from '@temporalio/common/lib/time';
 import type { SearchAttributes } from '@temporalio/common';
 import { SearchAttributeType, TypedSearchAttributes, defineSearchAttributeKey } from '@temporalio/common';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import { registerDefaultCustomSearchAttributes, RUN_INTEGRATION_TESTS, waitUntil } from './helpers';
 import { defaultSAKeys } from './helpers-integration';
 
@@ -22,7 +23,10 @@ export interface Context {
 }
 
 const taskQueue = 'async-activity-completion';
-const test = anyTest as TestFn<Context>;
+const test = requiresLocalServer<Context>(
+  'Current Cloud credentials cannot manage operator search attributes (temporalio/features#851).',
+  anyTest as TestFn<Context>
+);
 
 const dummyWorkflow = async () => undefined;
 const dummyWorkflowWith1Arg = async (_s: string) => undefined;

--- a/packages/test/src/test-schedules.ts
+++ b/packages/test/src/test-schedules.ts
@@ -10,22 +10,25 @@ import type {
   ScheduleUpdateOptions,
   ScheduleDescription,
 } from '@temporalio/client';
-import { defaultPayloadConverter, Client, Connection } from '@temporalio/client';
+import { defaultPayloadConverter, Client } from '@temporalio/client';
 import { msToNumber } from '@temporalio/common/lib/time';
 import type { SearchAttributes } from '@temporalio/common';
 import { SearchAttributeType, TypedSearchAttributes, defineSearchAttributeKey } from '@temporalio/common';
+import type { TestWorkflowEnvironment } from '@temporalio/test-helpers';
 import { requiresLocalServer } from '@temporalio/test-helpers';
 import { registerDefaultCustomSearchAttributes, RUN_INTEGRATION_TESTS, waitUntil } from './helpers';
-import { defaultSAKeys } from './helpers-integration';
+import { createTestWorkflowEnvironment, defaultSAKeys } from './helpers-integration';
 
 export interface Context {
   client: Client;
+  env: TestWorkflowEnvironment;
 }
 
-const taskQueue = 'async-activity-completion';
-const test = requiresLocalServer<Context>(
+const taskQueue = `schedules-${randomUUID()}`;
+const test = anyTest as TestFn<Context>;
+const localTest = requiresLocalServer<Context>(
   'Current Cloud credentials cannot manage operator search attributes (temporalio/features#851).',
-  anyTest as TestFn<Context>
+  test
 );
 
 const dummyWorkflow = async () => undefined;
@@ -45,11 +48,19 @@ const calendarSpecDescriptionDefaults: CalendarSpecDescription = {
 
 if (RUN_INTEGRATION_TESTS) {
   test.before(async (t) => {
-    const connection = await Connection.connect();
-    await registerDefaultCustomSearchAttributes(connection);
+    const env = await createTestWorkflowEnvironment();
     t.context = {
-      client: new Client({ connection }),
+      client: env.client,
+      env,
     };
+  });
+
+  localTest.before(async (t) => {
+    await registerDefaultCustomSearchAttributes(t.context.env.connection);
+  });
+
+  test.after.always(async (t) => {
+    await t.context.env.teardown();
   });
 
   test.serial('Can create schedule with calendar', async (t) => {
@@ -156,7 +167,7 @@ if (RUN_INTEGRATION_TESTS) {
     }
   });
 
-  test.serial('Can create schedule with startWorkflow action (no arg)', async (t) => {
+  localTest.serial('Can create schedule with startWorkflow action (no arg)', async (t) => {
     const { client } = t.context;
     const scheduleId = `can-create-schedule-with-startWorkflow-action-${randomUUID()}`;
     const handle = await client.schedule.create({
@@ -200,7 +211,7 @@ if (RUN_INTEGRATION_TESTS) {
     }
   });
 
-  test.serial('Can create schedule with startWorkflow action (with args)', async (t) => {
+  localTest.serial('Can create schedule with startWorkflow action (with args)', async (t) => {
     const { client } = t.context;
     const scheduleId = `can-create-schedule-with-startWorkflow-action-${randomUUID()}`;
     const handle = await client.schedule.create({
@@ -249,6 +260,7 @@ if (RUN_INTEGRATION_TESTS) {
   test.serial('Interceptor is called on create schedule', async (t) => {
     const clientWithInterceptor = new Client({
       connection: t.context.client.connection,
+      namespace: t.context.client.options.namespace,
       interceptors: {
         schedule: [
           {
@@ -291,6 +303,7 @@ if (RUN_INTEGRATION_TESTS) {
   test.serial('startWorkflow headers are kept on update', async (t) => {
     const clientWithInterceptor = new Client({
       connection: t.context.client.connection,
+      namespace: t.context.client.options.namespace,
       interceptors: {
         schedule: [
           {
@@ -333,7 +346,7 @@ if (RUN_INTEGRATION_TESTS) {
     }
   });
 
-  test.serial('Can pause and unpause schedule', async (t) => {
+  localTest.serial('Can pause and unpause schedule', async (t) => {
     const { client } = t.context;
     const scheduleId = `can-pause-and-unpause-schedule-${randomUUID()}`;
     const handle = await client.schedule.create({
@@ -571,7 +584,7 @@ if (RUN_INTEGRATION_TESTS) {
     }
   });
 
-  test.serial('Can list Schedules with a query string', async (t) => {
+  localTest.serial('Can list Schedules with a query string', async (t) => {
     const { client } = t.context;
 
     const groupId = randomUUID();
@@ -755,7 +768,7 @@ if (RUN_INTEGRATION_TESTS) {
     }
   });
 
-  test.serial('Can update search attributes of a schedule', async (t) => {
+  localTest.serial('Can update search attributes of a schedule', async (t) => {
     const { client } = t.context;
     const scheduleId = `can-update-search-attributes-of-schedule-${randomUUID()}`;
 

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -1,21 +1,23 @@
 /* eslint @typescript-eslint/no-non-null-assertion: 0 */
 import { randomUUID } from 'crypto';
 import anyTest from 'ava';
-import { Connection, WorkflowClient } from '@temporalio/client';
+import type { TestWorkflowEnvironment } from '@temporalio/test-helpers';
 import type { InjectedSinks, WorkerOptions, LogEntry } from '@temporalio/worker';
-import { DefaultLogger, Runtime, NativeConnection } from '@temporalio/worker';
+import { DefaultLogger, Runtime } from '@temporalio/worker';
 import type { SearchAttributes, WorkflowInfo } from '@temporalio/workflow';
 import type { UnsafeWorkflowInfo } from '@temporalio/workflow/lib/interfaces';
 import type { TypedSearchAttributes } from '@temporalio/common';
 import { SdkComponent } from '@temporalio/common';
 import { requiresLocalServer } from '@temporalio/test-helpers';
 import { RUN_INTEGRATION_TESTS, Worker, registerDefaultCustomSearchAttributes } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { defaultOptions } from './mock-native-worker';
 import * as workflows from './workflows';
 
-const test = requiresLocalServer(
+const test = anyTest;
+const localTest = requiresLocalServer(
   'Current Cloud credentials cannot manage operator search attributes (temporalio/features#851).',
-  anyTest
+  test
 );
 
 class DependencyError extends Error {
@@ -29,10 +31,13 @@ class DependencyError extends Error {
 
 if (RUN_INTEGRATION_TESTS) {
   const recordedLogs: { [workflowId: string]: LogEntry[] } = {};
-  let nativeConnection: NativeConnection;
+  let env: TestWorkflowEnvironment;
+  const workerEnvironmentOptions = (): Partial<WorkerOptions> => ({
+    connection: env.nativeConnection,
+    namespace: env.namespace,
+  });
 
   test.before(async (_) => {
-    await registerDefaultCustomSearchAttributes(await Connection.connect({}));
     Runtime.install({
       logger: new DefaultLogger('DEBUG', (entry: LogEntry) => {
         const workflowId = (entry.meta as any)?.workflowInfo?.workflowId;
@@ -40,17 +45,15 @@ if (RUN_INTEGRATION_TESTS) {
         recordedLogs[workflowId].push(entry);
       }),
     });
+    env = await createTestWorkflowEnvironment();
+  });
 
-    // FIXME(JWH): At some point, tests in this file ends up creating a situation where we no longer have any
-    // native resource tracked by the lang side Runtime object, so the lang Runtime tries to shutdown itself,
-    // but in the mean time, another test tries to create another resource. which results in a rust side
-    // finalization error. Holding on to a nativeConnection object avoids that situation. That's a dirty hack.
-    // Proper fix will be implemented in a distinct PR.
-    nativeConnection = await NativeConnection.connect({});
+  localTest.before(async () => {
+    await registerDefaultCustomSearchAttributes(env.connection);
   });
 
   test.after.always(async () => {
-    await nativeConnection.close();
+    await env.teardown();
   });
 
   test('Worker injects sinks', async (t) => {
@@ -67,7 +70,7 @@ if (RUN_INTEGRATION_TESTS) {
     }
 
     const recordedCalls: RecordedCall[] = [];
-    const taskQueue = `${__filename}-${t.title}`;
+    const taskQueue = `${__filename}-${t.title}-${randomUUID()}`;
     const thrownErrors = Array<DependencyError>();
     const sinks: InjectedSinks<workflows.TestSinks> = {
       success: {
@@ -104,10 +107,11 @@ if (RUN_INTEGRATION_TESTS) {
 
     const worker = await Worker.create({
       ...defaultOptions,
+      ...workerEnvironmentOptions(),
       taskQueue,
       sinks,
     });
-    const client = new WorkflowClient();
+    const client = env.client.workflow;
     const wf = await worker.runUntil(async () => {
       const wf = await client.start(workflows.sinksWorkflow, { taskQueue, workflowId: randomUUID() });
       await wf.result();
@@ -119,7 +123,7 @@ if (RUN_INTEGRATION_TESTS) {
     t.true(historySize > 300);
 
     const info: WorkflowInfo = {
-      namespace: 'default',
+      namespace: env.client.options.namespace,
       firstExecutionRunId: wf.firstExecutionRunId,
       attempt: 1,
       taskTimeoutMs: 10_000,
@@ -207,7 +211,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Sink functions are not called during replay if callDuringReplay is unset', async (t) => {
-    const taskQueue = `${__filename}-${t.title}`;
+    const taskQueue = `${__filename}-${t.title}-${randomUUID()}`;
 
     const recordedMessages = Array<{ message: string; historyLength: number; isReplaying: boolean }>();
     const sinks: InjectedSinks<workflows.CustomLoggerSinks> = {
@@ -224,9 +228,10 @@ if (RUN_INTEGRATION_TESTS) {
       },
     };
 
-    const client = new WorkflowClient();
+    const client = env.client.workflow;
     const worker = await Worker.create({
       ...defaultOptions,
+      ...workerEnvironmentOptions(),
       taskQueue,
       sinks,
       maxCachedWorkflows: 0,
@@ -249,7 +254,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Sink functions are called during replay if callDuringReplay is set', async (t) => {
-    const taskQueue = `${__filename}-${t.title}`;
+    const taskQueue = `${__filename}-${t.title}-${randomUUID()}`;
 
     const recordedMessages = Array<{ message: string; historyLength: number; isReplaying: boolean }>();
     const sinks: InjectedSinks<workflows.CustomLoggerSinks> = {
@@ -269,12 +274,13 @@ if (RUN_INTEGRATION_TESTS) {
 
     const worker = await Worker.create({
       ...defaultOptions,
+      ...workerEnvironmentOptions(),
       taskQueue,
       sinks,
       maxCachedWorkflows: 0,
       maxConcurrentWorkflowTaskExecutions: 2,
     });
-    const client = new WorkflowClient();
+    const client = env.client.workflow;
     await worker.runUntil(client.execute(workflows.logSinkTester, { taskQueue, workflowId: randomUUID() }));
 
     // Note that task may be replayed more than once and record the first messages multiple times.
@@ -313,10 +319,11 @@ if (RUN_INTEGRATION_TESTS) {
       },
     };
 
-    const client = new WorkflowClient();
-    const taskQueue = `${__filename}-${t.title}`;
+    const client = env.client.workflow;
+    const taskQueue = `${__filename}-${t.title}-${randomUUID()}`;
     const worker = await Worker.create({
       ...defaultOptions,
+      ...workerEnvironmentOptions(),
       taskQueue,
       sinks,
     });
@@ -341,7 +348,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Sink functions are called in runReplayHistories if callDuringReplay is set', async (t) => {
-    const taskQueue = `${__filename}-${t.title}`;
+    const taskQueue = `${__filename}-${t.title}-${randomUUID()}`;
 
     const recordedMessages = Array<{ message: string; historyLength: number; isReplaying: boolean }>();
     const sinks: InjectedSinks<workflows.CustomLoggerSinks> = {
@@ -361,10 +368,11 @@ if (RUN_INTEGRATION_TESTS) {
 
     const worker = await Worker.create({
       ...defaultOptions,
+      ...workerEnvironmentOptions(),
       taskQueue,
       sinks,
     });
-    const client = new WorkflowClient();
+    const client = env.client.workflow;
     const workflowId = randomUUID();
     await worker.runUntil(async () => {
       await client.execute(workflows.logSinkTester, { taskQueue, workflowId });
@@ -398,8 +406,8 @@ if (RUN_INTEGRATION_TESTS) {
     ]);
   });
 
-  test('Sink functions contains upserted search attributes', async (t) => {
-    const taskQueue = `${__filename}-${t.title}`;
+  localTest('Sink functions contains upserted search attributes', async (t) => {
+    const taskQueue = `${__filename}-${t.title}-${randomUUID()}`;
 
     const recordedMessages = Array<{ message: string; searchAttributes: SearchAttributes }>();
     const sinks: InjectedSinks<workflows.CustomLoggerSinks> = {
@@ -416,11 +424,12 @@ if (RUN_INTEGRATION_TESTS) {
       },
     };
 
-    const client = new WorkflowClient();
+    const client = env.client.workflow;
     const date = new Date();
 
     const worker = await Worker.create({
       ...defaultOptions,
+      ...workerEnvironmentOptions(),
       taskQueue,
       sinks,
     });
@@ -451,8 +460,8 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Sink functions contains upserted memo', async (t) => {
-    const taskQueue = `${__filename}-${t.title}`;
-    const client = new WorkflowClient();
+    const taskQueue = `${__filename}-${t.title}-${randomUUID()}`;
+    const client = env.client.workflow;
 
     const recordedMessages = Array<{ message: string; memo: Record<string, unknown> | undefined }>();
     const sinks: InjectedSinks<workflows.CustomLoggerSinks> = {
@@ -471,6 +480,7 @@ if (RUN_INTEGRATION_TESTS) {
 
     const worker = await Worker.create({
       ...defaultOptions,
+      ...workerEnvironmentOptions(),
       taskQueue,
       sinks,
     });
@@ -515,7 +525,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Core issue 589', async (t) => {
-    const taskQueue = `${__filename}-${t.title}`;
+    const taskQueue = `${__filename}-${t.title}-${randomUUID()}`;
 
     const recordedMessages = Array<{ message: string; historyLength: number; isReplaying: boolean }>();
     const sinks: InjectedSinks<workflows.CustomLoggerSinks> = {
@@ -533,11 +543,12 @@ if (RUN_INTEGRATION_TESTS) {
       },
     };
 
-    const client = new WorkflowClient();
+    const client = env.client.workflow;
     const handle = await client.start(workflows.coreIssue589, { taskQueue, workflowId: randomUUID() });
 
     const workerOptions: WorkerOptions = {
       ...defaultOptions,
+      ...workerEnvironmentOptions(),
       taskQueue,
       sinks,
 
@@ -568,7 +579,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Logging is allowed in query handlers and update validators', async (t) => {
-    const taskQueue = `${__filename}-${t.title}`;
+    const taskQueue = `${__filename}-${t.title}-${randomUUID()}`;
 
     let recordedMessages: { message: string; isReplaying: boolean }[] = [];
     const sinks: InjectedSinks<workflows.CustomLoggerSinks> = {
@@ -584,11 +595,12 @@ if (RUN_INTEGRATION_TESTS) {
       },
     };
 
-    const client = new WorkflowClient();
+    const client = env.client.workflow;
     const handle = await client.start(workflows.queryAndValidatorLogging, { taskQueue, workflowId: randomUUID() });
 
     const worker = await Worker.create({
       ...defaultOptions,
+      ...workerEnvironmentOptions(),
       taskQueue,
       sinks,
       // Avoid waiting for sticky execution timeout on worker transition
@@ -607,6 +619,7 @@ if (RUN_INTEGRATION_TESTS) {
 
     const worker2 = await Worker.create({
       ...defaultOptions,
+      ...workerEnvironmentOptions(),
       taskQueue,
       sinks,
       // Avoid waiting for sticky execution timeout on worker transition

--- a/packages/test/src/test-sinks.ts
+++ b/packages/test/src/test-sinks.ts
@@ -1,6 +1,6 @@
 /* eslint @typescript-eslint/no-non-null-assertion: 0 */
 import { randomUUID } from 'crypto';
-import test from 'ava';
+import anyTest from 'ava';
 import { Connection, WorkflowClient } from '@temporalio/client';
 import type { InjectedSinks, WorkerOptions, LogEntry } from '@temporalio/worker';
 import { DefaultLogger, Runtime, NativeConnection } from '@temporalio/worker';
@@ -8,9 +8,15 @@ import type { SearchAttributes, WorkflowInfo } from '@temporalio/workflow';
 import type { UnsafeWorkflowInfo } from '@temporalio/workflow/lib/interfaces';
 import type { TypedSearchAttributes } from '@temporalio/common';
 import { SdkComponent } from '@temporalio/common';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import { RUN_INTEGRATION_TESTS, Worker, registerDefaultCustomSearchAttributes } from './helpers';
 import { defaultOptions } from './mock-native-worker';
 import * as workflows from './workflows';
+
+const test = requiresLocalServer(
+  'Current Cloud credentials cannot manage operator search attributes (temporalio/features#851).',
+  anyTest
+);
 
 class DependencyError extends Error {
   constructor(

--- a/packages/test/src/test-typed-search-attributes.ts
+++ b/packages/test/src/test-typed-search-attributes.ts
@@ -20,6 +20,7 @@ import { helpers, makeTestFunction } from './helpers-integration';
 
 const test = makeTestFunction({
   workflowsPath: __filename,
+  requiresLocalServer: 'Current Cloud credentials cannot manage operator search attributes (temporalio/features#851).',
   workflowEnvironmentOpts: {
     server: {
       namespace: 'test-typed-search-attributes',

--- a/packages/test/src/test-workflow-nexus-cancellation.ts
+++ b/packages/test/src/test-workflow-nexus-cancellation.ts
@@ -13,7 +13,10 @@ import { helpers, makeTestFunction } from './helpers-integration';
 import { innermostHandlerError } from './helpers-nexus';
 import { waitUntil } from './helpers';
 
-const test = makeTestFunction({ workflowsPath: __filename });
+const test = makeTestFunction({
+  workflowsPath: __filename,
+  requiresLocalServer: 'Current Cloud credentials cannot manage Nexus endpoints (temporalio/features#851).',
+});
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // WORKFLOW's SCHEDULE NEXUS OPERATION's CANCELLATION TYPES


### PR DESCRIPTION
The ring-0 Cloud credentials used by SDK CI cannot create or delete Nexus endpoints and cannot administer namespace search attributes. Tests that require those privileges would otherwise fail for credential reasons rather than exercise SDK behavior.

This stacked change uses the local-server annotation from the base PR to classify Nexus endpoint suites and the typed-search-attribute coverage that depends on operator state. The schedule and sink files are mixed suites, so only their search-attribute-dependent cases are local-only; their remaining tests now use the configured environment connection and namespace and continue to run in Cloud. Local CI still runs every test unchanged.

Focused ESLint, Prettier, and `git diff --check` pass. The package build reaches TypeScript and reports only the unrelated `ActivityExecutionStatus.PAUSED` mismatch from the locally advanced core submodule.

Depends on the local-server annotation base PR. Part of temporalio/features#851.