### PR TITLE
Use configured test environments in worker integration suites

### DIFF
--- a/packages/test/src/test-native-connection.ts
+++ b/packages/test/src/test-native-connection.ts
@@ -14,6 +14,7 @@ import { toNativeClientOptions } from '@temporalio/worker/lib/connection-options
 import type { temporal } from '@temporalio/proto';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 
 const workflowServicePackageDefinition = protoLoader.loadSync(
   path.resolve(
@@ -106,35 +107,46 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('NativeConnection.close() throws when called a second time', async (t) => {
-    const conn = await NativeConnection.connect();
-    await conn.close();
-    await t.throwsAsync(() => conn.close(), {
-      instanceOf: IllegalStateError,
-      message: 'Client already closed',
-    });
+    const env = await createTestWorkflowEnvironment();
+    try {
+      const conn = env.nativeConnection;
+      await conn.close();
+      await t.throwsAsync(() => conn.close(), {
+        instanceOf: IllegalStateError,
+        message: 'Client already closed',
+      });
+    } finally {
+      await env.teardown();
+    }
   });
 
   test('NativeConnection.close() throws if being used by a Worker and succeeds if it has been shutdown', async (t) => {
-    const connection = await NativeConnection.connect();
-    const worker = await Worker.create({
-      connection,
-      taskQueue: 'default',
-      activities: {
-        async noop() {
-          // empty placeholder
-        },
-      },
-    });
+    const env = await createTestWorkflowEnvironment();
+    const connection = env.nativeConnection;
+    let worker: Worker | undefined;
     try {
+      worker = await Worker.create({
+        connection,
+        namespace: env.namespace,
+        taskQueue: 'default',
+        activities: {
+          async noop() {
+            // empty placeholder
+          },
+        },
+      });
       await t.throwsAsync(() => connection.close(), {
         instanceOf: IllegalStateError,
         message: 'Cannot close connection while Workers hold a reference to it',
       });
     } finally {
-      const p = worker.run();
-      worker.shutdown();
-      await p;
-      await connection.close();
+      if (worker) {
+        const p = worker.run();
+        worker.shutdown();
+        await p;
+        await connection.close();
+      }
+      await env.teardown();
     }
   });
 }

--- a/packages/test/src/test-runtime.ts
+++ b/packages/test/src/test-runtime.ts
@@ -5,13 +5,12 @@
 import { randomUUID } from 'crypto';
 import asyncRetry from 'async-retry';
 import type { LogEntry } from '@temporalio/worker';
-import { Runtime, DefaultLogger, makeTelemetryFilterString, NativeConnection } from '@temporalio/worker';
-import { Client, WorkflowClient } from '@temporalio/client';
+import { Runtime, DefaultLogger, makeTelemetryFilterString } from '@temporalio/worker';
 import * as wf from '@temporalio/workflow';
 import { defaultOptions } from './mock-native-worker';
 import * as workflows from './workflows';
 import { RUN_INTEGRATION_TESTS, Worker, test } from './helpers';
-import { createTestWorkflowBundle } from './helpers-integration';
+import { createTestWorkflowBundle, createTestWorkflowEnvironment } from './helpers-integration';
 
 if (RUN_INTEGRATION_TESTS) {
   test.serial('Runtime can be created and disposed', async (t) => {
@@ -20,63 +19,81 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test.serial('Runtime tracks registered workers, shuts down and restarts as expected', async (t) => {
+    const env = await createTestWorkflowEnvironment();
     // Create 2 Workers and verify Runtime keeps running after first Worker deregisteration
-    const worker1 = await Worker.create({
-      ...defaultOptions,
-      taskQueue: 'q1',
-    });
-    const worker2 = await Worker.create({
-      ...defaultOptions,
-      taskQueue: 'q2',
-    });
-    const worker1Drained = worker1.run();
-    const worker2Drained = worker2.run();
-    worker1.shutdown();
-    await worker1Drained;
-    const client = new WorkflowClient();
-    // Run a simple workflow
-    await client.execute(workflows.sleeper, { taskQueue: 'q2', workflowId: randomUUID(), args: [1] });
-    worker2.shutdown();
-    await worker2Drained;
+    try {
+      const worker1 = await Worker.create({
+        ...defaultOptions,
+        taskQueue: 'q1',
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+      });
+      const worker2 = await Worker.create({
+        ...defaultOptions,
+        taskQueue: 'q2',
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+      });
+      const worker1Drained = worker1.run();
+      const worker2Drained = worker2.run();
+      worker1.shutdown();
+      await worker1Drained;
+      // Run a simple workflow
+      await env.client.workflow.execute(workflows.sleeper, { taskQueue: 'q2', workflowId: randomUUID(), args: [1] });
+      worker2.shutdown();
+      await worker2Drained;
 
-    const worker3 = await Worker.create({
-      ...defaultOptions,
-      taskQueue: 'q1', // Same as the first Worker created
-    });
-    const worker3Drained = worker3.run();
-    // Run a simple workflow
-    await client.execute('sleeper', { taskQueue: 'q1', workflowId: randomUUID(), args: [1] });
-    worker3.shutdown();
-    await worker3Drained;
-    // No exceptions, test passes, Runtime is implicitly shut down
-    t.pass();
+      const worker3 = await Worker.create({
+        ...defaultOptions,
+        taskQueue: 'q1',
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+      }); // Same as the first Worker created
+      const worker3Drained = worker3.run();
+      // Run a simple workflow
+      await env.client.workflow.execute('sleeper', { taskQueue: 'q1', workflowId: randomUUID(), args: [1] });
+      worker3.shutdown();
+      await worker3Drained;
+      // No exceptions, test passes, Runtime is implicitly shut down
+      t.pass();
+    } finally {
+      await env.teardown();
+    }
   });
 
   // Stopping and starting Workers is probably not a common pattern but if we don't remember what
   // Runtime configuration was installed, creating a new Worker after Runtime shutdown we would fallback
   // to the default configuration (127.0.0.1) which is surprising behavior.
   test.serial('Runtime.install() remembers installed options after it has been shut down', async (t) => {
+    const env = await createTestWorkflowEnvironment();
     const logger = new DefaultLogger('DEBUG');
     Runtime.install({ logger });
     {
       const runtime = Runtime.instance();
       t.is(runtime.options.logger, logger);
     }
-    const worker = await Worker.create({
-      ...defaultOptions,
-      taskQueue: 'q1', // Same as the first Worker created
-    });
-    const workerDrained = worker.run();
-    worker.shutdown();
-    await workerDrained;
-    {
-      const runtime = Runtime.instance();
-      t.is(runtime.options.logger, logger);
-      await runtime.shutdown();
+    try {
+      const worker = await Worker.create({
+        ...defaultOptions,
+        taskQueue: 'q1',
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+      }); // Same as the first Worker created
+      const workerDrained = worker.run();
+      worker.shutdown();
+      await workerDrained;
+      {
+        const runtime = Runtime.instance();
+        t.is(runtime.options.logger, logger);
+        await runtime.shutdown();
+      }
+    } finally {
+      await env.teardown();
     }
   });
 
   test.serial('Runtime.install() Core forwarded logs contains metadata', async (t) => {
+    const env = await createTestWorkflowEnvironment();
     const logEntries: LogEntry[] = [];
     const logger = new DefaultLogger('DEBUG', (entry) => logEntries.push(entry));
     Runtime.install({
@@ -84,10 +101,12 @@ if (RUN_INTEGRATION_TESTS) {
       telemetryOptions: { logging: { forward: {}, filter: makeTelemetryFilterString({ core: 'DEBUG' }) } },
     });
     try {
-      await new Client().workflow.start('not-existant', { taskQueue: 'q1', workflowId: randomUUID() });
+      await env.client.workflow.start('not-existant', { taskQueue: 'q1', workflowId: randomUUID() });
       const worker = await Worker.create({
         ...defaultOptions,
         taskQueue: 'q1',
+        connection: env.nativeConnection,
+        namespace: env.namespace,
       });
       await worker.runUntil(() =>
         asyncRetry(
@@ -113,6 +132,7 @@ if (RUN_INTEGRATION_TESTS) {
       t.is(typeof failingWftEntry.meta?.['sdkComponent'], 'string');
     } finally {
       await Runtime.instance().shutdown();
+      await env.teardown();
     }
   });
 
@@ -128,8 +148,9 @@ if (RUN_INTEGRATION_TESTS) {
     });
     const bufferedLogger = runtime.logger;
 
+    const env = await createTestWorkflowEnvironment();
     // Hold on to a connection to prevent implicit shutdown of the runtime before we print 'final log'
-    const connection = await NativeConnection.connect();
+    const connection = env.nativeConnection;
 
     try {
       const taskQueue = `runtime-native-log-collector-preriodically-flushed-${randomUUID()}`;
@@ -141,7 +162,7 @@ if (RUN_INTEGRATION_TESTS) {
       });
 
       await worker.runUntil(async () => {
-        await new Client().workflow.execute(log5Times, { taskQueue, workflowId: randomUUID() });
+        await env.client.workflow.execute(log5Times, { taskQueue, workflowId: randomUUID() });
       });
       t.true(logEntries.some((x) => x.message.startsWith('workflow log ')));
 
@@ -149,8 +170,8 @@ if (RUN_INTEGRATION_TESTS) {
       bufferedLogger.info('final log');
       t.false(logEntries.some((x) => x.message.startsWith('final log')));
     } finally {
-      await connection.close();
       await runtime.shutdown();
+      await env.teardown();
     }
 
     // Assert all log messages have been flushed

--- a/packages/test/src/test-runtime.ts
+++ b/packages/test/src/test-runtime.ts
@@ -20,17 +20,19 @@ if (RUN_INTEGRATION_TESTS) {
 
   test.serial('Runtime tracks registered workers, shuts down and restarts as expected', async (t) => {
     const env = await createTestWorkflowEnvironment();
+    const q1 = `q1-${randomUUID()}`;
+    const q2 = `q2-${randomUUID()}`;
     // Create 2 Workers and verify Runtime keeps running after first Worker deregisteration
     try {
       const worker1 = await Worker.create({
         ...defaultOptions,
-        taskQueue: 'q1',
+        taskQueue: q1,
         connection: env.nativeConnection,
         namespace: env.namespace,
       });
       const worker2 = await Worker.create({
         ...defaultOptions,
-        taskQueue: 'q2',
+        taskQueue: q2,
         connection: env.nativeConnection,
         namespace: env.namespace,
       });
@@ -39,19 +41,19 @@ if (RUN_INTEGRATION_TESTS) {
       worker1.shutdown();
       await worker1Drained;
       // Run a simple workflow
-      await env.client.workflow.execute(workflows.sleeper, { taskQueue: 'q2', workflowId: randomUUID(), args: [1] });
+      await env.client.workflow.execute(workflows.sleeper, { taskQueue: q2, workflowId: randomUUID(), args: [1] });
       worker2.shutdown();
       await worker2Drained;
 
       const worker3 = await Worker.create({
         ...defaultOptions,
-        taskQueue: 'q1',
+        taskQueue: q1,
         connection: env.nativeConnection,
         namespace: env.namespace,
       }); // Same as the first Worker created
       const worker3Drained = worker3.run();
       // Run a simple workflow
-      await env.client.workflow.execute('sleeper', { taskQueue: 'q1', workflowId: randomUUID(), args: [1] });
+      await env.client.workflow.execute('sleeper', { taskQueue: q1, workflowId: randomUUID(), args: [1] });
       worker3.shutdown();
       await worker3Drained;
       // No exceptions, test passes, Runtime is implicitly shut down
@@ -66,6 +68,7 @@ if (RUN_INTEGRATION_TESTS) {
   // to the default configuration (127.0.0.1) which is surprising behavior.
   test.serial('Runtime.install() remembers installed options after it has been shut down', async (t) => {
     const env = await createTestWorkflowEnvironment();
+    const taskQueue = `runtime-restart-${randomUUID()}`;
     const logger = new DefaultLogger('DEBUG');
     Runtime.install({ logger });
     {
@@ -75,7 +78,7 @@ if (RUN_INTEGRATION_TESTS) {
     try {
       const worker = await Worker.create({
         ...defaultOptions,
-        taskQueue: 'q1',
+        taskQueue,
         connection: env.nativeConnection,
         namespace: env.namespace,
       }); // Same as the first Worker created
@@ -94,6 +97,7 @@ if (RUN_INTEGRATION_TESTS) {
 
   test.serial('Runtime.install() Core forwarded logs contains metadata', async (t) => {
     const env = await createTestWorkflowEnvironment();
+    const taskQueue = `runtime-forwarded-logs-${randomUUID()}`;
     const logEntries: LogEntry[] = [];
     const logger = new DefaultLogger('DEBUG', (entry) => logEntries.push(entry));
     Runtime.install({
@@ -101,10 +105,10 @@ if (RUN_INTEGRATION_TESTS) {
       telemetryOptions: { logging: { forward: {}, filter: makeTelemetryFilterString({ core: 'DEBUG' }) } },
     });
     try {
-      await env.client.workflow.start('not-existant', { taskQueue: 'q1', workflowId: randomUUID() });
+      await env.client.workflow.start('not-existant', { taskQueue, workflowId: randomUUID() });
       const worker = await Worker.create({
         ...defaultOptions,
-        taskQueue: 'q1',
+        taskQueue,
         connection: env.nativeConnection,
         namespace: env.namespace,
       });

--- a/packages/test/src/test-worker-debug-mode.ts
+++ b/packages/test/src/test-worker-debug-mode.ts
@@ -9,7 +9,7 @@ if (RUN_INTEGRATION_TESTS) {
   test('Worker works in debugMode', async (t) => {
     const env = await createTestWorkflowEnvironment();
     // To debug Workflows with this worker run the test with `ava debug` and add breakpoints to your Workflows
-    const taskQueue = 'debug-mode';
+    const taskQueue = `debug-mode-${randomUUID()}`;
     try {
       const worker = await Worker.create({
         ...defaultOptions,

--- a/packages/test/src/test-worker-debug-mode.ts
+++ b/packages/test/src/test-worker-debug-mode.ts
@@ -1,22 +1,32 @@
 import { randomUUID } from 'crypto';
 import test from 'ava';
-import { WorkflowClient } from '@temporalio/client';
 import { defaultOptions } from './mock-native-worker';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { successString } from './workflows';
 
 if (RUN_INTEGRATION_TESTS) {
   test('Worker works in debugMode', async (t) => {
+    const env = await createTestWorkflowEnvironment();
     // To debug Workflows with this worker run the test with `ava debug` and add breakpoints to your Workflows
     const taskQueue = 'debug-mode';
-    const worker = await Worker.create({ ...defaultOptions, taskQueue, debugMode: true });
-    const client = new WorkflowClient();
-    const result = await worker.runUntil(
-      client.execute(successString, {
-        workflowId: randomUUID(),
+    try {
+      const worker = await Worker.create({
+        ...defaultOptions,
         taskQueue,
-      })
-    );
-    t.is(result, 'success');
+        debugMode: true,
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+      });
+      const result = await worker.runUntil(
+        env.client.workflow.execute(successString, {
+          workflowId: randomUUID(),
+          taskQueue,
+        })
+      );
+      t.is(result, 'success');
+    } finally {
+      await env.teardown();
+    }
   });
 }

--- a/packages/test/src/test-worker-exposes-abortcontroller.ts
+++ b/packages/test/src/test-worker-exposes-abortcontroller.ts
@@ -8,17 +8,18 @@ import { abortController } from './workflows';
 if (RUN_INTEGRATION_TESTS) {
   test(`Worker runtime exposes AbortController as a global`, async (t) => {
     const env = await createTestWorkflowEnvironment();
+    const taskQueue = `test-worker-exposes-abortcontroller-${randomUUID()}`;
     try {
       const worker = await Worker.create({
         ...defaultOptions,
-        taskQueue: 'test-worker-exposes-abortcontroller',
+        taskQueue,
         connection: env.nativeConnection,
         namespace: env.namespace,
       });
       const result = await worker.runUntil(
         env.client.workflow.execute(abortController, {
           args: [],
-          taskQueue: 'test-worker-exposes-abortcontroller',
+          taskQueue,
           workflowId: randomUUID(),
           workflowExecutionTimeout: '5s',
         })

--- a/packages/test/src/test-worker-exposes-abortcontroller.ts
+++ b/packages/test/src/test-worker-exposes-abortcontroller.ts
@@ -1,22 +1,31 @@
 import { randomUUID } from 'crypto';
 import test from 'ava';
-import { Client } from '@temporalio/client';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
 import { defaultOptions } from './mock-native-worker';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { abortController } from './workflows';
 
 if (RUN_INTEGRATION_TESTS) {
   test(`Worker runtime exposes AbortController as a global`, async (t) => {
-    const worker = await Worker.create({ ...defaultOptions, taskQueue: 'test-worker-exposes-abortcontroller' });
-    const client = new Client();
-    const result = await worker.runUntil(
-      client.workflow.execute(abortController, {
-        args: [],
+    const env = await createTestWorkflowEnvironment();
+    try {
+      const worker = await Worker.create({
+        ...defaultOptions,
         taskQueue: 'test-worker-exposes-abortcontroller',
-        workflowId: randomUUID(),
-        workflowExecutionTimeout: '5s',
-      })
-    );
-    t.is(result, 'abort successful');
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+      });
+      const result = await worker.runUntil(
+        env.client.workflow.execute(abortController, {
+          args: [],
+          taskQueue: 'test-worker-exposes-abortcontroller',
+          workflowId: randomUUID(),
+          workflowExecutionTimeout: '5s',
+        })
+      );
+      t.is(result, 'abort successful');
+    } finally {
+      await env.teardown();
+    }
   });
 }

--- a/packages/test/src/test-worker-exposes-textencoderdecoder.ts
+++ b/packages/test/src/test-worker-exposes-textencoderdecoder.ts
@@ -1,36 +1,54 @@
 import { randomUUID } from 'crypto';
 import test from 'ava';
-import { Client } from '@temporalio/client';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
 import { defaultOptions } from './mock-native-worker';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { textEncoderDecoder, textEncoderDecoderFromImport } from './workflows';
 
 if (RUN_INTEGRATION_TESTS) {
   test('Worker runtime exposes TextEncoder and TextDecoder as globals', async (t) => {
-    const worker = await Worker.create({ ...defaultOptions, taskQueue: 'test-worker-exposes-textencoderdecoder' });
-    const client = new Client();
-    const result = await worker.runUntil(
-      client.workflow.execute(textEncoderDecoder, {
-        args: ['a string that will be encoded and decoded'],
+    const env = await createTestWorkflowEnvironment();
+    try {
+      const worker = await Worker.create({
+        ...defaultOptions,
         taskQueue: 'test-worker-exposes-textencoderdecoder',
-        workflowId: randomUUID(),
-        workflowExecutionTimeout: '5s',
-      })
-    );
-    t.is(result, 'a string that will be encoded and decoded');
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+      });
+      const result = await worker.runUntil(
+        env.client.workflow.execute(textEncoderDecoder, {
+          args: ['a string that will be encoded and decoded'],
+          taskQueue: 'test-worker-exposes-textencoderdecoder',
+          workflowId: randomUUID(),
+          workflowExecutionTimeout: '5s',
+        })
+      );
+      t.is(result, 'a string that will be encoded and decoded');
+    } finally {
+      await env.teardown();
+    }
   });
 
   test('Worker runtime exposes TextEncoder and TextDecoder as overrided import of util', async (t) => {
-    const worker = await Worker.create({ ...defaultOptions, taskQueue: 'test-worker-exposes-textencoderdecoder' });
-    const client = new Client();
-    const result = await worker.runUntil(
-      client.workflow.execute(textEncoderDecoderFromImport, {
-        args: ['a string that will be encoded and decoded'],
+    const env = await createTestWorkflowEnvironment();
+    try {
+      const worker = await Worker.create({
+        ...defaultOptions,
         taskQueue: 'test-worker-exposes-textencoderdecoder',
-        workflowId: randomUUID(),
-        workflowExecutionTimeout: '5s',
-      })
-    );
-    t.is(result, 'a string that will be encoded and decoded');
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+      });
+      const result = await worker.runUntil(
+        env.client.workflow.execute(textEncoderDecoderFromImport, {
+          args: ['a string that will be encoded and decoded'],
+          taskQueue: 'test-worker-exposes-textencoderdecoder',
+          workflowId: randomUUID(),
+          workflowExecutionTimeout: '5s',
+        })
+      );
+      t.is(result, 'a string that will be encoded and decoded');
+    } finally {
+      await env.teardown();
+    }
   });
 }

--- a/packages/test/src/test-worker-exposes-textencoderdecoder.ts
+++ b/packages/test/src/test-worker-exposes-textencoderdecoder.ts
@@ -8,17 +8,18 @@ import { textEncoderDecoder, textEncoderDecoderFromImport } from './workflows';
 if (RUN_INTEGRATION_TESTS) {
   test('Worker runtime exposes TextEncoder and TextDecoder as globals', async (t) => {
     const env = await createTestWorkflowEnvironment();
+    const taskQueue = `test-worker-exposes-textencoderdecoder-${randomUUID()}`;
     try {
       const worker = await Worker.create({
         ...defaultOptions,
-        taskQueue: 'test-worker-exposes-textencoderdecoder',
+        taskQueue,
         connection: env.nativeConnection,
         namespace: env.namespace,
       });
       const result = await worker.runUntil(
         env.client.workflow.execute(textEncoderDecoder, {
           args: ['a string that will be encoded and decoded'],
-          taskQueue: 'test-worker-exposes-textencoderdecoder',
+          taskQueue,
           workflowId: randomUUID(),
           workflowExecutionTimeout: '5s',
         })
@@ -31,17 +32,18 @@ if (RUN_INTEGRATION_TESTS) {
 
   test('Worker runtime exposes TextEncoder and TextDecoder as overrided import of util', async (t) => {
     const env = await createTestWorkflowEnvironment();
+    const taskQueue = `test-worker-exposes-textencoderdecoder-import-${randomUUID()}`;
     try {
       const worker = await Worker.create({
         ...defaultOptions,
-        taskQueue: 'test-worker-exposes-textencoderdecoder',
+        taskQueue,
         connection: env.nativeConnection,
         namespace: env.namespace,
       });
       const result = await worker.runUntil(
         env.client.workflow.execute(textEncoderDecoderFromImport, {
           args: ['a string that will be encoded and decoded'],
-          taskQueue: 'test-worker-exposes-textencoderdecoder',
+          taskQueue,
           workflowId: randomUUID(),
           workflowExecutionTimeout: '5s',
         })

--- a/packages/test/src/test-worker-lifecycle.ts
+++ b/packages/test/src/test-worker-lifecycle.ts
@@ -10,75 +10,99 @@ import test from 'ava';
 import type { LogEntry, NativeConnection } from '@temporalio/worker';
 import { Runtime, PromiseCompletionTimeoutError, DefaultLogger, MetricsBuffer } from '@temporalio/worker';
 import { TransportError, UnexpectedError } from '@temporalio/worker/lib/errors';
-import { Client } from '@temporalio/client';
 import { isBun, RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { defaultOptions, isolateFreeWorker, Worker as MockWorker } from './mock-native-worker';
 import { fillMemory } from './workflows';
 
 if (RUN_INTEGRATION_TESTS) {
   test.serial('Worker shuts down gracefully', async (t) => {
-    const worker = await Worker.create({
-      ...defaultOptions,
-      taskQueue: t.title.replace(/ /g, '_'),
-    });
-    t.is(worker.getState(), 'INITIALIZED');
-    t.not(Runtime._instance, undefined);
-    const p = worker.run();
-    t.is(worker.getState(), 'RUNNING');
-    process.emit('SIGINT', 'SIGINT');
-    // Shutdown callback is enqueued as a microtask
-    await new Promise((resolve) => process.nextTick(resolve));
-    t.is(worker.getState(), 'DRAINING');
-    await p;
-    t.is(worker.getState(), 'STOPPED');
-    await t.throwsAsync(worker.run(), { message: 'Poller was already started' });
-    t.is(Runtime._instance, undefined);
+    const env = await createTestWorkflowEnvironment();
+    try {
+      const worker = await Worker.create({
+        ...defaultOptions,
+        taskQueue: t.title.replace(/ /g, '_'),
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+      });
+      t.is(worker.getState(), 'INITIALIZED');
+      t.not(Runtime._instance, undefined);
+      const p = worker.run();
+      t.is(worker.getState(), 'RUNNING');
+      process.emit('SIGINT', 'SIGINT');
+      // Shutdown callback is enqueued as a microtask
+      await new Promise((resolve) => process.nextTick(resolve));
+      t.is(worker.getState(), 'DRAINING');
+      await p;
+      t.is(worker.getState(), 'STOPPED');
+      await t.throwsAsync(worker.run(), { message: 'Poller was already started' });
+      t.is(Runtime._instance, undefined);
+    } finally {
+      await env.teardown();
+    }
   });
 
   test.serial("Worker.runUntil doesn't hang if provided promise survives to Worker's shutdown", async (t) => {
-    const worker = await Worker.create({
-      ...defaultOptions,
-      taskQueue: t.title.replace(/ /g, '_'),
-    });
-    t.not(Runtime._instance, undefined);
-    const p = worker.runUntil(
-      new Promise(() => {
-        /* a promise that will never unblock */
-      })
-    );
-    t.is(worker.getState(), 'RUNNING');
-    worker.shutdown();
-    t.is(worker.getState(), 'DRAINING');
-    await t.throwsAsync(p, { instanceOf: PromiseCompletionTimeoutError });
-    t.is(worker.getState(), 'STOPPED');
-    t.is(Runtime._instance, undefined);
+    const env = await createTestWorkflowEnvironment();
+    try {
+      const worker = await Worker.create({
+        ...defaultOptions,
+        taskQueue: t.title.replace(/ /g, '_'),
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+      });
+      t.not(Runtime._instance, undefined);
+      const p = worker.runUntil(
+        new Promise(() => {
+          /* a promise that will never unblock */
+        })
+      );
+      t.is(worker.getState(), 'RUNNING');
+      worker.shutdown();
+      t.is(worker.getState(), 'DRAINING');
+      await t.throwsAsync(p, { instanceOf: PromiseCompletionTimeoutError });
+      t.is(worker.getState(), 'STOPPED');
+      t.is(Runtime._instance, undefined);
+    } finally {
+      await env.teardown();
+    }
   });
 
   test.serial('Worker shuts down gracefully if interrupted before running', async (t) => {
-    const worker = await Worker.create({
-      ...defaultOptions,
-      taskQueue: t.title.replace(/ /g, '_'),
-    });
-    t.is(worker.getState(), 'INITIALIZED');
-    process.emit('SIGINT', 'SIGINT');
-    const p = worker.run();
-    t.is(worker.getState(), 'RUNNING');
-    await p;
-    t.is(worker.getState(), 'STOPPED');
+    const env = await createTestWorkflowEnvironment();
+    try {
+      const worker = await Worker.create({
+        ...defaultOptions,
+        taskQueue: t.title.replace(/ /g, '_'),
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+      });
+      t.is(worker.getState(), 'INITIALIZED');
+      process.emit('SIGINT', 'SIGINT');
+      const p = worker.run();
+      t.is(worker.getState(), 'RUNNING');
+      await p;
+      t.is(worker.getState(), 'STOPPED');
+    } finally {
+      await env.teardown();
+    }
   });
 
   test.serial('Worker fails validation against unknown namespace', async (t) => {
-    await t.throwsAsync(
-      Worker.create({
-        ...defaultOptions,
-        taskQueue: t.title.replace(/ /g, '_'),
-        namespace: 'oogabooga',
-      }),
-      {
-        instanceOf: TransportError,
-        message: /Namespace oogabooga is not found/,
-      }
-    );
+    const env = await createTestWorkflowEnvironment();
+    try {
+      await t.throwsAsync(
+        Worker.create({
+          ...defaultOptions,
+          taskQueue: t.title.replace(/ /g, '_'),
+          connection: env.nativeConnection,
+          namespace: 'oogabooga',
+        }),
+        { instanceOf: TransportError, message: /Namespace oogabooga is not found/ }
+      );
+    } finally {
+      await env.teardown();
+    }
   });
 
   // Skip this test for Bun as the workflow doesn't cause an OOM unlike Node
@@ -88,16 +112,18 @@ if (RUN_INTEGRATION_TESTS) {
     t.timeout(30_000);
 
     const taskQueue = t.title.replace(/ /g, '_');
-    const client = new Client();
+    const env = await createTestWorkflowEnvironment();
     const worker = await Worker.create({
       ...defaultOptions,
       taskQueue,
+      connection: env.nativeConnection,
+      namespace: env.namespace,
     });
 
     // This workflow will allocate large block of memory, hopefully causing a ERR_WORKER_OUT_OF_MEMORY.
     // Note that due to the way Node/V8 optimize byte code, its possible that this may trigger
     // other type of errors, including some that can't be intercepted cleanly.
-    client.workflow
+    env.client.workflow
       .start(fillMemory, {
         taskQueue,
         workflowId: randomUUID(),
@@ -128,6 +154,7 @@ if (RUN_INTEGRATION_TESTS) {
       t.is(worker.getState(), 'FAILED');
     } finally {
       if (Runtime._instance) await Runtime._instance.shutdown();
+      await env.teardown();
     }
   });
 }

--- a/packages/test/src/test-worker-lifecycle.ts
+++ b/packages/test/src/test-worker-lifecycle.ts
@@ -21,7 +21,7 @@ if (RUN_INTEGRATION_TESTS) {
     try {
       const worker = await Worker.create({
         ...defaultOptions,
-        taskQueue: t.title.replace(/ /g, '_'),
+        taskQueue: `${t.title.replace(/ /g, '_')}-${randomUUID()}`,
         connection: env.nativeConnection,
         namespace: env.namespace,
       });
@@ -47,7 +47,7 @@ if (RUN_INTEGRATION_TESTS) {
     try {
       const worker = await Worker.create({
         ...defaultOptions,
-        taskQueue: t.title.replace(/ /g, '_'),
+        taskQueue: `${t.title.replace(/ /g, '_')}-${randomUUID()}`,
         connection: env.nativeConnection,
         namespace: env.namespace,
       });
@@ -73,7 +73,7 @@ if (RUN_INTEGRATION_TESTS) {
     try {
       const worker = await Worker.create({
         ...defaultOptions,
-        taskQueue: t.title.replace(/ /g, '_'),
+        taskQueue: `${t.title.replace(/ /g, '_')}-${randomUUID()}`,
         connection: env.nativeConnection,
         namespace: env.namespace,
       });
@@ -94,7 +94,7 @@ if (RUN_INTEGRATION_TESTS) {
       await t.throwsAsync(
         Worker.create({
           ...defaultOptions,
-          taskQueue: t.title.replace(/ /g, '_'),
+          taskQueue: `${t.title.replace(/ /g, '_')}-${randomUUID()}`,
           connection: env.nativeConnection,
           namespace: 'oogabooga',
         }),
@@ -111,7 +111,7 @@ if (RUN_INTEGRATION_TESTS) {
     // be non-conclusive. We need the test timeout to be longer than that.
     t.timeout(30_000);
 
-    const taskQueue = t.title.replace(/ /g, '_');
+    const taskQueue = `${t.title.replace(/ /g, '_')}-${randomUUID()}`;
     const env = await createTestWorkflowEnvironment();
     const worker = await Worker.create({
       ...defaultOptions,

--- a/packages/test/src/test-worker-no-activities.ts
+++ b/packages/test/src/test-worker-no-activities.ts
@@ -1,22 +1,31 @@
 import { randomUUID } from 'crypto';
 import test from 'ava';
-import { WorkflowClient } from '@temporalio/client';
 import { defaultOptions } from './mock-native-worker';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { successString } from './workflows';
 
 if (RUN_INTEGRATION_TESTS) {
   test('Worker functions when asked not to run Activities', async (t) => {
+    const env = await createTestWorkflowEnvironment();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { activities, taskQueue, ...rest } = defaultOptions;
-    const worker = await Worker.create({ taskQueue: 'only-workflows', ...rest });
-    const client = new WorkflowClient();
-    const result = await worker.runUntil(
-      client.execute(successString, {
-        workflowId: randomUUID(),
+    try {
+      const worker = await Worker.create({
         taskQueue: 'only-workflows',
-      })
-    );
-    t.is(result, 'success');
+        ...rest,
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+      });
+      const result = await worker.runUntil(
+        env.client.workflow.execute(successString, {
+          workflowId: randomUUID(),
+          taskQueue: 'only-workflows',
+        })
+      );
+      t.is(result, 'success');
+    } finally {
+      await env.teardown();
+    }
   });
 }

--- a/packages/test/src/test-worker-no-activities.ts
+++ b/packages/test/src/test-worker-no-activities.ts
@@ -8,11 +8,12 @@ import { successString } from './workflows';
 if (RUN_INTEGRATION_TESTS) {
   test('Worker functions when asked not to run Activities', async (t) => {
     const env = await createTestWorkflowEnvironment();
+    const workflowTaskQueue = `only-workflows-${randomUUID()}`;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { activities, taskQueue, ...rest } = defaultOptions;
     try {
       const worker = await Worker.create({
-        taskQueue: 'only-workflows',
+        taskQueue: workflowTaskQueue,
         ...rest,
         connection: env.nativeConnection,
         namespace: env.namespace,
@@ -20,7 +21,7 @@ if (RUN_INTEGRATION_TESTS) {
       const result = await worker.runUntil(
         env.client.workflow.execute(successString, {
           workflowId: randomUUID(),
-          taskQueue: 'only-workflows',
+          taskQueue: workflowTaskQueue,
         })
       );
       t.is(result, 'success');

--- a/packages/test/src/test-worker-no-workflows.ts
+++ b/packages/test/src/test-worker-no-workflows.ts
@@ -1,25 +1,39 @@
 import { randomUUID } from 'crypto';
 import test from 'ava';
-import { WorkflowClient } from '@temporalio/client';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
 import { defaultOptions } from './mock-native-worker';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { runActivityInDifferentTaskQueue } from './workflows';
 
 if (RUN_INTEGRATION_TESTS) {
   test('Worker functions when asked not to run Workflows', async (t) => {
+    const env = await createTestWorkflowEnvironment();
     const { activities } = defaultOptions;
-    const workflowlessWorker = await Worker.create({ taskQueue: 'only-activities', activities });
-    const normalWorker = await Worker.create({ ...defaultOptions, taskQueue: 'also-workflows' });
-    const client = new WorkflowClient();
-    const result = await normalWorker.runUntil(
-      workflowlessWorker.runUntil(
-        client.execute(runActivityInDifferentTaskQueue, {
-          args: ['only-activities'],
-          taskQueue: 'also-workflows',
-          workflowId: randomUUID(),
-        })
-      )
-    );
-    t.is(result, 'hi');
+    try {
+      const workflowlessWorker = await Worker.create({
+        taskQueue: 'only-activities',
+        activities,
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+      });
+      const normalWorker = await Worker.create({
+        ...defaultOptions,
+        taskQueue: 'also-workflows',
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+      });
+      const result = await normalWorker.runUntil(
+        workflowlessWorker.runUntil(
+          env.client.workflow.execute(runActivityInDifferentTaskQueue, {
+            args: ['only-activities'],
+            taskQueue: 'also-workflows',
+            workflowId: randomUUID(),
+          })
+        )
+      );
+      t.is(result, 'hi');
+    } finally {
+      await env.teardown();
+    }
   });
 }

--- a/packages/test/src/test-worker-no-workflows.ts
+++ b/packages/test/src/test-worker-no-workflows.ts
@@ -9,24 +9,26 @@ if (RUN_INTEGRATION_TESTS) {
   test('Worker functions when asked not to run Workflows', async (t) => {
     const env = await createTestWorkflowEnvironment();
     const { activities } = defaultOptions;
+    const activityTaskQueue = `only-activities-${randomUUID()}`;
+    const workflowTaskQueue = `also-workflows-${randomUUID()}`;
     try {
       const workflowlessWorker = await Worker.create({
-        taskQueue: 'only-activities',
+        taskQueue: activityTaskQueue,
         activities,
         connection: env.nativeConnection,
         namespace: env.namespace,
       });
       const normalWorker = await Worker.create({
         ...defaultOptions,
-        taskQueue: 'also-workflows',
+        taskQueue: workflowTaskQueue,
         connection: env.nativeConnection,
         namespace: env.namespace,
       });
       const result = await normalWorker.runUntil(
         workflowlessWorker.runUntil(
           env.client.workflow.execute(runActivityInDifferentTaskQueue, {
-            args: ['only-activities'],
-            taskQueue: 'also-workflows',
+            args: [activityTaskQueue],
+            taskQueue: workflowTaskQueue,
             workflowId: randomUUID(),
           })
         )

--- a/packages/test/src/test-worker-versioning.ts
+++ b/packages/test/src/test-worker-versioning.ts
@@ -9,14 +9,18 @@ import type { ImplementationFn, TestFn } from 'ava';
 import anyTest from 'ava';
 import { status } from '@grpc/grpc-js';
 import asyncRetry from 'async-retry';
-import { BuildIdNotFoundError, Client, UnversionedBuildId } from '@temporalio/client';
+import type { Client } from '@temporalio/client';
+import { BuildIdNotFoundError, UnversionedBuildId } from '@temporalio/client';
 import { DefaultLogger, Runtime } from '@temporalio/worker';
+import type { TestWorkflowEnvironment } from '@temporalio/testing';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import * as activities from './activities';
 import { unblockSignal } from './workflows';
 
 export interface Context {
   client: Client;
+  env: TestWorkflowEnvironment;
   doSkip: boolean;
 }
 
@@ -33,7 +37,8 @@ const withSkipper = test.macro<[ImplementationFn<[], Context>]>(async (t, fn) =>
 if (RUN_INTEGRATION_TESTS) {
   test.before(async (t) => {
     Runtime.install({ logger: new DefaultLogger('DEBUG') });
-    const client = new Client();
+    const env = await createTestWorkflowEnvironment();
+    const client = env.client;
     // Test if this server supports worker versioning
     let doSkip = false;
     const taskQueue = 'test-worker-versioning' + randomUUID();
@@ -52,8 +57,13 @@ if (RUN_INTEGRATION_TESTS) {
     }
     t.context = {
       client,
+      env,
       doSkip,
     };
+  });
+
+  test.after.always(async (t) => {
+    await t.context.env.teardown();
   });
 
   test('Worker versioning workers get appropriate tasks', withSkipper, async (t) => {
@@ -72,6 +82,8 @@ if (RUN_INTEGRATION_TESTS) {
       taskQueue,
       buildId: '1.0',
       useVersioning: true,
+      connection: t.context.env.nativeConnection,
+      namespace: t.context.env.namespace,
     });
     const worker1Prom = worker1.run();
     worker1Prom.catch((err) => {
@@ -98,6 +110,8 @@ if (RUN_INTEGRATION_TESTS) {
       taskQueue,
       buildId: '2.0',
       useVersioning: true,
+      connection: t.context.env.nativeConnection,
+      namespace: t.context.env.namespace,
     });
     const worker2Prom = worker2.run();
     worker2Prom.catch((err) => {

--- a/packages/test/src/test-workflow-unhandled-rejection-crash.ts
+++ b/packages/test/src/test-workflow-unhandled-rejection-crash.ts
@@ -1,33 +1,42 @@
 import { randomUUID } from 'crypto';
 import test from 'ava';
 import { UnexpectedError, Worker } from '@temporalio/worker';
-import { WorkflowClient } from '@temporalio/client';
 import { defaultOptions } from './mock-native-worker';
 import { RUN_INTEGRATION_TESTS, isBun } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { throwUnhandledRejection } from './workflows';
 
 if (RUN_INTEGRATION_TESTS) {
   test('Worker crashes if workflow throws unhandled rejection that cannot be associated with a workflow run', async (t) => {
     // To debug Workflows with this worker run the test with `ava debug` and add breakpoints to your Workflows
     const taskQueue = `unhandled-rejection-crash-${randomUUID()}`;
-    const worker = await Worker.create({ ...defaultOptions, taskQueue });
-    const client = new WorkflowClient();
-    const handle = await client.start(throwUnhandledRejection, {
-      workflowId: randomUUID(),
-      taskQueue,
-      args: [{ crashWorker: true }],
-    });
+    const env = await createTestWorkflowEnvironment();
     try {
-      await t.throwsAsync(worker.run(), {
-        instanceOf: UnexpectedError, // eslint-disable-line @typescript-eslint/no-deprecated
-        message:
-          `Workflow Worker Thread exited prematurely: ${isBun ? 'Error' : 'UnhandledRejectionError'}: ` +
-          "Unhandled Promise rejection for unknown Workflow Run id='undefined': " +
-          'Error: error to crash the worker',
+      const worker = await Worker.create({
+        ...defaultOptions,
+        connection: env.nativeConnection,
+        namespace: env.namespace,
+        taskQueue,
       });
-      t.is(worker.getState(), 'FAILED');
+      const handle = await env.client.workflow.start(throwUnhandledRejection, {
+        workflowId: randomUUID(),
+        taskQueue,
+        args: [{ crashWorker: true }],
+      });
+      try {
+        await t.throwsAsync(worker.run(), {
+          instanceOf: UnexpectedError, // eslint-disable-line @typescript-eslint/no-deprecated
+          message:
+            `Workflow Worker Thread exited prematurely: ${isBun ? 'Error' : 'UnhandledRejectionError'}: ` +
+            "Unhandled Promise rejection for unknown Workflow Run id='undefined': " +
+            'Error: error to crash the worker',
+        });
+        t.is(worker.getState(), 'FAILED');
+      } finally {
+        await handle.terminate();
+      }
     } finally {
-      await handle.terminate();
+      await env.teardown();
     }
   });
 }


### PR DESCRIPTION
Worker and runtime integration suites still constructed server-backed resources with implicit localhost defaults. That prevented the envconfig harness from directing these tests to Temporal Cloud even though their behavior does not intrinsically require a local server.

This moves those paths onto environment-owned clients, native connections, and namespaces, with explicit teardown. Mock gRPC and invalid-connection coverage remains local to its existing test setup, and the change does not alter tests already classified as intrinsically local.

Validation: focused ESLint, Prettier, and diff checks pass. `pnpm --dir packages/test build` reports only the existing `ActivityExecutionStatus.PAUSED` mismatch from the locally advanced core submodule.