### PR TITLE
fix: require ai@>=7.0.59 in @temporalio/ai-sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ to docs, or any other relevant information.
 
 - Nexus is now generally available (GA) for calling Nexus Operations from Workflows and handling
   Workflow-backed Operations with `WorkflowRunOperationHandler`.
+- `@temporalio/ai-sdk` now requires `ai@>=7.0.59` as a peer dependency, up from `7.0.0`, since
+  earlier releases threw a `TypeError` on import in runtimes without a global `fetch`.
 
 ## [1.22.0] - 2026-08-05
 

--- a/contrib/ai-sdk/package.json
+++ b/contrib/ai-sdk/package.json
@@ -58,13 +58,13 @@
   "peerDependencies": {
     "@ai-sdk/mcp": "^2.0.0",
     "@ai-sdk/provider": "^4.0.0",
-    "ai": "^7.0.0"
+    "ai": "^7.0.59"
   },
   "devDependencies": {
-    "@ai-sdk/mcp": "^2.0.0",
-    "@ai-sdk/openai": "^4.0.0",
-    "@ai-sdk/otel": "^1.0.0",
-    "@ai-sdk/provider": "^4.0.0",
+    "@ai-sdk/mcp": "^2.0.30",
+    "@ai-sdk/openai": "^4.0.37",
+    "@ai-sdk/otel": "^1.0.59",
+    "@ai-sdk/provider": "^4.0.7",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.25.1",
@@ -77,7 +77,7 @@
     "@temporalio/testing": "workspace:*",
     "@temporalio/worker": "workspace:*",
     "@types/ungap__structured-clone": "^1.2.0",
-    "ai": "^7.0.0",
+    "ai": "^7.0.59",
     "ava": "^5.3.1",
     "zod": "^3.25.76"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,17 +113,17 @@ importers:
         version: 4.2.0
     devDependencies:
       '@ai-sdk/mcp':
-        specifier: ^2.0.0
-        version: 2.0.1(zod@3.25.76)
+        specifier: ^2.0.30
+        version: 2.0.30(zod@3.25.76)
       '@ai-sdk/openai':
-        specifier: ^4.0.0
-        version: 4.0.0(zod@3.25.76)
+        specifier: ^4.0.37
+        version: 4.0.37(zod@3.25.76)
       '@ai-sdk/otel':
-        specifier: ^1.0.0
-        version: 1.0.2(zod@3.25.76)
+        specifier: ^1.0.59
+        version: 1.0.59(zod@3.25.76)
       '@ai-sdk/provider':
-        specifier: ^4.0.0
-        version: 4.0.0
+        specifier: ^4.0.7
+        version: 4.0.7
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
         version: 1.26.0(zod@3.25.76)
@@ -158,8 +158,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       ai:
-        specifier: ^7.0.0
-        version: 7.0.2(zod@3.25.76)
+        specifier: ^7.0.59
+        version: 7.0.59(zod@3.25.76)
       ava:
         specifier: ^5.3.1
         version: 5.3.1
@@ -1181,30 +1181,30 @@ packages:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
 
-  '@ai-sdk/gateway@4.0.2':
-    resolution: {integrity: sha512-Jz1BiiTSvhDsCBJrkFRSqLHDRMVjFtYk9GdbSi3UOqY+/epza+oIESMDzfN4m+YHT/1IYmNEmxaMfjXOvxKDjQ==}
+  '@ai-sdk/gateway@4.0.47':
+    resolution: {integrity: sha512-BuWWlA8atWEnEJzN4eamCpGZWkoK9V3TCyNaMwgRIazhqkgWkA1Wp36si3j2JeVYzlvlEAOWrJ92dr92j/Vkqg==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/mcp@2.0.1':
-    resolution: {integrity: sha512-tsk+FAX7TN8BsA3eqwR7jf33PiYaGh+w/rHofk7hj13mFvicAhrdITgSOvncULUReUZcDoS0axHEXv1y1/yR8Q==}
+  '@ai-sdk/mcp@2.0.30':
+    resolution: {integrity: sha512-blXjM1TVI6sYER6PuMd8ZM+nTq57LUHq4Cc5gmFw1ub9204rALpew0iiusYKjgyaEtCuUcFr/ybBr6RavqV/2A==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@4.0.0':
-    resolution: {integrity: sha512-XcI/bJEG+Ymx8ZwQMY9GE9waHdEcSzT6wn2o+YW80hOQPf8IAGQvdNWKaD0mxLi6AmOM0L01y/p626w7rImblQ==}
+  '@ai-sdk/openai@4.0.37':
+    resolution: {integrity: sha512-rQIdkvqHaqyu94zMJKkhucRwsyTpYUmI+vrH/Dm1Erc6ypURikOV+9e51Pni6RL8IxFlu2bv6y8hA1ghzCy7Gw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/otel@1.0.2':
-    resolution: {integrity: sha512-vmuuwOxJ5OuwMYDktABTLb9V33hwR2k77QIDPZ8mSHSo04seT88IXCmzZwLjTskHfIa5C9IRizzNy6sr2qOQWQ==}
+  '@ai-sdk/otel@1.0.59':
+    resolution: {integrity: sha512-dPmXKV3ZLBBe88n0rsW8f9ERW2yFksiokeoIaau9G/vuHvkW22Pmgql3EhXKmiTY9Su7NsSYhyVeH29E5z3aWg==}
     engines: {node: '>=22'}
 
-  '@ai-sdk/provider-utils@5.0.0':
-    resolution: {integrity: sha512-zj66M02jc6ASYwIgWZowsooDUwaVngeNZQ3H10GwcPMZ+KR6gHMhcUuKl6tkai+JPXTKDyHY1pnszuxRtw2D4A==}
+  '@ai-sdk/provider-utils@5.0.26':
+    resolution: {integrity: sha512-0mqhqx+Dcv+msI84+zkbLXmnCHb/mpkYJ9DU3HBvB1px+UjFQss4lLZqRCSzJ0w3NxwQk4Ishk7cP0r8wEQD5w==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1213,8 +1213,8 @@ packages:
     resolution: {integrity: sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/provider@4.0.0':
-    resolution: {integrity: sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg==}
+  '@ai-sdk/provider@4.0.7':
+    resolution: {integrity: sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==}
     engines: {node: '>=22'}
 
   '@ampproject/remapping@2.2.1':
@@ -2911,8 +2911,8 @@ packages:
     resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
     engines: {node: '>=12'}
 
-  ai@7.0.2:
-    resolution: {integrity: sha512-VMU08jHIDJnnKDrbC9AFa5ZsPpOTfAPRLvTRHtJk4FGAoeldmJROMxvZ2ak5lCjEJ2GP2OLPQbMRyEK8w0+S4A==}
+  ai@7.0.59:
+    resolution: {integrity: sha512-p10cqg8KvLIZi7Gk+XsQjoYoLENoDdEYvehP0rSo6Wg15nbCmP+nwIy1rOIX+WGIDWGdI+jmhjVx5fXShBVC3w==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -5918,6 +5918,10 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
   unionfs@4.5.1:
     resolution: {integrity: sha512-hn8pzkh0/80mpsIT/YBJKa4+BF/9pNh0IgysBi0CjL95Uok8Hus69TNfgeJckoUNwfTpBq26+F7edO1oBINaIw==}
 
@@ -6135,40 +6139,41 @@ snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
-  '@ai-sdk/gateway@4.0.2(zod@3.25.76)':
+  '@ai-sdk/gateway@4.0.47(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0
-      '@ai-sdk/provider-utils': 5.0.0(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.26(zod@3.25.76)
       '@vercel/oidc': 3.2.0
       zod: 3.25.76
 
-  '@ai-sdk/mcp@2.0.1(zod@3.25.76)':
+  '@ai-sdk/mcp@2.0.30(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0
-      '@ai-sdk/provider-utils': 5.0.0(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.26(zod@3.25.76)
       pkce-challenge: 5.0.1
       zod: 3.25.76
 
-  '@ai-sdk/openai@4.0.0(zod@3.25.76)':
+  '@ai-sdk/openai@4.0.37(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0
-      '@ai-sdk/provider-utils': 5.0.0(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.26(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/otel@1.0.2(zod@3.25.76)':
+  '@ai-sdk/otel@1.0.59(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider': 4.0.7
       '@opentelemetry/api': 1.9.1
-      ai: 7.0.2(zod@3.25.76)
+      ai: 7.0.59(zod@3.25.76)
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/provider-utils@5.0.0(zod@3.25.76)':
+  '@ai-sdk/provider-utils@5.0.26(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider': 4.0.7
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
+      undici: 7.29.0
       zod: 3.25.76
 
   '@ai-sdk/provider@3.0.0':
@@ -6176,7 +6181,7 @@ snapshots:
       json-schema: 0.4.0
     optional: true
 
-  '@ai-sdk/provider@4.0.0':
+  '@ai-sdk/provider@4.0.7':
     dependencies:
       json-schema: 0.4.0
 
@@ -8402,11 +8407,11 @@ snapshots:
       clean-stack: 4.2.0
       indent-string: 5.0.0
 
-  ai@7.0.2(zod@3.25.76):
+  ai@7.0.59(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 4.0.2(zod@3.25.76)
-      '@ai-sdk/provider': 4.0.0
-      '@ai-sdk/provider-utils': 5.0.0(zod@3.25.76)
+      '@ai-sdk/gateway': 4.0.47(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.26(zod@3.25.76)
       zod: 3.25.76
 
   ajv-formats@2.1.1(ajv@8.18.0):
@@ -11695,6 +11700,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@8.3.0: {}
+
+  undici@7.29.0: {}
 
   unionfs@4.5.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,10 +40,6 @@ minimumReleaseAgeExclude:
   - '@temporalio/*'
   - nexus-rpc
 
-  # Allow as part of #2170 mitigation to make sure our tests confirm validity
-  # of our fix against the behavior change introduced by webpack@5.108.0
-  - webpack@5.108.4
-
   # Minimum version carrying vercel/ai@401a4ba, which we depend upon. The AI SDK
   # packages pin exact versions of each other and must move in lockstep, so the
   # whole family has to be allowed together.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,17 @@ minimumReleaseAgeExclude:
   # of our fix against the behavior change introduced by webpack@5.108.0
   - webpack@5.108.4
 
+  # Minimum version carrying vercel/ai@401a4ba, which we depend upon. The AI SDK
+  # packages pin exact versions of each other and must move in lockstep, so the
+  # whole family has to be allowed together.
+  - ai@7.0.59
+  - '@ai-sdk/gateway@4.0.47'
+  - '@ai-sdk/mcp@2.0.30'
+  - '@ai-sdk/openai@4.0.37'
+  - '@ai-sdk/otel@1.0.59'
+  - '@ai-sdk/provider@4.0.7'
+  - '@ai-sdk/provider-utils@5.0.26'
+
 peerDependencyRules:
   ignoreMissing:
     # Peer of json-joy@9.9.1, missing in memfs@4.6.0


### PR DESCRIPTION
## What

Raises the `ai` floor in `@temporalio/ai-sdk` from `^7.0.0` to `^7.0.59`, in both `peerDependencies` and `devDependencies`.

## Why

Older releases of `@ai-sdk/provider-utils` evaluated `isNodeDefaultFetch(globalThis.fetch)` at module scope and called `Function.prototype.toString` on it unconditionally. Importing `ai` therefore threw a `TypeError` before any network operation in runtimes without a global `fetch` — including the Temporal workflow sandbox.

[vercel/ai@401a4ba](https://github.com/vercel/ai/commit/401a4ba53319a314f257351b6bb4bd3480c82faf) ("fix: allow AI SDK packages to import in runtimes without global fetch", vercel/ai#18535) adds a runtime function-type guard. `ai@7.0.59` is the first release carrying it.

## The `@ai-sdk/*` family moves in lockstep

The AI SDK packages pin exact versions of each other, so bumping `ai` alone wasn't enough. Leaving the siblings behind kept `provider-utils@5.0.0` in the tree via `@ai-sdk/otel@1.0.2`, which hard-pins `ai@7.0.2` — and that path is reachable from `src/__tests__/workflows/ai-sdk.ts`, i.e. inside the sandbox this fix targets. It also broke `tsc` outright with mismatched `Schema`/`ToolSet`/`FlexibleSchema` types across the two copies.

So `@ai-sdk/mcp`, `@ai-sdk/openai`, `@ai-sdk/otel` and `@ai-sdk/provider` are bumped alongside. Peer ranges for `@ai-sdk/mcp` (`^2.0.0`) and `@ai-sdk/provider` (`^4.0.0`) are left as-is — no reason to constrain consumers further.

## minimumReleaseAgeExclude

These releases are all newer than the two-week `minimumReleaseAge` quarantine, so they need pinned `minimumReleaseAgeExclude` entries, following the existing `webpack@5.108.4` precedent. **This is a supply-chain policy carve-out for seven packages** — narrow and version-pinned, but worth a reviewer's attention. If you'd rather not take it on, the alternative is waiting out the quarantine.

The second commit removes the now-expired `webpack@5.108.4` entry: published 2026-07-04, it clears the 14-day threshold on its own. Verified by re-resolving with the entry removed — webpack still lands on 5.108.4 and the lockfile is byte-identical.

## Testing

`@temporalio/ai-sdk`: **18 passed, 1 skipped** against a local dev server, including the `Telemetry` test that exercises `@ai-sdk/otel`. The skip is the pre-existing hardcoded `test.skip('MCP Use')`. Remote tests stayed off (no API keys set).

Confirmed the fix is present in the resolved dependency:

```
node_modules/.pnpm/@ai-sdk+provider-utils@5.0.26_.../dist/index.js:925:  if (typeof fetch !== "function") {
```

The broader workspace suite was not run locally — my `sdk-core` submodule is checked out off-pin, so `packages/core-bridge` won't build here. Relying on CI for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)