### PR TITLE
Remove default namespace assumptions from integration tests

### DIFF
--- a/packages/test/src/test-integration-extstore.ts
+++ b/packages/test/src/test-integration-extstore.ts
@@ -207,7 +207,7 @@ test('child workflow input and result are offloaded in both directions', async (
   t.is(driver.storeCalls[0].context.target?.type, 'externalStorageEcho');
   t.deepEqual(driver.storeCalls[1].context.target, {
     kind: 'workflow',
-    namespace: 'default',
+    namespace: t.context.env.client.options.namespace,
     id: handle.workflowId,
     runId: handle.firstExecutionRunId,
   });
@@ -221,7 +221,11 @@ test('continue-as-new offloads a large argument keyed under the target workflow 
   const sizeBytes = 4096;
 
   const worker = await createWorker({ dataConverter: { externalStorage } });
-  const client = new Client({ connection: t.context.env.connection, dataConverter: { externalStorage } });
+  const client = new Client({
+    connection: t.context.env.connection,
+    namespace: t.context.env.client.options.namespace,
+    dataConverter: { externalStorage },
+  });
 
   const workflowId = randomUUID();
   const handle = await client.workflow.start(externalStorageContinueAsNewSource, {
@@ -236,7 +240,7 @@ test('continue-as-new offloads a large argument keyed under the target workflow 
   t.is(driver.storeCalls.length, 1);
   t.deepEqual(driver.storeCalls[0].context.target, {
     kind: 'workflow',
-    namespace: 'default',
+    namespace: t.context.env.client.options.namespace,
     id: workflowId,
     runId: undefined,
     type: 'externalStorageContinueAsNewTarget',
@@ -343,7 +347,11 @@ test('client offloads a large start argument and retrieves a large result', asyn
   const data = new Uint8Array(4096).fill(3);
 
   const worker = await createWorker({ dataConverter: { externalStorage } });
-  const client = new Client({ connection: t.context.env.connection, dataConverter: { externalStorage } });
+  const client = new Client({
+    connection: t.context.env.connection,
+    namespace: t.context.env.client.options.namespace,
+    dataConverter: { externalStorage },
+  });
 
   const workflowId = randomUUID();
   const handle = await client.workflow.start(externalStorageEcho, { taskQueue, workflowId, args: [data] });
@@ -367,13 +375,13 @@ test('client offloads a large start argument and retrieves a large result', asyn
   t.is(driver.storeCalls.length, 2);
   t.deepEqual(driver.storeCalls[0].context.target, {
     kind: 'workflow',
-    namespace: 'default',
+    namespace: t.context.env.client.options.namespace,
     id: workflowId,
     type: 'externalStorageEcho',
   });
   t.deepEqual(driver.storeCalls[1].context.target, {
     kind: 'workflow',
-    namespace: 'default',
+    namespace: t.context.env.client.options.namespace,
     id: workflowId,
     runId: handle.firstExecutionRunId,
     type: 'externalStorageEcho',
@@ -389,7 +397,11 @@ test('client retrieves an offloaded query result', async (t) => {
   const expected = new Uint8Array(sizeBytes).fill(7);
 
   const worker = await createWorker({ dataConverter: { externalStorage } });
-  const client = new Client({ connection: t.context.env.connection, dataConverter: { externalStorage } });
+  const client = new Client({
+    connection: t.context.env.connection,
+    namespace: t.context.env.client.options.namespace,
+    dataConverter: { externalStorage },
+  });
 
   const workflowId = randomUUID();
   await worker.runUntil(async () => {
@@ -554,7 +566,11 @@ test('client offloads a large workflow memo and retrieves it via describe', asyn
   const memoBlob = new Uint8Array(4096).fill(5);
 
   const worker = await createWorker({ dataConverter: { externalStorage } });
-  const client = new Client({ connection: t.context.env.connection, dataConverter: { externalStorage } });
+  const client = new Client({
+    connection: t.context.env.connection,
+    namespace: t.context.env.client.options.namespace,
+    dataConverter: { externalStorage },
+  });
 
   const workflowId = randomUUID();
   const handle = await client.workflow.start(externalStorageEcho, {

--- a/packages/test/src/test-integration-split-one.ts
+++ b/packages/test/src/test-integration-split-one.ts
@@ -371,7 +371,7 @@ export async function childWorkflowStartFail(): Promise<void> {
 
   try {
     await startChild(workflows.successString, {
-      taskQueue: 'test',
+      taskQueue: `${child.workflowId}-duplicate`,
       workflowId: child.workflowId, // duplicate
       workflowIdReusePolicy: 'REJECT_DUPLICATE',
     });
@@ -778,7 +778,7 @@ test.serial('Workflow can read WorkflowInfo', configMacro, async (t, config) => 
     },
     attempt: 1,
     firstExecutionRunId: handle.firstExecutionRunId,
-    namespace: 'default',
+    namespace: env.client.options.namespace,
     taskTimeoutMs: 10_000,
     runId: handle.firstExecutionRunId,
     taskQueue,

--- a/packages/test/src/test-integration-split-two.ts
+++ b/packages/test/src/test-integration-split-two.ts
@@ -560,7 +560,7 @@ test.serial(
       await handle.result();
       await t.throwsAsync(
         client.workflow.signalWithStart(workflows.sleeper, {
-          taskQueue: 'test',
+          taskQueue: `${handle.workflowId}-duplicate`,
           workflowId: handle.workflowId,
           signal: workflows.interruptSignal,
           signalArgs: ['interrupted from signalWithStart'],
@@ -585,7 +585,7 @@ test.serial('Handle from WorkflowClient.start follows only own execution chain',
   await worker.runUntil(async () => {
     await t.throwsAsync(handleFromGet.result(), { message: /.*/ });
     const handleFromSleeperStart = await client.workflow.start(workflows.sleeper, {
-      taskQueue: 'test',
+      taskQueue: `${handleFromThrowerStart.workflowId}-unpolled`,
       workflowId: handleFromThrowerStart.workflowId,
       args: [1_000_000],
     });


### PR DESCRIPTION
The shared integration harness selects the configured environment, but several assertions and secondary clients still implicitly used the local `default` namespace. In Cloud, the external-storage clients sent workflow starts to `default`, which the API key cannot access; failed starts then left created workers holding native connection references.

This propagates the environment namespace into those clients and expected external-storage targets. It also makes intentionally unpolled or rejected alternate task queues unique to their workflow. Local behavior is unchanged, while persistent Cloud namespaces no longer fail authorization or risk cross-run interference.

Focused ESLint, Prettier, and `git diff --check` pass. The Cloud discovery run provided the failing secondary-client evidence.