### PR TITLE
Report non-retryable PayloadValidationError as BAD_REQUEST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ to docs, or any other relevant information.
   Workflow-backed Operations with `WorkflowRunOperationHandler`.
 - `@temporalio/ai-sdk` now requires `ai@>=7.0.59` as a peer dependency, up from `7.0.0`, since
   earlier releases threw a `TypeError` on import in runtimes without a global `fetch`.
+- A Payload Converter or Payload Codec that fails to decode a Nexus Operation's input with a
+  non-retryable `ApplicationFailure` of type `PayloadValidationError` now results in a `BAD_REQUEST`
+  Nexus Handler Error instead of `INTERNAL`, so the caller is not retried on invalid input. The
+  original `ApplicationFailure` is retained as the Handler Error's cause. Any other failure from the
+  data converter is unchanged.
 
 ## [1.22.0] - 2026-08-05
 

--- a/packages/test/src/payload-validation-failing-payload-converter.ts
+++ b/packages/test/src/payload-validation-failing-payload-converter.ts
@@ -1,0 +1,17 @@
+import type { Payload } from '@temporalio/common';
+import { ApplicationFailure, defaultPayloadConverter } from '@temporalio/common';
+import type { PayloadConverter } from '@temporalio/common/lib/converter/payload-converter';
+
+export const payloadConverter: PayloadConverter = {
+  toPayload<T>(value: T): Payload {
+    return defaultPayloadConverter.toPayload(value);
+  },
+  fromPayload<T>(_payload: Payload): T {
+    // The reserved type a converter uses to report that it understood the payload but rejects it.
+    throw ApplicationFailure.create({
+      message: 'Intentional payload validation failure for testing',
+      type: 'PayloadValidationError',
+      nonRetryable: true,
+    });
+  },
+};

--- a/packages/test/src/test-nexus-codec-converter-errors.cloud-unavailable.ts
+++ b/packages/test/src/test-nexus-codec-converter-errors.cloud-unavailable.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
 import * as nexus from 'nexus-rpc';
 import type { Payload } from '@temporalio/common';
-import { NexusOperationFailure } from '@temporalio/common';
+import { ApplicationFailure, NexusOperationFailure } from '@temporalio/common';
 import { Client, WorkflowFailedError } from '@temporalio/client';
 import type { PayloadCodec } from '@temporalio/common/lib/converter/payload-codec';
 import * as workflow from '@temporalio/workflow';
@@ -215,5 +215,127 @@ test('Nexus operation converter HandlerError is propagated as-is', async (t) => 
     t.is(handlerError.type, 'NOT_FOUND');
     t.false(handlerError.retryable);
     t.regex(handlerError.message, /Intentional payload converter HandlerError for testing/);
+  });
+});
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+test('Nexus operation codec PayloadValidationError is a non-retryable bad request', async (t) => {
+  const { createWorker, registerNexusEndpoint, taskQueue } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+
+  // Only fail when decoding the Nexus operation input ('hello'), so that the caller workflow's
+  // own activation payloads still decode successfully and the operation is actually reached.
+  let decodeAttempts = 0;
+  const validationCodec: PayloadCodec = {
+    async encode(payloads: Payload[]): Promise<Payload[]> {
+      return payloads;
+    },
+    async decode(payloads: Payload[]): Promise<Payload[]> {
+      for (const payload of payloads) {
+        if (payload.data != null && Buffer.from(payload.data).toString() === '"hello"') {
+          decodeAttempts++;
+          // The reserved type a codec uses to report that it understood the payload but rejects it.
+          throw ApplicationFailure.create({
+            message: 'Intentional payload validation failure for testing',
+            type: 'PayloadValidationError',
+            nonRetryable: true,
+          });
+        }
+      }
+      return payloads;
+    },
+  };
+
+  const worker = await createWorker({
+    dataConverter: { payloadCodecs: [validationCodec] },
+    nexusServices: [
+      nexus.serviceHandler(testService, {
+        async echoOp(_ctx, input) {
+          return input;
+        },
+      }),
+    ],
+  });
+
+  const customClient = new Client({
+    connection: t.context.env.connection,
+    dataConverter: { payloadCodecs: [validationCodec] },
+  });
+
+  await worker.runUntil(async () => {
+    const err = await t.throwsAsync(
+      () =>
+        customClient.workflow.execute(nexusEchoCaller, {
+          taskQueue,
+          workflowId: randomUUID(),
+          args: [endpointName],
+        }),
+      {
+        instanceOf: WorkflowFailedError,
+      }
+    );
+    t.true(err!.cause instanceof NexusOperationFailure);
+    const nexusFailure = err!.cause as NexusOperationFailure;
+    t.true(nexusFailure.cause instanceof nexus.HandlerError);
+    const handlerError = innermostHandlerError(nexusFailure.cause as nexus.HandlerError);
+    // A non-retryable validation failure means the input is invalid, so BAD_REQUEST rather than
+    // the INTERNAL any other ApplicationFailure from a codec gets.
+    t.is(handlerError.type, 'BAD_REQUEST');
+    t.false(handlerError.retryable);
+    t.is(handlerError.message, 'Invalid operation input');
+    // The wrapper message does not carry the codec's own message, so it has to survive on the cause.
+    t.true(handlerError.cause instanceof ApplicationFailure);
+    const cause = handlerError.cause as ApplicationFailure;
+    t.is(cause.type, 'PayloadValidationError');
+    t.regex(cause.message, /Intentional payload validation failure for testing/);
+  });
+
+  // Non-retryable, so the input is only decoded once.
+  t.is(decodeAttempts, 1);
+});
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+test('Nexus operation converter PayloadValidationError is a non-retryable bad request', async (t) => {
+  const { createWorker, registerNexusEndpoint, taskQueue } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+
+  const worker = await createWorker({
+    dataConverter: { payloadConverterPath: require.resolve('./payload-validation-failing-payload-converter') },
+    nexusServices: [
+      nexus.serviceHandler(testService, {
+        async echoOp(_ctx, input) {
+          return input;
+        },
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const err = await t.throwsAsync(
+      () =>
+        t.context.env.client.workflow.execute(nexusEchoCaller, {
+          taskQueue,
+          workflowId: randomUUID(),
+          args: [endpointName],
+        }),
+      {
+        instanceOf: WorkflowFailedError,
+      }
+    );
+    t.true(err!.cause instanceof NexusOperationFailure);
+    const nexusFailure = err!.cause as NexusOperationFailure;
+    t.true(nexusFailure.cause instanceof nexus.HandlerError);
+    const handlerError = innermostHandlerError(nexusFailure.cause as nexus.HandlerError);
+    t.is(handlerError.type, 'BAD_REQUEST');
+    t.false(handlerError.retryable);
+    // A validation failure gets its own message, distinct from the generic decode failure.
+    t.is(handlerError.message, 'Invalid operation input');
+    t.notRegex(handlerError.message, /Payload converter failed to decode/);
+    t.true(handlerError.cause instanceof ApplicationFailure);
+    const cause = handlerError.cause as ApplicationFailure;
+    t.is(cause.type, 'PayloadValidationError');
+    t.regex(cause.message, /Intentional payload validation failure for testing/);
   });
 });

--- a/packages/test/src/test-nexus-handler.ts
+++ b/packages/test/src/test-nexus-handler.ts
@@ -451,7 +451,10 @@ test('decodePayload maps non-retryable PayloadValidationError from converter to 
   t.false(err?.retryable);
   t.is(err?.message, 'Invalid operation input');
   // The original failure, including its message, is retained as the cause.
+  t.true(err?.cause instanceof ApplicationFailure);
   t.is(err?.cause, cause);
+  t.is((err?.cause as ApplicationFailure).type, PAYLOAD_VALIDATION_ERROR_TYPE);
+  t.true((err?.cause as ApplicationFailure).nonRetryable);
   t.is((err?.cause as ApplicationFailure).message, 'input payload is invalid');
 });
 
@@ -469,7 +472,10 @@ test('decodePayload maps non-retryable PayloadValidationError from codec to a ba
   t.false(err?.retryable);
   t.is(err?.message, 'Invalid operation input');
   // The original failure, including its message, is retained as the cause.
+  t.true(err?.cause instanceof ApplicationFailure);
   t.is(err?.cause, cause);
+  t.is((err?.cause as ApplicationFailure).type, PAYLOAD_VALIDATION_ERROR_TYPE);
+  t.true((err?.cause as ApplicationFailure).nonRetryable);
   t.is((err?.cause as ApplicationFailure).message, 'input payload is invalid');
 });
 

--- a/packages/test/src/test-nexus-handler.ts
+++ b/packages/test/src/test-nexus-handler.ts
@@ -9,7 +9,7 @@ import * as root from '@temporalio/proto';
 import * as testing from '@temporalio/testing';
 import type { LogEntry } from '@temporalio/worker';
 import { DefaultLogger, Runtime, Worker } from '@temporalio/worker';
-import type { ProtoFailure } from '@temporalio/common';
+import type { LoadedDataConverter, Payload, ProtoFailure } from '@temporalio/common';
 import {
   ApplicationFailure,
   CancelledFailure,
@@ -17,8 +17,14 @@ import {
   defaultPayloadConverter,
   defaultDataConverter,
 } from '@temporalio/common';
+import type { PayloadCodec } from '@temporalio/common/lib/converter/payload-codec';
 import { ServiceError } from '@temporalio/client';
-import { coerceToHandlerError, operationErrorToProto } from '@temporalio/worker/lib/nexus/conversions';
+import {
+  PAYLOAD_VALIDATION_ERROR_TYPE,
+  coerceToHandlerError,
+  decodePayload,
+  operationErrorToProto,
+} from '@temporalio/worker/lib/nexus/conversions';
 
 export interface Context {
   taskQueue: string;
@@ -396,6 +402,138 @@ test('coerceToHandlerError maps non-retryable ApplicationFailure to INTERNAL', (
 
 test('coerceToHandlerError maps unknown errors to INTERNAL', (t) => {
   t.is(coerceToHandlerError(new Error('something')).type, 'INTERNAL');
+});
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// decodePayload unit tests
+
+const encodedInputPayload = defaultPayloadConverter.toPayload('some-input') as Payload;
+
+/** A data converter whose Payload Converter always fails to decode with `err`. */
+function converterFailingWith(err: unknown): LoadedDataConverter {
+  return {
+    ...defaultDataConverter,
+    payloadConverter: {
+      toPayload<T>(value: T): Payload {
+        return defaultPayloadConverter.toPayload(value);
+      },
+      fromPayload<T>(): T {
+        throw err;
+      },
+    },
+  };
+}
+
+/** A data converter whose Payload Codec always fails to decode with `err`. */
+function codecFailingWith(err: unknown): LoadedDataConverter {
+  const codec: PayloadCodec = {
+    async encode(payloads: Payload[]): Promise<Payload[]> {
+      return payloads;
+    },
+    async decode(): Promise<Payload[]> {
+      throw err;
+    },
+  };
+  return { ...defaultDataConverter, payloadCodecs: [codec] };
+}
+
+test('decodePayload maps non-retryable PayloadValidationError from converter to a bad request handler error', async (t) => {
+  const cause = ApplicationFailure.create({
+    message: 'input payload is invalid',
+    type: PAYLOAD_VALIDATION_ERROR_TYPE,
+    nonRetryable: true,
+  });
+
+  const err = await t.throwsAsync(() => decodePayload(converterFailingWith(cause), encodedInputPayload), {
+    instanceOf: nexus.HandlerError,
+  });
+  t.is(err?.type, 'BAD_REQUEST');
+  t.false(err?.retryable);
+  t.is(err?.message, 'Invalid operation input');
+  // The original failure, including its message, is retained as the cause.
+  t.is(err?.cause, cause);
+  t.is((err?.cause as ApplicationFailure).message, 'input payload is invalid');
+});
+
+test('decodePayload maps non-retryable PayloadValidationError from codec to a bad request handler error', async (t) => {
+  const cause = ApplicationFailure.create({
+    message: 'input payload is invalid',
+    type: PAYLOAD_VALIDATION_ERROR_TYPE,
+    nonRetryable: true,
+  });
+
+  const err = await t.throwsAsync(() => decodePayload(codecFailingWith(cause), encodedInputPayload), {
+    instanceOf: nexus.HandlerError,
+  });
+  t.is(err?.type, 'BAD_REQUEST');
+  t.false(err?.retryable);
+  t.is(err?.message, 'Invalid operation input');
+  // The original failure, including its message, is retained as the cause.
+  t.is(err?.cause, cause);
+  t.is((err?.cause as ApplicationFailure).message, 'input payload is invalid');
+});
+
+test('decodePayload leaves non-retryable ApplicationFailure of another type as an internal handler error', async (t) => {
+  const cause = ApplicationFailure.create({
+    message: 'some other failure',
+    type: 'SomeOtherError',
+    nonRetryable: true,
+  });
+
+  const err = await t.throwsAsync(() => decodePayload(converterFailingWith(cause), encodedInputPayload), {
+    instanceOf: ApplicationFailure,
+  });
+  // The ApplicationFailure is rethrown as-is, and only later coerced into an INTERNAL handler error.
+  t.is(err, cause);
+  const handlerError = coerceToHandlerError(err);
+  t.is(handlerError.type, 'INTERNAL');
+  t.false(handlerError.retryable);
+});
+
+test('decodePayload leaves retryable PayloadValidationError as an internal handler error', async (t) => {
+  const cause = ApplicationFailure.create({
+    message: 'input payload is invalid',
+    type: PAYLOAD_VALIDATION_ERROR_TYPE,
+    nonRetryable: false,
+  });
+
+  const err = await t.throwsAsync(() => decodePayload(converterFailingWith(cause), encodedInputPayload), {
+    instanceOf: ApplicationFailure,
+  });
+  // The non-retryable condition is required; a retryable failure is rethrown as-is and coerced to INTERNAL.
+  t.is(err, cause);
+  t.is(coerceToHandlerError(err).type, 'INTERNAL');
+});
+
+test('decodePayload passes through HandlerError from converter unchanged', async (t) => {
+  const original = new nexus.HandlerError('NOT_FOUND', 'nope');
+
+  const err = await t.throwsAsync(() => decodePayload(converterFailingWith(original), encodedInputPayload), {
+    instanceOf: nexus.HandlerError,
+  });
+  t.is(err, original);
+});
+
+test('decodePayload maps other converter errors to a bad request handler error', async (t) => {
+  const cause = new Error('kaboom');
+
+  const err = await t.throwsAsync(() => decodePayload(converterFailingWith(cause), encodedInputPayload), {
+    instanceOf: nexus.HandlerError,
+  });
+  t.is(err?.type, 'BAD_REQUEST');
+  t.regex(err!.message, /Payload converter failed to decode Nexus operation input/);
+  t.is(err?.cause, cause);
+});
+
+test('decodePayload maps other codec errors to an internal handler error', async (t) => {
+  const cause = new Error('kaboom');
+
+  const err = await t.throwsAsync(() => decodePayload(codecFailingWith(cause), encodedInputPayload), {
+    instanceOf: nexus.HandlerError,
+  });
+  t.is(err?.type, 'INTERNAL');
+  t.regex(err!.message, /Payload codec failed to decode Nexus operation input/);
+  t.is(err?.cause, cause);
 });
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/worker/src/nexus/conversions.ts
+++ b/packages/worker/src/nexus/conversions.ts
@@ -10,6 +10,23 @@ import type { temporal } from '@temporalio/proto';
 // Payloads
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * Error type used by a Payload Converter or Payload Codec to report that a Payload failed
+ * validation, i.e. that the input is invalid rather than that the handler failed to process it.
+ *
+ * When a Nexus operation's input fails to decode with a non-retryable {@link ApplicationFailure} of
+ * this type, the resulting Nexus Handler Error is `BAD_REQUEST` rather than `INTERNAL`.
+ */
+export const PAYLOAD_VALIDATION_ERROR_TYPE = 'PayloadValidationError';
+
+/**
+ * Whether `err` is a non-retryable {@link ApplicationFailure} whose type is exactly
+ * {@link PAYLOAD_VALIDATION_ERROR_TYPE}.
+ */
+function isPayloadValidationFailure(err: unknown): err is ApplicationFailure {
+  return err instanceof ApplicationFailure && err.nonRetryable === true && err.type === PAYLOAD_VALIDATION_ERROR_TYPE;
+}
+
 export async function decodePayload(
   dataConverter: LoadedDataConverter,
   payload: temporal.api.common.v1.IPayload | undefined
@@ -18,6 +35,11 @@ export async function decodePayload(
   try {
     decoded = await decodeOptionalSingle(dataConverter.payloadCodecs, payload);
   } catch (err) {
+    if (isPayloadValidationFailure(err)) {
+      throw new nexus.HandlerError('BAD_REQUEST', `Invalid operation input`, {
+        cause: err,
+      });
+    }
     if (err instanceof ApplicationFailure || err instanceof nexus.HandlerError) {
       throw err;
     }
@@ -31,6 +53,11 @@ export async function decodePayload(
   try {
     return dataConverter.payloadConverter.fromPayload(decoded);
   } catch (err) {
+    if (isPayloadValidationFailure(err)) {
+      throw new nexus.HandlerError('BAD_REQUEST', `Invalid operation input`, {
+        cause: err,
+      });
+    }
     if (err instanceof ApplicationFailure || err instanceof nexus.HandlerError) {
       throw err;
     }


### PR DESCRIPTION
## What changed

A Payload Converter or Payload Codec can now signal that a Nexus Operation's input is invalid by throwing a non-retryable `ApplicationFailure` of type `PayloadValidationError` while decoding the input. Such a failure is translated into a `BAD_REQUEST` Nexus Handler Error with the message `Invalid operation input`, retaining the original failure as its cause.

Previously any `ApplicationFailure` thrown by the converter or codec became an `INTERNAL` Handler Error, which callers retry — so a caller sending invalid input was retried until timeout instead of failing fast.

## Unchanged

- `ApplicationFailure` of any other type → `INTERNAL` (as before)
- A **retryable** `PayloadValidationError` → `INTERNAL` (non-retryable is required)
- `HandlerError` thrown by the converter/codec → passed through untouched
- The encode/output path is untouched — `BAD_REQUEST` would be wrong for a result-encoding failure

## Tests

`packages/test/src/test-nexus-handler.ts` covers both the codec and converter stages: positive cases asserting `BAD_REQUEST`, `retryable === false`, the wrapper message and the preserved cause, plus negative cases asserting a different error type and a retryable `PayloadValidationError` still yield `INTERNAL`.

## Cross-SDK

Part of a coordinated change; equivalent PRs exist for Go, Java, Python and .NET. The wrapper message wording is aligned across SDKs, adapted to each SDK's message style.