### PR TITLE
fix inconsistencies in s3 and gcs drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ to docs, or any other relevant information.
 - `@temporalio/ai-sdk` now requires `ai@>=7.0.59` as a peer dependency, up from `7.0.0`, since
   earlier releases threw a `TypeError` on import in runtimes without a global `fetch`.
 
+### Fixed
+
+- **Experimental**: The external storage S3 and GCS drivers now use `hash_algorithm` and `hash_value` instead of
+  `hashAlgorithm` and `hashValue` in their claims. The GCS driver additionally uses `object_name` instead of
+  `object`. Retrieval still accepts the old key names.
+
 ## [1.22.0] - 2026-08-05
 
 ### Added

--- a/contrib/external-storage-gcs/src/__tests__/test-driver.ts
+++ b/contrib/external-storage-gcs/src/__tests__/test-driver.ts
@@ -65,10 +65,39 @@ test('object name is content-addressed and segmented by the store context', asyn
   const [claim] = await driver.store(workflowContext, [payload]);
   assert(claim);
 
-  t.is(claim.claimData.object, `v0/ns/my-ns/wt/MyWorkflow/wi/wf-1/ri/run-1/d/sha256/${expectedHash}`);
-  t.is(claim.claimData.hashValue, expectedHash);
-  t.is(claim.claimData.hashAlgorithm, 'sha256');
+  t.is(claim.claimData.object_name, `v0/ns/my-ns/wt/MyWorkflow/wi/wf-1/ri/run-1/d/sha256/${expectedHash}`);
+  t.is(claim.claimData.hash_value, expectedHash);
+  t.is(claim.claimData.hash_algorithm, 'sha256');
   t.is(claim.claimData.bucket, 'b');
+});
+
+test('claim data uses snake_case keys named after GCS terminology', async (t) => {
+  const driver = new GcsStorageDriver({ client: new FakeGcsClient(), bucket: 'b' });
+
+  const [claim] = await driver.store(workflowContext, [makePayload('"hello"')]);
+  assert(claim);
+
+  t.deepEqual(Object.keys(claim.claimData).sort(), ['bucket', 'hash_algorithm', 'hash_value', 'object_name']);
+});
+
+test('retrieve accepts a claim with object and camelCase hash keys written by <= 1.22.0', async (t) => {
+  const client = new FakeGcsClient();
+  const driver = new GcsStorageDriver({ client, bucket: 'b' });
+  const original = makePayload('"hello"');
+
+  const [claim] = await driver.store(workflowContext, [original]);
+  assert(claim?.claimData.object_name);
+  const legacyClaim = new StorageDriverClaim({
+    bucket: 'b',
+    object: claim.claimData.object_name,
+    hashAlgorithm: 'sha256',
+    hashValue: createHash('sha256').update(payloadBytes(original)).digest('hex'),
+  });
+
+  const [retrieved] = await driver.retrieve({}, [legacyClaim]);
+  assert(retrieved);
+
+  t.deepEqual(payloadBytes(retrieved), payloadBytes(original));
 });
 
 test('object name segments percent-encode only GCS-discouraged characters', async (t) => {
@@ -86,12 +115,12 @@ test('object name segments percent-encode only GCS-discouraged characters', asyn
     },
     [makePayload('"x"')]
   );
-  assert(claim?.claimData.object);
+  assert(claim?.claimData.object_name);
 
   // Per Google's recommendations: space, + = ~ ! ' ( ) are left intact;
   // / -> %2F and * -> %2A are escaped.
   t.true(
-    claim.claimData.object.startsWith(
+    claim.claimData.object_name.startsWith(
       "v0/ns/payments prod/wt/Capture%2FCharge!%2A'()/wi/order+123=abc/ri/r~1/d/sha256/"
     )
   );
@@ -105,18 +134,18 @@ test('reserved and empty segments are encoded', async (t) => {
   const [claim] = await driver.store({ target: { kind: 'workflow', namespace: '.', type: '..', runId: '' } }, [
     makePayload('"x"'),
   ]);
-  assert(claim?.claimData.object);
+  assert(claim?.claimData.object_name);
 
-  t.true(claim.claimData.object.startsWith('v0/ns/%2E/wt/%2E%2E/wi/null/ri/null/d/sha256/'));
+  t.true(claim.claimData.object_name.startsWith('v0/ns/%2E/wt/%2E%2E/wi/null/ri/null/d/sha256/'));
 });
 
 test('a target with no identity falls back to a bare digest object name', async (t) => {
   const driver = new GcsStorageDriver({ client: new FakeGcsClient(), bucket: 'b' });
 
   const [claim] = await driver.store({}, [makePayload('"x"')]);
-  assert(claim?.claimData.object);
+  assert(claim?.claimData.object_name);
 
-  t.regex(claim.claimData.object, /^v0\/d\/sha256\/[0-9a-f]{64}$/);
+  t.regex(claim.claimData.object_name, /^v0\/d\/sha256\/[0-9a-f]{64}$/);
 });
 
 test('identical payloads in the same scope deduplicate to one stored object', async (t) => {
@@ -141,7 +170,7 @@ test('concurrent identical payloads in one batch upload once', async (t) => {
   assert(second);
 
   t.is(client.saveCount, 1);
-  t.is(first.claimData.object, second.claimData.object);
+  t.is(first.claimData.object_name, second.claimData.object_name);
 });
 
 test('retrieve rejects when stored bytes fail the integrity check', async (t) => {
@@ -150,7 +179,7 @@ test('retrieve rejects when stored bytes fail the integrity check', async (t) =>
 
   const [claim] = await driver.store(workflowContext, [makePayload('"hello"')]);
   assert(claim);
-  client.objects.set(`${claim.claimData.bucket}/${claim.claimData.object}`, enc('tampered'));
+  client.objects.set(`${claim.claimData.bucket}/${claim.claimData.object_name}`, enc('tampered'));
 
   await t.throwsAsync(() => driver.retrieve({}, [claim]), {
     instanceOf: ValueError,
@@ -172,7 +201,7 @@ test('retrieve rejects a claim missing hash information', async (t) => {
   const driver = new GcsStorageDriver({ client, bucket: 'b' });
   client.objects.set('b/some-object', payloadBytes(makePayload('"hello"')));
 
-  const claim = new StorageDriverClaim({ bucket: 'b', object: 'some-object' });
+  const claim = new StorageDriverClaim({ bucket: 'b', object_name: 'some-object' });
 
   await t.throwsAsync(() => driver.retrieve({}, [claim]), {
     instanceOf: ValueError,

--- a/contrib/external-storage-gcs/src/driver.ts
+++ b/contrib/external-storage-gcs/src/driver.ts
@@ -205,21 +205,25 @@ export class GcsStorageDriver implements StorageDriver {
       );
     }
 
-    return new StorageDriverClaim({ bucket, object, hashAlgorithm: 'sha256', hashValue });
+    return new StorageDriverClaim({ bucket, object_name: object, hash_algorithm: 'sha256', hash_value: hashValue });
   }
 
   private async retrievePayload(claim: StorageDriverClaim, abortSignal: AbortSignal): Promise<Payload> {
-    const { bucket, object, hashAlgorithm, hashValue: expectedHash } = claim.claimData;
+    const { bucket } = claim.claimData;
+    // TODO: drop the backwards compat check (camelCase and "object") once we have GA release
+    const object = claim.claimData.object_name ?? claim.claimData.object;
+    const hashAlgorithm = claim.claimData.hash_algorithm ?? claim.claimData.hashAlgorithm;
+    const expectedHash = claim.claimData.hash_value ?? claim.claimData.hashValue;
     if (!bucket || !object) {
       throw new ValueError(
         `GcsStorageDriver claim is missing required location information: ` +
-          `claimData must contain 'bucket' and 'object'`
+          `claimData must contain 'bucket' and 'object_name'`
       );
     }
     if (!hashAlgorithm || !expectedHash) {
       throw new ValueError(
         `GcsStorageDriver claim is missing required content hash information [bucket=${bucket}, object=${object}]: ` +
-          `claimData must contain 'hashAlgorithm' and 'hashValue'`
+          `claimData must contain 'hash_algorithm' and 'hash_value'`
       );
     }
     if (hashAlgorithm !== 'sha256') {

--- a/contrib/external-storage-s3/src/__tests__/test-driver.ts
+++ b/contrib/external-storage-s3/src/__tests__/test-driver.ts
@@ -73,14 +73,43 @@ test('key is content-addressed and segmented by the store context', async (t) =>
 
   const digest = sha256Hex(payloadBytes(payload));
   t.is(claim.claimData.key, `v0/ns/my-ns/wt/MyWorkflow/wi/wf-1/ri/run-1/d/sha256/${digest}`);
-  t.is(claim.claimData.hashValue, digest);
-  t.is(claim.claimData.hashAlgorithm, 'sha256');
+  t.is(claim.claimData.hash_value, digest);
+  t.is(claim.claimData.hash_algorithm, 'sha256');
   t.is(claim.claimData.bucket, 'b');
 
   const [other] = await driver.store(workflowContext, [makePayload('"world"')]);
   assert(other?.claimData.key);
   t.not(other.claimData.key, claim.claimData.key);
   t.is(other.claimData.key.replace(/[0-9a-f]{64}$/, ''), claim.claimData.key.replace(/[0-9a-f]{64}$/, ''));
+});
+
+test('claim data uses the snake_case keys shared with the Go and Python S3 drivers', async (t) => {
+  const driver = new S3StorageDriver({ client: new FakeS3Client(), bucket: 'b' });
+
+  const [claim] = await driver.store(workflowContext, [makePayload('"hello"')]);
+  assert(claim);
+
+  t.deepEqual(Object.keys(claim.claimData).sort(), ['bucket', 'hash_algorithm', 'hash_value', 'key']);
+});
+
+test('retrieve accepts a claim with camelCase hash keys written by <= 1.22.0', async (t) => {
+  const client = new FakeS3Client();
+  const driver = new S3StorageDriver({ client, bucket: 'b' });
+  const original = makePayload('"hello"');
+
+  const [claim] = await driver.store(workflowContext, [original]);
+  assert(claim?.claimData.key);
+  const legacyClaim = new StorageDriverClaim({
+    bucket: 'b',
+    key: claim.claimData.key,
+    hashAlgorithm: 'sha256',
+    hashValue: sha256Hex(payloadBytes(original)),
+  });
+
+  const [retrieved] = await driver.retrieve({}, [legacyClaim]);
+  assert(retrieved);
+
+  t.deepEqual(payloadBytes(retrieved), payloadBytes(original));
 });
 
 test('key segments percent-encode anything outside the S3 safe set', async (t) => {

--- a/contrib/external-storage-s3/src/driver.ts
+++ b/contrib/external-storage-s3/src/driver.ts
@@ -188,7 +188,7 @@ export class S3StorageDriver implements StorageDriver {
       );
     }
 
-    return new StorageDriverClaim({ bucket, key, hashAlgorithm: 'sha256', hashValue });
+    return new StorageDriverClaim({ bucket, key, hash_algorithm: 'sha256', hash_value: hashValue });
   }
 
   private async uploadIfAbsent(
@@ -203,7 +203,10 @@ export class S3StorageDriver implements StorageDriver {
   }
 
   private async retrievePayload(claim: StorageDriverClaim, abortSignal: AbortSignal): Promise<Payload> {
-    const { bucket, key, hashAlgorithm, hashValue: expectedHash } = claim.claimData;
+    const { bucket, key } = claim.claimData;
+    // TODO: drop the backwards compat check (camelCase) once we have GA release
+    const hashAlgorithm = claim.claimData.hash_algorithm ?? claim.claimData.hashAlgorithm;
+    const expectedHash = claim.claimData.hash_value ?? claim.claimData.hashValue;
     if (!bucket || !key) {
       throw new ValueError(
         `S3StorageDriver claim is missing required location information: ` + `claimData must contain 'bucket' and 'key'`
@@ -212,7 +215,7 @@ export class S3StorageDriver implements StorageDriver {
     if (!hashAlgorithm || !expectedHash) {
       throw new ValueError(
         `S3StorageDriver claim is missing required content hash information [bucket=${bucket}, key=${key}]: ` +
-          `claimData must contain 'hashAlgorithm' and 'hashValue'`
+          `claimData must contain 'hash_algorithm' and 'hash_value'`
       );
     }
     if (hashAlgorithm !== 'sha256') {


### PR DESCRIPTION
## What was changed
- s3 and gcs drivers were using camelCase instead of snake_case for claim metadata which broke cross-sdk consistency.
- gcs now refers to the object name as `object_name` instead of `object`.

## Why?
- cross sdk consistency: Fixes https://github.com/temporalio/sdk-typescript/issues/2277
- consistency with GCS documentation and platform.

## Checklist
- Added tests