### PR TITLE
build(core): bump quinn-proto from 0.11.14 to 0.11.15 in core-bridge Cargo.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ to docs, or any other relevant information.
 - Workflows no longer retain completion state when a child Workflow fails or is cancelled before starting.
 - Local Activity tests now use `makeTestFunction` to manage their test environment.
 
+### Security
+
+- Bumped the vendored `quinn-proto` in `@temporalio/core-bridge`'s `Cargo.lock` from 0.11.14 to
+  0.11.15, clearing GHSA-4w2j-m93h-cj5j / RUSTSEC-2026-0185 (unbounded out-of-order stream
+  reassembly DoS) for downstream image scanners.
+
 ## [1.21.1] - 2026-07-23
 
 ### Fixed

--- a/packages/core-bridge/Cargo.lock
+++ b/packages/core-bridge/Cargo.lock
@@ -1861,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## What was changed

Bumped the vendored `quinn-proto` in `packages/core-bridge/Cargo.lock` from `0.11.14` to `0.11.15`. Lockfile-only change, produced with:

```bash
cd packages/core-bridge
cargo update -p quinn-proto --precise 0.11.15
```

## Why?

`quinn-proto` 0.11.14 is affected by [GHSA-4w2j-m93h-cj5j](https://github.com/quinn-rs/quinn/security/advisories/GHSA-4w2j-m93h-cj5j) / [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185.html) (CVSS 7.5 DoS, unbounded out-of-order stream reassembly), fixed in 0.11.15.

`Cargo.lock` is shipped inside the published `@temporalio/core-bridge` tarball, so image scanners (Trivy, Grype, AWS Inspector) flag every image that installs the SDK, even with `--ignore-unfixed`:

```bash
npm pack @temporalio/core-bridge@1.21.1
tar -xOzf temporalio-core-bridge-*.tgz package/Cargo.lock | grep -A1 'name = "quinn-proto"'
# -> version = "0.11.14"
```

`quinn` only enters the graph as an optional dependency of `reqwest` (`http3` feature), so in practice this is lockfile visibility rather than compiled code. The bump still clears the finding for everyone scanning the published package, without any behavioural change.

Same shape as #1961, which handled the previous `quinn-proto` advisory and shipped in 1.16.0 (see #2003).

## Checklist

1. Closes #2261

2. How was this tested:
Lockfile-only change with no `Cargo.toml` edits. `quinn 0.11.9` requires `quinn-proto ^0.11.12`, so `0.11.15` is semver-compatible and the rest of the resolution is untouched (the diff is exactly the `version` and `checksum` lines). `0.11.15` was chosen over `0.11.16` because `0.11.16` additionally pulls in `rand_pcg`, which would grow the lockfile diff. Relying on CI to validate the Rust build.

3. Any docs updates needed?
No.

---

One follow-up ask: since the finding only clears for consumers once a new `@temporalio/core-bridge` is published, a patch release (and ideally a `release-1-21` backport) after merge would be much appreciated.