### PR TITLE
docs: add the langsmith package and the openai-agents Workflow and OTel subpaths to the API reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ to docs, or any other relevant information.
 - `@temporalio/ai-sdk` now requires `ai@>=7.0.59` as a peer dependency, up from `7.0.0`, since
   earlier releases threw a `TypeError` on import in runtimes without a global `fetch`.
 
+### Fixed
+
+- The [API reference](https://typescript.temporal.io) now documents `@temporalio/langsmith` and the
+  Workflow-side and OpenTelemetry subpaths of `@temporalio/openai-agents`.
+
 ## [1.22.0] - 2026-08-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,6 @@ to docs, or any other relevant information.
 - `@temporalio/ai-sdk` now requires `ai@>=7.0.59` as a peer dependency, up from `7.0.0`, since
   earlier releases threw a `TypeError` on import in runtimes without a global `fetch`.
 
-### Fixed
-
-- The [API reference](https://typescript.temporal.io) now documents `@temporalio/langsmith` and the
-  Workflow-side and OpenTelemetry subpaths of `@temporalio/openai-agents`.
-
 ## [1.22.0] - 2026-08-05
 
 ### Added

--- a/packages/meta/package.json
+++ b/packages/meta/package.json
@@ -11,6 +11,7 @@
     "@temporalio/envconfig": "workspace:*",
     "@temporalio/interceptors-opentelemetry": "workspace:*",
     "@temporalio/interceptors-opentelemetry-v2": "workspace:*",
+    "@temporalio/langsmith": "workspace:*",
     "@temporalio/nexus": "workspace:*",
     "@temporalio/openai-agents": "workspace:*",
     "@temporalio/plugin": "workspace:*",

--- a/packages/meta/src/index.ts
+++ b/packages/meta/src/index.ts
@@ -19,3 +19,6 @@ export * as strands from '@temporalio/strands-agents';
 export * as openaiAgents from '@temporalio/openai-agents';
 export * as workflowStreams from '@temporalio/workflow-streams/workflow';
 export * as workflowStreamsClient from '@temporalio/workflow-streams/client';
+export * as openaiAgentsWorkflow from '@temporalio/openai-agents/workflow';
+export * as openaiAgentsOtel from '@temporalio/openai-agents/otel';
+export * as langsmith from '@temporalio/langsmith';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,6 +829,9 @@ importers:
       '@temporalio/interceptors-opentelemetry-v2':
         specifier: workspace:*
         version: link:../../contrib/interceptors-opentelemetry-v2
+      '@temporalio/langsmith':
+        specifier: workspace:*
+        version: link:../../contrib/langsmith
       '@temporalio/nexus':
         specifier: workspace:*
         version: link:../nexus


### PR DESCRIPTION
`packages/meta` is the single TypeDoc entry point for typescript.temporal.io — `packages/docs/docusaurus.config.js` points `entryPoints` at `../meta/src/index.ts`, and nothing else enumerates packages. A package absent from it has no published API reference at all.

`@temporalio/langsmith` was never added: #2099 introduced the package across 33 files without touching `packages/meta`. Separately, only the `@temporalio/openai-agents` root was re-exported, so its `/workflow` and `/otel` surfaces — `TemporalOpenAIRunner`, `activityAsTool`, `agentAsTool`, `WorkflowSafeMemorySession`, `createTracerProvider`, `TemporalIdGenerator`, among others — have no pages either, even though the package README directs users to import from both. This is the same catch-up as #1781 (nexus) and #2125 (workflow-streams + openai-agents); nothing in CI asserts that every package appears in meta, which is why it recurs.

`@temporalio/openai-agents/workflow-interceptor` stays out: it exports only the `interceptors()` factory that the bundler resolves by path, not an API anyone calls — the same shape as langsmith's `@internal` `./workflow-interceptors`. `@temporalio/ai-sdk` needs nothing, since its root already re-exports `./provider` and `./mcp`, covering its workflow surface.

Note: this appends to the same two files as #2321, which adds google-adk to meta. Whichever merges second gets an append-only conflict in `src/index.ts` and an alphabetical insert in `package.json`.
