### PR TITLE
Mark Nexus as GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 
+### Changed
+
+- Nexus is now generally available (GA) for calling Nexus Operations from Workflows and handling
+  Workflow-backed Operations with `WorkflowRunOperationHandler`.
+
 ## [1.22.0] - 2026-08-05
 
 ### Added

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -381,7 +381,6 @@ export class ChildWorkflowFailure extends TemporalFailure {
 /**
  * Thrown when a Nexus Operation executed inside a Workflow fails.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 @SymbolBasedInstanceOfError('NexusOperationFailure')
 export class NexusOperationFailure extends TemporalFailure {

--- a/packages/nexus/src/context.ts
+++ b/packages/nexus/src/context.ts
@@ -38,7 +38,6 @@ export interface HandlerContext {
 /**
  * Holds information about the current Nexus Operation Execution.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export interface OperationInfo {
   /**
@@ -62,7 +61,7 @@ export interface OperationInfo {
  * Context received by a {@link TemporalOperationHandler}'s start handler when a Nexus Operation is
  * started.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
+ * @experimental Temporal Operation handlers are experimental.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface TemporalStartOperationContext extends nexus.StartOperationContext {}
@@ -71,7 +70,7 @@ export interface TemporalStartOperationContext extends nexus.StartOperationConte
  * Context received by a {@link TemporalOperationHandler}'s cancel handler when a Nexus Operation is
  * canceled.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
+ * @experimental Temporal Operation handlers are experimental.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface TemporalCancelOperationContext extends nexus.CancelOperationContext {}
@@ -89,7 +88,6 @@ export interface TemporalCancelOperationContext extends nexus.CancelOperationCon
  * To customize log attributes, register a {@link nexus.NexusOutboundCallsInterceptor} that
  * intercepts the `getLogAttributes()` method.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export const log: Logger = {
   log(level: LogLevel, message: string, meta?: LogMetadata): any {
@@ -118,7 +116,6 @@ export const log: Logger = {
  * To add custom tags, register a {@link nexus.NexusOutboundCallsInterceptor} that
  * intercepts the `getMetricTags()` method.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export const metricMeter: MetricMeter = {
   createCounter(name, unit, description) {
@@ -139,7 +136,6 @@ export const metricMeter: MetricMeter = {
  * Returns a client to be used in a Nexus Operation's context, this Client is powered by the same
  * NativeConnection that the worker was created with.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export function getClient(): Client {
   return getHandlerContext().client;
@@ -150,7 +146,6 @@ export function getClient(): Client {
  *
  * @return OperationInfo for the current Nexus Operation being executed
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export function operationInfo(): OperationInfo {
   const ctx = getHandlerContext();

--- a/packages/nexus/src/workflow-helpers.ts
+++ b/packages/nexus/src/workflow-helpers.ts
@@ -63,8 +63,6 @@ declare const workflowResultType: unique symbol;
  * The type parameter `T` carries the workflow's result type for downstream type inference in
  * {@link WorkflowRunOperationHandler}. It is encoded in the {@link workflowResultType} brand so
  * that `WorkflowHandle<string>` and `WorkflowHandle<number>` are structurally distinct.
- *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export interface WorkflowHandle<T> {
   readonly workflowId: string;
@@ -82,8 +80,6 @@ export interface WorkflowHandle<T> {
    *
    * @internal
    * @hidden
-   *
-   * @experimental Nexus support in Temporal SDK is experimental.
    */
   readonly [isNexusWorkflowHandle]: typeof isNexusWorkflowHandle;
 
@@ -93,8 +89,6 @@ export interface WorkflowHandle<T> {
    *
    * @internal
    * @hidden
-   *
-   * @experimental Nexus support in Temporal SDK is experimental.
    */
   readonly [workflowResultType]: T;
 }
@@ -108,7 +102,7 @@ export interface WorkflowHandle<T> {
  * they refer to already backs the operation, and a Nexus Operation handler invocation may only start
  * one async backing operation.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
+ * @experimental Workflow Updates as Nexus Operations are experimental.
  */
 export interface UpdatableWorkflowHandle<T> extends WorkflowHandle<T> {
   /**
@@ -128,7 +122,7 @@ export interface UpdatableWorkflowHandle<T> extends WorkflowHandle<T> {
    * If the Update takes arguments, `options.args` is required; an Update that takes no arguments
    * accepts no `args` and may be called without options at all.
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
+   * @experimental Workflow Updates as Nexus Operations are experimental.
    */
   update<Ret, Args extends [any, ...any[]], Name extends string = string>(
     def: UpdateDefinition<Ret, Args, Name> | string,
@@ -145,8 +139,6 @@ export interface UpdatableWorkflowHandle<T> extends WorkflowHandle<T> {
  * Options for starting a workflow using {@link startWorkflow}, this type is identical to the
  * client's `WorkflowStartOptions` with the exception that `taskQueue` is optional and defaults
  * to the current worker's task queue.
- *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export type WorkflowStartOptions<T extends Workflow> = Replace<ClientWorkflowStartOptions<T>, { taskQueue?: string }>;
 
@@ -155,8 +147,6 @@ export type WorkflowStartOptions<T extends Workflow> = Replace<ClientWorkflowSta
  * to a Nexus Operation (subsequent runs started from continue-as-new and retries). Automatically
  * propagates the callback, request ID, and request and response links from the Nexus options to the
  * Workflow.
- *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export async function startWorkflow<T extends Workflow>(
   ctx: nexus.StartOperationContext,
@@ -312,8 +302,6 @@ function createWorkflowHandle<T extends Workflow>(
 /**
  * Options for {@link signalWithStartWorkflow}, identical to the client's `WorkflowSignalWithStartOptions`
  * except that `taskQueue` is optional and defaults to the current worker's task queue.
- *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export type WorkflowSignalWithStartOptions<SignalArgs extends any[] = []> = Replace<
   ClientWorkflowSignalWithStartOptions<SignalArgs>,
@@ -322,8 +310,6 @@ export type WorkflowSignalWithStartOptions<SignalArgs extends any[] = []> = Repl
 
 /**
  * Signals a Workflow, starting it first if it is not already running, as part of a Nexus Operation.
- *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export async function signalWithStartWorkflow<T extends Workflow, SignalArgs extends any[] = []>(
   ctx: nexus.StartOperationContext,
@@ -356,8 +342,6 @@ export async function signalWithStartWorkflow<T extends Workflow, SignalArgs ext
 
 /**
  * A handler function for the {@link WorkflowRunOperationHandler} constructor.
- *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export type WorkflowRunOperationStartHandler<I, O> = (
   ctx: nexus.StartOperationContext,
@@ -366,8 +350,6 @@ export type WorkflowRunOperationStartHandler<I, O> = (
 
 /**
  * A Nexus Operation implementation that is backed by a Workflow run.
- *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export class WorkflowRunOperationHandler<I, O> implements nexus.OperationHandler<I, O> {
   constructor(readonly handler: WorkflowRunOperationStartHandler<I, O>) {}
@@ -474,7 +456,7 @@ const operationResult: unique symbol = Symbol('temporal_nexus_TemporalOperationR
  * A result produced by a {@link TemporalOperationHandler}. Construct via
  * {@link TemporalOperationResult.sync} or {@link TemporalOperationResult.async}.
 
- * @experimental Nexus support in Temporal SDK is experimental.
+ * @experimental Temporal Operation handlers are experimental.
  */
 export interface TemporalOperationResult<T> {
   readonly [operationResult]: nexus.HandlerStartOperationResult<T>;
@@ -502,7 +484,7 @@ export const TemporalOperationResult = {
  * The Update's arguments are intersected onto this type by each `update` overload, so that `args` is
  * required for an Update that takes arguments and rejected for one that does not.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
+ * @experimental Workflow Updates as Nexus Operations are experimental.
  */
 export interface NexusUpdateWorkflowOptions {
   /**
@@ -517,20 +499,20 @@ export interface NexusUpdateWorkflowOptions {
 /**
  * A Nexus-aware Temporal Client for use inside {@link TemporalOperationHandler} implementations.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
+ * @experimental Temporal Operation handlers are experimental.
  */
 export interface TemporalNexusClient {
   /**
    * The Temporal Client for the active Nexus Operation.
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
+   * @experimental Temporal Operation handlers are experimental.
    */
   readonly client: Client;
 
   /**
    * Starts a workflow run as the asynchronous backing operation for the current Nexus Operation.
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
+   * @experimental Temporal Operation handlers are experimental.
    */
   startWorkflow<T extends Workflow>(
     workflowTypeOrFunc: string | T,
@@ -548,7 +530,7 @@ export interface TemporalNexusClient {
    * This method does not validate `workflowId`. If there is no Workflow Execution with the given `workflowId`, handle
    * methods like `handle.signal()` will throw a {@link WorkflowNotFoundError} error.
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
+   * @experimental Temporal Operation handlers are experimental.
    */
   getWorkflowHandle<T extends Workflow>(
     workflowId: string,
@@ -559,7 +541,7 @@ export interface TemporalNexusClient {
    * Signals a Workflow, starting it first if it is not already running, forwarding the Nexus
    * Operation's request links and propagating the response link the server returns (when supported).
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
+   * @experimental Temporal Operation handlers are experimental.
    */
   signalWithStartWorkflow<T extends Workflow, SignalArgs extends any[] = []>(
     workflowTypeOrFunc: string | T,
@@ -631,7 +613,7 @@ class TemporalNexusClientImpl implements TemporalNexusClient {
   /**
    * The Temporal Client for the active Nexus Operation.
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
+   * @experimental Temporal Operation handlers are experimental.
    */
   public get client(): Client {
     return getClient();
@@ -648,7 +630,7 @@ class TemporalNexusClientImpl implements TemporalNexusClient {
    * This method does not validate `workflowId`. If there is no Workflow Execution with the given `workflowId`, handle
    * methods like `handle.signal()` will throw a {@link WorkflowNotFoundError} error.
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
+   * @experimental Temporal Operation handlers are experimental.
    */
   public getWorkflowHandle<T extends Workflow>(
     workflowId: string,
@@ -660,7 +642,7 @@ class TemporalNexusClientImpl implements TemporalNexusClient {
   /**
    * Starts a workflow run as the asynchronous backing operation for the current Nexus Operation.
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
+   * @experimental Temporal Operation handlers are experimental.
    */
   public async startWorkflow<T extends Workflow>(
     workflowTypeOrFunc: string | T,
@@ -676,7 +658,7 @@ class TemporalNexusClientImpl implements TemporalNexusClient {
   /**
    * Signals a Workflow, starting it first if it is not already running.
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
+   * @experimental Temporal Operation handlers are experimental.
    */
   public async signalWithStartWorkflow<T extends Workflow, SignalArgs extends any[] = []>(
     workflowTypeOrFunc: string | T,
@@ -807,7 +789,7 @@ async function updateWorkflowOperation<Ret, Args extends any[]>(
 /**
  * A handler function for the {@link TemporalOperationHandler} constructor.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
+ * @experimental Temporal Operation handlers are experimental.
  */
 export type TemporalOperationStartHandler<I, O> = (
   ctx: TemporalStartOperationContext,
@@ -819,7 +801,7 @@ export type TemporalOperationStartHandler<I, O> = (
  * Options passed to a {@link TemporalOperationHandlerOptions.cancelWorkflowRun} handler describing
  * the workflow run to cancel.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
+ * @experimental Temporal Operation handlers are experimental.
  */
 export interface CancelWorkflowRunOptions {
   /**
@@ -832,7 +814,7 @@ export interface CancelWorkflowRunOptions {
  * Options passed to a {@link TemporalOperationHandlerOptions.cancelWorkflowUpdate} handler describing
  * the Workflow Update to cancel.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
+ * @experimental Workflow Updates as Nexus Operations are experimental.
  */
 export interface CancelWorkflowUpdateOptions {
   /**
@@ -872,7 +854,7 @@ export interface CancelActivityOptions {
 /**
  * Options for customizing a {@link TemporalOperationHandler}.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
+ * @experimental Temporal Operation handlers are experimental.
  */
 export interface TemporalOperationHandlerOptions {
   /**
@@ -893,7 +875,7 @@ export interface TemporalOperationHandlerOptions {
 /**
  * A Nexus Operation implementation for operations that interact with Temporal.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
+ * @experimental Temporal Operation handlers are experimental.
  */
 export class TemporalOperationHandler<I, O> implements nexus.OperationHandler<I, O> {
   private readonly startHandler: TemporalOperationStartHandler<I, O>;

--- a/packages/worker/src/interceptors.ts
+++ b/packages/worker/src/interceptors.ts
@@ -114,23 +114,18 @@ export interface ActivityInboundCallsInterceptorFactory {
  * parameter. Interceptor functions may then rely on APIs provided by the `@temporalio/nexus` package
  * to access the Nexus Operation Context where needed.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export type NexusInterceptorsFactory = (ctx: nexus.OperationContext) => NexusInterceptors;
 
 /**
  * Interceptors for Nexus Operation execution.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export type NexusInterceptors = {
   inbound?: NexusInboundCallsInterceptor;
   outbound?: NexusOutboundCallsInterceptor;
 };
 
-/**
- * @experimental Nexus support in Temporal SDK is experimental.
- */
 export type NexusInboundCallsInterceptor = {
   startOperation?: (
     input: NexusStartOperationInput,
@@ -146,7 +141,6 @@ export type NexusInboundCallsInterceptor = {
 /**
  * Input for {@link NexusInboundCallsInterceptor.startOperation}
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export interface NexusStartOperationInput {
   readonly ctx: nexus.StartOperationContext;
@@ -156,7 +150,6 @@ export interface NexusStartOperationInput {
 /**
  * Output for {@link NexusInboundCallsInterceptor.startOperation}
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export interface NexusStartOperationOutput {
   readonly result: nexus.HandlerStartOperationResult<unknown>;
@@ -165,16 +158,12 @@ export interface NexusStartOperationOutput {
 /**
  * Input for {@link NexusInboundCallsInterceptor.cancelOperation}
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export interface NexusCancelOperationInput {
   readonly ctx: nexus.CancelOperationContext;
   readonly token: string;
 }
 
-/**
- * @experimental Nexus support in Temporal SDK is experimental.
- */
 export type NexusOutboundCallsInterceptor = {
   getLogAttributes?: (
     input: GetLogAttributesInput,
@@ -219,7 +208,6 @@ export interface WorkerInterceptors {
   /**
    * List of factory functions that instanciate {@link NexusInterceptors}s.
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
    */
   nexus?: NexusInterceptorsFactory[];
 

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -130,7 +130,6 @@ export interface WorkerOptions {
   /**
    * An array of Nexus services
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
    */
   nexusServices?: nexus.ServiceHandler<any>[];
 
@@ -228,7 +227,6 @@ export interface WorkerOptions {
    *
    * @default 100 if no {@link tuner} is set
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
    */
   maxConcurrentNexusTaskExecutions?: number;
 
@@ -369,7 +367,6 @@ export interface WorkerOptions {
    *
    * @default A fixed maximum whose value is min(10, maxConcurrentNexusTaskExecutions).
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
    */
   nexusTaskPollerBehavior?: PollerBehavior;
 
@@ -394,7 +391,6 @@ export interface WorkerOptions {
    *
    * @default min(10, maxConcurrentNexusTaskExecutions)
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
    */
   maxConcurrentNexusTaskPolls?: number;
 

--- a/packages/workflow/src/interceptors.ts
+++ b/packages/workflow/src/interceptors.ts
@@ -157,7 +157,6 @@ export interface WorkflowOutboundCallsInterceptor {
   /**
    * Called when Workflow starts a Nexus Operation.
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
    */
   startNexusOperation?: (
     input: StartNexusOperationInput,
@@ -261,7 +260,6 @@ export interface LocalActivityInput {
 /**
  * Input for {@link WorkflowOutboundCallsInterceptor.startNexusOperation}.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export interface StartNexusOperationInput {
   readonly input: unknown;
@@ -276,7 +274,6 @@ export interface StartNexusOperationInput {
 /**
  * Options for starting a Nexus Operation.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export interface StartNexusOperationOptions {
   /**
@@ -328,7 +325,6 @@ export interface StartNexusOperationOptions {
 /**
  * Output for {@link WorkflowOutboundCallsInterceptor.startNexusOperation}.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export interface StartNexusOperationOutput {
   /**

--- a/packages/workflow/src/nexus.ts
+++ b/packages/workflow/src/nexus.ts
@@ -12,14 +12,12 @@ import type { StartNexusOperationInput, StartNexusOperationOutput, StartNexusOpe
 /**
  * A Nexus client for invoking Nexus Operations for a specific service from a Workflow.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export interface NexusServiceClient<T extends nexus.ServiceDefinition> {
   /**
    * Start a Nexus Operation and wait for its completion taking a {@link nexus.operation}.
    * Returns the operation's result.
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
    */
   executeOperation<O extends T['operations'][keyof T['operations']]>(
     op: O,
@@ -38,7 +36,6 @@ export interface NexusServiceClient<T extends nexus.ServiceDefinition> {
    * the {@link nexus.ServiceDefinition} object; it may differ from the value of the `name` property
    * if one was explicitly specified on the {@link nexus.OperationDefinition} object.
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
    */
   executeOperation<K extends nexus.OperationKey<T['operations']>>(
     op: K,
@@ -51,7 +48,6 @@ export interface NexusServiceClient<T extends nexus.ServiceDefinition> {
    *
    * Returns a handle that can be used to wait for the Operation's result.
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
    */
   startOperation<O extends T['operations'][keyof T['operations']]>(
     op: O,
@@ -67,7 +63,6 @@ export interface NexusServiceClient<T extends nexus.ServiceDefinition> {
    * the {@link nexus.ServiceDefinition} object; it may differ from the value of the `name` property
    * if one was explicitly specified on the {@link nexus.OperationDefinition} object.
    *
-   * @experimental Nexus support in Temporal SDK is experimental.
    */
   startOperation<K extends nexus.OperationKey<T['operations']>>(
     op: K,
@@ -79,7 +74,6 @@ export interface NexusServiceClient<T extends nexus.ServiceDefinition> {
 /**
  * A handle to a Nexus Operation.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export interface NexusOperationHandle<T> {
   /**
@@ -114,7 +108,6 @@ export interface NexusServiceClientOptions<T> {
 /**
  * Create a Nexus client for invoking Nexus Operations from a Workflow.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 export function createNexusServiceClient<T extends nexus.ServiceDefinition>(
   options: NexusServiceClientOptions<T>
@@ -255,7 +248,6 @@ function startNexusOperationNextHandler({
  * Workflow itself, or from internal cancellation of the `CancellationScope` in which the
  * Operation call was made.
  *
- * @experimental Nexus support in Temporal SDK is experimental.
  */
 // MAINTENANCE: Keep this typedoc in sync with the `StartNexusOperationOptions.cancellationType` field
 export const NexusOperationCancellationType = {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Mark Nexus as GA

## Why?
Nexus was approved for GA

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and API stability metadata only; no runtime or behavioral code changes in this diff.
> 
> **Overview**
> Promotes **Nexus** from blanket experimental status to **GA** in the changelog and public API docs, reflecting approval for calling Nexus Operations from Workflows and handling workflow-run-backed operations with **`WorkflowRunOperationHandler`**.
> 
> The broad `@experimental Nexus support in Temporal SDK is experimental` tag is **removed** from stable surfaces including workflow **`createNexusServiceClient`**, **`NexusOperationFailure`**, worker **`nexusServices`** / concurrency / polling options, and Nexus handler **`log`**, **`getClient`**, **`operationInfo`**, **`WorkflowRunOperationHandler`**, and related interceptors.
> 
> **Narrower experimental labels remain** where features are still pre-GA: **`TemporalOperationHandler`**, **`TemporalNexusClient`**, workflow **Updates as Nexus backing operations**, and **standalone Activity** Nexus helpers in `workflow-helpers.ts` still carry `@experimental` with feature-specific wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ad9bea55752902945ee65cbb5594a6b9bfc0c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->