### PR TITLE
Use new payload visitor for workflow activations and completions

### DIFF
--- a/packages/common/src/internal-non-workflow/codec-helpers.ts
+++ b/packages/common/src/internal-non-workflow/codec-helpers.ts
@@ -45,7 +45,7 @@ export async function encode(
 }
 
 /** Run {@link PayloadCodec.decode} on `payloads` */
-export async function decodeOptional(
+async function decodeOptional(
   codecs: PayloadCodec[],
   payloads: Payload[] | null | undefined,
   context?: SerializationContext
@@ -160,17 +160,6 @@ export async function decodeOptionalFailureToOptionalError(
   return failure
     ? failureConverter.failureToError(await decodeFailure(payloadCodecs, failure, context), payloadConverter, context)
     : undefined;
-}
-
-export async function decodeOptionalMap(
-  codecs: PayloadCodec[],
-  payloads: Record<string, Payload> | null | undefined,
-  context?: SerializationContext
-): Promise<Record<string, DecodedPayload> | null | undefined> {
-  if (payloads == null) return payloads;
-  return Object.fromEntries(
-    await Promise.all(Object.entries(payloads).map(async ([k, v]) => [k, (await decode(codecs, [v], context))[0]]))
-  );
 }
 
 /**
@@ -374,28 +363,6 @@ export async function decodeFailure(
         }
       : undefined,
   };
-}
-
-/**
- * Return a new {@link ProtoFailure} with `codec.encode()` run on all the {@link Payload}s.
- */
-export async function decodeOptionalFailure(
-  codecs: PayloadCodec[],
-  failure: ProtoFailure | null | undefined,
-  context?: SerializationContext
-): Promise<DecodedProtoFailure | null | undefined> {
-  if (failure == null) return failure;
-  return await decodeFailure(codecs, failure, context);
-}
-
-/**
- * Mark all values in the map as decoded.
- * Use this for headers, which we don't encode.
- */
-export function noopDecodeMap<K extends string>(
-  map: Record<K, Payload> | null | undefined
-): Record<K, DecodedPayload> | null | undefined {
-  return map as Record<K, DecodedPayload> | null | undefined;
 }
 
 export async function encodeUserMetadata(

--- a/packages/common/src/internal-non-workflow/codec-helpers.ts
+++ b/packages/common/src/internal-non-workflow/codec-helpers.ts
@@ -44,16 +44,6 @@ export async function encode(
   return payloads as EncodedPayload[];
 }
 
-/** Run {@link PayloadCodec.encode} on `payloads` */
-export async function encodeOptional(
-  codecs: PayloadCodec[],
-  payloads: Payload[] | null | undefined,
-  context?: SerializationContext
-): Promise<EncodedPayload[] | null | undefined> {
-  if (payloads == null) return payloads;
-  return await encode(codecs, payloads, context);
-}
-
 /** Run {@link PayloadCodec.decode} on `payloads` */
 export async function decodeOptional(
   codecs: PayloadCodec[],
@@ -83,7 +73,7 @@ async function decodeSingle(
 }
 
 /** Run {@link PayloadCodec.encode} on a single Payload */
-export async function encodeOptionalSingle(
+async function encodeOptionalSingle(
   codecs: PayloadCodec[],
   payload: Payload | null | undefined,
   context?: SerializationContext
@@ -229,23 +219,6 @@ export async function decodeMapFromPayloads<K extends string>(
       })
     )
   ) as Record<K, unknown>;
-}
-
-/** Run {@link PayloadCodec.encode} on all values in `map` */
-export async function encodeMap<K extends string>(
-  codecs: PayloadCodec[],
-  map: Record<K, Payload> | null | undefined,
-  context?: SerializationContext
-): Promise<Record<K, EncodedPayload> | null | undefined> {
-  if (map === null) return null;
-  if (map === undefined) return undefined;
-  return Object.fromEntries(
-    await Promise.all(
-      Object.entries(map).map(async ([k, payload]): Promise<[K, EncodedPayload]> => {
-        return [k as K, await encodeSingle(codecs, payload as Payload, context)];
-      })
-    )
-  ) as Record<K, EncodedPayload>;
 }
 
 /**
@@ -406,18 +379,6 @@ export async function decodeFailure(
 /**
  * Return a new {@link ProtoFailure} with `codec.encode()` run on all the {@link Payload}s.
  */
-export async function encodeOptionalFailure(
-  codecs: PayloadCodec[],
-  failure: ProtoFailure | null | undefined,
-  context?: SerializationContext
-): Promise<EncodedProtoFailure | null | undefined> {
-  if (failure == null) return failure;
-  return await encodeFailure(codecs, failure, context);
-}
-
-/**
- * Return a new {@link ProtoFailure} with `codec.encode()` run on all the {@link Payload}s.
- */
 export async function decodeOptionalFailure(
   codecs: PayloadCodec[],
   failure: ProtoFailure | null | undefined,
@@ -425,27 +386,6 @@ export async function decodeOptionalFailure(
 ): Promise<DecodedProtoFailure | null | undefined> {
   if (failure == null) return failure;
   return await decodeFailure(codecs, failure, context);
-}
-
-/**
- * Mark all values in the map as encoded.
- * Use this for headers, which we don't encode.
- */
-export function noopEncodeMap<K extends string>(
-  map: Record<K, Payload> | null | undefined
-): Record<K, EncodedPayload> | null | undefined {
-  return map as Record<K, EncodedPayload> | null | undefined;
-}
-
-export function noopEncodeSearchAttrs(
-  attrs: temporal.api.common.v1.ISearchAttributes | null | undefined
-): temporal.api.common.v1.ISearchAttributes | null | undefined {
-  if (!attrs) {
-    return attrs;
-  }
-  return {
-    indexedFields: noopEncodeMap(attrs.indexedFields),
-  };
 }
 
 /**

--- a/packages/test/src/test-workflow-codec-runner.ts
+++ b/packages/test/src/test-workflow-codec-runner.ts
@@ -56,6 +56,104 @@ test('decodeActivation binds workflow codec context for initializeWorkflow paylo
   ]);
 });
 
+test('decodeActivation covers every initializeWorkflow payload field but headers and search attributes', async (t) => {
+  const runner = new WorkflowCodecRunner([new FreePayloadCodec()], {
+    type: 'workflow',
+    namespace: 'default',
+    workflowId: 'wf-1',
+  });
+
+  const decoded = await runner.decodeActivation({
+    runId: 'run-1',
+    jobs: [
+      {
+        initializeWorkflow: {
+          workflowId: 'wf-1',
+          workflowType: 'test',
+          randomnessSeed: { toBytes: () => new Uint8Array([1]) } as any,
+          firstExecutionRunId: 'run-1',
+          attempt: 1,
+          startTime: {} as any,
+          headers: { 'header-key': payload('header') },
+          continuedFailure: failureWithDetail('continued-failure'),
+          memo: { fields: { 'memo-key': payload('memo') } },
+          lastCompletionResult: { payloads: [payload('last-completion')] },
+          searchAttributes: { indexedFields: { 'attr-key': payload('search-attribute') } },
+        },
+      },
+    ],
+  });
+
+  const initializeWorkflow = decoded.jobs?.[0]?.initializeWorkflow;
+  t.deepEqual(
+    traceFromPayload(initializeWorkflow?.continuedFailure?.applicationFailureInfo?.details?.payloads?.[0] as Payload),
+    ['codec.decode.bound|continued-failure|workflow.default.wf-1']
+  );
+  t.deepEqual(traceFromPayload(initializeWorkflow?.memo?.fields?.['memo-key'] as Payload), [
+    'codec.decode.bound|memo|workflow.default.wf-1',
+  ]);
+  t.deepEqual(traceFromPayload(initializeWorkflow?.lastCompletionResult?.payloads?.[0] as Payload), [
+    'codec.decode.bound|last-completion|workflow.default.wf-1',
+  ]);
+  // Headers and search attributes are converted by the workflow itself, never by the codec.
+  t.deepEqual(traceFromPayload(initializeWorkflow?.headers?.['header-key'] as Payload), []);
+  t.deepEqual(traceFromPayload(initializeWorkflow?.searchAttributes?.indexedFields?.['attr-key'] as Payload), []);
+});
+
+test('decodeActivation decodes query, update, and signal inputs with workflow context', async (t) => {
+  const runner = new WorkflowCodecRunner([new FreePayloadCodec()], {
+    type: 'workflow',
+    namespace: 'default',
+    workflowId: 'wf-1',
+  });
+
+  const decoded = await runner.decodeActivation({
+    runId: 'run-1',
+    jobs: [
+      { queryWorkflow: { queryId: 'q-1', queryType: 'q', arguments: [payload('query-input')] } },
+      { doUpdate: { id: 'u-1', name: 'u', input: [payload('update-input')] } },
+      { signalWorkflow: { signalName: 's', input: [payload('signal-input')] } },
+    ],
+  });
+
+  t.deepEqual(traceFromPayload(decoded.jobs?.[0]?.queryWorkflow?.arguments?.[0] as Payload), [
+    'codec.decode.bound|query-input|workflow.default.wf-1',
+  ]);
+  t.deepEqual(traceFromPayload(decoded.jobs?.[1]?.doUpdate?.input?.[0] as Payload), [
+    'codec.decode.bound|update-input|workflow.default.wf-1',
+  ]);
+  t.deepEqual(traceFromPayload(decoded.jobs?.[2]?.signalWorkflow?.input?.[0] as Payload), [
+    'codec.decode.bound|signal-input|workflow.default.wf-1',
+  ]);
+});
+
+test('decodeActivation decodes resolveNexusOperationStart failures', async (t) => {
+  const runner = new WorkflowCodecRunner([new FreePayloadCodec()], {
+    type: 'workflow',
+    namespace: 'default',
+    workflowId: 'wf-1',
+  });
+
+  const decoded = await runner.decodeActivation({
+    runId: 'run-1',
+    jobs: [
+      {
+        resolveNexusOperationStart: {
+          seq: 8,
+          failed: failureWithDetail('nexus-start-failure'),
+        },
+      },
+    ],
+  });
+
+  t.deepEqual(
+    traceFromPayload(
+      decoded.jobs?.[0]?.resolveNexusOperationStart?.failed?.applicationFailureInfo?.details?.payloads?.[0] as Payload
+    ),
+    ['codec.decode.bound|nexus-start-failure|workflow.default.wf-1']
+  );
+});
+
 test('encodeCompletion stores activity context and decodeActivation reuses it for resolveActivity', async (t) => {
   const runner = new WorkflowCodecRunner([new FreePayloadCodec()], {
     type: 'workflow',

--- a/packages/test/src/test-workflow-codec-runner.ts
+++ b/packages/test/src/test-workflow-codec-runner.ts
@@ -34,7 +34,7 @@ test('decodeActivation binds workflow codec context for initializeWorkflow paylo
     workflowId: 'wf-1',
   });
 
-  const decoded = await runner.decodeActivation({
+  const activation = {
     runId: 'run-1',
     jobs: [
       {
@@ -49,11 +49,13 @@ test('decodeActivation binds workflow codec context for initializeWorkflow paylo
         },
       },
     ],
-  });
+  };
+  const decoded = await runner.decodeActivation(activation);
 
   t.deepEqual(traceFromPayload(decoded.jobs?.[0]?.initializeWorkflow?.arguments?.[0] as Payload), [
     'codec.decode.bound|wf-input|workflow.default.wf-1',
   ]);
+  t.deepEqual(traceFromPayload(activation.jobs[0]?.initializeWorkflow?.arguments?.[0] as Payload), []);
 });
 
 test('decodeActivation covers every initializeWorkflow payload field but headers and search attributes', async (t) => {

--- a/packages/test/src/test-workflow-codec-runner.ts
+++ b/packages/test/src/test-workflow-codec-runner.ts
@@ -202,6 +202,44 @@ test('encodeCompletion stores activity context and decodeActivation reuses it fo
   ]);
 });
 
+test('encodeCompletion encodes event group marker labels with the command context', async (t) => {
+  const runner = new WorkflowCodecRunner([new FreePayloadCodec()], {
+    type: 'workflow',
+    namespace: 'default',
+    workflowId: 'wf-1',
+  });
+
+  const encoded = decodeCompletion(
+    await runner.encodeCompletion({
+      successful: {
+        commands: [
+          {
+            scheduleActivity: {
+              seq: 1,
+              activityId: 'act-1',
+              arguments: [payload('activity-input')],
+            },
+            eventGroupMarkers: [{ label: { id: 'group-1', label: payload('activity-marker') } }],
+          },
+          {
+            completeWorkflowExecution: {},
+            eventGroupMarkers: [{ label: { id: 'group-2', label: payload('workflow-marker') } }],
+          },
+        ],
+      },
+    })
+  );
+
+  const commands = encoded.successful?.commands ?? [];
+  t.deepEqual(traceFromPayload(commands[0]?.eventGroupMarkers?.[0]?.label?.label as Payload), [
+    'codec.encode.bound|activity-marker|activity.default.wf-1.act-1.false',
+  ]);
+  // A command that targets nothing of its own leaves its markers on the workflow context.
+  t.deepEqual(traceFromPayload(commands[1]?.eventGroupMarkers?.[0]?.label?.label as Payload), [
+    'codec.encode.bound|workflow-marker|workflow.default.wf-1',
+  ]);
+});
+
 test('encodeCompletion keeps distinct child-workflow contexts for start and completion', async (t) => {
   const runner = new WorkflowCodecRunner([new FreePayloadCodec()], {
     type: 'workflow',

--- a/packages/worker/src/workflow-codec-runner.ts
+++ b/packages/worker/src/workflow-codec-runner.ts
@@ -22,13 +22,13 @@ import { coresdk } from '@temporalio/proto';
  * Maximum number of concurrent codec encodes for workflow completions. Previously,
  * this was unbounded.
  */
-const MAX_CONCURRENT_CODEC_ENCODES = 20;
+const MAX_CONCURRENT_CODEC_OPERATIONS = 20;
 
 /**
  * Helper class for decoding Workflow activations and encoding Workflow completions.
  */
 export class WorkflowCodecRunner {
-  private readonly codecEncodeLimit = limit(MAX_CONCURRENT_CODEC_ENCODES);
+  private readonly codecOperationLimit = limit(MAX_CONCURRENT_CODEC_OPERATIONS);
 
   private readonly pendingCompletionContexts = {
     activity: new Map<number, ActivitySerializationContext>(),
@@ -371,7 +371,7 @@ export class WorkflowCodecRunner {
         initialContext: this.workflowContext,
         skipHeaders: true,
         skipSearchAttributes: true,
-        limit: this.codecEncodeLimit,
+        limit: this.codecOperationLimit,
         deriveContext: (message, typeName, context) => {
           if (typeName !== 'coresdk.workflow_commands.WorkflowCommand') {
             if (typeName === 'coresdk.workflow_commands.ScheduleActivity') {

--- a/packages/worker/src/workflow-codec-runner.ts
+++ b/packages/worker/src/workflow-codec-runner.ts
@@ -15,12 +15,21 @@ import {
   visit,
   walkWorkflowActivationCompletion,
 } from '@temporalio/common/lib/internal-non-workflow';
+import { limit } from '@temporalio/common/lib/concurrency/limit';
 import { coresdk } from '@temporalio/proto';
+
+/**
+ * Maximum number of concurrent codec encodes for workflow completions. Previously,
+ * this was unbounded.
+ */
+const MAX_CONCURRENT_CODEC_ENCODES = 20;
 
 /**
  * Helper class for decoding Workflow activations and encoding Workflow completions.
  */
 export class WorkflowCodecRunner {
+  private readonly codecEncodeLimit = limit(MAX_CONCURRENT_CODEC_ENCODES);
+
   private readonly pendingCompletionContexts = {
     activity: new Map<number, ActivitySerializationContext>(),
     childWorkflowStart: new Map<number, WorkflowSerializationContext>(),
@@ -360,9 +369,9 @@ export class WorkflowCodecRunner {
         transformPayload: async (payload, context) => (await encode(this.codecs, [payload], context))[0]!,
         transformPayloads: (payloads, context) => encode(this.codecs, payloads, context),
         initialContext: this.workflowContext,
-        // Headers and search attributes are not payload-converted by workflows.
         skipHeaders: true,
         skipSearchAttributes: true,
+        limit: this.codecEncodeLimit,
         deriveContext: (message, typeName, context) => {
           if (typeName !== 'coresdk.workflow_commands.WorkflowCommand') {
             if (typeName === 'coresdk.workflow_commands.ScheduleActivity') {

--- a/packages/worker/src/workflow-codec-runner.ts
+++ b/packages/worker/src/workflow-codec-runner.ts
@@ -16,8 +16,7 @@ import { limit } from '@temporalio/common/lib/concurrency/limit';
 import { coresdk } from '@temporalio/proto';
 
 /**
- * Maximum number of concurrent codec calls per activation or completion. Previously,
- * this was unbounded.
+ * Maximum number of concurrent codec calls per activation or completion.
  */
 const MAX_CONCURRENT_CODEC_OPERATIONS = 20;
 

--- a/packages/worker/src/workflow-codec-runner.ts
+++ b/packages/worker/src/workflow-codec-runner.ts
@@ -6,20 +6,17 @@ import type {
 } from '@temporalio/common';
 import type { Decoded, Encoded } from '@temporalio/common/lib/internal-non-workflow';
 import {
+  decode,
   encode,
-  decodeOptional,
-  decodeOptionalFailure,
-  decodeOptionalMap,
-  decodeOptionalSingle,
-  noopDecodeMap,
   visit,
+  walkWorkflowActivation,
   walkWorkflowActivationCompletion,
 } from '@temporalio/common/lib/internal-non-workflow';
 import { limit } from '@temporalio/common/lib/concurrency/limit';
 import { coresdk } from '@temporalio/proto';
 
 /**
- * Maximum number of concurrent codec encodes for workflow completions. Previously,
+ * Maximum number of concurrent codec calls per activation or completion. Previously,
  * this was unbounded.
  */
 const MAX_CONCURRENT_CODEC_OPERATIONS = 20;
@@ -100,259 +97,50 @@ export class WorkflowCodecRunner {
   public async decodeActivation<T extends coresdk.workflow_activation.IWorkflowActivation>(
     activation: T
   ): Promise<Decoded<T>> {
-    return coresdk.workflow_activation.WorkflowActivation.fromObject(<
-      Decoded<coresdk.workflow_activation.IWorkflowActivation>
-    >{
-      ...activation,
-      jobs: activation.jobs
-        ? await Promise.all(
-            activation.jobs.map(async (job) => {
-              const resolveActivityContext = job.resolveActivity
-                ? this.consumeContext(this.pendingCompletionContexts.activity, job.resolveActivity.seq)
-                : undefined;
-              const resolveChildWorkflowExecutionContext = job.resolveChildWorkflowExecution
-                ? this.consumeContext(
-                    this.pendingCompletionContexts.childWorkflowComplete,
-                    job.resolveChildWorkflowExecution.seq
-                  )
-                : undefined;
-              const resolveChildWorkflowStartContext = job.resolveChildWorkflowExecutionStart
-                ? this.consumeContext(
-                    this.pendingCompletionContexts.childWorkflowStart,
-                    job.resolveChildWorkflowExecutionStart.seq
-                  )
-                : undefined;
-              const resolveSignalContext = job.resolveSignalExternalWorkflow
-                ? this.consumeContext(
-                    this.pendingCompletionContexts.signalWorkflow,
-                    job.resolveSignalExternalWorkflow.seq
-                  )
-                : undefined;
-              const resolveCancelContext = job.resolveRequestCancelExternalWorkflow
-                ? this.consumeContext(
-                    this.pendingCompletionContexts.cancelWorkflow,
-                    job.resolveRequestCancelExternalWorkflow.seq
-                  )
-                : undefined;
-
-              return {
-                ...job,
-                initializeWorkflow: job.initializeWorkflow
-                  ? {
-                      ...job.initializeWorkflow,
-                      arguments: await decodeOptional(
-                        this.codecs,
-                        job.initializeWorkflow.arguments,
-                        this.workflowContext
-                      ),
-                      headers: noopDecodeMap(job.initializeWorkflow.headers),
-                      continuedFailure: await decodeOptionalFailure(
-                        this.codecs,
-                        job.initializeWorkflow.continuedFailure,
-                        this.workflowContext
-                      ),
-                      memo: {
-                        ...job.initializeWorkflow.memo,
-                        fields: await decodeOptionalMap(
-                          this.codecs,
-                          job.initializeWorkflow.memo?.fields,
-                          this.workflowContext
-                        ),
-                      },
-                      lastCompletionResult: {
-                        ...job.initializeWorkflow.lastCompletionResult,
-                        payloads: await decodeOptional(
-                          this.codecs,
-                          job.initializeWorkflow.lastCompletionResult?.payloads,
-                          this.workflowContext
-                        ),
-                      },
-                      searchAttributes: job.initializeWorkflow.searchAttributes
-                        ? {
-                            ...job.initializeWorkflow.searchAttributes,
-                            indexedFields: job.initializeWorkflow.searchAttributes.indexedFields
-                              ? noopDecodeMap(job.initializeWorkflow.searchAttributes.indexedFields)
-                              : undefined,
-                          }
-                        : undefined,
-                    }
-                  : null,
-                queryWorkflow: job.queryWorkflow
-                  ? {
-                      ...job.queryWorkflow,
-                      arguments: await decodeOptional(this.codecs, job.queryWorkflow.arguments, this.workflowContext),
-                      headers: noopDecodeMap(job.queryWorkflow.headers),
-                    }
-                  : null,
-                doUpdate: job.doUpdate
-                  ? {
-                      ...job.doUpdate,
-                      input: await decodeOptional(this.codecs, job.doUpdate.input, this.workflowContext),
-                      headers: noopDecodeMap(job.doUpdate.headers),
-                    }
-                  : null,
-                signalWorkflow: job.signalWorkflow
-                  ? {
-                      ...job.signalWorkflow,
-                      input: await decodeOptional(this.codecs, job.signalWorkflow.input, this.workflowContext),
-                      headers: noopDecodeMap(job.signalWorkflow.headers),
-                    }
-                  : null,
-                resolveActivity: job.resolveActivity
-                  ? {
-                      ...job.resolveActivity,
-                      result: job.resolveActivity.result
-                        ? {
-                            ...job.resolveActivity.result,
-                            completed: job.resolveActivity.result.completed
-                              ? {
-                                  ...job.resolveActivity.result.completed,
-                                  result: await decodeOptionalSingle(
-                                    this.codecs,
-                                    job.resolveActivity.result.completed.result,
-                                    resolveActivityContext
-                                  ),
-                                }
-                              : null,
-                            failed: job.resolveActivity.result.failed
-                              ? {
-                                  ...job.resolveActivity.result.failed,
-                                  failure: await decodeOptionalFailure(
-                                    this.codecs,
-                                    job.resolveActivity.result.failed.failure,
-                                    resolveActivityContext
-                                  ),
-                                }
-                              : null,
-                            cancelled: job.resolveActivity.result.cancelled
-                              ? {
-                                  ...job.resolveActivity.result.cancelled,
-                                  failure: await decodeOptionalFailure(
-                                    this.codecs,
-                                    job.resolveActivity.result.cancelled.failure,
-                                    resolveActivityContext
-                                  ),
-                                }
-                              : null,
-                          }
-                        : null,
-                    }
-                  : null,
-                resolveChildWorkflowExecution: job.resolveChildWorkflowExecution
-                  ? {
-                      ...job.resolveChildWorkflowExecution,
-                      result: job.resolveChildWorkflowExecution.result
-                        ? {
-                            ...job.resolveChildWorkflowExecution.result,
-                            completed: job.resolveChildWorkflowExecution.result.completed
-                              ? {
-                                  ...job.resolveChildWorkflowExecution.result.completed,
-                                  result: await decodeOptionalSingle(
-                                    this.codecs,
-                                    job.resolveChildWorkflowExecution.result.completed.result,
-                                    resolveChildWorkflowExecutionContext
-                                  ),
-                                }
-                              : null,
-                            failed: job.resolveChildWorkflowExecution.result.failed
-                              ? {
-                                  ...job.resolveChildWorkflowExecution.result.failed,
-                                  failure: await decodeOptionalFailure(
-                                    this.codecs,
-                                    job.resolveChildWorkflowExecution.result.failed.failure,
-                                    resolveChildWorkflowExecutionContext
-                                  ),
-                                }
-                              : null,
-                            cancelled: job.resolveChildWorkflowExecution.result.cancelled
-                              ? {
-                                  ...job.resolveChildWorkflowExecution.result.cancelled,
-                                  failure: await decodeOptionalFailure(
-                                    this.codecs,
-                                    job.resolveChildWorkflowExecution.result.cancelled.failure,
-                                    resolveChildWorkflowExecutionContext
-                                  ),
-                                }
-                              : null,
-                          }
-                        : null,
-                    }
-                  : null,
-                resolveChildWorkflowExecutionStart: job.resolveChildWorkflowExecutionStart
-                  ? {
-                      ...job.resolveChildWorkflowExecutionStart,
-                      cancelled: job.resolveChildWorkflowExecutionStart.cancelled
-                        ? {
-                            ...job.resolveChildWorkflowExecutionStart.cancelled,
-                            failure: await decodeOptionalFailure(
-                              this.codecs,
-                              job.resolveChildWorkflowExecutionStart.cancelled.failure,
-                              resolveChildWorkflowStartContext
-                            ),
-                          }
-                        : null,
-                    }
-                  : null,
-                resolveNexusOperation: job.resolveNexusOperation
-                  ? {
-                      ...job.resolveNexusOperation,
-                      result: {
-                        completed: job.resolveNexusOperation.result?.completed
-                          ? await decodeOptionalSingle(
-                              this.codecs,
-                              job.resolveNexusOperation.result.completed,
-                              this.workflowContext
-                            )
-                          : null,
-                        failed: job.resolveNexusOperation.result?.failed
-                          ? await decodeOptionalFailure(
-                              this.codecs,
-                              job.resolveNexusOperation.result.failed,
-                              this.workflowContext
-                            )
-                          : null,
-                        cancelled: job.resolveNexusOperation.result?.cancelled
-                          ? await decodeOptionalFailure(
-                              this.codecs,
-                              job.resolveNexusOperation.result.cancelled,
-                              this.workflowContext
-                            )
-                          : null,
-                        timedOut: job.resolveNexusOperation.result?.timedOut
-                          ? await decodeOptionalFailure(
-                              this.codecs,
-                              job.resolveNexusOperation.result.timedOut,
-                              this.workflowContext
-                            )
-                          : null,
-                      },
-                    }
-                  : null,
-                resolveSignalExternalWorkflow: job.resolveSignalExternalWorkflow
-                  ? {
-                      ...job.resolveSignalExternalWorkflow,
-                      failure: await decodeOptionalFailure(
-                        this.codecs,
-                        job.resolveSignalExternalWorkflow.failure,
-                        resolveSignalContext
-                      ),
-                    }
-                  : null,
-                resolveRequestCancelExternalWorkflow: job.resolveRequestCancelExternalWorkflow
-                  ? {
-                      ...job.resolveRequestCancelExternalWorkflow,
-                      failure: await decodeOptionalFailure(
-                        this.codecs,
-                        job.resolveRequestCancelExternalWorkflow.failure,
-                        resolveCancelContext
-                      ),
-                    }
-                  : null,
-              };
-            })
-          )
-        : null,
-    }) as Decoded<T>;
+    await visit<coresdk.workflow_activation.IWorkflowActivation, SerializationContext | undefined>(
+      activation,
+      walkWorkflowActivation,
+      {
+        transformPayload: async (payload, context) => (await decode(this.codecs, [payload], context))[0]!,
+        transformPayloads: (payloads, context) => decode(this.codecs, payloads, context),
+        initialContext: this.workflowContext,
+        skipHeaders: true,
+        skipSearchAttributes: true,
+        limit: this.codecOperationLimit,
+        deriveContext: (message, typeName, context) => {
+          switch (typeName) {
+            case 'coresdk.workflow_activation.ResolveActivity':
+              return this.consumeContext(
+                this.pendingCompletionContexts.activity,
+                (message as coresdk.workflow_activation.IResolveActivity).seq
+              );
+            case 'coresdk.workflow_activation.ResolveChildWorkflowExecution':
+              return this.consumeContext(
+                this.pendingCompletionContexts.childWorkflowComplete,
+                (message as coresdk.workflow_activation.IResolveChildWorkflowExecution).seq
+              );
+            case 'coresdk.workflow_activation.ResolveChildWorkflowExecutionStart':
+              return this.consumeContext(
+                this.pendingCompletionContexts.childWorkflowStart,
+                (message as coresdk.workflow_activation.IResolveChildWorkflowExecutionStart).seq
+              );
+            case 'coresdk.workflow_activation.ResolveSignalExternalWorkflow':
+              return this.consumeContext(
+                this.pendingCompletionContexts.signalWorkflow,
+                (message as coresdk.workflow_activation.IResolveSignalExternalWorkflow).seq
+              );
+            case 'coresdk.workflow_activation.ResolveRequestCancelExternalWorkflow':
+              return this.consumeContext(
+                this.pendingCompletionContexts.cancelWorkflow,
+                (message as coresdk.workflow_activation.IResolveRequestCancelExternalWorkflow).seq
+              );
+            default:
+              return context;
+          }
+        },
+      }
+    );
+    return activation as unknown as Decoded<T>;
   }
 
   /**

--- a/packages/worker/src/workflow-codec-runner.ts
+++ b/packages/worker/src/workflow-codec-runner.ts
@@ -6,17 +6,14 @@ import type {
 } from '@temporalio/common';
 import type { Decoded, Encoded } from '@temporalio/common/lib/internal-non-workflow';
 import {
+  encode,
   decodeOptional,
   decodeOptionalFailure,
   decodeOptionalMap,
   decodeOptionalSingle,
-  encodeMap,
-  encodeOptional,
-  encodeOptionalFailure,
-  encodeOptionalSingle,
   noopDecodeMap,
-  noopEncodeMap,
-  noopEncodeSearchAttrs,
+  visit,
+  walkWorkflowActivationCompletion,
 } from '@temporalio/common/lib/internal-non-workflow';
 import { coresdk } from '@temporalio/proto';
 
@@ -86,42 +83,6 @@ export class WorkflowCodecRunner {
       namespace: command.workflowExecution?.namespace || this.workflowContext.namespace,
       workflowId,
     };
-  }
-
-  private async encodeUserMetadata(
-    context: SerializationContext,
-    userMetadata: coresdk.workflow_commands.IWorkflowCommand['userMetadata']
-  ): Promise<Encoded<NonNullable<coresdk.workflow_commands.IWorkflowCommand['userMetadata']>> | undefined> {
-    if (!(userMetadata && (userMetadata.summary || userMetadata.details))) {
-      return undefined;
-    }
-
-    return {
-      summary: await encodeOptionalSingle(this.codecs, userMetadata.summary, context),
-      details: await encodeOptionalSingle(this.codecs, userMetadata.details, context),
-    };
-  }
-
-  private async encodeEventGroupMarkers(
-    context: SerializationContext,
-    markers: coresdk.workflow_commands.IWorkflowCommand['eventGroupMarkers']
-  ): Promise<Encoded<NonNullable<coresdk.workflow_commands.IWorkflowCommand['eventGroupMarkers']>> | undefined> {
-    if (!markers?.length) {
-      return undefined;
-    }
-
-    // Only the `label` variant carries a payload; `inboundEvent` and `inboundUpdate` are ids.
-    return await Promise.all(
-      markers.map(async (marker) => ({
-        ...marker,
-        label: marker.label
-          ? {
-              ...marker.label,
-              label: await encodeOptionalSingle(this.codecs, marker.label.label, context),
-            }
-          : undefined,
-      }))
-    );
   }
 
   /**
@@ -391,249 +352,74 @@ export class WorkflowCodecRunner {
   public async encodeCompletion(
     completion: coresdk.workflow_completion.IWorkflowActivationCompletion
   ): Promise<Encoded<coresdk.workflow_completion.IWorkflowActivationCompletion>> {
-    const encodedCompletion: Encoded<coresdk.workflow_completion.IWorkflowActivationCompletion> = {
-      ...completion,
-      failed: completion.failed
-        ? {
-            ...completion.failed,
-            failure: await encodeOptionalFailure(this.codecs, completion.failed.failure, this.workflowContext),
+    const encodedCompletion = coresdk.workflow_completion.WorkflowActivationCompletion.fromObject(completion);
+    await visit<coresdk.workflow_completion.IWorkflowActivationCompletion, SerializationContext>(
+      encodedCompletion,
+      walkWorkflowActivationCompletion,
+      {
+        transformPayload: async (payload, context) => (await encode(this.codecs, [payload], context))[0]!,
+        transformPayloads: (payloads, context) => encode(this.codecs, payloads, context),
+        initialContext: this.workflowContext,
+        // Headers and search attributes are not payload-converted by workflows.
+        skipHeaders: true,
+        skipSearchAttributes: true,
+        deriveContext: (message, typeName, context) => {
+          if (typeName !== 'coresdk.workflow_commands.WorkflowCommand') {
+            if (typeName === 'coresdk.workflow_commands.ScheduleActivity') {
+              return this.activityContext(message as coresdk.workflow_commands.IScheduleActivity, false);
+            }
+            if (typeName === 'coresdk.workflow_commands.ScheduleLocalActivity') {
+              return this.activityContext(message as coresdk.workflow_commands.IScheduleLocalActivity, true);
+            }
+            if (typeName === 'coresdk.workflow_commands.StartChildWorkflowExecution') {
+              return (
+                this.childWorkflowContext(message as coresdk.workflow_commands.IStartChildWorkflowExecution) ?? context
+              );
+            }
+            if (typeName === 'coresdk.workflow_commands.SignalExternalWorkflowExecution') {
+              return (
+                this.externalWorkflowContext(message as coresdk.workflow_commands.ISignalExternalWorkflowExecution) ??
+                context
+              );
+            }
+            return context;
           }
-        : null,
-      successful: completion.successful
-        ? {
-            ...completion.successful,
-            commands: completion.successful.commands
-              ? await Promise.all(
-                  completion.successful.commands.map(async (command) => {
-                    let userMetadataContext: SerializationContext = this.workflowContext;
 
-                    const scheduleActivityContext = command.scheduleActivity
-                      ? this.activityContext(command.scheduleActivity, false)
-                      : undefined;
-                    if (command.scheduleActivity?.seq != null && scheduleActivityContext) {
-                      this.pendingCompletionContexts.activity.set(
-                        command.scheduleActivity.seq,
-                        scheduleActivityContext
-                      );
-                      userMetadataContext = scheduleActivityContext;
-                    }
-
-                    const scheduleLocalActivityContext = command.scheduleLocalActivity
-                      ? this.activityContext(command.scheduleLocalActivity, true)
-                      : undefined;
-                    if (command.scheduleLocalActivity?.seq != null && scheduleLocalActivityContext) {
-                      this.pendingCompletionContexts.activity.set(
-                        command.scheduleLocalActivity.seq,
-                        scheduleLocalActivityContext
-                      );
-                      userMetadataContext = scheduleLocalActivityContext;
-                    }
-
-                    const childWorkflowContext = command.startChildWorkflowExecution
-                      ? this.childWorkflowContext(command.startChildWorkflowExecution)
-                      : undefined;
-                    if (command.startChildWorkflowExecution?.seq != null && childWorkflowContext) {
-                      this.pendingCompletionContexts.childWorkflowStart.set(
-                        command.startChildWorkflowExecution.seq,
-                        childWorkflowContext
-                      );
-                      this.pendingCompletionContexts.childWorkflowComplete.set(
-                        command.startChildWorkflowExecution.seq,
-                        childWorkflowContext
-                      );
-                      userMetadataContext = childWorkflowContext;
-                    }
-
-                    const signalWorkflowContext = command.signalExternalWorkflowExecution
-                      ? this.externalWorkflowContext(command.signalExternalWorkflowExecution)
-                      : undefined;
-                    if (command.signalExternalWorkflowExecution?.seq != null && signalWorkflowContext) {
-                      this.pendingCompletionContexts.signalWorkflow.set(
-                        command.signalExternalWorkflowExecution.seq,
-                        signalWorkflowContext
-                      );
-                    }
-
-                    const cancelWorkflowContext = command.requestCancelExternalWorkflowExecution
-                      ? this.externalWorkflowContext(command.requestCancelExternalWorkflowExecution)
-                      : undefined;
-                    if (command.requestCancelExternalWorkflowExecution?.seq != null && cancelWorkflowContext) {
-                      this.pendingCompletionContexts.cancelWorkflow.set(
-                        command.requestCancelExternalWorkflowExecution.seq,
-                        cancelWorkflowContext
-                      );
-                    }
-
-                    return <Encoded<coresdk.workflow_commands.IWorkflowCommand>>{
-                      ...command,
-                      scheduleActivity: command.scheduleActivity
-                        ? {
-                            ...command.scheduleActivity,
-                            arguments: await encodeOptional(
-                              this.codecs,
-                              command.scheduleActivity.arguments,
-                              scheduleActivityContext
-                            ),
-                            headers: noopEncodeMap(command.scheduleActivity.headers),
-                          }
-                        : undefined,
-                      upsertWorkflowSearchAttributes: command.upsertWorkflowSearchAttributes
-                        ? {
-                            ...command.upsertWorkflowSearchAttributes,
-                            searchAttributes: noopEncodeSearchAttrs(
-                              command.upsertWorkflowSearchAttributes.searchAttributes
-                            ),
-                          }
-                        : undefined,
-                      respondToQuery: command.respondToQuery
-                        ? {
-                            ...command.respondToQuery,
-                            succeeded: {
-                              ...command.respondToQuery.succeeded,
-                              response: await encodeOptionalSingle(
-                                this.codecs,
-                                command.respondToQuery.succeeded?.response,
-                                this.workflowContext
-                              ),
-                            },
-                            failed: await encodeOptionalFailure(
-                              this.codecs,
-                              command.respondToQuery.failed,
-                              this.workflowContext
-                            ),
-                          }
-                        : undefined,
-                      updateResponse: command.updateResponse
-                        ? {
-                            ...command.updateResponse,
-                            rejected: await encodeOptionalFailure(
-                              this.codecs,
-                              command.updateResponse.rejected,
-                              this.workflowContext
-                            ),
-                            completed: await encodeOptionalSingle(
-                              this.codecs,
-                              command.updateResponse.completed,
-                              this.workflowContext
-                            ),
-                          }
-                        : undefined,
-                      completeWorkflowExecution: command.completeWorkflowExecution
-                        ? {
-                            ...command.completeWorkflowExecution,
-                            result: await encodeOptionalSingle(
-                              this.codecs,
-                              command.completeWorkflowExecution.result,
-                              this.workflowContext
-                            ),
-                          }
-                        : undefined,
-                      failWorkflowExecution: command.failWorkflowExecution
-                        ? {
-                            ...command.failWorkflowExecution,
-                            failure: await encodeOptionalFailure(
-                              this.codecs,
-                              command.failWorkflowExecution.failure,
-                              this.workflowContext
-                            ),
-                          }
-                        : undefined,
-                      continueAsNewWorkflowExecution: command.continueAsNewWorkflowExecution
-                        ? {
-                            ...command.continueAsNewWorkflowExecution,
-                            arguments: await encodeOptional(
-                              this.codecs,
-                              command.continueAsNewWorkflowExecution.arguments,
-                              this.workflowContext
-                            ),
-                            memo: await encodeMap(
-                              this.codecs,
-                              command.continueAsNewWorkflowExecution.memo,
-                              this.workflowContext
-                            ),
-                            headers: noopEncodeMap(command.continueAsNewWorkflowExecution.headers),
-                            searchAttributes: noopEncodeSearchAttrs(
-                              command.continueAsNewWorkflowExecution.searchAttributes
-                            ),
-                          }
-                        : undefined,
-                      startChildWorkflowExecution: command.startChildWorkflowExecution
-                        ? {
-                            ...command.startChildWorkflowExecution,
-                            input: await encodeOptional(
-                              this.codecs,
-                              command.startChildWorkflowExecution.input,
-                              childWorkflowContext
-                            ),
-                            memo: await encodeMap(
-                              this.codecs,
-                              command.startChildWorkflowExecution.memo,
-                              childWorkflowContext
-                            ),
-                            headers: noopEncodeMap(command.startChildWorkflowExecution.headers),
-                            searchAttributes: noopEncodeSearchAttrs(
-                              command.startChildWorkflowExecution.searchAttributes
-                            ),
-                          }
-                        : undefined,
-                      signalExternalWorkflowExecution: command.signalExternalWorkflowExecution
-                        ? {
-                            ...command.signalExternalWorkflowExecution,
-                            args: await encodeOptional(
-                              this.codecs,
-                              command.signalExternalWorkflowExecution.args,
-                              signalWorkflowContext
-                            ),
-                            headers: noopEncodeMap(command.signalExternalWorkflowExecution.headers),
-                          }
-                        : undefined,
-                      scheduleLocalActivity: command.scheduleLocalActivity
-                        ? {
-                            ...command.scheduleLocalActivity,
-                            arguments: await encodeOptional(
-                              this.codecs,
-                              command.scheduleLocalActivity.arguments,
-                              scheduleLocalActivityContext
-                            ),
-                            headers: noopEncodeMap(command.scheduleLocalActivity.headers),
-                          }
-                        : undefined,
-                      scheduleNexusOperation: command.scheduleNexusOperation
-                        ? {
-                            ...command.scheduleNexusOperation,
-                            input: await encodeOptionalSingle(
-                              this.codecs,
-                              command.scheduleNexusOperation.input,
-                              this.workflowContext
-                            ),
-                          }
-                        : undefined,
-                      modifyWorkflowProperties: command.modifyWorkflowProperties
-                        ? {
-                            ...command.modifyWorkflowProperties,
-                            upsertedMemo: {
-                              ...command.modifyWorkflowProperties.upsertedMemo,
-                              fields: await encodeMap(
-                                this.codecs,
-                                command.modifyWorkflowProperties.upsertedMemo?.fields,
-                                this.workflowContext
-                              ),
-                            },
-                          }
-                        : undefined,
-                      userMetadata: await this.encodeUserMetadata(userMetadataContext, command.userMetadata),
-                      eventGroupMarkers: await this.encodeEventGroupMarkers(
-                        userMetadataContext,
-                        command.eventGroupMarkers
-                      ),
-                    };
-                  })
-                )
-              : null,
+          const command = message as coresdk.workflow_commands.IWorkflowCommand;
+          let userMetadataContext: SerializationContext = this.workflowContext;
+          const scheduleActivity = command.scheduleActivity;
+          if (scheduleActivity?.seq != null) {
+            const activityContext = this.activityContext(scheduleActivity, false);
+            this.pendingCompletionContexts.activity.set(scheduleActivity.seq, activityContext);
+            userMetadataContext = activityContext;
           }
-        : null,
-    };
-
-    return encodedCompletion;
+          const scheduleLocalActivity = command.scheduleLocalActivity;
+          if (scheduleLocalActivity?.seq != null) {
+            const activityContext = this.activityContext(scheduleLocalActivity, true);
+            this.pendingCompletionContexts.activity.set(scheduleLocalActivity.seq, activityContext);
+            userMetadataContext = activityContext;
+          }
+          const startChild = command.startChildWorkflowExecution;
+          const childContext = startChild ? this.childWorkflowContext(startChild) : undefined;
+          if (startChild?.seq != null && childContext) {
+            this.pendingCompletionContexts.childWorkflowStart.set(startChild.seq, childContext);
+            this.pendingCompletionContexts.childWorkflowComplete.set(startChild.seq, childContext);
+            userMetadataContext = childContext;
+          }
+          const signal = command.signalExternalWorkflowExecution;
+          const signalContext = signal ? this.externalWorkflowContext(signal) : undefined;
+          if (signal?.seq != null && signalContext) {
+            this.pendingCompletionContexts.signalWorkflow.set(signal.seq, signalContext);
+          }
+          const cancel = command.requestCancelExternalWorkflowExecution;
+          const cancelContext = cancel ? this.externalWorkflowContext(cancel) : undefined;
+          if (cancel?.seq != null && cancelContext) {
+            this.pendingCompletionContexts.cancelWorkflow.set(cancel.seq, cancelContext);
+          }
+          return userMetadataContext;
+        },
+      }
+    );
+    return encodedCompletion as unknown as Encoded<coresdk.workflow_completion.IWorkflowActivationCompletion>;
   }
 }

--- a/packages/worker/src/workflow-codec-runner.ts
+++ b/packages/worker/src/workflow-codec-runner.ts
@@ -96,8 +96,9 @@ export class WorkflowCodecRunner {
   public async decodeActivation<T extends coresdk.workflow_activation.IWorkflowActivation>(
     activation: T
   ): Promise<Decoded<T>> {
+    const decodedActivation = coresdk.workflow_activation.WorkflowActivation.fromObject(activation);
     await visit<coresdk.workflow_activation.IWorkflowActivation, SerializationContext | undefined>(
-      activation,
+      decodedActivation,
       walkWorkflowActivation,
       {
         transformPayload: async (payload, context) => (await decode(this.codecs, [payload], context))[0]!,
@@ -139,7 +140,7 @@ export class WorkflowCodecRunner {
         },
       }
     );
-    return activation as unknown as Decoded<T>;
+    return decodedActivation as unknown as Decoded<T>;
   }
 
   /**

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -670,7 +670,7 @@ export class Activator implements ActivationHandler {
       searchAttributes: decodeSearchAttributes(searchAttributes?.indexedFields),
       typedSearchAttributes: decodeTypedSearchAttributes(searchAttributes?.indexedFields),
 
-      memo: mapFromPayloads(this.payloadConverter, memo?.fields, context),
+      memo: mapFromPayloads(this.payloadConverter, memo?.fields, context) ?? {},
       lastResult: fromPayloadsAtIndex(this.payloadConverter, 0, lastCompletionResult?.payloads, context),
       lastFailure:
         continuedFailure != null


### PR DESCRIPTION
## Summary
- encode workflow activations and completions through the shared payload visitor
- preserve workflow, activity, child workflow, and external workflow serialization contexts
- keep workflow headers and search attributes outside payload codec processing
- add tests
- remove dead code in codec-helpers