### PR TITLE
chore: ensure local activity replay issue is resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ to docs, or any other relevant information.
 - **Experimental**: The external storage S3 and GCS drivers now use `hash_algorithm` and `hash_value` instead of
   `hashAlgorithm` and `hashValue` in their claims. The GCS driver additionally uses `object_name` instead of
   `object`. Retrieval still accepts the old key names.
+- Fixed issue where replaying a workflow with Local Activities scheduled from a nested Promise could
+  trigger a nondeterminism error.
 
 ## [1.22.0] - 2026-08-05
 

--- a/packages/test/history_files/nested_promise_1_13_2.json
+++ b/packages/test/history_files/nested_promise_1_13_2.json
@@ -1,0 +1,225 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2025-10-27T19:29:55.404350Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048592",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "nestedPromises"
+        },
+        "taskQueue": {
+          "name": "Can_replay_local_activities",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {},
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "019a2726-08cc-7557-bd6f-5c92d9a25df0",
+        "identity": "99302@mac.lan",
+        "firstExecutionRunId": "019a2726-08cc-7557-bd6f-5c92d9a25df0",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {
+          "fields": {}
+        },
+        "workflowId": "ab029efc-e83c-4d93-9045-3ff03b4be2aa"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2025-10-27T19:29:55.404397Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048593",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "Can_replay_local_activities",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2025-10-27T19:29:55.411330Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048598",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "99302@mac.lan",
+        "requestId": "c88dfa85-db42-4237-b511-866cd465f0b3",
+        "historySizeBytes": "290",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.13.1+d02bdd0ca5147c5a6e881ce260afc16cd2a63e56890fb8968660a46fc6021680"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2025-10-27T19:29:55.493142Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048602",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "99302@mac.lan",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.13.1+d02bdd0ca5147c5a6e881ce260afc16cd2a63e56890fb8968660a46fc6021680"
+        },
+        "sdkMetadata": {
+          "coreUsedFlags": [
+            1,
+            2,
+            3
+          ],
+          "sdkName": "temporal-typescript",
+          "sdkVersion": "1.13.1"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2025-10-27T19:29:55.493234Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048603",
+      "markerRecordedEventAttributes": {
+        "details": {
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "YmluYXJ5L251bGw="
+                }
+              }
+            ]
+          },
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJzZXEiOjIsImF0dGVtcHQiOjEsImFjdGl2aXR5X2lkIjoiMiIsImFjdGl2aXR5X3R5cGUiOiJiIiwiY29tcGxldGVfdGltZSI6eyJzZWNvbmRzIjoxNzYxNTkzMzk1LCJuYW5vcyI6NDEzMDMzNjI1fSwiYmFja29mZiI6bnVsbCwib3JpZ2luYWxfc2NoZWR1bGVfdGltZSI6eyJzZWNvbmRzIjoxNzYxNTkzMzk1LCJuYW5vcyI6NDMyNDIzMDAwfX0="
+              }
+            ]
+          }
+        },
+        "markerName": "core_local_activity",
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2025-10-27T19:29:55.493236Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048604",
+      "markerRecordedEventAttributes": {
+        "details": {
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJzZXEiOjEsImF0dGVtcHQiOjEsImFjdGl2aXR5X2lkIjoiMSIsImFjdGl2aXR5X3R5cGUiOiJhIiwiY29tcGxldGVfdGltZSI6eyJzZWNvbmRzIjoxNzYxNTkzMzk1LCJuYW5vcyI6NDY0NzYzNDU4fSwiYmFja29mZiI6bnVsbCwib3JpZ2luYWxfc2NoZWR1bGVfdGltZSI6eyJzZWNvbmRzIjoxNzYxNTkzMzk1LCJuYW5vcyI6NDMyMzQ5MDAwfX0="
+              }
+            ]
+          },
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "YmluYXJ5L251bGw="
+                }
+              }
+            ]
+          }
+        },
+        "markerName": "core_local_activity",
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2025-10-27T19:29:55.493238Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048605",
+      "markerRecordedEventAttributes": {
+        "details": {
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "YmluYXJ5L251bGw="
+                }
+              }
+            ]
+          },
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJzZXEiOjMsImF0dGVtcHQiOjEsImFjdGl2aXR5X2lkIjoiMyIsImFjdGl2aXR5X3R5cGUiOiJkIiwiY29tcGxldGVfdGltZSI6eyJzZWNvbmRzIjoxNzYxNTkzMzk1LCJuYW5vcyI6NDY1MzIwNzQ5fSwiYmFja29mZiI6bnVsbCwib3JpZ2luYWxfc2NoZWR1bGVfdGltZSI6eyJzZWNvbmRzIjoxNzYxNTkzMzk1LCJuYW5vcyI6NDg5NDY2MDAwfX0="
+              }
+            ]
+          }
+        },
+        "markerName": "core_local_activity",
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2025-10-27T19:29:55.493239Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048606",
+      "markerRecordedEventAttributes": {
+        "details": {
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "YmluYXJ5L251bGw="
+                }
+              }
+            ]
+          },
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJzZXEiOjQsImF0dGVtcHQiOjEsImFjdGl2aXR5X2lkIjoiNCIsImFjdGl2aXR5X3R5cGUiOiJjIiwiY29tcGxldGVfdGltZSI6eyJzZWNvbmRzIjoxNzYxNTkzMzk1LCJuYW5vcyI6NDY1NDQ0NTQxfSwiYmFja29mZiI6bnVsbCwib3JpZ2luYWxfc2NoZWR1bGVfdGltZSI6eyJzZWNvbmRzIjoxNzYxNTkzMzk1LCJuYW5vcyI6NDg5NDcyMDAwfX0="
+              }
+            ]
+          }
+        },
+        "markerName": "core_local_activity",
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2025-10-27T19:29:55.493262Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1048607",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "workflowTaskCompletedEventId": "4"
+      }
+    }
+  ]
+}

--- a/packages/test/history_files/nested_promise_1_13_2.json
+++ b/packages/test/history_files/nested_promise_1_13_2.json
@@ -68,11 +68,7 @@
           "buildId": "@temporalio/worker@1.13.1+d02bdd0ca5147c5a6e881ce260afc16cd2a63e56890fb8968660a46fc6021680"
         },
         "sdkMetadata": {
-          "coreUsedFlags": [
-            1,
-            2,
-            3
-          ],
+          "coreUsedFlags": [1, 2, 3],
           "sdkName": "temporal-typescript",
           "sdkVersion": "1.13.1"
         },

--- a/packages/test/src/test-integration-replay-and-flags.ts
+++ b/packages/test/src/test-integration-replay-and-flags.ts
@@ -7,7 +7,7 @@ import {
   langFlagsReplayCorrectly,
   setAndClearTimeout,
 } from './integration-workflows-common';
-import { helpers, makeTestFunction } from './helpers-integration';
+import { createTestWorkflowBundle, helpers, makeTestFunction } from './helpers-integration';
 import { loadHistory, RUN_TIME_SKIPPING_TESTS } from './helpers';
 
 export * from './integration-workflows-common';
@@ -86,6 +86,20 @@ test("Lang's SDK flags from 1.11.2 are retroactively applied on replay", async (
   const hist = await loadHistory('lang_flags_replay_correctly_1_11_2.json');
   await runReplayHistory({}, hist);
   t.pass();
+});
+
+// Previously on replay, core would resolve LA based on schedule order instead of the order of results in history.
+// This could cause NDE if additional LAs were scheduled upon LA completion.
+test('GH 1744', async (t) => {
+  const { runReplayHistory } = helpers(t);
+
+  const workflowBundle = await createTestWorkflowBundle({
+    workflowsPath: require.resolve('./workflows/nested-promise'),
+  });
+  const hist = await loadHistory('nested_promise_1_13_2.json');
+  await t.notThrowsAsync(async () => {
+    await runReplayHistory({ workflowBundle }, hist);
+  });
 });
 
 if (RUN_TIME_SKIPPING_TESTS) {

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -49,6 +49,7 @@ export * from './long-history-generator';
 export * from './multiple-activities-single-timeout';
 export { initAndResetFlag, checkDisposeRan } from './internal-interceptor-dispose-global';
 export * from './nested-cancellation';
+export * from './nested-promise';
 export * from './noncancellable-shields-children';
 export * from './partial-noncancelable';
 export * from './patched';

--- a/packages/test/src/workflows/nested-promise.ts
+++ b/packages/test/src/workflows/nested-promise.ts
@@ -1,0 +1,7 @@
+import { proxyLocalActivities } from '@temporalio/workflow';
+
+const { a, b, c, d } = proxyLocalActivities({ startToCloseTimeout: '5m' });
+
+export async function nestedPromises(): Promise<void> {
+  await Promise.all([a().then(() => c()), b().then(() => d())]);
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added regression test for #1744

## Why?
Ensure https://github.com/temporalio/sdk-rust/pull/1442 (included first in #2314) resolved #1744

## Checklist
<!--- add/delete as needed --->

1. Closes #1744 (not really #2314 included the core commit that fixed this, but this displays it was fixed)

2. How was this tested:
Had this history on a branch I created back when I was initially working on this issue. The test now passes.

Just to make sure my past self wasn't doing funny business, I cherry picked this commit to `b802d1a2e15f1d47e01e2b013e966e3fc9f1855a` (the commit before the core fix was introduced) and confirmed it failed as expected:
```
  GH 1744

  Returned promise rejected with:

  DeterminismViolationError {
    message: 'Replay failed with a nondeterminism error. This means that the workflow code as written is not compatible with the history that was fed in. Details: Workflow activation completion failed: Failure { failure: Some(Failure { message: "[TMPRL1100] Nondeterminism error: Activity type of recorded marker \'d\' does not match activity type of local activity command \'c\'", source: "", stack_trace: "", encoded_attributes: None, cause: None, failure_info: Some(ApplicationFailureInfo(ApplicationFailureInfo { r#type: "", non_retryable: false, details: None, next_retry_delay: None, category: Unspecified })) }), force_cause: NonDeterministicError }',
  }
```

3. Any docs updates needed?
N/A
