### PR TITLE
feat(extstore): expose concurrent payload visit limit for external storage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ to docs, or any other relevant information.
 - **Experimental**: `TemporalOperationHandler` can now use Standalone Activities as asynchronous
   Nexus Operation backing executions through `TemporalNexusClient.startActivity` and
   `typedActivity`.
+- **Experimental**: Added `ExternalStorage.maxConcurrentVisits` which limits the number of in-flight payload visits
+  for external storage. This does not limit the total number of concurrent external storage operations or concurrent 
+  drivers actively processing payloads. 
 
 ### Changed
 

--- a/packages/common/src/converter/extstore.ts
+++ b/packages/common/src/converter/extstore.ts
@@ -104,6 +104,9 @@ export type StorageDriverSelector = (context: StorageDriverStoreContext, payload
 /** Default {@link ExternalStorage.payloadSizeThreshold}: 256 KiB. */
 const DEFAULT_PAYLOAD_SIZE_THRESHOLD = 256 * 1024;
 
+/** Default {@link ExternalStorage.maxConcurrentVisits}. */
+const DEFAULT_MAX_CONCURRENT_VISITS = 3;
+
 /**
  * Configuration for external storage. Holds the registered drivers, an
  * optional selector, and the size threshold above which payloads are
@@ -120,17 +123,31 @@ export class ExternalStorage {
    */
   readonly driverSelector: StorageDriverSelector;
   readonly payloadSizeThreshold: number;
+  readonly maxConcurrentVisits: number;
   private readonly driversByName: ReadonlyMap<string, StorageDriver>;
 
   constructor({
     drivers,
     driverSelector,
     payloadSizeThreshold = DEFAULT_PAYLOAD_SIZE_THRESHOLD,
+    maxConcurrentVisits = DEFAULT_MAX_CONCURRENT_VISITS,
   }: {
     drivers: StorageDriver[];
     driverSelector?: StorageDriverSelector;
     /** Omit for default (256 KiB). Set `0` to consider all payloads regardless of size. */
     payloadSizeThreshold?: number;
+    /**
+     * Maximum number of payload-bearing fields ("visits") whose {@link StorageDriver.store} or
+     * {@link StorageDriver.retrieve} calls may be in flight at once while a single message is
+     * encoded or decoded. Each visit results in driver calls and each driver call may carry several
+     * payloads. This means that this does not limit the number of requests drivers make to
+     * external storage nor the number of drivers concurrently processing payloads. It only limits
+     * the number of payloads being processed at once for a single message. If you need more granular
+     * control consider implementing a custom {@link StorageDriver}.
+     *
+     * @default 3
+     */
+    maxConcurrentVisits?: number;
   }) {
     if (!Array.isArray(drivers) || drivers.length === 0) {
       throw new ValueError('ExternalStorage requires at least one driver');
@@ -142,6 +159,11 @@ export class ExternalStorage {
     ) {
       throw new ValueError(
         `ExternalStorage.payloadSizeThreshold must be a non-negative finite number, got ${String(payloadSizeThreshold)}`
+      );
+    }
+    if (!Number.isSafeInteger(maxConcurrentVisits) || maxConcurrentVisits < 1) {
+      throw new ValueError(
+        `ExternalStorage.maxConcurrentVisits must be a positive integer, got ${String(maxConcurrentVisits)}`
       );
     }
 
@@ -163,6 +185,7 @@ export class ExternalStorage {
     this.drivers = [...drivers];
     this.driverSelector = driverSelector ?? (() => drivers[0] as StorageDriver);
     this.payloadSizeThreshold = payloadSizeThreshold;
+    this.maxConcurrentVisits = maxConcurrentVisits;
     this.driversByName = driversByName;
   }
 

--- a/packages/common/src/internal-non-workflow/external-storage-visitor.ts
+++ b/packages/common/src/internal-non-workflow/external-storage-visitor.ts
@@ -4,7 +4,7 @@
  *
  * @module
  */
-import type { ConcurrencyLimit } from '../concurrency/limit';
+import { limit, type ConcurrencyLimit } from '../concurrency/limit';
 import type { ExternalStorage, StorageDriverTargetInfo } from '../converter/extstore';
 import { ExternalStorageNotConfiguredError } from '../errors';
 import type { Payload } from '../interfaces';
@@ -25,8 +25,6 @@ export interface ExternalStorageStoreOptions {
   initialTarget?: StorageDriverTargetInfo;
   /** Derives new storage target from the current message. */
   deriveContext?: ContextDeriver<StoreTarget>;
-  /** Bounds concurrent transform calls across payload sites. Omit for sequential. */
-  limit?: ConcurrencyLimit;
   /** Aborts the walk and every in-flight driver call. */
   abortSignal?: AbortSignal;
 }
@@ -37,7 +35,7 @@ export interface ExternalStorageStoreOptions {
  */
 export function extstoreStoreOptions(
   externalStorage: ExternalStorage,
-  { initialTarget, deriveContext, limit, abortSignal }: ExternalStorageStoreOptions = {}
+  { initialTarget, deriveContext, abortSignal }: ExternalStorageStoreOptions = {}
 ): VisitOptions<StoreTarget> {
   const runner = new ExternalStorageRunner(externalStorage);
   return {
@@ -48,14 +46,14 @@ export function extstoreStoreOptions(
     initialContext: initialTarget,
     // Search attributes must keep their literal values so the server can index/search on them.
     skipSearchAttributes: true,
-    limit,
+    limit: limit(externalStorage.maxConcurrentVisits),
     abortSignal,
   };
 }
 
 function extstoreRetrieveOptions(
   externalStorage: ExternalStorage,
-  { limit, abortSignal }: { limit?: ConcurrencyLimit; abortSignal?: AbortSignal } = {}
+  { abortSignal }: { abortSignal?: AbortSignal } = {}
 ): VisitOptions<void> {
   const runner = new ExternalStorageRunner(externalStorage);
   return {
@@ -63,7 +61,7 @@ function extstoreRetrieveOptions(
     transformPayload: (payload, _context, signal) =>
       runner.retrieve([payload], { abortSignal: signal }).then((retrieved) => retrieved[0]!),
     skipSearchAttributes: true,
-    limit,
+    limit: limit(externalStorage.maxConcurrentVisits),
     abortSignal,
   };
 }

--- a/packages/test/src/test-extstore-config.ts
+++ b/packages/test/src/test-extstore-config.ts
@@ -86,6 +86,22 @@ test('ExternalStorage rejects non-finite payloadSizeThreshold', (t) => {
   );
 });
 
+test('ExternalStorage defaults maxConcurrentVisits to 3', (t) => {
+  t.is(new ExternalStorage({ drivers: [stubDriver('only')] }).maxConcurrentVisits, 3);
+});
+
+test('ExternalStorage accepts an explicit maxConcurrentVisits', (t) => {
+  t.is(new ExternalStorage({ drivers: [stubDriver('only')], maxConcurrentVisits: 8 }).maxConcurrentVisits, 8);
+});
+
+test('ExternalStorage rejects non-positive or non-integer maxConcurrentVisits', (t) => {
+  for (const maxConcurrentVisits of [0, -1, 1.5, Number.NaN]) {
+    t.throws(() => new ExternalStorage({ drivers: [stubDriver('only')], maxConcurrentVisits }), {
+      instanceOf: ValueError,
+    });
+  }
+});
+
 test('ExternalStorage rejects a driver with an empty name', (t) => {
   t.throws(() => new ExternalStorage({ drivers: [stubDriver('')] }), {
     instanceOf: ValueError,

--- a/packages/test/src/test-extstore-visit.ts
+++ b/packages/test/src/test-extstore-visit.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import type { Payload } from '@temporalio/common';
 import { ExternalStorageNotConfiguredError } from '@temporalio/common';
-import { ExternalStorage } from '@temporalio/common/lib/converter/extstore';
+import { ExternalStorage, type StorageDriver } from '@temporalio/common/lib/converter/extstore';
 import {
   ExternalStorageRunner,
   extstoreInboundOptions,
@@ -264,4 +264,110 @@ test('inbound options leave a reference-free message untouched when storage is n
 
   await t.notThrowsAsync(() => visit(task, walkActivityTask, extstoreInboundOptions(undefined)));
   t.deepEqual(task.start!.input![0], input, 'payload passes through unchanged');
+});
+
+/**
+ * Wraps the in-memory fake driver so every call overlaps with any sibling the walk let through,
+ * and records the highest number that were ever in flight at once.
+ */
+function gatedDriver(): { driver: StorageDriver; peakConcurrency: () => number } {
+  const inner = makeFakeDriver({ name: 'mem' });
+  let inFlight = 0;
+  let peak = 0;
+  const gate = async <T>(op: () => Promise<T>): Promise<T> => {
+    peak = Math.max(peak, ++inFlight);
+    try {
+      // Hold the call open long enough for every sibling the limit permits to enter before any exits.
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      return await op();
+    } finally {
+      inFlight--;
+    }
+  };
+  return {
+    driver: {
+      name: inner.name,
+      type: inner.type,
+      store: (context, payloads) => gate(() => inner.store(context, payloads)),
+      retrieve: (context, claims) => gate(() => inner.retrieve(context, claims)),
+    },
+    peakConcurrency: () => peak,
+  };
+}
+
+/** A completion scheduling `count` activities, each carrying one above-threshold argument. */
+function completionSchedulingActivities(count: number): coresdk.workflow_completion.IWorkflowActivationCompletion {
+  return {
+    successful: {
+      commands: Array.from({ length: count }, (_, i) => ({
+        scheduleActivity: { activityId: `act-${i}`, arguments: [makePayload(256, i)] },
+      })),
+    },
+  };
+}
+
+/** External storage over a {@link gatedDriver}, offloading everything above 96 bytes. */
+function gatedExternalStorage(maxConcurrentVisits?: number) {
+  const { driver, peakConcurrency } = gatedDriver();
+  const externalStorage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 96, maxConcurrentVisits });
+  return { externalStorage, peakConcurrency };
+}
+
+test('store walk bounds concurrent driver calls to maxConcurrentVisits', async (t) => {
+  const { externalStorage, peakConcurrency } = gatedExternalStorage(2);
+  const completion = completionSchedulingActivities(6);
+
+  await visit(
+    completion,
+    walkWorkflowActivationCompletion,
+    extstoreStoreOptions(externalStorage, { initialTarget: WORKFLOW_TARGET })
+  );
+
+  t.is(peakConcurrency(), 2);
+  for (const command of completion.successful!.commands!) {
+    t.true(isReferencePayload(command.scheduleActivity!.arguments![0]!));
+  }
+});
+
+test('store walk runs one driver call at a time at maxConcurrentVisits = 1', async (t) => {
+  const { externalStorage, peakConcurrency } = gatedExternalStorage(1);
+
+  await visit(
+    completionSchedulingActivities(4),
+    walkWorkflowActivationCompletion,
+    extstoreStoreOptions(externalStorage, { initialTarget: WORKFLOW_TARGET })
+  );
+
+  t.is(peakConcurrency(), 1);
+});
+
+test('store walk defaults to 3 concurrent driver calls', async (t) => {
+  const { externalStorage, peakConcurrency } = gatedExternalStorage();
+
+  await visit(
+    completionSchedulingActivities(6),
+    walkWorkflowActivationCompletion,
+    extstoreStoreOptions(externalStorage, { initialTarget: WORKFLOW_TARGET })
+  );
+
+  t.is(peakConcurrency(), 3);
+});
+
+test('inbound walk bounds concurrent driver calls to maxConcurrentVisits', async (t) => {
+  const { externalStorage, peakConcurrency } = gatedExternalStorage(2);
+  const originals = Array.from({ length: 6 }, (_, i) => makePayload(256, i));
+  const jobs: coresdk.workflow_activation.IWorkflowActivationJob[] = [];
+  for (const original of originals) {
+    // Awaited one at a time, so the setup itself never exceeds a concurrency of 1.
+    jobs.push({ resolveActivity: { result: { completed: { result: await toReference(externalStorage, original) } } } });
+  }
+  const activation: coresdk.workflow_activation.IWorkflowActivation = { jobs };
+
+  await visit(activation, walkWorkflowActivation, extstoreInboundOptions(externalStorage));
+
+  t.is(peakConcurrency(), 2);
+  t.deepEqual(
+    activation.jobs!.map((job) => job.resolveActivity!.result!.completed!.result!),
+    originals
+  );
 });


### PR DESCRIPTION
## What was changed
- Added `maxConcurrentVisits` to `ExternalStorage` constructor for limiting concurrent payload visits.
- This diverges from Go and Python which expose the limit on their worker options. I think a) external storage is the more natural place for this option and b) having the option on external storage allows us to also configure this limit for clients (which is currently not possible in go and python, they are hardcoded to 1). 

## Why?
- This was previously not configurable.

## Checklist
- Closes https://github.com/temporalio/sdk-typescript/issues/2275