### PR TITLE
feat(workflow): add TypeInfo to Queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ to docs, or any other relevant information.
 - Core logs written directly to the console can now use compact, pretty, or newline-delimited JSON
   output via `telemetryOptions.logging.console.format`.
 - **Experimental**: Workflow Clients can now use `TypeInfo` to encode Workflow inputs and decode Workflow results.
+- **Experimental**: Query definitions and string-named Client Queries can now provide `TypeInfo` for converting Query
+  arguments and results.
 - **Experimental**: `@temporalio/google-adk-agents` package for running Google ADK agents as durable Temporal Workflows,
   requiring `@google/adk@>=1.5.0 <1.6.0` as a peer dependency.
   ADK's OpenTelemetry agent-loop spans can be exported replay-safely from the Workflow sandbox by composing with

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -4,7 +4,7 @@
  * @module
  */
 
-import type { Duration, SearchAttributePair, SignalTypeInfo, TypedSearchAttributes } from '@temporalio/common';
+import type { Duration, PayloadTypeInfo, SearchAttributePair, SignalTypeInfo, TypedSearchAttributes } from '@temporalio/common';
 import { Headers, Next } from '@temporalio/common';
 import type { temporal } from '@temporalio/proto';
 import type { NexusOperationHandle } from './nexus-client';
@@ -106,6 +106,7 @@ export interface WorkflowSignalWithStartInput {
 export interface WorkflowQueryInput {
   readonly queryType: string;
   readonly args: unknown[];
+  readonly typeInfo?: PayloadTypeInfo;
   readonly workflowExecution: WorkflowExecution;
   readonly queryRejectCondition?: temporal.api.enums.v1.QueryRejectCondition;
   readonly headers: Headers;

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -4,7 +4,13 @@
  * @module
  */
 
-import type { Duration, PayloadTypeInfo, SearchAttributePair, SignalTypeInfo, TypedSearchAttributes } from '@temporalio/common';
+import type {
+  Duration,
+  PayloadTypeInfo,
+  SearchAttributePair,
+  SignalTypeInfo,
+  TypedSearchAttributes,
+} from '@temporalio/common';
 import { Headers, Next } from '@temporalio/common';
 import type { temporal } from '@temporalio/proto';
 import type { NexusOperationHandle } from './nexus-client';

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -1847,12 +1847,6 @@ export class WorkflowClient extends BaseClient {
         queryName: string,
         options: WorkflowQueryOptions<Args>
       ): Promise<Ret> {
-        if (typeof queryName !== 'string') {
-          throw new TypeError(
-            'Query TypeInfo can only be provided when querying by name. ' +
-              'Use defineQuery(..., { typeInfo }) on the Query definition instead.'
-          );
-        }
         return await _query(queryName, options.args ?? [], options.typeInfo);
       },
     };

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -1037,7 +1037,9 @@ export class WorkflowClient extends BaseClient {
       execution: input.workflowExecution,
       query: {
         queryType: input.queryType,
-        queryArgs: { payloads: await encodeToPayloadsWithContext(dataConverter, context, input.args) },
+        queryArgs: {
+          payloads: await encodeToPayloadsWithContext(dataConverter, context, input.args, input.typeInfo?.inputTypes),
+        },
         header: { fields: input.headers },
       },
     };
@@ -1078,7 +1080,13 @@ export class WorkflowClient extends BaseClient {
       throw new TypeError('Invalid response from server');
     }
     // We ignore anything but the first result
-    return await decodeFromPayloadsAtIndex(dataConverter, 0, response.queryResult?.payloads, context);
+    return await decodeFromPayloadsAtIndex(
+      dataConverter,
+      0,
+      response.queryResult?.payloads,
+      context,
+      input.typeInfo?.outputType
+    );
   }
 
   protected async _createUpdateWorkflowRequest(
@@ -1815,6 +1823,7 @@ export class WorkflowClient extends BaseClient {
           queryRejectCondition: encodeQueryRejectCondition(this.client.options.queryRejectCondition),
           queryType: typeof def === 'string' ? def : def.name,
           args,
+          typeInfo: typeof def === 'string' ? undefined : def.typeInfo,
           headers: {},
         }) as Promise<Ret>;
       },

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -15,6 +15,7 @@ import type {
   WorkflowTypeOptions,
   PayloadTypeInfo,
   TypeInfo,
+  WorkflowQueryOptions,
   WorkflowSignalOptions,
 } from '@temporalio/common';
 import {
@@ -244,6 +245,13 @@ export interface WorkflowHandle<T extends Workflow = Workflow> extends BaseWorkf
    * ```
    */
   query<Ret, Args extends any[] = []>(def: QueryDefinition<Ret, Args> | string, ...args: Args): Promise<Ret>;
+
+  /**
+   * Query a running or completed Workflow by Query name with additional options, including call-site TypeInfo.
+   *
+   * @experimental
+   */
+  queryWithOptions<Ret, Args extends any[] = []>(queryName: string, options: WorkflowQueryOptions<Args>): Promise<Ret>;
 
   /**
    * Terminate a running Workflow
@@ -1721,6 +1729,19 @@ export class WorkflowClient extends BaseClient {
       await fn(input);
     };
 
+    const _query = async <Ret>(queryType: string, args: unknown[], typeInfo?: PayloadTypeInfo): Promise<Ret> => {
+      const next = this._queryWorkflowHandler.bind(this);
+      const fn = composeInterceptors(interceptors, 'query', next);
+      return (await fn({
+        workflowExecution: { workflowId, runId },
+        queryRejectCondition: encodeQueryRejectCondition(this.options.queryRejectCondition),
+        queryType,
+        args,
+        typeInfo,
+        headers: {},
+      })) as Ret;
+    };
+
     return {
       client: this,
       workflowId,
@@ -1816,16 +1837,23 @@ export class WorkflowClient extends BaseClient {
         await _signal(this as InternalWorkflowHandle, signalName, options.args ?? [], options.typeInfo);
       },
       async query<Ret, Args extends any[]>(def: QueryDefinition<Ret, Args> | string, ...args: Args): Promise<Ret> {
-        const next = this.client._queryWorkflowHandler.bind(this.client);
-        const fn = composeInterceptors(interceptors, 'query', next);
-        return fn({
-          workflowExecution: { workflowId, runId },
-          queryRejectCondition: encodeQueryRejectCondition(this.client.options.queryRejectCondition),
-          queryType: typeof def === 'string' ? def : def.name,
+        return await _query(
+          typeof def === 'string' ? def : def.name,
           args,
-          typeInfo: typeof def === 'string' ? undefined : def.typeInfo,
-          headers: {},
-        }) as Promise<Ret>;
+          typeof def === 'string' ? undefined : def.typeInfo
+        );
+      },
+      async queryWithOptions<Ret, Args extends any[]>(
+        queryName: string,
+        options: WorkflowQueryOptions<Args>
+      ): Promise<Ret> {
+        if (typeof queryName !== 'string') {
+          throw new TypeError(
+            'Query TypeInfo can only be provided when querying by name. ' +
+              'Use defineQuery(..., { typeInfo }) on the Query definition instead.'
+          );
+        }
+        return await _query(queryName, options.args ?? [], options.typeInfo);
       },
     };
   }

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -1837,11 +1837,11 @@ export class WorkflowClient extends BaseClient {
         await _signal(this as InternalWorkflowHandle, signalName, options.args ?? [], options.typeInfo);
       },
       async query<Ret, Args extends any[]>(def: QueryDefinition<Ret, Args> | string, ...args: Args): Promise<Ret> {
-        return await _query(
-          typeof def === 'string' ? def : def.name,
-          args,
-          typeof def === 'string' ? undefined : def.typeInfo
-        );
+        if (typeof def === 'string') {
+          return await _query(def, args);
+        } else {
+          return await _query(def.name, args, def.typeInfo);
+        }
       },
       async queryWithOptions<Ret, Args extends any[]>(
         queryName: string,

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -21,7 +21,11 @@ export type WorkflowSignalAnnotatedType = {
   typeInfo?: SignalTypeInfo;
 };
 export type WorkflowQueryType = (...args: any[]) => any;
-export type WorkflowQueryAnnotatedType = { handler: WorkflowQueryType; description?: string };
+export type WorkflowQueryAnnotatedType = {
+  handler: WorkflowQueryType;
+  description?: string;
+  typeInfo?: PayloadTypeInfo;
+};
 
 /**
  * Broad Workflow function definition, specific Workflows will typically use a narrower type definition, e.g:
@@ -86,6 +90,16 @@ export interface SignalDefinition<Args extends any[] = [], Name extends string =
 }
 
 /**
+ * Options for {@link QueryDefinition}.
+ *
+ * @experimental
+ */
+export interface QueryDefinitionOptions {
+  /** Type information used to convert Query arguments and results. */
+  typeInfo?: PayloadTypeInfo;
+}
+
+/**
  * An interface representing a Workflow query definition as returned from {@link defineQuery}
  *
  * @remarks `Args` and `Ret` can be used for parameter type inference in handler functions and WorkflowHandle methods.
@@ -94,6 +108,8 @@ export interface SignalDefinition<Args extends any[] = [], Name extends string =
 export interface QueryDefinition<Ret, Args extends any[] = [], Name extends string = string> {
   type: 'query';
   name: Name;
+  /** Type information used to convert Query arguments and results. */
+  typeInfo?: PayloadTypeInfo;
   /**
    * Virtual type brand to maintain a distinction between {@link QueryDefinition} types with different args.
    * This field is not present at run-time.

--- a/packages/common/src/workflow-handle.ts
+++ b/packages/common/src/workflow-handle.ts
@@ -1,4 +1,5 @@
-import type { Workflow, WorkflowResultType, SignalDefinition, SignalTypeInfo } from './interfaces';
+import type { SignalDefinition, SignalTypeInfo, Workflow, WorkflowResultType } from './interfaces';
+import type { PayloadTypeInfo } from './type-info';
 
 /**
  * Options for signaling a Workflow by Signal name.
@@ -11,6 +12,19 @@ export interface WorkflowSignalOptions<Args extends any[] = []> {
 
   /** Type information used to convert Signal arguments. */
   typeInfo?: SignalTypeInfo;
+}
+
+/**
+ * Options for querying a Workflow by Query name.
+ *
+ * @experimental
+ */
+export interface WorkflowQueryOptions<Args extends any[] = []> {
+  /** Arguments to pass to the Query handler. */
+  args?: Args;
+
+  /** Type information used to convert Query arguments and results. */
+  typeInfo?: PayloadTypeInfo;
 }
 
 /**

--- a/packages/test/src/test-type-info.ts
+++ b/packages/test/src/test-type-info.ts
@@ -14,6 +14,8 @@ import {
   finishSignal,
   finishUpdate,
   Order,
+  orderQuery,
+  orderQueryTypeInfo,
   orderSignal,
   orderSignalTypeInfo,
   parentWorkflowChildString,
@@ -23,6 +25,7 @@ import {
   signalExternalTarget,
   signalExternalTargetWithCallSiteTypeInfo,
   signalTarget,
+  queryTarget,
   workflowTypeInfo,
   workflowWithSignalStart,
   workflowWithTypeInfo,
@@ -293,6 +296,113 @@ test('Update-with-Start carries Workflow input and output TypeInfo from the defi
   });
 });
 
+// Queries
+
+test('Client Workflow handle converts Query input and result using definition TypeInfo', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker();
+
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(queryTarget, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+    });
+    assertReceipt(t, await handle.query(orderQuery, new Order('order-1', 12345n)));
+    await handle.signal(finishSignal);
+    await handle.result();
+  });
+});
+
+test('Client Workflow handle converts string Query input and result using call-site TypeInfo', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker();
+
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(queryTarget, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+    });
+    assertReceipt(
+      t,
+      await handle.queryWithOptions<Receipt, [Order]>('order', {
+        args: [new Order('order-1', 12345n)],
+        typeInfo: orderQueryTypeInfo,
+      })
+    );
+    await handle.signal(finishSignal);
+    await handle.result();
+  });
+});
+
+test('Client Query interceptor receives definition TypeInfo', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = new Client({
+    connection: t.context.env.client.connection,
+    namespace: t.context.env.client.options.namespace,
+    interceptors: {
+      workflow: [
+        {
+          async query(input, next) {
+            t.is(input.typeInfo, orderQueryTypeInfo);
+            return await next(input);
+          },
+        },
+      ],
+    },
+  });
+  const worker = await h.createWorker();
+
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(queryTarget, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+    });
+    assertReceipt(t, await handle.query(orderQuery, new Order('order-1', 12345n)));
+    await handle.signal(finishSignal);
+    await handle.result();
+  });
+});
+
+test('Workflow Query interceptor uses output TypeInfo from the retargeted handler', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker();
+
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(queryTarget, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+    });
+    assertReceipt(
+      t,
+      await handle.queryWithOptions<Receipt, [Order]>('order-alias', {
+        args: [new Order('order-1', 12345n)],
+        typeInfo: orderQueryTypeInfo,
+      })
+    );
+    await handle.signal(finishSignal);
+    await handle.result();
+  });
+});
+
+test('Client Workflow handle rejects Query definitions passed to queryWithOptions', async (t) => {
+  const client = makeClient(t.context.env);
+  const handle = client.workflow.getHandle('workflow-id');
+
+  await t.throwsAsync(
+    (handle.queryWithOptions as any)(orderQuery, {
+      args: [new Order('order-1', 12345n)],
+      typeInfo: orderQueryTypeInfo,
+    }),
+    {
+      instanceOf: TypeError,
+      message: /Query TypeInfo can only be provided when querying by name/,
+    }
+  );
+});
+
 // Signals
 
 test('Client Workflow handle converts Signal input using definition TypeInfo', async (t) => {
@@ -481,6 +591,29 @@ test('Signal-with-Start accepts definition, string, and union Signal references'
       taskQueue: 'task-queue',
       signal: signalReference,
       signalArgs: [new Order('order-1', 12345n)],
+    });
+  }
+
+  t.pass();
+});
+
+test('queryWithOptions accepts only string Query names', (t) => {
+  function _assertion(client: Client, queryReference: typeof orderQuery | string) {
+    void client.workflow.getHandle('workflow-id').queryWithOptions<Receipt, [Order]>('order', {
+      args: [new Order('order-1', 12345n)],
+      typeInfo: orderQueryTypeInfo,
+    });
+
+    // @ts-expect-error Call-site TypeInfo requires a Query name, not a Query definition.
+    void client.workflow.getHandle('workflow-id').queryWithOptions(orderQuery, {
+      args: [new Order('order-1', 12345n)],
+      typeInfo: orderQueryTypeInfo,
+    });
+
+    // @ts-expect-error Call-site TypeInfo requires a Query name, not a definition-or-name union.
+    void client.workflow.getHandle('workflow-id').queryWithOptions(queryReference, {
+      args: [new Order('order-1', 12345n)],
+      typeInfo: orderQueryTypeInfo,
     });
   }
 

--- a/packages/test/src/test-type-info.ts
+++ b/packages/test/src/test-type-info.ts
@@ -598,7 +598,7 @@ test('Signal-with-Start accepts definition, string, and union Signal references'
 });
 
 test('queryWithOptions accepts only string Query names', (t) => {
-  function _assertion(client: Client, queryReference: typeof orderQuery | string) {
+  function _assertQueryWithOptionsTypes(client: Client, queryReference: typeof orderQuery | string) {
     void client.workflow.getHandle('workflow-id').queryWithOptions<Receipt, [Order]>('order', {
       args: [new Order('order-1', 12345n)],
       typeInfo: orderQueryTypeInfo,

--- a/packages/test/src/test-type-info.ts
+++ b/packages/test/src/test-type-info.ts
@@ -336,7 +336,7 @@ test('Client Workflow handle converts string Query input and result using call-s
   });
 });
 
-test('Client Query interceptor receives definition TypeInfo', async (t) => {
+test('Client Query interceptor can provide TypeInfo for a string Query', async (t) => {
   const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
   const client = new Client({
     connection: t.context.env.client.connection,
@@ -345,8 +345,7 @@ test('Client Query interceptor receives definition TypeInfo', async (t) => {
       workflow: [
         {
           async query(input, next) {
-            t.is(input.typeInfo, orderQueryTypeInfo);
-            return await next(input);
+            return await next({ ...input, typeInfo: orderQueryTypeInfo });
           },
         },
       ],
@@ -359,7 +358,12 @@ test('Client Query interceptor receives definition TypeInfo', async (t) => {
       workflowId: `wf-${randomUUID()}`,
       taskQueue: h.taskQueue,
     });
-    assertReceipt(t, await handle.query(orderQuery, new Order('order-1', 12345n)));
+    assertReceipt(
+      t,
+      await handle.queryWithOptions<Receipt, [Order]>('order', {
+        args: [new Order('order-1', 12345n)],
+      })
+    );
     await handle.signal(finishSignal);
     await handle.result();
   });
@@ -385,22 +389,6 @@ test('Workflow Query interceptor uses output TypeInfo from the retargeted handle
     await handle.signal(finishSignal);
     await handle.result();
   });
-});
-
-test('Client Workflow handle rejects Query definitions passed to queryWithOptions', async (t) => {
-  const client = makeClient(t.context.env);
-  const handle = client.workflow.getHandle('workflow-id');
-
-  await t.throwsAsync(
-    (handle.queryWithOptions as any)(orderQuery, {
-      args: [new Order('order-1', 12345n)],
-      typeInfo: orderQueryTypeInfo,
-    }),
-    {
-      instanceOf: TypeError,
-      message: /Query TypeInfo can only be provided when querying by name/,
-    }
-  );
 });
 
 // Signals

--- a/packages/test/src/workflows/type-info/interceptors.ts
+++ b/packages/test/src/workflows/type-info/interceptors.ts
@@ -3,6 +3,16 @@ import { workflowInfo } from '@temporalio/workflow';
 import { workflowTypeInfo } from './models';
 
 export const interceptors = (): WorkflowInterceptors => ({
+  inbound: [
+    {
+      handleQuery(input, next) {
+        if (workflowInfo().workflowType !== 'queryTarget' || input.queryName !== 'order-alias') {
+          return next(input);
+        }
+        return next({ ...input, queryName: 'order' });
+      },
+    },
+  ],
   outbound: [
     {
       continueAsNew(input, next) {

--- a/packages/test/src/workflows/type-info/messages.ts
+++ b/packages/test/src/workflows/type-info/messages.ts
@@ -1,6 +1,7 @@
-import type { SignalTypeInfo } from '@temporalio/common';
+import type { PayloadTypeInfo, SignalTypeInfo, TypeInfo } from '@temporalio/common';
 import {
   condition,
+  defineQuery,
   defineSignal,
   defineUpdate,
   defineWorkflowOptions,
@@ -11,6 +12,44 @@ import {
 import { assertOrder, Order, orderTypeInfo, Receipt, workflowTypeInfo } from './models';
 
 export const finishSignal = defineSignal('finish');
+
+export const orderQueryTypeInfo: PayloadTypeInfo = {
+  inputTypes: [orderTypeInfo],
+  outputType: workflowTypeInfo.outputType,
+};
+
+const unexpectedQueryOutputType: TypeInfo<Receipt, never> = {
+  transferTypeConverter: {
+    toTransferType(): never {
+      throw new Error('The retargeted Query must not use the original output TypeInfo');
+    },
+    fromTransferType(): Receipt {
+      throw new Error('The retargeted Query must not use the original output TypeInfo');
+    },
+  },
+};
+
+const orderAliasQuery = defineQuery<Receipt, [Order]>('order-alias', {
+  typeInfo: { inputTypes: [orderTypeInfo], outputType: unexpectedQueryOutputType },
+});
+
+export const orderQuery = defineQuery<Receipt, [Order]>('order', { typeInfo: orderQueryTypeInfo });
+
+export async function queryTarget(): Promise<void> {
+  let finished = false;
+  setHandler(orderQuery, (order) => {
+    assertOrder(order);
+    return new Receipt(order.id, order.totalCents);
+  });
+  setHandler(orderAliasQuery, (order) => {
+    assertOrder(order);
+    return new Receipt(order.id, order.totalCents);
+  });
+  setHandler(finishSignal, () => {
+    finished = true;
+  });
+  await condition(() => finished);
+}
 
 export const orderSignalTypeInfo: SignalTypeInfo = { inputTypes: [orderTypeInfo] };
 

--- a/packages/test/src/workflows/type-info/messages.ts
+++ b/packages/test/src/workflows/type-info/messages.ts
@@ -18,7 +18,8 @@ export const orderQueryTypeInfo: PayloadTypeInfo = {
   outputType: workflowTypeInfo.outputType,
 };
 
-const unexpectedQueryOutputType: TypeInfo<Receipt, never> = {
+// The inbound interceptor retargets this Query to `order`; this TypeInfo must never encode the result.
+const aliasQueryOutputTypeThatMustNotRun: TypeInfo<Receipt, never> = {
   transferTypeConverter: {
     toTransferType(): never {
       throw new Error('The retargeted Query must not use the original output TypeInfo');
@@ -30,7 +31,7 @@ const unexpectedQueryOutputType: TypeInfo<Receipt, never> = {
 };
 
 const orderAliasQuery = defineQuery<Receipt, [Order]>('order-alias', {
-  typeInfo: { inputTypes: [orderTypeInfo], outputType: unexpectedQueryOutputType },
+  typeInfo: { inputTypes: [orderTypeInfo], outputType: aliasQueryOutputTypeThatMustNotRun },
 });
 
 export const orderQuery = defineQuery<Receipt, [Order]>('order', { typeInfo: orderQueryTypeInfo });

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -889,15 +889,20 @@ export class Activator implements ActivationHandler {
       queryType === STACK_TRACE_QUERY_NAME ||
       queryType === ENHANCED_STACK_TRACE_QUERY_NAME;
     const interceptors = isInternalQuery ? [] : this.interceptors.inbound;
-    const execute = composeInterceptors(interceptors, 'handleQuery', this.queryWorkflowNextHandler.bind(this));
     const context = this.workflowSerializationContext();
+    const typeInfo = this.queryHandlers.get(queryType)?.typeInfo;
+    let outputTypeInfo = typeInfo?.outputType;
+    const execute = composeInterceptors(interceptors, 'handleQuery', (input) => {
+      outputTypeInfo = this.queryHandlers.get(input.queryName)?.typeInfo?.outputType;
+      return this.queryWorkflowNextHandler(input);
+    });
     execute({
       queryName: queryType,
-      args: arrayFromPayloads(this.payloadConverter, activation.arguments, context),
+      args: arrayFromPayloads(this.payloadConverter, activation.arguments, context, typeInfo?.inputTypes),
       queryId,
       headers: headers ?? {},
     }).then(
-      (result) => this.completeQuery(queryId, result),
+      (result) => this.completeQuery(queryId, result, outputTypeInfo),
       (reason) => this.failQuery(queryId, reason)
     );
   }
@@ -1390,10 +1395,13 @@ export class Activator implements ActivationHandler {
     if (this.workflowTaskError) throw this.workflowTaskError;
   }
 
-  private completeQuery(queryId: string, result: unknown): void {
+  private completeQuery(queryId: string, result: unknown, typeInfo?: TypeInfo): void {
     const context = this.workflowSerializationContext();
     this.pushCommand({
-      respondToQuery: { queryId, succeeded: { response: this.payloadConverter.toPayload(result, context) } },
+      respondToQuery: {
+        queryId,
+        succeeded: { response: toPayloadWithTypeInfo(this.payloadConverter, result, context, typeInfo) },
+      },
     });
   }
 

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -4,6 +4,7 @@ import type {
   ActivityOptions,
   LocalActivityOptions,
   QueryDefinition,
+  QueryDefinitionOptions,
   SearchAttributes,
   SearchAttributeValue,
   SignalDefinition,
@@ -1340,11 +1341,13 @@ export function defineSignal<Args extends any[] = [], Name extends string = stri
  * A definition can be reused in multiple Workflows.
  */
 export function defineQuery<Ret, Args extends any[] = [], Name extends string = string>(
-  name: Name
+  name: Name,
+  options: QueryDefinitionOptions = {}
 ): QueryDefinition<Ret, Args, Name> {
   return {
     type: 'query',
     name,
+    ...options,
   } as QueryDefinition<Ret, Args, Name>;
 }
 
@@ -1499,7 +1502,7 @@ export function setHandler<
     }
   } else if (def.type === 'query') {
     if (typeof handler === 'function') {
-      activator.queryHandlers.set(def.name, { handler: handler as any, description });
+      activator.queryHandlers.set(def.name, { handler: handler as any, description, typeInfo: def.typeInfo });
     } else if (handler == null) {
       activator.queryHandlers.delete(def.name);
     } else {


### PR DESCRIPTION
## What was changed

Added TypeInfo to Query definitions and introduced `queryWithOptions` for string-named Queries. Query arguments and results now use the resolved TypeInfo across Client conversion, interceptors, and Workflow handlers, including when an inbound interceptor retargets a Query to another handler.

Reviewing commit-by-commit separates the definition, call-site, test, and changelog changes.

## Why?

JSON conversion otherwise loses application runtime types at the Query boundary. Definitions can now carry their conversion contract, while string callers can provide the same information explicitly.

Existing Query calls without TypeInfo retain their current behavior. There is no rollout step or manual action required.

## Checklist

1. Closes: N/A

2. How was this tested: Proto, Common, Client, Workflow, and Test builds; all 31 TypeInfo tests; ESLint; Prettier; `ts-prune`; and `git diff --check`.

3. Any docs updates needed? No; documentation will accompany the completed experimental API.
