### PR TITLE
feat(workflow): support TypeInfo for string Signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ to docs, or any other relevant information.
 - **Experimental**: Signal definitions can now provide `TypeInfo` for converting Signal arguments on Client and
   Workflow callers and in Workflow handlers.
 - **Experimental**: Workflows can now use `TypeInfo` for Child Workflow inputs and results and continue-as-new inputs.
+- **Experimental**: String-named Signal calls can now provide `TypeInfo` through explicit options on Client and
+  Workflow handles and in signal-with-start requests.
 
 ### Changed
 

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -601,11 +601,20 @@ export class WorkflowClient extends BaseClient {
     interceptors: WorkflowClientInterceptor[]
   ): Promise<string> {
     const { signal, signalArgs, signalTypeInfo, ...rest } = options;
-    if (typeof signal !== 'string' && signalTypeInfo !== undefined) {
-      throw new TypeError(
-        'Cannot provide call-site Signal TypeInfo with a Signal definition. ' +
-          'Use defineSignal(..., { typeInfo }) on the Signal definition instead.'
-      );
+    let signalName: string;
+    let resolvedSignalTypeInfo: SignalTypeInfo | undefined;
+    if (typeof signal === 'string') {
+      signalName = signal;
+      resolvedSignalTypeInfo = signalTypeInfo;
+    } else {
+      if (signalTypeInfo !== undefined) {
+        throw new TypeError(
+          'Cannot provide call-site Signal TypeInfo with a Signal definition. ' +
+            'Use defineSignal(..., { typeInfo }) on the Signal definition instead.'
+        );
+      }
+      signalName = signal.name;
+      resolvedSignalTypeInfo = signal.typeInfo;
     }
     const { type: workflowType, typeInfo } = extractWorkflowTypeAndConfig(workflowTypeOrFunc, rest.typeInfo);
     assertRequiredWorkflowOptions(rest);
@@ -624,9 +633,9 @@ export class WorkflowClient extends BaseClient {
       options: compiledOptions,
       headers: {},
       workflowType,
-      signalName: typeof signal === 'string' ? signal : signal.name,
+      signalName,
       signalArgs: signalArgs ?? [],
-      signalTypeInfo: typeof signal === 'string' ? signalTypeInfo : signal.typeInfo,
+      signalTypeInfo: resolvedSignalTypeInfo,
     });
   }
 
@@ -669,6 +678,9 @@ export class WorkflowClient extends BaseClient {
    * is `USE_EXISTING`, then the Signal is issued against the already existing Workflow Execution;
    * however, if the policy is `FAIL`, then an error is thrown. If no policy is specified,
    * Signal-with-Start defaults to `USE_EXISTING`.
+   *
+   * A Signal definition supplies its own TypeInfo. When signaling by name, provide call-site TypeInfo through
+   * {@link WorkflowSignalWithStartOptions.signalTypeInfo}.
    *
    * @returns a {@link WorkflowHandle} to the started Workflow
    */
@@ -1681,7 +1693,7 @@ export class WorkflowClient extends BaseClient {
     };
 
     const _signal = async (
-      handle: InternalWorkflowHandle,
+      sourceHandle: InternalWorkflowHandle,
       signalName: string,
       args: unknown[],
       typeInfo?: SignalTypeInfo
@@ -1696,7 +1708,7 @@ export class WorkflowClient extends BaseClient {
         headers: {},
         // Forward any SDK-internal signal options (e.g. Nexus request links) that were attached to
         // this handle, and let the signal handler write the response link back onto the same payload.
-        [InternalWorkflowSignalOptionsSymbol]: handle[InternalWorkflowSignalOptionsSymbol],
+        [InternalWorkflowSignalOptionsSymbol]: sourceHandle[InternalWorkflowSignalOptionsSymbol],
       };
       await fn(input);
     };
@@ -1783,12 +1795,11 @@ export class WorkflowClient extends BaseClient {
         return this.client.createWorkflowUpdateHandle(updateId, workflowId, runId);
       },
       async signal<Args extends any[]>(def: SignalDefinition<Args> | string, ...args: Args): Promise<void> {
-        await _signal(
-          this as InternalWorkflowHandle,
-          typeof def === 'string' ? def : def.name,
-          args,
-          typeof def === 'string' ? undefined : def.typeInfo
-        );
+        if (typeof def === 'string') {
+          await _signal(this as InternalWorkflowHandle, def, args);
+        } else {
+          await _signal(this as InternalWorkflowHandle, def.name, args, def.typeInfo);
+        }
       },
       async signalWithOptions<Args extends any[]>(
         signalName: string,

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -5,6 +5,7 @@ import type {
   HistoryAndWorkflowId,
   QueryDefinition,
   SignalDefinition,
+  SignalTypeInfo,
   UpdateDefinition,
   WithWorkflowArgs,
   Workflow,
@@ -14,6 +15,7 @@ import type {
   WorkflowTypeOptions,
   PayloadTypeInfo,
   TypeInfo,
+  WorkflowSignalOptions,
 } from '@temporalio/common';
 import {
   CancelledFailure,
@@ -598,7 +600,13 @@ export class WorkflowClient extends BaseClient {
     options: WithWorkflowArgs<T, WorkflowSignalWithStartOptions<SA>>,
     interceptors: WorkflowClientInterceptor[]
   ): Promise<string> {
-    const { signal, signalArgs, ...rest } = options;
+    const { signal, signalArgs, signalTypeInfo, ...rest } = options;
+    if (typeof signal !== 'string' && signalTypeInfo !== undefined) {
+      throw new TypeError(
+        'Cannot provide call-site Signal TypeInfo with a Signal definition. ' +
+          'Use defineSignal(..., { typeInfo }) on the Signal definition instead.'
+      );
+    }
     const { type: workflowType, typeInfo } = extractWorkflowTypeAndConfig(workflowTypeOrFunc, rest.typeInfo);
     assertRequiredWorkflowOptions(rest);
     const workflowOptions = {
@@ -618,7 +626,7 @@ export class WorkflowClient extends BaseClient {
       workflowType,
       signalName: typeof signal === 'string' ? signal : signal.name,
       signalArgs: signalArgs ?? [],
-      signalTypeInfo: typeof signal === 'string' ? undefined : signal.typeInfo,
+      signalTypeInfo: typeof signal === 'string' ? signalTypeInfo : signal.typeInfo,
     });
   }
 
@@ -1672,6 +1680,27 @@ export class WorkflowClient extends BaseClient {
       return handle;
     };
 
+    const _signal = async (
+      handle: InternalWorkflowHandle,
+      signalName: string,
+      args: unknown[],
+      typeInfo?: SignalTypeInfo
+    ): Promise<void> => {
+      const next = this._signalWorkflowHandler.bind(this);
+      const fn = composeInterceptors(interceptors, 'signal', next);
+      const input: InternalWorkflowSignalInput = {
+        workflowExecution: { workflowId, runId },
+        signalName,
+        args,
+        typeInfo,
+        headers: {},
+        // Forward any SDK-internal signal options (e.g. Nexus request links) that were attached to
+        // this handle, and let the signal handler write the response link back onto the same payload.
+        [InternalWorkflowSignalOptionsSymbol]: handle[InternalWorkflowSignalOptionsSymbol],
+      };
+      await fn(input);
+    };
+
     return {
       client: this,
       workflowId,
@@ -1754,19 +1783,18 @@ export class WorkflowClient extends BaseClient {
         return this.client.createWorkflowUpdateHandle(updateId, workflowId, runId);
       },
       async signal<Args extends any[]>(def: SignalDefinition<Args> | string, ...args: Args): Promise<void> {
-        const next = this.client._signalWorkflowHandler.bind(this.client);
-        const fn = composeInterceptors(interceptors, 'signal', next);
-        const input: InternalWorkflowSignalInput = {
-          workflowExecution: { workflowId, runId },
-          signalName: typeof def === 'string' ? def : def.name,
+        await _signal(
+          this as InternalWorkflowHandle,
+          typeof def === 'string' ? def : def.name,
           args,
-          typeInfo: typeof def === 'string' ? undefined : def.typeInfo,
-          headers: {},
-          // Forward any SDK-internal signal options (e.g. Nexus request links) that were attached to
-          // this handle, and let the signal handler write the response link back onto the same payload.
-          [InternalWorkflowSignalOptionsSymbol]: (this as InternalWorkflowHandle)[InternalWorkflowSignalOptionsSymbol],
-        };
-        await fn(input);
+          typeof def === 'string' ? undefined : def.typeInfo
+        );
+      },
+      async signalWithOptions<Args extends any[]>(
+        signalName: string,
+        options: WorkflowSignalOptions<Args>
+      ): Promise<void> {
+        await _signal(this as InternalWorkflowHandle, signalName, options.args ?? [], options.typeInfo);
       },
       async query<Ret, Args extends any[]>(def: QueryDefinition<Ret, Args> | string, ...args: Args): Promise<Ret> {
         const next = this.client._queryWorkflowHandler.bind(this.client);

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -1,6 +1,7 @@
 import type {
   CommonWorkflowOptions,
   SignalDefinition,
+  SignalTypeInfo,
   WithWorkflowArgs,
   Workflow,
   VersioningOverride,
@@ -119,6 +120,13 @@ export interface WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs extends an
   signal: SignalDefinition<SignalArgs> | string;
 
   /**
+   * Type information used to convert Signal arguments when {@link signal} is a Signal name.
+   *
+   * @experimental
+   */
+  signalTypeInfo?: SignalTypeInfo;
+
+  /**
    * Arguments to invoke the signal handler with
    */
   signalArgs?: SignalArgs;
@@ -130,6 +138,13 @@ export interface WorkflowSignalWithStartOptionsWithArgs<SignalArgs extends any[]
    * SignalDefinition or name of signal
    */
   signal: SignalDefinition<SignalArgs> | string;
+
+  /**
+   * Type information used to convert Signal arguments when {@link signal} is a Signal name.
+   *
+   * @experimental
+   */
+  signalTypeInfo?: SignalTypeInfo;
 
   /**
    * Arguments to invoke the signal handler with

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -108,9 +108,15 @@ export interface WorkflowUpdateOptions {
   readonly updateId?: string;
 }
 
+type SignalWithStartTarget<SignalArgs extends any[]> =
+  | { signal: SignalDefinition<SignalArgs>; signalTypeInfo?: never }
+  | { signal: string; signalTypeInfo?: SignalTypeInfo };
+
 export type WorkflowSignalWithStartOptions<SignalArgs extends any[] = []> = SignalArgs extends [any, ...any[]]
-  ? WorkflowSignalWithStartOptionsWithArgs<SignalArgs>
-  : WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs>;
+  ? Omit<WorkflowSignalWithStartOptionsWithArgs<SignalArgs>, 'signal' | 'signalTypeInfo'> &
+      SignalWithStartTarget<SignalArgs>
+  : Omit<WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs>, 'signal' | 'signalTypeInfo'> &
+      SignalWithStartTarget<SignalArgs>;
 
 export interface WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs extends any[]>
   extends Omit<WorkflowOptions, 'requestEagerStart'> {

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -108,15 +108,25 @@ export interface WorkflowUpdateOptions {
   readonly updateId?: string;
 }
 
-type SignalWithStartTarget<SignalArgs extends any[]> =
-  | { signal: SignalDefinition<SignalArgs>; signalTypeInfo?: never }
-  | { signal: string; signalTypeInfo?: SignalTypeInfo };
+type WorkflowSignalWithStartOptionsBase<SignalArgs extends any[]> = SignalArgs extends [any, ...any[]]
+  ? WorkflowSignalWithStartOptionsWithArgs<SignalArgs>
+  : WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs>;
 
-export type WorkflowSignalWithStartOptions<SignalArgs extends any[] = []> = SignalArgs extends [any, ...any[]]
-  ? Omit<WorkflowSignalWithStartOptionsWithArgs<SignalArgs>, 'signal' | 'signalTypeInfo'> &
-      SignalWithStartTarget<SignalArgs>
-  : Omit<WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs>, 'signal' | 'signalTypeInfo'> &
-      SignalWithStartTarget<SignalArgs>;
+type SignalWithStartTypeInfoOptions =
+  | { signalTypeInfo?: never }
+  | {
+      signal: string;
+
+      /**
+       * Type information used to convert Signal arguments.
+       *
+       * @experimental
+       */
+      signalTypeInfo?: SignalTypeInfo;
+    };
+
+export type WorkflowSignalWithStartOptions<SignalArgs extends any[] = []> =
+  WorkflowSignalWithStartOptionsBase<SignalArgs> & SignalWithStartTypeInfoOptions;
 
 export interface WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs extends any[]>
   extends Omit<WorkflowOptions, 'requestEagerStart'> {
@@ -124,13 +134,6 @@ export interface WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs extends an
    * SignalDefinition or name of signal
    */
   signal: SignalDefinition<SignalArgs> | string;
-
-  /**
-   * Type information used to convert Signal arguments when {@link signal} is a Signal name.
-   *
-   * @experimental
-   */
-  signalTypeInfo?: SignalTypeInfo;
 
   /**
    * Arguments to invoke the signal handler with
@@ -144,13 +147,6 @@ export interface WorkflowSignalWithStartOptionsWithArgs<SignalArgs extends any[]
    * SignalDefinition or name of signal
    */
   signal: SignalDefinition<SignalArgs> | string;
-
-  /**
-   * Type information used to convert Signal arguments when {@link signal} is a Signal name.
-   *
-   * @experimental
-   */
-  signalTypeInfo?: SignalTypeInfo;
 
   /**
    * Arguments to invoke the signal handler with

--- a/packages/common/src/workflow-handle.ts
+++ b/packages/common/src/workflow-handle.ts
@@ -27,7 +27,9 @@ export interface BaseWorkflowHandle<T extends Workflow> {
   /**
    * Signal a running Workflow.
    *
-   * @param def a signal definition as returned from {@link defineSignal}
+   * To provide call-site TypeInfo when signaling by name, use {@link signalWithOptions}.
+   *
+   * @param def a signal definition as returned from {@link defineSignal}, or a signal name
    *
    * @example
    * ```ts
@@ -40,7 +42,7 @@ export interface BaseWorkflowHandle<T extends Workflow> {
   ): Promise<void>;
 
   /**
-   * Signal a running Workflow by Signal name with additional options.
+   * Signal a running Workflow by Signal name with additional options, including call-site TypeInfo.
    *
    * @experimental
    */

--- a/packages/common/src/workflow-handle.ts
+++ b/packages/common/src/workflow-handle.ts
@@ -1,4 +1,17 @@
-import type { Workflow, WorkflowResultType, SignalDefinition } from './interfaces';
+import type { Workflow, WorkflowResultType, SignalDefinition, SignalTypeInfo } from './interfaces';
+
+/**
+ * Options for signaling a Workflow by Signal name.
+ *
+ * @experimental
+ */
+export interface WorkflowSignalOptions<Args extends any[] = []> {
+  /** Arguments to pass to the Signal handler. */
+  args?: Args;
+
+  /** Type information used to convert Signal arguments. */
+  typeInfo?: SignalTypeInfo;
+}
 
 /**
  * Base WorkflowHandle interface, extended in workflow and client libs.
@@ -25,6 +38,13 @@ export interface BaseWorkflowHandle<T extends Workflow> {
     def: SignalDefinition<Args, Name> | string,
     ...args: Args
   ): Promise<void>;
+
+  /**
+   * Signal a running Workflow by Signal name with additional options.
+   *
+   * @experimental
+   */
+  signalWithOptions<Args extends any[] = []>(signalName: string, options: WorkflowSignalOptions<Args>): Promise<void>;
 
   /**
    * The workflowId of the current Workflow

--- a/packages/test/src/test-signal-type-info-types.ts
+++ b/packages/test/src/test-signal-type-info-types.ts
@@ -15,7 +15,9 @@ interface Order {
 
 declare const client: Client;
 declare const order: Order;
+declare const noArgSignal: SignalDefinition<[]>;
 declare const orderSignal: SignalDefinition<[Order]>;
+declare const orderSignalOrName: SignalDefinition<[Order]> | string;
 declare const orderSignalTypeInfo: SignalTypeInfo;
 declare const workflow: () => Promise<string>;
 
@@ -35,6 +37,45 @@ test('Signal-with-Start accepts TypeInfo according to the Signal reference form'
       signalArgs: [order],
       signalTypeInfo: orderSignalTypeInfo,
     });
+
+    void client.workflow.signalWithStart<typeof workflow, [Order]>(workflow, {
+      workflowId: 'workflow-id',
+      taskQueue: 'task-queue',
+      signal: orderSignalOrName,
+      signalArgs: [order],
+    });
+  }
+
+  t.pass();
+});
+
+test('Signal-with-Start permits omitted arguments for zero-argument Signals', (t) => {
+  function _assertion() {
+    void client.workflow.signalWithStart(workflow, {
+      workflowId: 'workflow-id',
+      taskQueue: 'task-queue',
+      signal: noArgSignal,
+    });
+
+    void client.workflow.signalWithStart(workflow, {
+      workflowId: 'workflow-id',
+      taskQueue: 'task-queue',
+      signal: 'no-arg-signal',
+      signalTypeInfo: orderSignalTypeInfo,
+    });
+  }
+
+  t.pass();
+});
+
+test('Signal-with-Start requires arguments for Signals with inputs', (t) => {
+  function _assertion() {
+    // @ts-expect-error Signals with inputs require signalArgs.
+    void client.workflow.signalWithStart<typeof workflow, [Order]>(workflow, {
+      workflowId: 'workflow-id',
+      taskQueue: 'task-queue',
+      signal: orderSignal,
+    });
   }
 
   t.pass();
@@ -47,6 +88,23 @@ test('Signal-with-Start rejects call-site TypeInfo with a Signal definition', (t
       workflowId: 'workflow-id',
       taskQueue: 'task-queue',
       signal: orderSignal,
+      signalArgs: [order],
+      signalTypeInfo: orderSignalTypeInfo,
+    });
+
+    // @ts-expect-error TypeInfo must be defined on a referenced Signal definition.
+    void client.workflow.signalWithStart(workflow, {
+      workflowId: 'workflow-id',
+      taskQueue: 'task-queue',
+      signal: noArgSignal,
+      signalTypeInfo: orderSignalTypeInfo,
+    });
+
+    // @ts-expect-error Call-site TypeInfo requires a Signal name, not a definition-or-name union.
+    void client.workflow.signalWithStart<typeof workflow, [Order]>(workflow, {
+      workflowId: 'workflow-id',
+      taskQueue: 'task-queue',
+      signal: orderSignalOrName,
       signalArgs: [order],
       signalTypeInfo: orderSignalTypeInfo,
     });

--- a/packages/test/src/test-signal-type-info-types.ts
+++ b/packages/test/src/test-signal-type-info-types.ts
@@ -1,0 +1,56 @@
+/**
+ * Compile-time coverage for Signal definition and string reference TypeInfo.
+ *
+ * Assertions live inside never-called `_assertion` functions. Positive calls fail the build if they stop compiling,
+ * while `@ts-expect-error` calls fail the build if an invalid call becomes legal.
+ */
+import test from 'ava';
+import type { Client } from '@temporalio/client';
+import type { SignalTypeInfo } from '@temporalio/common';
+import type { SignalDefinition } from '@temporalio/workflow';
+
+interface Order {
+  id: string;
+}
+
+declare const client: Client;
+declare const order: Order;
+declare const orderSignal: SignalDefinition<[Order]>;
+declare const orderSignalTypeInfo: SignalTypeInfo;
+declare const workflow: () => Promise<string>;
+
+test('Signal-with-Start accepts TypeInfo according to the Signal reference form', (t) => {
+  function _assertion() {
+    void client.workflow.signalWithStart(workflow, {
+      workflowId: 'workflow-id',
+      taskQueue: 'task-queue',
+      signal: orderSignal,
+      signalArgs: [order],
+    });
+
+    void client.workflow.signalWithStart(workflow, {
+      workflowId: 'workflow-id',
+      taskQueue: 'task-queue',
+      signal: 'order',
+      signalArgs: [order],
+      signalTypeInfo: orderSignalTypeInfo,
+    });
+  }
+
+  t.pass();
+});
+
+test('Signal-with-Start rejects call-site TypeInfo with a Signal definition', (t) => {
+  function _assertion() {
+    // @ts-expect-error TypeInfo must be defined on a referenced Signal definition.
+    void client.workflow.signalWithStart(workflow, {
+      workflowId: 'workflow-id',
+      taskQueue: 'task-queue',
+      signal: orderSignal,
+      signalArgs: [order],
+      signalTypeInfo: orderSignalTypeInfo,
+    });
+  }
+
+  t.pass();
+});

--- a/packages/test/src/test-type-info.ts
+++ b/packages/test/src/test-type-info.ts
@@ -20,10 +20,13 @@ import {
   finishUpdate,
   Order,
   orderSignal,
+  orderSignalTypeInfo,
   parentWorkflowChildString,
   Receipt,
   signalChildTarget,
+  signalChildTargetWithCallSiteTypeInfo,
   signalExternalTarget,
+  signalExternalTargetWithCallSiteTypeInfo,
   signalTarget,
   workflowTypeInfo,
   workflowWithSignalStart,
@@ -246,6 +249,24 @@ test('signal uses definition-supplied input type information', async (t) => {
   });
 });
 
+test('string Signal call uses call-site input type information', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker();
+
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(signalTarget, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+    });
+    await handle.signalWithOptions('order', {
+      args: [new Order('order-1', 12345n)],
+      typeInfo: orderSignalTypeInfo,
+    });
+    t.is(await handle.result(), 'order-1:12345:0');
+  });
+});
+
 test('signal-with-start uses definition-supplied Signal input type information', async (t) => {
   const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
   const client = makeClient(t.context.env);
@@ -260,6 +281,41 @@ test('signal-with-start uses definition-supplied Signal input type information',
     });
     t.is(await handle.result(), 'order-1:12345:0');
   });
+});
+
+test('signal-with-start uses string Signal call-site input type information', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker();
+
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.signalWithStart(signalTarget, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+      signal: 'order',
+      signalArgs: [new Order('order-1', 12345n)],
+      signalTypeInfo: orderSignalTypeInfo,
+    });
+    t.is(await handle.result(), 'order-1:12345:0');
+  });
+});
+
+test('signal-with-start rejects call-site type information with a Signal definition', async (t) => {
+  const client = makeClient(t.context.env);
+
+  await t.throwsAsync(
+    client.workflow.signalWithStart(signalTarget, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: 'unused',
+      signal: orderSignal,
+      signalArgs: [new Order('order-1', 12345n)],
+      signalTypeInfo: orderSignalTypeInfo,
+    }),
+    {
+      instanceOf: TypeError,
+      message: /Cannot provide call-site Signal TypeInfo with a Signal definition/,
+    }
+  );
 });
 
 test('external Workflow signal uses definition-supplied input type information', async (t) => {
@@ -279,6 +335,23 @@ test('external Workflow signal uses definition-supplied input type information',
   });
 });
 
+test('external Workflow string Signal uses call-site input type information', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker();
+
+  await worker.runUntil(async () => {
+    const workflowId = `wf-${randomUUID()}`;
+    const target = await client.workflow.start(signalTarget, { workflowId, taskQueue: h.taskQueue });
+    await client.workflow.execute(signalExternalTargetWithCallSiteTypeInfo, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+      args: [workflowId],
+    });
+    t.is(await target.result(), 'order-1:12345:0');
+  });
+});
+
 test('child Workflow signal uses definition-supplied input type information', async (t) => {
   const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
   const client = makeClient(t.context.env);
@@ -287,6 +360,22 @@ test('child Workflow signal uses definition-supplied input type information', as
   await worker.runUntil(async () => {
     t.is(
       await client.workflow.execute(signalChildTarget, {
+        workflowId: `wf-${randomUUID()}`,
+        taskQueue: h.taskQueue,
+      }),
+      'order-1:12345:0'
+    );
+  });
+});
+
+test('child Workflow string Signal uses call-site input type information', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker();
+
+  await worker.runUntil(async () => {
+    t.is(
+      await client.workflow.execute(signalChildTargetWithCallSiteTypeInfo, {
         workflowId: `wf-${randomUUID()}`,
         taskQueue: h.taskQueue,
       }),

--- a/packages/test/src/test-type-info.ts
+++ b/packages/test/src/test-type-info.ts
@@ -302,15 +302,17 @@ test('signal-with-start uses string Signal call-site input type information', as
 
 test('signal-with-start rejects call-site type information with a Signal definition', async (t) => {
   const client = makeClient(t.context.env);
+  const options = {
+    workflowId: `wf-${randomUUID()}`,
+    taskQueue: 'unused',
+    signal: orderSignal,
+    signalArgs: [new Order('order-1', 12345n)] as [Order],
+    signalTypeInfo: orderSignalTypeInfo,
+  };
 
   await t.throwsAsync(
-    client.workflow.signalWithStart(signalTarget, {
-      workflowId: `wf-${randomUUID()}`,
-      taskQueue: 'unused',
-      signal: orderSignal,
-      signalArgs: [new Order('order-1', 12345n)],
-      signalTypeInfo: orderSignalTypeInfo,
-    }),
+    // @ts-expect-error TypeInfo must be defined on a referenced Signal definition.
+    client.workflow.signalWithStart(signalTarget, options),
     {
       instanceOf: TypeError,
       message: /Cannot provide call-site Signal TypeInfo with a Signal definition/,

--- a/packages/test/src/test-type-info.ts
+++ b/packages/test/src/test-type-info.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import type { ExecutionContext } from 'ava';
+import type { WorkflowSignalWithStartOptions } from '@temporalio/client';
 import { Client, WithStartWorkflowOperation, WorkflowFailedError } from '@temporalio/client';
 import { workflowInterceptorModules } from '@temporalio/testing';
 import { bundleWorkflowCode } from '@temporalio/worker';
@@ -300,24 +301,20 @@ test('signal-with-start uses string Signal call-site input type information', as
   });
 });
 
-test('signal-with-start rejects call-site type information with a Signal definition', async (t) => {
+test('signal-with-start rejects call-site type information with a Signal definition at runtime', async (t) => {
   const client = makeClient(t.context.env);
   const options = {
     workflowId: `wf-${randomUUID()}`,
     taskQueue: 'unused',
     signal: orderSignal,
-    signalArgs: [new Order('order-1', 12345n)] as [Order],
+    signalArgs: [new Order('order-1', 12345n)],
     signalTypeInfo: orderSignalTypeInfo,
-  };
+  } as unknown as WorkflowSignalWithStartOptions<[Order]>;
 
-  await t.throwsAsync(
-    // @ts-expect-error TypeInfo must be defined on a referenced Signal definition.
-    client.workflow.signalWithStart(signalTarget, options),
-    {
-      instanceOf: TypeError,
-      message: /Cannot provide call-site Signal TypeInfo with a Signal definition/,
-    }
-  );
+  await t.throwsAsync(client.workflow.signalWithStart(signalTarget, options), {
+    instanceOf: TypeError,
+    message: /Cannot provide call-site Signal TypeInfo with a Signal definition/,
+  });
 });
 
 test('external Workflow signal uses definition-supplied input type information', async (t) => {

--- a/packages/test/src/workflows/type-info.ts
+++ b/packages/test/src/workflows/type-info.ts
@@ -1,4 +1,4 @@
-import type { PayloadTypeInfo, TypeInfo } from '@temporalio/common';
+import type { PayloadTypeInfo, SignalTypeInfo, TypeInfo } from '@temporalio/common';
 import {
   condition,
   continueAsNew,
@@ -163,9 +163,9 @@ defineWorkflowOptions(continueAsNewWithInterceptorTypeInfo, {
 
 export const finishSignal = defineSignal('finish');
 
-export const orderSignal = defineSignal<[Order]>('order', {
-  typeInfo: { inputTypes: [orderTypeInfo] },
-});
+export const orderSignalTypeInfo: SignalTypeInfo = { inputTypes: [orderTypeInfo] };
+
+export const orderSignal = defineSignal<[Order]>('order', { typeInfo: orderSignalTypeInfo });
 
 export async function signalTarget(): Promise<string> {
   let summary: string | undefined;
@@ -184,9 +184,25 @@ export async function signalExternalTarget(workflowId: string): Promise<void> {
   await getExternalWorkflowHandle(workflowId).signal(orderSignal, new Order('order-1', 12345n));
 }
 
+export async function signalExternalTargetWithCallSiteTypeInfo(workflowId: string): Promise<void> {
+  await getExternalWorkflowHandle(workflowId).signalWithOptions('order', {
+    args: [new Order('order-1', 12345n)],
+    typeInfo: orderSignalTypeInfo,
+  });
+}
+
 export async function signalChildTarget(): Promise<string> {
   const child = await startChild(signalTarget);
   await child.signal(orderSignal, new Order('order-1', 12345n));
+  return await child.result();
+}
+
+export async function signalChildTargetWithCallSiteTypeInfo(): Promise<string> {
+  const child = await startChild(signalTarget);
+  await child.signalWithOptions('order', {
+    args: [new Order('order-1', 12345n)],
+    typeInfo: orderSignalTypeInfo,
+  });
   return await child.result();
 }
 

--- a/packages/workflow/src/workflow-handle.ts
+++ b/packages/workflow/src/workflow-handle.ts
@@ -1,4 +1,4 @@
-import type { BaseWorkflowHandle, SignalDefinition, Workflow } from '@temporalio/common';
+import type { BaseWorkflowHandle, SignalDefinition, Workflow, WorkflowSignalOptions } from '@temporalio/common';
 
 /**
  * Handle representing an external Workflow Execution.
@@ -21,6 +21,13 @@ export interface ExternalWorkflowHandle {
     def: SignalDefinition<Args, Name> | string,
     ...args: Args
   ): Promise<void>;
+
+  /**
+   * Signal a running Workflow by Signal name with additional options.
+   *
+   * @experimental
+   */
+  signalWithOptions<Args extends any[] = []>(signalName: string, options: WorkflowSignalOptions<Args>): Promise<void>;
 
   /**
    * Cancel the external Workflow execution.

--- a/packages/workflow/src/workflow-handle.ts
+++ b/packages/workflow/src/workflow-handle.ts
@@ -3,12 +3,14 @@ import type { BaseWorkflowHandle, SignalDefinition, Workflow, WorkflowSignalOpti
 /**
  * Handle representing an external Workflow Execution.
  *
- * This handle only has methods `cancel` and `signal`. To call other methods, like `query` and `result`, use
- * {@link WorkflowClient.getHandle} inside an Activity.
+ * This handle only has methods `cancel`, `signal`, and `signalWithOptions`. To call other methods, like `query` and
+ * `result`, use {@link WorkflowClient.getHandle} inside an Activity.
  */
 export interface ExternalWorkflowHandle {
   /**
    * Signal a running Workflow.
+   *
+   * To provide call-site TypeInfo when signaling by name, use {@link signalWithOptions}.
    *
    * @param def a signal definition as returned from {@link defineSignal} or signal name (string)
    *
@@ -23,7 +25,7 @@ export interface ExternalWorkflowHandle {
   ): Promise<void>;
 
   /**
-   * Signal a running Workflow by Signal name with additional options.
+   * Signal a running Workflow by Signal name with additional options, including call-site TypeInfo.
    *
    * @experimental
    */

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -8,6 +8,7 @@ import type {
   SearchAttributeValue,
   SignalDefinition,
   SignalDefinitionOptions,
+  SignalTypeInfo,
   UntypedActivities,
   UpdateDefinition,
   WithWorkflowArgs,
@@ -19,6 +20,7 @@ import type {
   SearchAttributeUpdatePair,
   WorkflowDefinitionOptionsOrGetter,
   WorkflowDefinitionConfig,
+  WorkflowSignalOptions,
 } from '@temporalio/common';
 import {
   compileRetryPolicy,
@@ -748,6 +750,23 @@ export function getExternalWorkflowHandle(workflowId: string, runId?: string): E
   const activator = assertInWorkflowContext(
     'Workflow.getExternalWorkflowHandle(...) may only be used from a Workflow Execution. Consider using Client.workflow.getHandle(...) instead.)'
   );
+  const signal = (signalName: string, args: unknown[], typeInfo?: SignalTypeInfo): Promise<void> => {
+    return composeInterceptors(
+      activator.interceptors.outbound,
+      'signalWorkflow',
+      signalWorkflowNextHandler
+    )({
+      seq: activator.nextSeqs.signalWorkflow++,
+      signalName,
+      args,
+      typeInfo,
+      target: {
+        type: 'external',
+        workflowExecution: { workflowId, runId },
+      },
+      headers: {},
+    });
+  };
   return {
     workflowId,
     runId,
@@ -795,21 +814,10 @@ export function getExternalWorkflowHandle(workflowId: string, runId?: string): E
       });
     },
     signal<Args extends any[]>(def: SignalDefinition<Args> | string, ...args: Args): Promise<void> {
-      return composeInterceptors(
-        activator.interceptors.outbound,
-        'signalWorkflow',
-        signalWorkflowNextHandler
-      )({
-        seq: activator.nextSeqs.signalWorkflow++,
-        signalName: typeof def === 'string' ? def : def.name,
-        args,
-        typeInfo: typeof def === 'string' ? undefined : def.typeInfo,
-        target: {
-          type: 'external',
-          workflowExecution: { workflowId, runId },
-        },
-        headers: {},
-      });
+      return signal(typeof def === 'string' ? def : def.name, args, typeof def === 'string' ? undefined : def.typeInfo);
+    },
+    signalWithOptions<Args extends any[]>(signalName: string, options: WorkflowSignalOptions<Args>): Promise<void> {
+      return signal(signalName, options.args ?? [], options.typeInfo);
     },
   };
 }
@@ -901,6 +909,24 @@ export async function startChild<T extends Workflow>(
   });
   const firstExecutionRunId = await started;
 
+  const signal = (signalName: string, args: unknown[], typeInfo?: SignalTypeInfo): Promise<void> => {
+    return composeInterceptors(
+      activator.interceptors.outbound,
+      'signalWorkflow',
+      signalWorkflowNextHandler
+    )({
+      seq: activator.nextSeqs.signalWorkflow++,
+      signalName,
+      args,
+      typeInfo,
+      target: {
+        type: 'child',
+        childWorkflowId: optionsWithDefaults.workflowId,
+      },
+      headers: {},
+    });
+  };
+
   return {
     workflowId: workflowOptions.workflowId,
     firstExecutionRunId,
@@ -908,21 +934,13 @@ export async function startChild<T extends Workflow>(
       return (await completed) as any;
     },
     async signal<Args extends any[]>(def: SignalDefinition<Args> | string, ...args: Args): Promise<void> {
-      return composeInterceptors(
-        activator.interceptors.outbound,
-        'signalWorkflow',
-        signalWorkflowNextHandler
-      )({
-        seq: activator.nextSeqs.signalWorkflow++,
-        signalName: typeof def === 'string' ? def : def.name,
-        args,
-        typeInfo: typeof def === 'string' ? undefined : def.typeInfo,
-        target: {
-          type: 'child',
-          childWorkflowId: workflowOptions.workflowId,
-        },
-        headers: {},
-      });
+      return signal(typeof def === 'string' ? def : def.name, args, typeof def === 'string' ? undefined : def.typeInfo);
+    },
+    async signalWithOptions<Args extends any[]>(
+      signalName: string,
+      options: WorkflowSignalOptions<Args>
+    ): Promise<void> {
+      return signal(signalName, options.args ?? [], options.typeInfo);
     },
   };
 }

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -814,7 +814,11 @@ export function getExternalWorkflowHandle(workflowId: string, runId?: string): E
       });
     },
     signal<Args extends any[]>(def: SignalDefinition<Args> | string, ...args: Args): Promise<void> {
-      return signal(typeof def === 'string' ? def : def.name, args, typeof def === 'string' ? undefined : def.typeInfo);
+      if (typeof def === 'string') {
+        return signal(def, args);
+      } else {
+        return signal(def.name, args, def.typeInfo);
+      }
     },
     signalWithOptions<Args extends any[]>(signalName: string, options: WorkflowSignalOptions<Args>): Promise<void> {
       return signal(signalName, options.args ?? [], options.typeInfo);
@@ -921,7 +925,7 @@ export async function startChild<T extends Workflow>(
       typeInfo,
       target: {
         type: 'child',
-        childWorkflowId: optionsWithDefaults.workflowId,
+        childWorkflowId: workflowOptions.workflowId,
       },
       headers: {},
     });
@@ -934,7 +938,11 @@ export async function startChild<T extends Workflow>(
       return (await completed) as any;
     },
     async signal<Args extends any[]>(def: SignalDefinition<Args> | string, ...args: Args): Promise<void> {
-      return signal(typeof def === 'string' ? def : def.name, args, typeof def === 'string' ? undefined : def.typeInfo);
+      if (typeof def === 'string') {
+        return signal(def, args);
+      } else {
+        return signal(def.name, args, def.typeInfo);
+      }
     },
     async signalWithOptions<Args extends any[]>(
       signalName: string,


### PR DESCRIPTION
## What was changed

String-named Signal calls can now provide input `TypeInfo` through `signalWithOptions` on Client, child Workflow, and external Workflow handles. Signal-with-start options can provide the same metadata through `signalTypeInfo`.

Both new call-site paths reuse the existing Signal interceptor and serialization flow. Definition-based Signals remain unchanged, and signal-with-start rejects explicit call-site metadata when a Signal definition is supplied.

This builds on the definition-supplied Signal TypeInfo support merged in #2318.

## Why?

When only a Signal name is available, the SDK cannot obtain conversion metadata from a Signal definition. The existing variadic `signal` method also cannot safely distinguish user arguments from an options object, so string call sites need an explicit options-based API.

This API is experimental. Existing Signal calls retain their current behavior, with no rollout or manual steps required.

## Checklist

1. Closes: N/A

2. How was this tested: Common, Client, Workflow, and integration package builds; focused ESLint and Prettier checks; `ts-prune`; and all 17 focused TypeInfo integration tests, including Client, signal-with-start, external Workflow, child Workflow, and definition/call-site conflict coverage.

3. Any docs updates needed? No; documentation will accompany the completed experimental API.
