### PR TITLE
fix(client): reject call-site TypeInfo for Workflow functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ to docs, or any other relevant information.
 
 ### Changed
 
+- **Experimental**: Workflow Client APIs now reject call-site `TypeInfo` at compile time when a Workflow function is
+  supplied. Define TypeInfo on the Workflow function or use a string Workflow type for call-site metadata.
 - Nexus is now generally available (GA) for calling Nexus Operations from Workflows and handling
   Workflow-backed Operations with `WorkflowRunOperationHandler`.
 - `@temporalio/ai-sdk` now requires `ai@>=7.0.59` as a peer dependency, up from `7.0.0`, since

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -513,6 +513,16 @@ export class WithStartWorkflowOperation<T extends Workflow> {
   private workflowHandlePromise: Promise<WorkflowHandle<T>>;
 
   constructor(
+    workflowType: string,
+    options: WorkflowStartOptions<T> & { workflowIdConflictPolicy: WorkflowIdConflictPolicy }
+  );
+  constructor(
+    workflowFunc: T,
+    options: WorkflowStartOptions<T> & { typeInfo?: never } & {
+      workflowIdConflictPolicy: WorkflowIdConflictPolicy;
+    }
+  );
+  constructor(
     public workflowTypeOrFunc: string | T,
     public options: WorkflowStartOptions<T> & { workflowIdConflictPolicy: WorkflowIdConflictPolicy }
   ) {
@@ -627,6 +637,14 @@ export class WorkflowClient extends BaseClient {
    *
    * @returns a {@link WorkflowHandle} to the started Workflow
    */
+  public start<T extends Workflow>(
+    workflowType: string,
+    options: WorkflowStartOptions<T>
+  ): Promise<WorkflowHandleWithStartDetails<T>>;
+  public start<T extends Workflow>(
+    workflowFunc: T,
+    options: WorkflowStartOptions<T> & { typeInfo?: never }
+  ): Promise<WorkflowHandleWithStartDetails<T>>;
   public async start<T extends Workflow>(
     workflowTypeOrFunc: string | T,
     options: WorkflowStartOptions<T>
@@ -664,6 +682,14 @@ export class WorkflowClient extends BaseClient {
    *
    * @returns a {@link WorkflowHandle} to the started Workflow
    */
+  public signalWithStart<WorkflowFn extends Workflow, SignalArgs extends any[] = []>(
+    workflowType: string,
+    options: WithWorkflowArgs<WorkflowFn, WorkflowSignalWithStartOptions<SignalArgs>>
+  ): Promise<WorkflowHandleWithSignaledRunId<WorkflowFn>>;
+  public signalWithStart<WorkflowFn extends Workflow, SignalArgs extends any[] = []>(
+    workflowFunc: WorkflowFn,
+    options: WithWorkflowArgs<WorkflowFn, WorkflowSignalWithStartOptions<SignalArgs>> & { typeInfo?: never }
+  ): Promise<WorkflowHandleWithSignaledRunId<WorkflowFn>>;
   public async signalWithStart<WorkflowFn extends Workflow, SignalArgs extends any[] = []>(
     workflowTypeOrFunc: string | WorkflowFn,
     options: WithWorkflowArgs<WorkflowFn, WorkflowSignalWithStartOptions<SignalArgs>>
@@ -828,6 +854,14 @@ export class WorkflowClient extends BaseClient {
    *
    * @returns the result of the Workflow execution
    */
+  public execute<T extends Workflow>(
+    workflowType: string,
+    options: WorkflowStartOptions<T>
+  ): Promise<WorkflowResultType<T>>;
+  public execute<T extends Workflow>(
+    workflowFunc: T,
+    options: WorkflowStartOptions<T> & { typeInfo?: never }
+  ): Promise<WorkflowResultType<T>>;
   public async execute<T extends Workflow>(
     workflowTypeOrFunc: string | T,
     options: WorkflowStartOptions<T>

--- a/packages/nexus/src/workflow-helpers.ts
+++ b/packages/nexus/src/workflow-helpers.ts
@@ -14,6 +14,8 @@ import type {
   ActivityOptionsFor as ClientActivityOptionsFor,
   ActivityResult,
   Client,
+  WorkflowHandleWithSignaledRunId,
+  WorkflowHandleWithStartDetails,
   WorkflowStartOptions as ClientWorkflowStartOptions,
   WorkflowSignalWithStartOptions as ClientWorkflowSignalWithStartOptions,
 } from '@temporalio/client';
@@ -55,6 +57,34 @@ import {
 
 declare const isNexusWorkflowHandle: unique symbol;
 declare const workflowResultType: unique symbol;
+
+/**
+ * Nexus currently accepts a string-or-function union, while Client overloads distinguish those references.
+ * Keep that compatibility assertion here until the Nexus TypeInfo PR adds the same public overload distinction.
+ */
+async function startWorkflowFromNexusReference<T extends Workflow>(
+  client: Client,
+  workflowTypeOrFunction: string | T,
+  options: ClientWorkflowStartOptions
+): Promise<WorkflowHandleWithStartDetails<T>> {
+  const start = client.workflow.start as unknown as (
+    workflowTypeOrFunction: string | T,
+    options: ClientWorkflowStartOptions
+  ) => Promise<WorkflowHandleWithStartDetails<T>>;
+  return await start(workflowTypeOrFunction, options);
+}
+
+async function signalWithStartFromNexusReference<T extends Workflow, SignalArgs extends any[]>(
+  client: Client,
+  workflowTypeOrFunction: string | T,
+  options: WithWorkflowArgs<T, ClientWorkflowSignalWithStartOptions<SignalArgs>>
+): Promise<WorkflowHandleWithSignaledRunId<T>> {
+  const signalWithStart = client.workflow.signalWithStart as unknown as (
+    workflowTypeOrFunction: string | T,
+    options: WithWorkflowArgs<T, ClientWorkflowSignalWithStartOptions<SignalArgs>>
+  ) => Promise<WorkflowHandleWithSignaledRunId<T>>;
+  return await signalWithStart(workflowTypeOrFunction, options);
+}
 
 /**
  * A handle to a running workflow that is returned by the {@link startWorkflow} helper.
@@ -189,7 +219,7 @@ export async function startWorkflow<T extends Workflow>(
     [InternalWorkflowStartOptionsSymbol]: internalOptions,
   };
 
-  const handle = await client.workflow.start(workflowTypeOrFunc, startOptions);
+  const handle = await startWorkflowFromNexusReference(client, workflowTypeOrFunc, startOptions);
   if (internalOptions.responseLink != null) {
     pushResponseLink(ctx, internalOptions.responseLink);
   }
@@ -329,7 +359,7 @@ export async function signalWithStartWorkflow<T extends Workflow, SignalArgs ext
     [InternalWorkflowStartOptionsSymbol]: internalOptions,
   } as unknown as WithWorkflowArgs<T, ClientWorkflowSignalWithStartOptions<SignalArgs>>;
 
-  const handle = await client.workflow.signalWithStart(workflowTypeOrFunc, signalWithStartOptions);
+  const handle = await signalWithStartFromNexusReference(client, workflowTypeOrFunc, signalWithStartOptions);
   if (internalOptions.responseLink != null) {
     pushResponseLink(ctx, internalOptions.responseLink);
   }

--- a/packages/test-helpers/src/helpers.ts
+++ b/packages/test-helpers/src/helpers.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto';
 import type { ExecutionContext } from 'ava';
-import type { WorkflowHandleWithFirstExecutionRunId, WorkflowStartOptions } from '@temporalio/client';
+import type { Client, WorkflowHandleWithFirstExecutionRunId, WorkflowStartOptions } from '@temporalio/client';
 import type { TestWorkflowEnvironment as RealTestWorkflowEnvironment } from '@temporalio/testing';
 import type { WorkerOptions, WorkflowBundle } from '@temporalio/worker';
 import type * as workflow from '@temporalio/workflow';
@@ -10,6 +10,31 @@ import { Worker } from './wrappers';
 export const isBun = typeof (globalThis as any).Bun !== 'undefined';
 /** Union type for all supported test environment types */
 export type AnyTestWorkflowEnvironment = TestWorkflowEnvironment | RealTestWorkflowEnvironment;
+
+/** Test Helpers intentionally accept broad Workflow options; Client still validates TypeInfo at runtime. */
+async function executeWorkflowFromTestHelper(
+  client: Client,
+  workflowFunction: workflow.Workflow,
+  options: WorkflowStartOptions
+): Promise<any> {
+  const execute = client.workflow.execute as unknown as (
+    workflowFunction: workflow.Workflow,
+    options: WorkflowStartOptions
+  ) => Promise<any>;
+  return await execute(workflowFunction, options);
+}
+
+async function startWorkflowFromTestHelper(
+  client: Client,
+  workflowFunction: workflow.Workflow,
+  options: WorkflowStartOptions
+): Promise<WorkflowHandleWithFirstExecutionRunId<workflow.Workflow>> {
+  const start = client.workflow.start as unknown as (
+    workflowFunction: workflow.Workflow,
+    options: WorkflowStartOptions
+  ) => Promise<WorkflowHandleWithFirstExecutionRunId<workflow.Workflow>>;
+  return await start(workflowFunction, options);
+}
 
 /**
  * Base context interface for test environments.
@@ -85,7 +110,7 @@ export function helpers<TEnv extends AnyTestWorkflowEnvironment = TestWorkflowEn
       workflowOpts?: Omit<WorkflowStartOptions, 'taskQueue' | 'workflowId'> &
         Partial<Pick<WorkflowStartOptions, 'workflowId'>>
     ): Promise<any> {
-      return await env.client.workflow.execute(fn, {
+      return await executeWorkflowFromTestHelper(env.client, fn, {
         taskQueue,
         workflowId: randomUUID(),
         ...workflowOpts,
@@ -96,7 +121,7 @@ export function helpers<TEnv extends AnyTestWorkflowEnvironment = TestWorkflowEn
       workflowOpts?: Omit<WorkflowStartOptions, 'taskQueue' | 'workflowId'> &
         Partial<Pick<WorkflowStartOptions, 'workflowId'>>
     ): Promise<WorkflowHandleWithFirstExecutionRunId<workflow.Workflow>> {
-      return await env.client.workflow.start(fn, {
+      return await startWorkflowFromTestHelper(env.client, fn, {
         taskQueue,
         workflowId: randomUUID(),
         ...workflowOpts,

--- a/packages/test/src/test-type-info.ts
+++ b/packages/test/src/test-type-info.ts
@@ -56,14 +56,16 @@ function makeClient(env: TestWorkflowEnvironment): Client {
 
 test('workflow definition with call-site type information is invalid', async (t) => {
   const client = makeClient(t.context.env);
+  const options = {
+    workflowId: `wf-${randomUUID()}`,
+    taskQueue: 'unused',
+    args: [new Order('order-1', 12345n)] as [Order],
+    typeInfo: workflowTypeInfo,
+  };
 
   await t.throwsAsync(
-    client.workflow.execute(workflowWithTypeInfo, {
-      workflowId: `wf-${randomUUID()}`,
-      taskQueue: 'unused',
-      args: [new Order('order-1', 12345n)],
-      typeInfo: workflowTypeInfo,
-    }),
+    // @ts-expect-error TypeInfo must be defined on a referenced Workflow function.
+    client.workflow.execute(workflowWithTypeInfo, options),
     {
       instanceOf: TypeError,
       message: /Workflow type information cannot be supplied at the call site when using a workflow function/,

--- a/packages/test/src/test-workflow-definition-type-info-types.ts
+++ b/packages/test/src/test-workflow-definition-type-info-types.ts
@@ -1,0 +1,68 @@
+/**
+ * Compile-time coverage for Workflow function and string overloads.
+ *
+ * Assertions live in never-called functions. Positive calls fail the build if they stop compiling, while
+ * `@ts-expect-error` calls fail the build if an invalid call becomes legal.
+ */
+import test from 'ava';
+import type { Client } from '@temporalio/client';
+import { WithStartWorkflowOperation } from '@temporalio/client';
+import type { PayloadTypeInfo } from '@temporalio/common';
+
+declare const client: Client;
+declare const workflow: (input: string) => Promise<string>;
+declare const typeInfo: PayloadTypeInfo;
+
+test('string Workflow references accept call-site TypeInfo', (t) => {
+  function _assertion() {
+    const options = {
+      workflowId: 'workflow-id',
+      taskQueue: 'task-queue',
+      args: ['input'] as [string],
+      typeInfo,
+    };
+
+    void client.workflow.start<typeof workflow>('workflow', options);
+    void client.workflow.execute<typeof workflow>('workflow', options);
+    void client.workflow.signalWithStart<typeof workflow, []>('workflow', {
+      ...options,
+      signal: 'signal',
+      signalArgs: [],
+    });
+    void new WithStartWorkflowOperation<typeof workflow>('workflow', {
+      ...options,
+      workflowIdConflictPolicy: 'FAIL',
+    });
+  }
+
+  t.pass();
+});
+
+test('Workflow function references reject call-site TypeInfo', (t) => {
+  function _assertion() {
+    const options = {
+      workflowId: 'workflow-id',
+      taskQueue: 'task-queue',
+      args: ['input'] as [string],
+      typeInfo,
+    };
+
+    // @ts-expect-error TypeInfo must be defined on a referenced Workflow function.
+    void client.workflow.start(workflow, options);
+    // @ts-expect-error TypeInfo must be defined on a referenced Workflow function.
+    void client.workflow.execute(workflow, options);
+    // @ts-expect-error TypeInfo must be defined on a referenced Workflow function.
+    void client.workflow.signalWithStart(workflow, {
+      ...options,
+      signal: 'signal',
+      signalArgs: [],
+    });
+    // @ts-expect-error TypeInfo must be defined on a referenced Workflow function.
+    void new WithStartWorkflowOperation(workflow, {
+      ...options,
+      workflowIdConflictPolicy: 'FAIL',
+    });
+  }
+
+  t.pass();
+});


### PR DESCRIPTION
## What was changed

Workflow Client APIs that accept either a Workflow function or a string name now reject call-site `TypeInfo` at compile time when a function is supplied. This covers start, execute, signal-with-start, and Update-with-Start operations.

String-named calls continue accepting call-site metadata. Runtime validation remains in place for JavaScript and dynamically typed calls. Existing Nexus and Test Helper APIs retain their current broad signatures through localized internal compatibility adapters; Nexus public parity is deferred to the Nexus TypeInfo PR.

## Why?

Workflow functions already carry definition-supplied TypeInfo. Supplying call-site TypeInfo with the same function is ambiguous and previously failed only at runtime.

The overloads now make the definition-versus-string resolution rule visible to TypeScript users without changing runtime behavior or requiring rollout steps.

## Checklist

1. Closes: N/A

2. How was this tested: Common, Client, Nexus compatibility, Test Helpers, AI SDK, and Test TypeScript builds; focused Client compile-time tests; ESLint; Prettier; `ts-prune`; and commit lint.

3. Any docs updates needed? No; the experimental API documentation already describes definition-supplied and string call-site TypeInfo.
