### PR TITLE
Mark intrinsic local-server integration tests

### DIFF
--- a/packages/test-helpers/src/ava-helpers.ts
+++ b/packages/test-helpers/src/ava-helpers.ts
@@ -1,6 +1,7 @@
-import type { TestFn } from 'ava';
+import type { AfterFn, AlwaysInterface, FailingFn, OnlyFn, SerialFn, TestFn } from 'ava';
 import ava from 'ava';
 import { inWorkflowContext } from '@temporalio/workflow';
+import { isSet } from './flags';
 
 function noopTest(): void {
   // eslint: this function body is empty and it's okay.
@@ -19,5 +20,72 @@ noopTest.skip = () => noopTest;
  * (Mostly complete) helper to allow mixing workflow and non-workflow code in the same test file.
  */
 export const test: TestFn<unknown> = inWorkflowContext() ? (noopTest as any) : ava;
+
+function assertReason(reason: string): void {
+  if (typeof reason !== 'string' || reason.trim() === '') {
+    throw new TypeError('A non-empty reason is required for a local-server-only test');
+  }
+}
+
+function localServerSkipTitle(title: string, reason: string): string {
+  return `${title} (requires local server: ${reason})`;
+}
+
+/**
+ * Return a test function which skips its tests and hooks when the integration suite is configured to use envconfig.
+ *
+ * Local-server requirements must always include a reason so Cloud output makes the excluded capability explicit.
+ */
+export function requiresLocalServer<Context = unknown>(reason: string, baseTest?: TestFn<Context>): TestFn<Context> {
+  assertReason(reason);
+  const source = (baseTest ?? test) as TestFn<Context>;
+  if (!isSet(process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER, false)) {
+    return source;
+  }
+
+  const skip = ((titleOrMacro: any, implementation?: any, ...args: any[]) => {
+    if (typeof titleOrMacro === 'string') {
+      source.skip(localServerSkipTitle(titleOrMacro, reason), implementation, ...args);
+    } else {
+      // AVA macros generate their own title, so they cannot be decorated without changing their public contract.
+      if (implementation === undefined) source.skip(titleOrMacro, ...args);
+      else source.skip(titleOrMacro, implementation, ...args);
+    }
+  }) as TestFn<Context>['skip'];
+
+  // Skip hooks as well as tests: suite setup must not create a local server in envconfig mode.
+  const noopHook = (() => undefined) as any;
+  const before = (source.before.skip ?? noopHook) as TestFn<Context>['before'];
+  const after = (source.after.skip ?? noopHook) as AfterFn<Context>;
+  after.always = ((source.after as any).always?.skip ?? noopHook) as AlwaysInterface<Context>;
+  const beforeEach = (source.beforeEach.skip ?? noopHook) as TestFn<Context>['beforeEach'];
+  const afterEach = (source.afterEach.skip ?? noopHook) as AfterFn<Context>;
+  afterEach.always = ((source.afterEach as any).always?.skip ?? noopHook) as AlwaysInterface<Context>;
+  const serial = skip as SerialFn<Context>;
+  serial.before = before;
+  serial.after = after;
+  serial.beforeEach = beforeEach;
+  serial.afterEach = afterEach;
+  serial.failing = skip as FailingFn<Context>;
+  serial.only = skip as OnlyFn<Context>;
+  serial.skip = skip;
+  serial.todo = source.todo;
+  const failing = skip as FailingFn<Context>;
+  failing.only = skip as OnlyFn<Context>;
+  failing.skip = skip;
+  const skipped = skip as TestFn<Context>;
+  skipped.before = before;
+  skipped.after = after;
+  skipped.beforeEach = beforeEach;
+  skipped.afterEach = afterEach;
+  skipped.serial = serial;
+  skipped.failing = failing;
+  skipped.only = skip as OnlyFn<Context>;
+  skipped.skip = skip;
+  skipped.todo = source.todo;
+  skipped.macro = source.macro;
+  skipped.meta = source.meta;
+  return skipped;
+}
 
 export { noopTest };

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -27,7 +27,7 @@ export { baseBundlerIgnoreModules, createBaseBundlerOptions } from './bundler';
 export { ByteSkewerPayloadCodec } from './codecs';
 
 // AVA helpers
-export { test, noopTest } from './ava-helpers';
+export { test, noopTest, requiresLocalServer } from './ava-helpers';
 
 // Wrappers
 export { Worker, TestWorkflowEnvironment } from './wrappers';

--- a/packages/test/src/helpers-integration.ts
+++ b/packages/test/src/helpers-integration.ts
@@ -30,6 +30,8 @@ import {
   createTestWorkflowEnvironment as createTestWorkflowEnvironmentBase,
   createLocalTestEnvironment,
   defaultSAKeys,
+  isSet,
+  requiresLocalServer,
   test as anyTest,
   Worker,
 } from '@temporalio/test-helpers';
@@ -89,8 +91,12 @@ export function makeConfigurableEnvironmentTestFn<T>(opts: {
   createTestContext: (t: ExecutionContext) => Promise<T>;
   teardown: (t: T) => Promise<void>;
   runtimeOpts?: Partial<RuntimeOptions> | (() => Promise<[Partial<RuntimeOptions>, Partial<T>]>) | undefined;
+  requiresLocalServer?: string;
 }): TestFn<T> {
-  const test = anyTest as TestFn<T>;
+  const test =
+    opts.requiresLocalServer !== undefined
+      ? requiresLocalServer<T>(opts.requiresLocalServer, anyTest as TestFn<T>)
+      : (anyTest as TestFn<T>);
   test.before(async (t) => {
     const [runtimeOpts, extraContext] =
       typeof opts.runtimeOpts === 'function' ? await opts.runtimeOpts() : [opts.runtimeOpts, {}];
@@ -105,6 +111,8 @@ export function makeConfigurableEnvironmentTestFn<T>(opts: {
 
 export interface TestFunctionOptions<C extends Context = Context> {
   workflowsPath: string;
+  /** Why this suite needs an ephemeral/local Temporal server rather than an envconfig-selected server. */
+  requiresLocalServer?: string;
   workflowEnvironmentOpts?: LocalTestWorkflowEnvironmentOptions;
   workflowInterceptorModules?: string[];
   recordedLogs?: { [workflowId: string]: LogEntry[] };
@@ -115,6 +123,7 @@ export function makeTestFunction<C extends Context = Context>(opts: TestFunction
   return makeConfigurableEnvironmentTestFn<C>({
     recordedLogs: opts.recordedLogs,
     runtimeOpts: opts.runtimeOpts,
+    requiresLocalServer: opts.requiresLocalServer,
     createTestContext: makeDefaultTestContextFunction(opts) as (t: ExecutionContext) => Promise<C>,
     teardown: async (c: Context) => {
       if (c.env) {
@@ -143,6 +152,11 @@ export function makeDefaultTestContextFunction(opts: TestFunctionOptions): (t: E
 export async function createTestWorkflowEnvironment(
   opts?: LocalTestWorkflowEnvironmentOptions
 ): Promise<TestWorkflowEnvironment> {
+  if (isSet(process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER, false) && opts?.server) {
+    throw new Error(
+      'workflowEnvironmentOpts.server cannot be used when TEMPORAL_TEST_ENV_CONFIG_SERVER is enabled; mark the suite requiresLocalServer instead'
+    );
+  }
   return createTestWorkflowEnvironmentBase(opts);
 }
 

--- a/packages/test/src/test-bridge.ts
+++ b/packages/test/src/test-bridge.ts
@@ -2,6 +2,7 @@ import { setTimeout } from 'node:timers/promises';
 import ms from 'ms';
 import test from 'ava';
 import { native, errors } from '@temporalio/core-bridge';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 
 // TESTING NOTES
 //
@@ -9,6 +10,11 @@ import { native, errors } from '@temporalio/core-bridge';
 //   server support provided by Core SDK would affect the behavior that we're testing here.
 // - Tests in this file can't be run in parallel, since the bridge is mostly a singleton.
 // - Some of these tests explicitly use the native bridge, without going through the lang side Runtime/Worker.
+
+const localTest = requiresLocalServer(
+  'uses low-level bridge client configuration that targets the external local server',
+  test
+);
 
 test('Can instantiate and shutdown the native runtime', async (t) => {
   const runtime = native.newRuntime(GenericConfigs.runtime.basic);
@@ -29,7 +35,7 @@ test('Can instantiate and shutdown the native runtime', async (t) => {
   });
 });
 
-test('Can run multiple runtime concurrently', async (t) => {
+localTest('Can run multiple runtime concurrently', async (t) => {
   const runtime1 = native.newRuntime(GenericConfigs.runtime.basic);
   const runtime2 = native.newRuntime(GenericConfigs.runtime.basic);
   const runtime3 = native.newRuntime(GenericConfigs.runtime.basic);
@@ -141,13 +147,13 @@ test("Creating Runtime without shutting it down doesn't hang process", (t) => {
   t.pass();
 });
 
-test("Dropping Client without closing doesn't hang process", (t) => {
+localTest("Dropping Client without closing doesn't hang process", (t) => {
   const runtime = native.newRuntime(GenericConfigs.runtime.basic);
   const _client = native.newClient(runtime, GenericConfigs.client.basic);
   t.pass();
 });
 
-test("Dropping Worker without shutting it down doesn't hang process", async (t) => {
+localTest("Dropping Worker without shutting it down doesn't hang process", async (t) => {
   const runtime = native.newRuntime(GenericConfigs.runtime.basic);
   const client = await native.newClient(runtime, GenericConfigs.client.basic);
   const worker = native.newWorker(client, GenericConfigs.worker.basic);
@@ -162,7 +168,7 @@ test("Dropping EphemeralServer without shutting it down doesn't hang process", a
   t.pass();
 });
 
-test("Stopping Worker after creating another runtime doesn't fail", async (t) => {
+localTest("Stopping Worker after creating another runtime doesn't fail", async (t) => {
   async function expectShutdownError(taskPromise: () => Promise<Buffer>) {
     await t.throwsAsync(taskPromise, {
       instanceOf: errors.ShutdownError,

--- a/packages/test/src/test-client-errors.ts
+++ b/packages/test/src/test-client-errors.ts
@@ -7,13 +7,14 @@ import type {
   WorkflowTerminateInput,
 } from '@temporalio/client';
 import { ApplicationFailure, Client, NamespaceNotFoundError, ValueError } from '@temporalio/client';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import { TestWorkflowEnvironment } from './helpers';
 
 interface Context {
   testEnv: TestWorkflowEnvironment;
 }
 
-const test = anyTest as TestFn<Context>;
+const test = requiresLocalServer('asserts dev server namespace-not-found error details', anyTest as TestFn<Context>);
 
 const unserializableObject = {
   toJSON() {

--- a/packages/test/src/test-default-workflow.ts
+++ b/packages/test/src/test-default-workflow.ts
@@ -3,10 +3,13 @@
  */
 import { randomUUID } from 'crypto';
 import test from 'ava';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import { TestWorkflowEnvironment, Worker } from './helpers';
 import { existing } from './workflows/default-workflow-function';
 
-test('Default workflow handler is used if requested workflow does not exist', async (t) => {
+const localTest = requiresLocalServer('creates an ephemeral server for default workflow handler tests', test);
+
+localTest('Default workflow handler is used if requested workflow does not exist', async (t) => {
   const env = await TestWorkflowEnvironment.createLocal();
   try {
     const taskQueue = `${t.title}-${randomUUID()}`;
@@ -30,7 +33,7 @@ test('Default workflow handler is used if requested workflow does not exist', as
   }
 });
 
-test('Default workflow handler is not used if requested workflow exists', async (t) => {
+localTest('Default workflow handler is not used if requested workflow exists', async (t) => {
   const env = await TestWorkflowEnvironment.createLocal();
   try {
     const taskQueue = `${t.title}-${randomUUID()}`;

--- a/packages/test/src/test-ephemeral-server.ts
+++ b/packages/test/src/test-ephemeral-server.ts
@@ -6,6 +6,7 @@ import type { WorkflowBundle } from '@temporalio/worker';
 import { bundleWorkflowCode } from '@temporalio/worker';
 import { Connection } from '@temporalio/client';
 import { TestWorkflowEnvironment as RealTestWorkflowEnvironment } from '@temporalio/testing';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import {
   Worker,
   TestWorkflowEnvironment,
@@ -19,8 +20,11 @@ interface Context {
   taskQueue: string;
 }
 
-const test = anyTest as TestFn<Context>;
-const testTimeSkipping = testTimeSkippingFromHelpers as TestFn<Context>;
+const test = requiresLocalServer('starts and configures ephemeral Temporal servers', anyTest as TestFn<Context>);
+const testTimeSkipping = requiresLocalServer(
+  'starts and configures ephemeral Temporal servers',
+  testTimeSkippingFromHelpers as TestFn<Context>
+);
 
 test.before(async (t) => {
   t.context.bundle = await bundleWorkflowCode({ workflowsPath: require.resolve('./workflows') });

--- a/packages/test/src/test-failure-converter.ts
+++ b/packages/test/src/test-failure-converter.ts
@@ -4,6 +4,7 @@ import { DefaultFailureConverter, ApplicationFailure, TemporalFailure } from '@t
 import { proxyActivities } from '@temporalio/workflow';
 import type { WorkflowFailedError } from '@temporalio/client';
 import { decodeFromPayloadsAtIndex } from '@temporalio/common/lib/internal-non-workflow';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import { test, bundlerOptions, ByteSkewerPayloadCodec, Worker, TestWorkflowEnvironment } from './helpers';
 
 export const failureConverter = new DefaultFailureConverter({ encodeCommonAttributes: true });
@@ -19,7 +20,9 @@ export async function workflow(): Promise<void> {
   await activities.raise();
 }
 
-test('Client and Worker use provided failureConverter', async (t) => {
+const localTest = requiresLocalServer('creates an ephemeral server with a custom data converter', test);
+
+localTest('Client and Worker use provided failureConverter', async (t) => {
   const dataConverter: DataConverter = {
     // Use a payload codec to verify that it's being utilized to encode / decode the failure
     payloadCodecs: [new ByteSkewerPayloadCodec()],

--- a/packages/test/src/test-integration-envconfig.ts
+++ b/packages/test/src/test-integration-envconfig.ts
@@ -1,9 +1,10 @@
 import test from 'ava';
-import { TestWorkflowEnvironment } from '@temporalio/test-helpers';
+import { requiresLocalServer, TestWorkflowEnvironment } from '@temporalio/test-helpers';
 
 const namespace = 'envconfig-test';
+const localTest = requiresLocalServer('starts a local source server to validate envconfig parsing', test);
 
-test('Envconfig factory connects through envconfig', async (t) => {
+localTest('Envconfig factory connects through envconfig', async (t) => {
   const sourceEnv = await TestWorkflowEnvironment.createLocal({ server: { namespace } });
   let env: TestWorkflowEnvironment | undefined;
 

--- a/packages/test/src/test-integration-replay-and-flags.ts
+++ b/packages/test/src/test-integration-replay-and-flags.ts
@@ -1,6 +1,7 @@
 import asyncRetry from 'async-retry';
 import { tsToMs } from '@temporalio/common/lib/time';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import {
   conditionTimeout0,
   issue1423Workflow,
@@ -89,7 +90,8 @@ test("Lang's SDK flags from 1.11.2 are retroactively applied on replay", async (
 });
 
 if (RUN_TIME_SKIPPING_TESTS) {
-  test.serial('setTimeout and clearTimeout - works before and after 1.10.3', async (t) => {
+  const localTest = requiresLocalServer('uses the time-skipping test server', test);
+  localTest.serial('setTimeout and clearTimeout - works before and after 1.10.3', async (t) => {
     const env = await TestWorkflowEnvironment.createTimeSkipping();
     const { createWorker, startWorkflow } = helpers(t, env);
     try {

--- a/packages/test/src/test-integration-split-one.ts
+++ b/packages/test/src/test-integration-split-one.ts
@@ -23,6 +23,7 @@ import { tsToMs } from '@temporalio/common/lib/time';
 import type { InjectedSinks } from '@temporalio/worker';
 import pkg from '@temporalio/worker/lib/pkg';
 import type { UnsafeWorkflowInfo, WorkflowInfo } from '@temporalio/workflow/lib/interfaces';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 
 import {
   CancellationScope,
@@ -54,12 +55,16 @@ const CHANGE_MARKER_NAME = 'core_patch';
 
 const test = makeTestFn(() => createTestWorkflowBundle({ workflowsPath: __filename }));
 test.macro(configMacro);
+const localTest = requiresLocalServer(
+  'asserts the local server workflow-task failure detail for an unknown workflow type',
+  test
+);
 
 // FIXME: Unless we add .serial() here, ava tries to start all async tests in parallel, which
 //        is ok in most environments, but has been causing flakyness in CI, especially on Windows.
 //        We can probably avoid this by using larger runners, and there is some opportunity for
 //        optimization here, but for now, let's just run these tests serially.
-test.serial('Workflow not found results in task retry', configMacro, async (t, config) => {
+localTest.serial('Workflow not found results in task retry', configMacro, async (t, config) => {
   const { env, createWorkerWithDefaults } = config;
   const { taskQueue } = configurableHelpers(t, t.context.workflowBundle, env);
   const worker = await createWorkerWithDefaults(t);

--- a/packages/test/src/test-integration-update.ts
+++ b/packages/test/src/test-integration-update.ts
@@ -32,6 +32,7 @@ const test = makeTestFunction({
       ],
     },
   },
+  requiresLocalServer: 'configures the dev server long-poll expiration timeout',
   recordedLogs,
 });
 

--- a/packages/test/src/test-integration-workflow-info.ts
+++ b/packages/test/src/test-integration-workflow-info.ts
@@ -11,6 +11,7 @@ import {
   TypedSearchAttributes,
 } from '@temporalio/common';
 import { encode } from '@temporalio/common/lib/encoding';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import {
   buildIdTester,
   completableWorkflow,
@@ -189,7 +190,9 @@ test('Count workflow executions', async (t) => {
   });
 });
 
-test.serial('can register search attributes to dev server', async (t) => {
+const localTest = requiresLocalServer('starts a dev server with a custom search attribute', test);
+
+localTest.serial('can register search attributes to dev server', async (t) => {
   const key = defineSearchAttributeKey('new-search-attr', SearchAttributeType.INT);
   const newSearchAttribute: SearchAttributePair = { key, value: 12 };
 

--- a/packages/test/src/test-local-activities.ts
+++ b/packages/test/src/test-local-activities.ts
@@ -18,6 +18,7 @@ const test = makeTestFunction({
       extraArgs: ['--dynamic-config-value', 'system.enableActivityEagerExecution=false'],
     },
   },
+  requiresLocalServer: 'configures the dev server to disable eager activity execution',
 });
 
 export async function runOneLocalActivity(s: string): Promise<string> {

--- a/packages/test/src/test-local-server-annotation.ts
+++ b/packages/test/src/test-local-server-annotation.ts
@@ -1,0 +1,92 @@
+import test from 'ava';
+import type { TestFn } from 'ava';
+import { requiresLocalServer } from '@temporalio/test-helpers';
+import { makeDefaultTestContextFunction } from './helpers-integration';
+
+function makeFakeTest(registrations: string[], hooks: string[]): TestFn<unknown> {
+  const register = ((title: string) => registrations.push(title)) as any;
+  register.skip = ((title: string) => registrations.push(`skip:${title}`)) as any;
+
+  const before = (() => hooks.push('before')) as any;
+  before.skip = (() => hooks.push('before.skip')) as any;
+  const beforeEach = (() => hooks.push('beforeEach')) as any;
+  beforeEach.skip = (() => hooks.push('beforeEach.skip')) as any;
+  const after = (() => hooks.push('after')) as any;
+  after.skip = (() => hooks.push('after.skip')) as any;
+  after.always = (() => hooks.push('after.always')) as any;
+  after.always.skip = (() => hooks.push('after.always.skip')) as any;
+  const afterEach = (() => hooks.push('afterEach')) as any;
+  afterEach.skip = (() => hooks.push('afterEach.skip')) as any;
+  afterEach.always = (() => hooks.push('afterEach.always')) as any;
+  afterEach.always.skip = (() => hooks.push('afterEach.always.skip')) as any;
+
+  register.before = before;
+  register.after = after;
+  register.beforeEach = beforeEach;
+  register.afterEach = afterEach;
+  register.serial = register;
+  register.failing = register;
+  register.only = register;
+  register.todo = () => undefined;
+  register.macro = () => undefined;
+  register.meta = {};
+  return register;
+}
+
+test.serial('requiresLocalServer passes through when envconfig is disabled', (t) => {
+  const previous = process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+  t.teardown(() => {
+    if (previous === undefined) delete process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+    else process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER = previous;
+  });
+  delete process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+
+  const base = makeFakeTest([], []);
+  t.is(requiresLocalServer('starts an ephemeral server', base), base);
+});
+
+test.serial('requiresLocalServer skips tests and hooks in envconfig mode', (t) => {
+  const previous = process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+  t.teardown(() => {
+    if (previous === undefined) delete process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+    else process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER = previous;
+  });
+  process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER = 'true';
+
+  const registrations: string[] = [];
+  const hooks: string[] = [];
+  const localOnly = requiresLocalServer('starts an ephemeral server', makeFakeTest(registrations, hooks));
+  localOnly('regular test', () => undefined);
+  localOnly.serial('serial test', () => undefined);
+  localOnly.before(() => undefined);
+  localOnly.after.always(() => undefined);
+
+  t.deepEqual(registrations, [
+    'skip:regular test (requires local server: starts an ephemeral server)',
+    'skip:serial test (requires local server: starts an ephemeral server)',
+  ]);
+  t.deepEqual(hooks, ['before.skip', 'after.always.skip']);
+});
+
+test.serial('requiresLocalServer requires a reason', (t) => {
+  t.throws(() => requiresLocalServer(''), {
+    instanceOf: TypeError,
+    message: 'A non-empty reason is required for a local-server-only test',
+  });
+});
+
+test.serial('envconfig rejects local server options before creating an environment', async (t) => {
+  const previous = process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+  t.teardown(() => {
+    if (previous === undefined) delete process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER;
+    else process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER = previous;
+  });
+  process.env.TEMPORAL_TEST_ENV_CONFIG_SERVER = 'true';
+
+  const createContext = makeDefaultTestContextFunction({
+    workflowsPath: __filename,
+    workflowEnvironmentOpts: { server: { extraArgs: ['--dynamic-config-value', 'test.value=true'] } },
+  });
+  const error = await t.throwsAsync(createContext({} as any));
+  t.regex(error!.message, /workflowEnvironmentOpts\.server cannot be used/);
+});

--- a/packages/test/src/test-native-connection.ts
+++ b/packages/test/src/test-native-connection.ts
@@ -13,6 +13,7 @@ import { IllegalStateError, NativeConnection, TransportError } from '@temporalio
 import { toNativeClientOptions } from '@temporalio/worker/lib/connection-options';
 import type { temporal } from '@temporalio/proto';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
 
 const workflowServicePackageDefinition = protoLoader.loadSync(
@@ -425,7 +426,9 @@ test('all TestService methods are implemented', async (t) => {
   server.forceShutdown();
 });
 
-test('can power workflow client calls', async (t) => {
+const localTest = requiresLocalServer('creates an ephemeral server for native connection client calls', test);
+
+localTest('can power workflow client calls', async (t) => {
   const env = await TestWorkflowEnvironment.createLocal();
   try {
     {

--- a/packages/test/src/test-payload-size-limits.ts
+++ b/packages/test/src/test-payload-size-limits.ts
@@ -13,7 +13,7 @@ import type { LogEntry } from '@temporalio/worker';
 import { Client, WorkflowFailedError } from '@temporalio/client';
 import proto from '@temporalio/proto'; // eslint-disable-line import/default
 import { TestWorkflowEnvironment } from '@temporalio/testing';
-import { waitUntil } from '@temporalio/test-helpers';
+import { requiresLocalServer, waitUntil } from '@temporalio/test-helpers';
 import { Worker } from './helpers';
 import * as activities from './activities';
 import { payloadSizeLimitsWorkflow } from './workflows/payload-size-limits';
@@ -58,7 +58,9 @@ async function withLocalEnv(fn: (env: TestWorkflowEnvironment) => Promise<void>)
   }
 }
 
-test.serial('oversized worker completion is failed by core with a [TMPRL1103] error log', async (t) => {
+const localTest = requiresLocalServer('configures dev server payload size limits', test);
+
+localTest.serial('oversized worker completion is failed by core with a [TMPRL1103] error log', async (t) => {
   capturedLogs.length = 0;
   await withLocalEnv(async (env) => {
     const worker = await Worker.create({
@@ -102,7 +104,7 @@ test.serial('oversized worker completion is failed by core with a [TMPRL1103] er
   });
 });
 
-test.serial('disablePayloadErrorLimit sends the oversized payload to the server', async (t) => {
+localTest.serial('disablePayloadErrorLimit sends the oversized payload to the server', async (t) => {
   await withLocalEnv(async (env) => {
     const worker = await Worker.create({
       connection: env.nativeConnection,
@@ -129,7 +131,7 @@ test.serial('disablePayloadErrorLimit sends the oversized payload to the server'
   });
 });
 
-test.serial('connection payloadsWarnSize produces a forwarded [TMPRL1103] warning', async (t) => {
+localTest.serial('connection payloadsWarnSize produces a forwarded [TMPRL1103] warning', async (t) => {
   capturedLogs.length = 0;
   await withLocalEnv(async (env) => {
     // The warn threshold is configured on the (worker's) connection and forwarded to core.
@@ -168,7 +170,7 @@ test.serial('connection payloadsWarnSize produces a forwarded [TMPRL1103] warnin
   });
 });
 
-test.serial('connection memoWarnSize produces a forwarded [TMPRL1103] warning', async (t) => {
+localTest.serial('connection memoWarnSize produces a forwarded [TMPRL1103] warning', async (t) => {
   capturedLogs.length = 0;
   await withLocalEnv(async (env) => {
     const connection = await NativeConnection.connect({

--- a/packages/test/src/test-plugins.ts
+++ b/packages/test/src/test-plugins.ts
@@ -12,6 +12,7 @@ import type {
 } from '@temporalio/worker';
 import { Worker, bundleWorkflowCode } from '@temporalio/worker';
 import { SimplePlugin } from '@temporalio/plugin';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import { activityWorkflow, helloWorkflow } from './workflows/plugins';
 import { TestWorkflowEnvironment } from './helpers';
 
@@ -20,7 +21,7 @@ import * as activities from './activities';
 interface Context {
   testEnv: TestWorkflowEnvironment;
 }
-const test = anyTest as TestFn<Context>;
+const test = requiresLocalServer('creates an ephemeral server to test environment plugins', anyTest as TestFn<Context>);
 
 test.before(async (t) => {
   t.context = {

--- a/packages/test/src/test-runtime-otel.ts
+++ b/packages/test/src/test-runtime-otel.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'crypto';
 import test from 'ava';
 import { WorkflowClient } from '@temporalio/client';
 import { Runtime } from '@temporalio/worker';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import { TestWorkflowEnvironment, Worker } from './helpers';
 import * as workflows from './workflows';
 
@@ -103,7 +104,9 @@ test.serial('Runtime.install() accepts metrics.otel.url without headers', async 
   }
 });
 
-test.serial('Exporting OTEL metrics from Core works', async (t) => {
+const localTest = requiresLocalServer('creates an ephemeral server to generate worker metrics', test);
+
+localTest.serial('Exporting OTEL metrics from Core works', async (t) => {
   let resolveCapturedRequest = (_req: http2.Http2ServerRequest) => undefined as void;
   const capturedRequest = new Promise<http2.Http2ServerRequest>((r) => (resolveCapturedRequest = r));
   try {
@@ -155,7 +158,7 @@ test.serial('Exporting OTEL metrics from Core works', async (t) => {
   }
 });
 
-test.serial('Exporting OTEL metrics using OTLP/HTTP from Core works', async (t) => {
+localTest.serial('Exporting OTEL metrics using OTLP/HTTP from Core works', async (t) => {
   let resolveCapturedRequest = (_req: http.IncomingMessage) => undefined as void;
   const capturedRequest = new Promise<http.IncomingMessage>((r) => (resolveCapturedRequest = r));
   try {

--- a/packages/test/src/test-runtime-prometheus.ts
+++ b/packages/test/src/test-runtime-prometheus.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import test from 'ava';
 import { WorkflowClient } from '@temporalio/client';
 import { Runtime } from '@temporalio/worker';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import { Worker, getRandomPort, TestWorkflowEnvironment, assertEventually } from './helpers';
 import * as workflows from './workflows';
 
@@ -27,7 +28,9 @@ test.serial(
   }
 );
 
-test.serial('Exporting Prometheus metrics from Core works', async (t) => {
+const localTest = requiresLocalServer('creates an ephemeral server to generate worker metrics', test);
+
+localTest.serial('Exporting Prometheus metrics from Core works', async (t) => {
   const port = await getRandomPort();
   Runtime.install({
     telemetryOptions: {
@@ -66,7 +69,7 @@ test.serial('Exporting Prometheus metrics from Core works', async (t) => {
   }
 });
 
-test.serial('Exporting Prometheus metrics from Core works with lots of options', async (t) => {
+localTest.serial('Exporting Prometheus metrics from Core works with lots of options', async (t) => {
   const port = await getRandomPort();
   Runtime.install({
     telemetryOptions: {

--- a/packages/test/src/test-signal-query-patch.ts
+++ b/packages/test/src/test-signal-query-patch.ts
@@ -1,10 +1,13 @@
 import crypto from 'crypto';
 import test from 'ava';
 import * as wf from '@temporalio/workflow';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import { Worker, TestWorkflowEnvironment } from './helpers';
 import * as workflows from './workflows/signal-query-patch-pre-patch';
 
-test('Signal+Query+Patch does not cause non-determinism error on replay', async (t) => {
+const localTest = requiresLocalServer('creates an ephemeral server for a worker replacement test', test);
+
+localTest('Signal+Query+Patch does not cause non-determinism error on replay', async (t) => {
   const env = await TestWorkflowEnvironment.createLocal();
   try {
     const workflowId = crypto.randomUUID();

--- a/packages/test/src/test-standalone-activities.ts
+++ b/packages/test/src/test-standalone-activities.ts
@@ -13,6 +13,7 @@ import {
 } from '@temporalio/client';
 import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
 import { activityInfo } from '@temporalio/activity';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import type { TestWorkflowEnvironment } from './helpers';
 import { RUN_INTEGRATION_TESTS, waitUntil, Worker } from './helpers';
 import { echo, throwAnError } from './activities';
@@ -71,7 +72,10 @@ const defaultOptions: Omit<ActivityOptions, 'id' | 'args'> = {
   idReusePolicy: 'ALLOW_DUPLICATE',
 };
 
-const test = anyTest as TestFn<Context>;
+const test = requiresLocalServer(
+  'configures dev server standalone-activity capabilities and polling timeouts',
+  anyTest as TestFn<Context>
+);
 
 async function waitForValue<T>(subject: rxjs.Subject<T>, value: T) {
   await rxjs.firstValueFrom(subject.pipe(rxjs.first((v) => v === value)));

--- a/packages/test/src/test-testenvironment.ts
+++ b/packages/test/src/test-testenvironment.ts
@@ -5,6 +5,7 @@ import { WorkflowFailedError } from '@temporalio/client';
 import { workflowInterceptorModules } from '@temporalio/testing';
 import type { WorkflowBundleWithSourceMap } from '@temporalio/worker';
 import { bundleWorkflowCode } from '@temporalio/worker';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import {
   assertFromWorkflow,
   asyncChildStarter,
@@ -20,7 +21,10 @@ interface Context {
   bundle: WorkflowBundleWithSourceMap;
 }
 
-const testTimeSkipping = anyTestTimeSkipping as TestFn<Context>;
+const testTimeSkipping = requiresLocalServer(
+  'uses the time-skipping test server',
+  anyTestTimeSkipping as TestFn<Context>
+);
 
 testTimeSkipping.before(async (t) => {
   t.context = {

--- a/packages/test/src/test-worker-connection-replacement.ts
+++ b/packages/test/src/test-worker-connection-replacement.ts
@@ -6,6 +6,7 @@ import { waitUntil } from './helpers';
 
 const test = makeTestFunction({
   workflowsPath: __filename,
+  requiresLocalServer: 'starts a second ephemeral server to replace the worker connection',
 });
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/test/src/test-worker-poller-autoscale.ts
+++ b/packages/test/src/test-worker-poller-autoscale.ts
@@ -1,11 +1,14 @@
 import { randomUUID } from 'crypto';
 import test from 'ava';
 import { Runtime, Worker } from '@temporalio/worker';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import { getRandomPort, TestWorkflowEnvironment, assertEventually } from './helpers';
 import * as activities from './activities';
 import * as workflows from './workflows';
 
-test.serial('Can run autoscaling polling worker', async (t) => {
+const localTest = requiresLocalServer('creates an ephemeral server to exercise autoscaling pollers', test);
+
+localTest.serial('Can run autoscaling polling worker', async (t) => {
   const port = await getRandomPort();
   Runtime.install({
     telemetryOptions: {

--- a/packages/test/src/test-workflow-log-interceptor.ts
+++ b/packages/test/src/test-workflow-log-interceptor.ts
@@ -3,6 +3,7 @@ import type { TestFn, ExecutionContext } from 'ava';
 import anyTest from 'ava';
 import type { InjectedSinks, LogEntry, LogLevel, LoggerSinks } from '@temporalio/worker';
 import { DefaultLogger, Runtime, defaultSinks } from '@temporalio/worker';
+import { requiresLocalServer } from '@temporalio/test-helpers';
 import type { WorkflowInfo } from '@temporalio/workflow';
 import * as workflows from './workflows';
 import { Worker, TestWorkflowEnvironment } from './helpers';
@@ -11,7 +12,7 @@ interface Context {
   testEnv: TestWorkflowEnvironment;
   taskQueue: string;
 }
-const test = anyTest as TestFn<Context>;
+const test = requiresLocalServer('uses an ephemeral server with the default namespace', anyTest as TestFn<Context>);
 
 const recordedLogs: { [workflowId: string]: LogEntry[] } = {};
 


### PR DESCRIPTION
Several TypeScript integration tests intentionally start an ephemeral or time-skipping server, inject dynamic configuration, assert dev-server-specific errors, or create a second server. Those behaviors cannot be redirected to a persistent Cloud namespace and need an explicit classification before the normal AVA suite can run through envconfig.

This stacked change applies the local-server annotation at the narrowest practical scope: entire suites when their setup is local-only, and individual test aliases when the rest of the file remains Cloud-capable. It covers ephemeral-server and envconfig bridge tests, payload and polling configuration, time skipping, secondary-server replacement, plugin environments, and direct local runtime/connection cases. Tests that merely still use implicit localhost are intentionally not marked; they remain visible for harness migration.

Formatter-only indentation churn was removed before publication. Prettier, focused ESLint, and `git diff --check` pass.

Depends on the local-server annotation base PR. Part of temporalio/features#851.