### PR TITLE
Surface Nexus endpoint cleanup failures

### DIFF
--- a/packages/test/src/helpers-integration.ts
+++ b/packages/test/src/helpers-integration.ts
@@ -237,11 +237,15 @@ export function helpers(t: ExecutionContext<Context>, env?: TestWorkflowEnvironm
       const endpointName = (suffix ? `${taskQueue}-${suffix}` : taskQueue).replaceAll('_', '-');
       try {
         const endpointIdentifier = await testEnv.createNexusEndpoint(endpointName, taskQueue);
-        t.teardown(() =>
-          testEnv.deleteNexusEndpoint(endpointIdentifier).catch(() => {
-            /* ignore cleanup errors */
-          })
-        );
+        t.teardown(async () => {
+          try {
+            await testEnv.deleteNexusEndpoint(endpointIdentifier);
+          } catch (err) {
+            if (!isGrpcServiceError(err) || err.code !== grpcStatus.NOT_FOUND) {
+              throw err;
+            }
+          }
+        });
         return { endpointName, endpointIdentifier };
       } catch (err) {
         if (err instanceof Error) {

--- a/packages/test/src/test-nexus-endpoint-cleanup.ts
+++ b/packages/test/src/test-nexus-endpoint-cleanup.ts
@@ -1,0 +1,51 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
+import test from 'ava';
+import { helpers } from './helpers-integration';
+
+function testContext(deleteNexusEndpoint: () => Promise<void>): {
+  context: Parameters<typeof helpers>[0];
+  cleanup: () => Promise<void>;
+} {
+  let cleanup: (() => Promise<void>) | undefined;
+  const context = {
+    title: 'Nexus endpoint cleanup',
+    context: {
+      env: {
+        createNexusEndpoint: async () => ({ id: 'endpoint-id', version: 1 }),
+        deleteNexusEndpoint,
+      },
+      workflowBundle: {},
+    },
+    teardown(fn: () => Promise<void>) {
+      cleanup = fn;
+    },
+  } as any;
+  return {
+    context,
+    cleanup: async () => await cleanup!(),
+  };
+}
+
+test('Nexus endpoint cleanup surfaces deletion failures', async (t) => {
+  const failure = new Error('permission denied');
+  const { context, cleanup } = testContext(async () => {
+    throw failure;
+  });
+
+  await helpers(context).registerNexusEndpoint();
+  t.is(await t.throwsAsync(cleanup()), failure);
+});
+
+test('Nexus endpoint cleanup tolerates an already-deleted endpoint', async (t) => {
+  const notFound = Object.assign(new Error('endpoint not found'), {
+    code: grpcStatus.NOT_FOUND,
+    details: 'endpoint not found',
+    metadata: {},
+  });
+  const { context, cleanup } = testContext(async () => {
+    throw notFound;
+  });
+
+  await helpers(context).registerNexusEndpoint();
+  await t.notThrowsAsync(cleanup());
+});


### PR DESCRIPTION
The Nexus test helper currently catches and discards every endpoint-deletion error during AVA teardown. That is mostly hidden by ephemeral dev servers, but it would leak endpoints on a persistent server when deletion fails because of permissions, transport errors, or version conflicts.

This change makes teardown fail for every deletion error except `NOT_FOUND`, which preserves idempotency for tests that explicitly deleted the endpoint before their registered teardown runs. No Nexus test is enabled against Cloud by this PR; it establishes the cleanup guarantee required before privileged Cloud coverage can be considered.

Focused AVA coverage verifies both propagated deletion failures and tolerated already-deleted endpoints. Prettier and ESLint pass. The package TypeScript build reaches only the unrelated `ActivityExecutionStatus.PAUSED` errors present in this worktree's advanced sdk-core submodule.

Part of temporalio/features#851.