### PR TITLE
Use configured test environments in client integration suites

### DIFF
--- a/packages/test/src/test-async-completion.ts
+++ b/packages/test/src/test-async-completion.ts
@@ -4,26 +4,23 @@ import anyTest from 'ava';
 import type { Observable } from 'rxjs';
 import { ReplaySubject, firstValueFrom } from 'rxjs';
 import { filter } from 'rxjs/operators';
-import type { ConnectionLike } from '@temporalio/client';
-import {
-  ActivityCancelledError,
-  Client,
-  ActivityNotFoundError,
-  WorkflowFailedError,
-  Connection,
-} from '@temporalio/client';
+import type { Connection, ConnectionLike } from '@temporalio/client';
+import type { TestWorkflowEnvironment } from '@temporalio/test-helpers';
+import { ActivityCancelledError, Client, ActivityNotFoundError, WorkflowFailedError } from '@temporalio/client';
 import type { Info } from '@temporalio/activity';
 import type { ActivitySerializationContext } from '@temporalio/common';
 import { ApplicationFailure, defaultPayloadConverter, fromPayloadsAtIndex, rootCause } from '@temporalio/common';
 import type { temporal } from '@temporalio/proto';
 import { isCancellation } from '@temporalio/workflow';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { runAnAsyncActivity } from './workflows';
 import { createActivities } from './activities/async-completer';
 import { activityCtx, enc, makeContextTrace } from './payload-converters/serialization-context-converter';
 import type { ContextTrace } from './payload-converters/serialization-context-converter';
 
 export interface Context {
+  env: TestWorkflowEnvironment;
   worker: Worker;
   client: Client;
   activityStarted$: Observable<Info>;
@@ -64,7 +61,7 @@ async function makeNotFoundTaskToken(conn: Connection, namespace: string): Promi
   return new Uint8Array(buf);
 }
 
-const taskQueue = 'async-activity-completion';
+const taskQueue = `async-activity-completion-${randomUUID()}`;
 const test = anyTest as TestFn<Context>;
 const TASK_TOKEN = new Uint8Array([1]);
 const dataConverter = {
@@ -239,31 +236,35 @@ test('AsyncCompletionClient heartbeat with task token uses explicit activity con
 
 if (RUN_INTEGRATION_TESTS) {
   test.before(async (t) => {
+    const env = await createTestWorkflowEnvironment();
     const infoSubject = new ReplaySubject<Info>();
 
     const worker = await Worker.create({
       workflowsPath: require.resolve('./workflows'),
       activities: createActivities(infoSubject),
       taskQueue,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
     const runPromise = worker.run();
     // Catch the error here to avoid unhandled rejection
     runPromise.catch((err) => {
       console.error('Caught error while worker was running', err);
     });
-    const connection = await Connection.connect();
     t.context = {
       worker,
       runPromise,
       activityStarted$: infoSubject,
-      client: new Client({ connection }),
-      notFoundTaskToken: await makeNotFoundTaskToken(connection, 'default'),
+      client: new Client({ connection: env.connection, namespace: env.namespace }),
+      notFoundTaskToken: await makeNotFoundTaskToken(env.connection, env.client.options.namespace),
+      env,
     };
   });
 
   test.after.always(async (t) => {
     t.context.worker.shutdown();
     await t.context.runPromise;
+    await t.context.env.teardown();
   });
 
   test('Activity can complete asynchronously', async (t) => {

--- a/packages/test/src/test-bundler.ts
+++ b/packages/test/src/test-bundler.ts
@@ -11,12 +11,14 @@ import test from 'ava';
 import { moduleMatches } from '@temporalio/worker/lib/workflow/bundler';
 import type { LogEntry, WorkerOptions } from '@temporalio/worker';
 import { bundleWorkflowCode, DefaultLogger } from '@temporalio/worker';
-import { Client } from '@temporalio/client';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { issue516 } from './mocks/workflows-with-node-dependencies/issue-516';
 import { preloadSharedCounter } from './workflows/preload-shared-counter';
 import { workflowWithPrebundledDep } from './workflows/workflow-with-prebundled-dep';
 import { successString } from './workflows';
+
+let env: Awaited<ReturnType<typeof createTestWorkflowEnvironment>>;
 
 test('moduleMatches works', (t) => {
   t.true(moduleMatches('fs', ['fs']));
@@ -29,10 +31,12 @@ async function runPreloadSharedCounter(
   workerOptions: Pick<WorkerOptions, 'bundlerOptions' | 'workflowBundle' | 'workflowsPath'>
 ): Promise<[number, number]> {
   const taskQueue = `${t.title}-${randomUUID()}`;
-  const client = new Client();
+  const client = env.client;
   const worker = await Worker.create({
     taskQueue,
     reuseV8Context: true,
+    connection: env.nativeConnection,
+    namespace: env.namespace,
     ...workerOptions,
   });
   return await worker.runUntil(async () => {
@@ -43,6 +47,13 @@ async function runPreloadSharedCounter(
 }
 
 if (RUN_INTEGRATION_TESTS) {
+  test.before(async () => {
+    env = await createTestWorkflowEnvironment();
+  });
+  test.after.always(async () => {
+    await env.teardown();
+  });
+
   test('Worker can be created from bundle code', async (t) => {
     const taskQueue = `${t.title}-${randomUUID()}`;
     const workflowBundle = await bundleWorkflowCode({
@@ -51,8 +62,10 @@ if (RUN_INTEGRATION_TESTS) {
     const worker = await Worker.create({
       taskQueue,
       workflowBundle,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
-    const client = new Client();
+    const client = env.client;
     await worker.runUntil(client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
     t.pass();
   });
@@ -69,8 +82,10 @@ if (RUN_INTEGRATION_TESTS) {
     const worker = await Worker.create({
       taskQueue,
       workflowBundle,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
-    const client = new Client();
+    const client = env.client;
     try {
       await worker.runUntil(client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
     } finally {
@@ -88,8 +103,10 @@ if (RUN_INTEGRATION_TESTS) {
     const worker = await Worker.create({
       taskQueue,
       workflowBundle,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
-    const client = new Client();
+    const client = env.client;
     await worker.runUntil(client.workflow.execute(issue516, { taskQueue, workflowId: randomUUID() }));
     t.pass();
   });
@@ -119,6 +136,8 @@ if (RUN_INTEGRATION_TESTS) {
       Worker.create({
         taskQueue,
         workflowsPath: require.resolve('./workflows'),
+        connection: env.nativeConnection,
+        namespace: env.namespace,
         bundlerOptions: {
           webpackConfigHook: (config) => {
             t.is(config.mode, 'development');
@@ -245,8 +264,14 @@ if (RUN_INTEGRATION_TESTS) {
     const workflowBundle = await bundleWorkflowCode({
       workflowsPath: require.resolve('./workflows/workflow-with-prebundled-dep'),
     });
-    const client = new Client();
-    const worker = await Worker.create({ taskQueue, reuseV8Context: true, workflowBundle });
+    const client = env.client;
+    const worker = await Worker.create({
+      taskQueue,
+      reuseV8Context: true,
+      workflowBundle,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
+    });
     const results = await worker.runUntil(async () => {
       const first = await client.workflow.execute(workflowWithPrebundledDep, { taskQueue, workflowId: randomUUID() });
       const second = await client.workflow.execute(workflowWithPrebundledDep, { taskQueue, workflowId: randomUUID() });

--- a/packages/test/src/test-custom-payload-codec.ts
+++ b/packages/test/src/test-custom-payload-codec.ts
@@ -6,6 +6,7 @@ import { decode } from '@temporalio/common/lib/encoding';
 import type { InjectedSinks } from '@temporalio/worker';
 import { createConcatActivity } from './activities/create-concat-activity';
 import { RUN_INTEGRATION_TESTS, u8, Worker } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { defaultOptions } from './mock-native-worker';
 import type { LogSinks } from './workflows';
 import { twoStrings, twoStringsActivity } from './workflows';
@@ -37,6 +38,15 @@ class TestDecodeCodec implements PayloadCodec {
 }
 
 if (RUN_INTEGRATION_TESTS) {
+  let env: Awaited<ReturnType<typeof createTestWorkflowEnvironment>>;
+
+  test.before(async () => {
+    env = await createTestWorkflowEnvironment();
+  });
+  test.after.always(async () => {
+    await env.teardown();
+  });
+
   test('Workflow arguments and retvals are encoded', async (t) => {
     const logs: string[] = [];
     const sinks: InjectedSinks<LogSinks> = {
@@ -50,14 +60,16 @@ if (RUN_INTEGRATION_TESTS) {
     };
 
     const dataConverter = { payloadCodecs: [new TestEncodeCodec()] };
-    const taskQueue = 'test-workflow-encoded';
+    const taskQueue = `test-workflow-encoded-${randomUUID()}`;
     const worker = await Worker.create({
       ...defaultOptions,
       taskQueue,
       dataConverter,
       sinks,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
-    const client = new WorkflowClient({ dataConverter });
+    const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace, dataConverter });
     await worker.runUntil(async () => {
       const result = await client.execute(twoStrings, {
         args: ['arg1', 'arg2'],
@@ -83,14 +95,16 @@ if (RUN_INTEGRATION_TESTS) {
     };
 
     const dataConverter = { payloadCodecs: [new TestDecodeCodec()] };
-    const taskQueue = 'test-workflow-decoded';
+    const taskQueue = `test-workflow-decoded-${randomUUID()}`;
     const worker = await Worker.create({
       ...defaultOptions,
       taskQueue,
       dataConverter,
       sinks,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
-    const client = new WorkflowClient({ dataConverter });
+    const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace, dataConverter });
     await worker.runUntil(async () => {
       const result = await client.execute(twoStrings, {
         args: ['arg1', 'arg2'],
@@ -117,15 +131,17 @@ if (RUN_INTEGRATION_TESTS) {
     const activityLogs: string[] = [];
 
     const dataConverter = { payloadCodecs: [new TestEncodeCodec()] };
-    const taskQueue = 'test-activity-encoded';
+    const taskQueue = `test-activity-encoded-${randomUUID()}`;
     const worker = await Worker.create({
       ...defaultOptions,
       activities: createConcatActivity(activityLogs),
       taskQueue,
       dataConverter,
       sinks,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
-    const client = new WorkflowClient({ dataConverter });
+    const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace, dataConverter });
     await worker.runUntil(async () => {
       await client.execute(twoStringsActivity, {
         workflowId: randomUUID(),
@@ -150,15 +166,17 @@ if (RUN_INTEGRATION_TESTS) {
     const activityLogs: string[] = [];
 
     const dataConverter = { payloadCodecs: [new TestDecodeCodec()] };
-    const taskQueue = 'test-activity-decoded';
+    const taskQueue = `test-activity-decoded-${randomUUID()}`;
     const worker = await Worker.create({
       ...defaultOptions,
       activities: createConcatActivity(activityLogs),
       taskQueue,
       dataConverter,
       sinks,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
-    const client = new WorkflowClient({ dataConverter });
+    const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace, dataConverter });
     await worker.runUntil(async () => {
       await client.execute(twoStringsActivity, {
         workflowId: randomUUID(),
@@ -197,14 +215,16 @@ if (RUN_INTEGRATION_TESTS) {
         },
       ],
     };
-    const taskQueue = 'test-workflow-encoded-order';
+    const taskQueue = `test-workflow-encoded-order-${randomUUID()}`;
     const worker = await Worker.create({
       ...defaultOptions,
       taskQueue,
       dataConverter,
       sinks,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
-    const client = new WorkflowClient({ dataConverter });
+    const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace, dataConverter });
     await worker.runUntil(async () => {
       const result = await client.execute(twoStrings, {
         args: ['arg1', 'arg2'],
@@ -246,14 +266,16 @@ if (RUN_INTEGRATION_TESTS) {
         new TestDecodeCodec(),
       ],
     };
-    const taskQueue = 'test-workflow-decoded-order';
+    const taskQueue = `test-workflow-decoded-order-${randomUUID()}`;
     const worker = await Worker.create({
       ...defaultOptions,
       taskQueue,
       dataConverter,
       sinks,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
-    const client = new WorkflowClient({ dataConverter });
+    const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace, dataConverter });
     await worker.runUntil(async () => {
       const result = await client.execute(twoStrings, {
         args: ['arg1', 'arg2'],

--- a/packages/test/src/test-custom-payload-converter.ts
+++ b/packages/test/src/test-custom-payload-converter.ts
@@ -62,8 +62,10 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('fromPayload throws on Client when receiving result from client.execute()', async (t) => {
+    const taskQueue = `test-custom-payload-converter-error-${randomUUID()}`;
     const worker = await Worker.create({
       ...defaultOptions,
+      taskQueue,
       connection: env.nativeConnection,
       namespace: env.namespace,
     });
@@ -78,7 +80,7 @@ if (RUN_INTEGRATION_TESTS) {
     await worker.runUntil(
       t.throwsAsync(
         client.execute(workflows.successString, {
-          taskQueue: 'test',
+          taskQueue,
           workflowId: randomUUID(),
         }),
         {

--- a/packages/test/src/test-custom-payload-converter.ts
+++ b/packages/test/src/test-custom-payload-converter.ts
@@ -7,6 +7,7 @@ import { coresdk } from '@temporalio/proto';
 import { ProtoActivityResult } from '../protos/root';
 import { protoActivity } from './activities';
 import { cleanOptionalStackTrace, RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { defaultOptions, isolateFreeWorker } from './mock-native-worker';
 import { messageInstance, payloadConverter } from './payload-converters/proto-payload-converter';
 import * as workflows from './workflows';
@@ -28,16 +29,27 @@ function compareCompletion(
 }
 
 if (RUN_INTEGRATION_TESTS) {
+  let env: Awaited<ReturnType<typeof createTestWorkflowEnvironment>>;
+
+  test.before(async () => {
+    env = await createTestWorkflowEnvironment();
+  });
+  test.after.always(async () => {
+    await env.teardown();
+  });
+
   test('Client and Worker work with provided dataConverter', async (t) => {
     const dataConverter = { payloadConverterPath: require.resolve('./payload-converters/proto-payload-converter') };
-    const taskQueue = 'test-custom-payload-converter';
+    const taskQueue = `test-custom-payload-converter-${randomUUID()}`;
     const worker = await Worker.create({
       ...defaultOptions,
       workflowsPath: require.resolve('./workflows/protobufs'),
       taskQueue,
       dataConverter,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
-    const client = new WorkflowClient({ dataConverter });
+    const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace, dataConverter });
     await worker.runUntil(async () => {
       const result = await client.execute(protobufWorkflow, {
         args: [messageInstance],
@@ -52,12 +64,16 @@ if (RUN_INTEGRATION_TESTS) {
   test('fromPayload throws on Client when receiving result from client.execute()', async (t) => {
     const worker = await Worker.create({
       ...defaultOptions,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
 
     const client = new WorkflowClient({
       dataConverter: {
         payloadConverterPath: require.resolve('./payload-converters/payload-converter-throws-from-payload'),
       },
+      connection: env.connection,
+      namespace: env.namespace,
     });
     await worker.runUntil(
       t.throwsAsync(

--- a/packages/test/src/test-interceptors.ts
+++ b/packages/test/src/test-interceptors.ts
@@ -14,6 +14,7 @@ import { DefaultLogger, Runtime } from '@temporalio/worker';
 import type { WorkflowInfo } from '@temporalio/workflow';
 import { defaultPayloadConverter } from '@temporalio/workflow';
 import { isBun, cleanOptionalStackTrace, compareStackTrace, RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { defaultOptions } from './mock-native-worker';
 import {
   checkDisposeRan,
@@ -28,17 +29,27 @@ import {
 import { getSecretQuery, unblockWithSecretSignal } from './workflows/interceptor-example';
 
 if (RUN_INTEGRATION_TESTS) {
+  let env: Awaited<ReturnType<typeof createTestWorkflowEnvironment>>;
+
   test.before(() => {
     Runtime.install({ logger: new DefaultLogger('DEBUG') });
   });
+  test.before(async () => {
+    env = await createTestWorkflowEnvironment();
+  });
+  test.after.always(async () => {
+    await env.teardown();
+  });
 
   test.serial('Tracing can be implemented using interceptors', async (t) => {
-    const taskQueue = 'test-interceptors';
+    const taskQueue = `test-interceptors-${randomUUID()}`;
     const message = randomUUID();
 
     const worker = await Worker.create({
       ...defaultOptions,
       taskQueue,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
       interceptors: {
         activity: [
           () => ({
@@ -55,6 +66,8 @@ if (RUN_INTEGRATION_TESTS) {
       },
     });
     const client = new WorkflowClient({
+      connection: env.connection,
+      namespace: env.namespace,
       interceptors: [
         {
           async start(input, next) {
@@ -132,14 +145,18 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test.serial('(Legacy) WorkflowClientCallsInterceptor intercepts terminate and cancel', async (t) => {
-    const taskQueue = 'test-interceptor-term-and-cancel';
+    const taskQueue = `test-interceptor-term-and-cancel-${randomUUID()}`;
     const message = randomUUID();
     // Use these to coordinate with workflow activation to complete only after termination
     const worker = await Worker.create({
       ...defaultOptions,
       taskQueue,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
     const client = new WorkflowClient({
+      connection: env.connection,
+      namespace: env.namespace,
       interceptors: {
         calls: [
           () => ({
@@ -176,14 +193,18 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test.serial('WorkflowClientInterceptor intercepts terminate and cancel', async (t) => {
-    const taskQueue = 'test-interceptor-term-and-cancel';
+    const taskQueue = `test-interceptor-term-and-cancel-${randomUUID()}`;
     const message = randomUUID();
     // Use these to coordinate with workflow activation to complete only after termination
     const worker = await Worker.create({
       ...defaultOptions,
       taskQueue,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
     const client = new WorkflowClient({
+      connection: env.connection,
+      namespace: env.namespace,
       interceptors: [
         {
           async terminate(input, next) {
@@ -218,7 +239,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test.serial('Workflow continueAsNew can be intercepted', async (t) => {
-    const taskQueue = 'test-continue-as-new-interceptor';
+    const taskQueue = `test-continue-as-new-interceptor-${randomUUID()}`;
     const worker = await Worker.create({
       ...defaultOptions,
       taskQueue,
@@ -226,8 +247,10 @@ if (RUN_INTEGRATION_TESTS) {
         // Includes an interceptor for ContinueAsNew that will throw an error when used with the workflow below
         workflowModules: [require.resolve('./workflows/interceptor-example')],
       },
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
-    const client = new WorkflowClient();
+    const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace });
     const err = await worker.runUntil(async () => {
       return (await t.throwsAsync(
         client.execute(continueAsNewToDifferentWorkflow, {
@@ -268,7 +291,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test.serial('Internals can be intercepted for observing Workflow state changes', async (t) => {
-    const taskQueue = 'test-internals-interceptor';
+    const taskQueue = `test-internals-interceptor-${randomUUID()}`;
 
     const events = Array<string>();
     const worker = await Worker.create({
@@ -287,8 +310,10 @@ if (RUN_INTEGRATION_TESTS) {
           },
         },
       },
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
-    const client = new WorkflowClient();
+    const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace });
     await worker.runUntil(
       client.execute(internalsInterceptorExample, {
         taskQueue,
@@ -299,16 +324,18 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test.serial('Internal interceptor disposes in reusable VM', async (t) => {
-    const taskQueue = 'test-reusable-vm-internal-interceptor-disposes';
+    const taskQueue = `test-reusable-vm-internal-interceptor-disposes-${randomUUID()}`;
     const worker = await Worker.create({
       ...defaultOptions,
       taskQueue,
       interceptors: {
         workflowModules: [require.resolve('./workflows/internal-interceptor-dispose-global')],
       },
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
 
-    const client = new WorkflowClient();
+    const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace });
     await worker.runUntil(async () => {
       const disposeFlagSet = await client.execute(initAndResetFlag, {
         taskQueue,
@@ -333,13 +360,15 @@ if (RUN_INTEGRATION_TESTS) {
   // CancellationScope.current().cancel() to clean up.
   // When storage is disabled, this incorrectly cancels the rootScope, failing the workflow with "Workflow cancelled".
   test.serial('workflow disposal does not break CancellationScope in other workflows in reusable vm', async (t) => {
-    const taskQueue = 'test-reusable-vm-disposal-cancellation-scope';
+    const taskQueue = `test-reusable-vm-disposal-cancellation-scope-${randomUUID()}`;
     const worker = await Worker.create({
       ...defaultOptions,
       taskQueue,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
 
-    const client = new WorkflowClient();
+    const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace });
     const result = await worker.runUntil(async () => {
       // Fill the cache with workflow that complete immediately
       await client.execute(successString, { taskQueue, workflowId: randomUUID() });

--- a/packages/test/src/test-nyc-coverage.ts
+++ b/packages/test/src/test-nyc-coverage.ts
@@ -2,9 +2,10 @@ import { randomUUID } from 'crypto';
 import test from 'ava';
 import * as libCoverage from 'istanbul-lib-coverage';
 import { bundleWorkflowCode, Worker } from '@temporalio/worker';
-import { Client, WorkflowClient } from '@temporalio/client';
+import { WorkflowClient } from '@temporalio/client';
 import { WorkflowCoverage } from '@temporalio/nyc-test-coverage';
 import { RUN_INTEGRATION_TESTS } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { successString } from './workflows';
 
 declare global {
@@ -12,6 +13,15 @@ declare global {
 }
 
 if (RUN_INTEGRATION_TESTS) {
+  let env: Awaited<ReturnType<typeof createTestWorkflowEnvironment>>;
+
+  test.before(async () => {
+    env = await createTestWorkflowEnvironment();
+  });
+  test.after.always(async () => {
+    await env.teardown();
+  });
+
   test('Istanbul injector execute correctly in Worker', async (t) => {
     // Make it believe that NYC has been loaded
     (global as any).__coverage__ = {};
@@ -23,9 +33,11 @@ if (RUN_INTEGRATION_TESTS) {
       workflowCoverage.augmentWorkerOptions({
         taskQueue,
         workflowsPath: require.resolve('./workflows'),
+        connection: env.nativeConnection,
+        namespace: env.namespace,
       })
     );
-    const client = new Client();
+    const client = env.client;
     await worker.runUntil(client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
 
     workflowCoverage.mergeIntoGlobalCoverage();
@@ -54,9 +66,11 @@ if (RUN_INTEGRATION_TESTS) {
       workflowCoverageWorker.augmentWorkerOptionsWithBundle({
         taskQueue,
         workflowBundle: { code },
+        connection: env.nativeConnection,
+        namespace: env.namespace,
       })
     );
-    const client = new Client();
+    const client = env.client;
     await worker.runUntil(client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
 
     workflowCoverageBundler.mergeIntoGlobalCoverage();
@@ -81,9 +95,11 @@ if (RUN_INTEGRATION_TESTS) {
       workflowCoverage.augmentWorkerOptions({
         taskQueue,
         workflowsPath: require.resolve('./workflows'),
+        connection: env.nativeConnection,
+        namespace: env.namespace,
       })
     );
-    const client = new WorkflowClient();
+    const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace });
     await worker.runUntil(client.execute(successString, { taskQueue, workflowId: randomUUID() }));
 
     workflowCoverage.mergeIntoGlobalCoverage();

--- a/packages/test/src/test-patch-and-condition.ts
+++ b/packages/test/src/test-patch-and-condition.ts
@@ -18,10 +18,11 @@ if (RUN_INTEGRATION_TESTS) {
   test('Patch in condition does not cause non-determinism error on replay', async (t) => {
     const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace });
     const workflowId = crypto.randomUUID();
+    const taskQueue = `patch-in-condition-${crypto.randomUUID()}`;
 
     // Create the first worker with pre-patched version of the workflow
     const worker1 = await Worker.create({
-      taskQueue: 'patch-in-condition',
+      taskQueue,
       workflowsPath: require.resolve('./workflows/patch-and-condition-pre-patch'),
       // Avoid waiting for sticky execution timeout on each worker transition
       maxCachedWorkflows: 0,
@@ -32,7 +33,7 @@ if (RUN_INTEGRATION_TESTS) {
     // Start the workflow and wait for the first task to be processed
     const handle = await worker1.runUntil(async () => {
       const handle = await client.start(workflows.patchInCondition, {
-        taskQueue: 'patch-in-condition',
+        taskQueue,
         workflowId,
       });
       await handle.query('__temporal_workflow_metadata');
@@ -41,7 +42,7 @@ if (RUN_INTEGRATION_TESTS) {
 
     // Create the second worker with post-patched version of the workflow
     const worker2 = await Worker.create({
-      taskQueue: 'patch-in-condition',
+      taskQueue,
       workflowsPath: require.resolve('./workflows/patch-and-condition-post-patch'),
       maxCachedWorkflows: 0,
       connection: env.nativeConnection,
@@ -56,7 +57,7 @@ if (RUN_INTEGRATION_TESTS) {
 
     // Create the third worker that is identical to the second one
     const worker3 = await Worker.create({
-      taskQueue: 'patch-in-condition',
+      taskQueue,
       workflowsPath: require.resolve('./workflows/patch-and-condition-post-patch'),
       maxCachedWorkflows: 0,
       connection: env.nativeConnection,

--- a/packages/test/src/test-patch-and-condition.ts
+++ b/packages/test/src/test-patch-and-condition.ts
@@ -2,11 +2,21 @@ import crypto from 'crypto';
 import test from 'ava';
 import { WorkflowClient } from '@temporalio/client';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import * as workflows from './workflows/patch-and-condition-pre-patch';
 
 if (RUN_INTEGRATION_TESTS) {
+  let env: Awaited<ReturnType<typeof createTestWorkflowEnvironment>>;
+
+  test.before(async () => {
+    env = await createTestWorkflowEnvironment();
+  });
+  test.after.always(async () => {
+    await env.teardown();
+  });
+
   test('Patch in condition does not cause non-determinism error on replay', async (t) => {
-    const client = new WorkflowClient();
+    const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace });
     const workflowId = crypto.randomUUID();
 
     // Create the first worker with pre-patched version of the workflow
@@ -15,6 +25,8 @@ if (RUN_INTEGRATION_TESTS) {
       workflowsPath: require.resolve('./workflows/patch-and-condition-pre-patch'),
       // Avoid waiting for sticky execution timeout on each worker transition
       maxCachedWorkflows: 0,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
 
     // Start the workflow and wait for the first task to be processed
@@ -32,6 +44,8 @@ if (RUN_INTEGRATION_TESTS) {
       taskQueue: 'patch-in-condition',
       workflowsPath: require.resolve('./workflows/patch-and-condition-post-patch'),
       maxCachedWorkflows: 0,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
 
     // Trigger a signal and wait for it to be processed
@@ -45,6 +59,8 @@ if (RUN_INTEGRATION_TESTS) {
       taskQueue: 'patch-in-condition',
       workflowsPath: require.resolve('./workflows/patch-and-condition-post-patch'),
       maxCachedWorkflows: 0,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
 
     // Trigger a workflow task that will cause replay.

--- a/packages/test/src/test-payload-converter.ts
+++ b/packages/test/src/test-payload-converter.ts
@@ -23,6 +23,7 @@ import {
 import { DefaultLogger, Runtime } from '@temporalio/worker';
 import root from '../protos/root'; // eslint-disable-line import/default
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { defaultOptions } from './mock-native-worker';
 import { messageInstance } from './payload-converters/proto-payload-converter';
 import { protobufWorkflow } from './workflows/protobufs';
@@ -188,6 +189,15 @@ test(`SearchAttributePayloadConverter doesn't fail if Array.prototype contains e
 });
 
 if (RUN_INTEGRATION_TESTS) {
+  let env: Awaited<ReturnType<typeof createTestWorkflowEnvironment>>;
+
+  test.before(async () => {
+    env = await createTestWorkflowEnvironment();
+  });
+  test.after.always(async () => {
+    await env.teardown();
+  });
+
   test('Worker throws decoding proto JSON without WorkerOptions.dataConverter', async (t) => {
     let markErrorThrown: () => void;
     const expectedErrorWasThrown = new Promise<void>((resolve) => {
@@ -206,14 +216,18 @@ if (RUN_INTEGRATION_TESTS) {
       telemetryOptions: { logging: { forward: {}, filter: 'WARN' } },
     });
 
-    const taskQueue = `${__filename}/${t.title}`;
+    const taskQueue = `${__filename}/${t.title}/${randomUUID()}`;
     const worker = await Worker.create({
       ...defaultOptions,
       workflowsPath: require.resolve('./workflows/protobufs'),
       taskQueue,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
     const client = new WorkflowClient({
       dataConverter: { payloadConverterPath: require.resolve('./payload-converters/proto-payload-converter') },
+      connection: env.connection,
+      namespace: env.namespace,
     });
 
     const handle = await client.start(protobufWorkflow, {
@@ -235,16 +249,18 @@ if (RUN_INTEGRATION_TESTS) {
   test('Worker encodes/decodes a protobuf containing a binary array', async (t) => {
     const binaryInstance = root.BinaryMessage.create({ data: encode('abc') });
     const dataConverter = { payloadConverterPath: require.resolve('./payload-converters/proto-payload-converter') };
-    const taskQueue = `${__filename}/${t.title}`;
+    const taskQueue = `${__filename}/${t.title}/${randomUUID()}`;
 
     const worker = await Worker.create({
       ...defaultOptions,
       workflowsPath: require.resolve('./workflows/echo-binary-protobuf'),
       taskQueue,
       dataConverter,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
 
-    const client = new WorkflowClient({ dataConverter });
+    const client = new WorkflowClient({ connection: env.connection, namespace: env.namespace, dataConverter });
 
     await worker.runUntil(async () => {
       const result = await client.execute(echoBinaryProtobuf, {

--- a/packages/test/src/test-signals-are-always-delivered.ts
+++ b/packages/test/src/test-signals-are-always-delivered.ts
@@ -13,16 +13,23 @@ import type { InjectedSinks } from '@temporalio/worker';
 import { DefaultLogger, Runtime } from '@temporalio/worker';
 import { defaultOptions } from './mock-native-worker';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import * as workflows from './workflows';
 
 if (RUN_INTEGRATION_TESTS) {
+  let env: Awaited<ReturnType<typeof createTestWorkflowEnvironment>>;
+
   test.before(async () => {
     Runtime.install({ logger: new DefaultLogger('DEBUG') });
+    env = await createTestWorkflowEnvironment();
+  });
+  test.after.always(async () => {
+    await env.teardown();
   });
 
   test('Signals are always delivered', async (t) => {
-    const taskQueue = 'test-signal-delivery';
-    const conn = new WorkflowClient();
+    const taskQueue = `test-signal-delivery-${randomUUID()}`;
+    const conn = new WorkflowClient({ connection: env.connection, namespace: env.namespace });
     const wf = await conn.start(workflows.signalsAreAlwaysProcessed, { taskQueue, workflowId: randomUUID() });
 
     const sinks: InjectedSinks<workflows.SignalProcessTestSinks> = {
@@ -40,6 +47,8 @@ if (RUN_INTEGRATION_TESTS) {
       ...defaultOptions,
       taskQueue,
       sinks,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
 
     await worker.runUntil(wf.result());


### PR DESCRIPTION
Several integration suites still created workers and clients with implicit localhost defaults, so the envconfig support added in #2163 could not run them against Temporal Cloud.

This migrates the client-, codec-, bundler-, interceptor-, and payload-oriented suites to one environment-owned connection and namespace per file. Worker and client lifecycles now share that environment, task queues are unique for persistent namespaces, and existing mock-only paths remain unchanged.

Validation: focused ESLint and Prettier checks pass. `pnpm --dir packages/test build` reaches TypeScript and reports only the existing `ActivityExecutionStatus.PAUSED` mismatch caused by the locally advanced `packages/core-bridge/sdk-core` submodule; no errors remain in these test files.