### PR TITLE
feat(workflow): add TypeInfo to Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ to docs, or any other relevant information.
 - **Experimental**: Workflow Clients can now use `TypeInfo` to encode Workflow inputs and decode Workflow results.
 - **Experimental**: Query definitions and string-named Client Queries can now provide `TypeInfo` for converting Query
   arguments and results.
+- **Experimental**: Update definitions and named Update calls can use `TypeInfo` to convert Update arguments and
+  results.
 - **Experimental**: `@temporalio/google-adk-agents` package for running Google ADK agents as durable Temporal Workflows,
   requiring `@google/adk@>=1.5.0 <1.6.0` as a peer dependency.
   ADK's OpenTelemetry agent-loop spans can be exported replay-safely from the Workflow sandbox by composing with

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -48,6 +48,7 @@ export interface WorkflowStartInput {
 export interface WorkflowStartUpdateInput {
   readonly updateName: string;
   readonly args: unknown[];
+  readonly typeInfo?: PayloadTypeInfo;
   readonly workflowExecution: WorkflowExecution;
   readonly firstExecutionRunId?: string;
   readonly headers: Headers;
@@ -65,6 +66,7 @@ export interface WorkflowStartUpdateOutput {
   readonly updateId: string;
   readonly workflowRunId: string;
   readonly outcome?: temporal.api.update.v1.IOutcome;
+  readonly typeInfo?: PayloadTypeInfo;
 }
 
 /**
@@ -76,6 +78,7 @@ export interface WorkflowStartUpdateWithStartInput {
   readonly workflowStartHeaders: Headers;
   readonly updateName: string;
   readonly updateArgs: unknown[];
+  readonly updateTypeInfo?: PayloadTypeInfo;
   readonly updateOptions: WorkflowUpdateOptions;
   readonly updateHeaders: Headers;
 }
@@ -87,6 +90,7 @@ export interface WorkflowStartUpdateWithStartOutput {
   readonly workflowExecution: WorkflowExecution;
   readonly updateId: string;
   readonly updateOutcome?: temporal.api.update.v1.IOutcome;
+  readonly updateTypeInfo?: PayloadTypeInfo;
 }
 
 /** Input for WorkflowClientInterceptor.signal */

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -9,6 +9,7 @@ import type {
   PayloadTypeInfo,
   SearchAttributePair,
   SignalTypeInfo,
+  TypeInfo,
   TypedSearchAttributes,
 } from '@temporalio/common';
 import { Headers, Next } from '@temporalio/common';
@@ -48,6 +49,7 @@ export interface WorkflowStartInput {
 export interface WorkflowStartUpdateInput {
   readonly updateName: string;
   readonly args: unknown[];
+  /** Type information used to encode Update arguments and decode its result. */
   readonly typeInfo?: PayloadTypeInfo;
   readonly workflowExecution: WorkflowExecution;
   readonly firstExecutionRunId?: string;
@@ -66,7 +68,8 @@ export interface WorkflowStartUpdateOutput {
   readonly updateId: string;
   readonly workflowRunId: string;
   readonly outcome?: temporal.api.update.v1.IOutcome;
-  readonly typeInfo?: PayloadTypeInfo;
+  /** Type information used to decode the Update result. */
+  readonly outputTypeInfo?: TypeInfo;
 }
 
 /**
@@ -78,6 +81,7 @@ export interface WorkflowStartUpdateWithStartInput {
   readonly workflowStartHeaders: Headers;
   readonly updateName: string;
   readonly updateArgs: unknown[];
+  /** Type information used to encode Update arguments and decode its result. */
   readonly updateTypeInfo?: PayloadTypeInfo;
   readonly updateOptions: WorkflowUpdateOptions;
   readonly updateHeaders: Headers;
@@ -90,7 +94,8 @@ export interface WorkflowStartUpdateWithStartOutput {
   readonly workflowExecution: WorkflowExecution;
   readonly updateId: string;
   readonly updateOutcome?: temporal.api.update.v1.IOutcome;
-  readonly updateTypeInfo?: PayloadTypeInfo;
+  /** Type information used to decode the Update result. */
+  readonly updateOutputTypeInfo?: TypeInfo;
 }
 
 /** Input for WorkflowClientInterceptor.signal */

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -800,13 +800,21 @@ export class WorkflowClient extends BaseClient {
       typeInfo: callSiteTypeInfo,
       ...updateOptions
     } = updateWithStartOptions;
-    if (typeof updateDef !== 'string' && callSiteTypeInfo !== undefined) {
-      throw new TypeError(
-        'Cannot provide call-site Update TypeInfo with an Update definition. ' +
-          'Define TypeInfo when creating the Update definition instead.'
-      );
+    let updateName: string;
+    let updateTypeInfo: PayloadTypeInfo | undefined;
+    if (typeof updateDef === 'string') {
+      updateName = updateDef;
+      updateTypeInfo = callSiteTypeInfo;
+    } else {
+      if (callSiteTypeInfo !== undefined) {
+        throw new TypeError(
+          'Cannot provide call-site Update TypeInfo with an Update definition. ' +
+            'Define TypeInfo when creating the Update definition instead.'
+        );
+      }
+      updateName = updateDef.name;
+      updateTypeInfo = updateDef.typeInfo;
     }
-    const updateTypeInfo = typeof updateDef === 'string' ? callSiteTypeInfo : updateDef.typeInfo;
     const { workflowTypeOrFunc, options: workflowOptions } = startWorkflowOperation;
     const { workflowId } = workflowOptions;
 
@@ -825,7 +833,7 @@ export class WorkflowClient extends BaseClient {
       workflowType,
       workflowStartOptions: compileWorkflowOptions(ensureArgs(resolvedWorkflowOptions)),
       workflowStartHeaders: {},
-      updateName: typeof updateDef === 'string' ? updateDef : updateDef.name,
+      updateName,
       updateArgs: args ?? [],
       updateTypeInfo,
       updateOptions,
@@ -864,12 +872,12 @@ export class WorkflowClient extends BaseClient {
       });
     }
 
-    return this.createWorkflowUpdateHandle<Ret>(
+    return this.createWorkflowUpdateHandle(
       updateOutput.updateId,
       workflowId,
       updateOutput.workflowExecution.runId,
       outcome,
-      updateOutput.updateTypeInfo?.outputType as TypeInfo<Ret, unknown> | undefined
+      updateOutput.updateOutputTypeInfo
     );
   }
 
@@ -1215,7 +1223,7 @@ export class WorkflowClient extends BaseClient {
 
       workflowRunId: response.updateRef!.workflowExecution!.runId!,
       outcome: response.outcome ?? undefined,
-      typeInfo: input.typeInfo,
+      outputTypeInfo: input.typeInfo?.outputType,
     };
   }
 
@@ -1307,7 +1315,7 @@ export class WorkflowClient extends BaseClient {
         },
         updateId: updateRequest.request!.meta!.updateId!,
         updateOutcome: updateResp.outcome ?? undefined,
-        updateTypeInfo: input.updateTypeInfo,
+        updateOutputTypeInfo: input.updateTypeInfo?.outputType,
       };
     } catch (thrownError) {
       let err = thrownError;
@@ -1333,7 +1341,7 @@ export class WorkflowClient extends BaseClient {
     workflowId: string,
     workflowRunId?: string,
     outcome?: temporal.api.update.v1.IOutcome,
-    typeInfo?: TypeInfo<Ret, unknown>
+    outputTypeInfo?: TypeInfo
   ): WorkflowUpdateHandle<Ret> {
     const dataConverter = this.dataConverter;
     const context = this.workflowSerializationContext(workflowId);
@@ -1350,12 +1358,13 @@ export class WorkflowClient extends BaseClient {
             await decodeOptionalFailureToOptionalError(dataConverter, completedOutcome.failure, context)
           );
         } else {
+          // Interceptor metadata erases its application type; the handle's result type restores it at this boundary.
           return await decodeFromPayloadsAtIndex<Ret, unknown>(
             dataConverter,
             0,
             completedOutcome.success?.payloads,
             context,
-            typeInfo
+            outputTypeInfo as TypeInfo<Ret, unknown> | undefined
           );
         }
       },
@@ -1720,29 +1729,38 @@ export class WorkflowClient extends BaseClient {
       const next = this._startUpdateHandler.bind(this, waitForStage);
       const fn = composeInterceptors(interceptors, 'startUpdate', next);
       const { args, typeInfo: callSiteTypeInfo, ...opts } = options ?? {};
-      if (typeof def !== 'string' && callSiteTypeInfo !== undefined) {
-        throw new TypeError(
-          'Cannot provide call-site Update TypeInfo with an Update definition. ' +
-            'Define TypeInfo when creating the Update definition instead.'
-        );
+      let updateName: string;
+      let updateTypeInfo: PayloadTypeInfo | undefined;
+      if (typeof def === 'string') {
+        updateName = def;
+        updateTypeInfo = callSiteTypeInfo;
+      } else {
+        if (callSiteTypeInfo !== undefined) {
+          throw new TypeError(
+            'Cannot provide call-site Update TypeInfo with an Update definition. ' +
+              'Define TypeInfo when creating the Update definition instead.'
+          );
+        }
+        updateName = def.name;
+        updateTypeInfo = def.typeInfo;
       }
       const input = {
         workflowExecution: { workflowId, runId },
         firstExecutionRunId,
-        updateName: typeof def === 'string' ? def : def.name,
+        updateName,
         args: args ?? [],
-        typeInfo: typeof def === 'string' ? callSiteTypeInfo : def.typeInfo,
+        typeInfo: updateTypeInfo,
         waitForStage,
         headers: {},
         options: opts,
       };
       const output = await fn(input);
-      const handle = this.createWorkflowUpdateHandle<Ret>(
+      const handle: WorkflowUpdateHandle<Ret> = this.createWorkflowUpdateHandle(
         output.updateId,
         input.workflowExecution.workflowId,
         output.workflowRunId,
         output.outcome,
-        output.typeInfo?.outputType as TypeInfo<Ret, unknown> | undefined
+        output.outputTypeInfo
       );
       if (!output.outcome && waitForStage === WorkflowUpdateStage.COMPLETED) {
         await this._pollForUpdateOutcome(handle.updateId, input.workflowExecution);
@@ -1853,22 +1871,22 @@ export class WorkflowClient extends BaseClient {
           waitForStage: typeof WorkflowUpdateStage.ACCEPTED;
         }
       ): Promise<WorkflowUpdateHandle<Ret>> {
-        return await _startUpdate<Ret, Args>(def, options.waitForStage, options);
+        return await _startUpdate(def, options.waitForStage, options);
       },
       async executeUpdate<Ret, Args extends any[]>(
         def: UpdateDefinition<Ret, Args> | string,
         options?: WorkflowUpdateOptions & { args?: Args }
       ): Promise<Ret> {
-        const handle = await _startUpdate<Ret, Args>(def, WorkflowUpdateStage.COMPLETED, options);
+        const handle = await _startUpdate(def, WorkflowUpdateStage.COMPLETED, options);
         return await handle.result();
       },
       getUpdateHandle<Ret>(updateId: string, options?: GetWorkflowUpdateHandleOptions): WorkflowUpdateHandle<Ret> {
-        return this.client.createWorkflowUpdateHandle<Ret>(
+        return this.client.createWorkflowUpdateHandle(
           updateId,
           workflowId,
           options?.workflowRunId ?? runId,
           undefined,
-          options?.typeInfo?.outputType as TypeInfo<Ret, unknown> | undefined
+          options?.typeInfo?.outputType
         );
       },
       async signal<Args extends any[]>(def: SignalDefinition<Args> | string, ...args: Args): Promise<void> {

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -231,7 +231,7 @@ export interface WorkflowHandle<T extends Workflow = Workflow> extends BaseWorkf
   /**
    * Get a handle to an Update of this Workflow.
    */
-  getUpdateHandle<Ret>(updateId: string): WorkflowUpdateHandle<Ret>;
+  getUpdateHandle<Ret>(updateId: string, options?: GetWorkflowUpdateHandleOptions): WorkflowUpdateHandle<Ret>;
 
   /**
    * Query a running or completed Workflow.
@@ -465,6 +465,13 @@ export interface GetWorkflowUpdateHandleOptions {
    * The ID of the Run of the Workflow targeted by the Update.
    */
   workflowRunId?: string;
+
+  /**
+   * Type information used to decode the Update result.
+   *
+   * @experimental
+   */
+  typeInfo?: Pick<PayloadTypeInfo, 'outputType'>;
 }
 
 /**
@@ -786,7 +793,20 @@ export class WorkflowClient extends BaseClient {
       startWorkflowOperation: WithStartWorkflowOperation<T>;
     }
   ): Promise<WorkflowUpdateHandle<Ret>> {
-    const { waitForStage, args, startWorkflowOperation, ...updateOptions } = updateWithStartOptions;
+    const {
+      waitForStage,
+      args,
+      startWorkflowOperation,
+      typeInfo: callSiteTypeInfo,
+      ...updateOptions
+    } = updateWithStartOptions;
+    if (typeof updateDef !== 'string' && callSiteTypeInfo !== undefined) {
+      throw new TypeError(
+        'Cannot provide call-site Update TypeInfo with an Update definition. ' +
+          'Define TypeInfo when creating the Update definition instead.'
+      );
+    }
+    const updateTypeInfo = typeof updateDef === 'string' ? callSiteTypeInfo : updateDef.typeInfo;
     const { workflowTypeOrFunc, options: workflowOptions } = startWorkflowOperation;
     const { workflowId } = workflowOptions;
 
@@ -807,6 +827,7 @@ export class WorkflowClient extends BaseClient {
       workflowStartHeaders: {},
       updateName: typeof updateDef === 'string' ? updateDef : updateDef.name,
       updateArgs: args ?? [],
+      updateTypeInfo,
       updateOptions,
       updateHeaders: {},
     };
@@ -847,7 +868,8 @@ export class WorkflowClient extends BaseClient {
       updateOutput.updateId,
       workflowId,
       updateOutput.workflowExecution.runId,
-      outcome
+      outcome,
+      updateOutput.updateTypeInfo?.outputType as TypeInfo<Ret, unknown> | undefined
     );
   }
 
@@ -1120,7 +1142,9 @@ export class WorkflowClient extends BaseClient {
         input: {
           header: { fields: input.headers },
           name: input.updateName,
-          args: { payloads: await encodeToPayloadsWithContext(dataConverter, context, input.args) },
+          args: {
+            payloads: await encodeToPayloadsWithContext(dataConverter, context, input.args, input.typeInfo?.inputTypes),
+          },
         },
         requestId: internalOptions?.requestId,
         completionCallbacks: internalOptions?.completionCallbacks,
@@ -1191,6 +1215,7 @@ export class WorkflowClient extends BaseClient {
 
       workflowRunId: response.updateRef!.workflowExecution!.runId!,
       outcome: response.outcome ?? undefined,
+      typeInfo: input.typeInfo,
     };
   }
 
@@ -1214,6 +1239,7 @@ export class WorkflowClient extends BaseClient {
     const updateInput: WorkflowStartUpdateInput = {
       updateName: input.updateName,
       args: input.updateArgs,
+      typeInfo: input.updateTypeInfo,
       workflowExecution: {
         workflowId: input.workflowStartOptions.workflowId,
       },
@@ -1281,6 +1307,7 @@ export class WorkflowClient extends BaseClient {
         },
         updateId: updateRequest.request!.meta!.updateId!,
         updateOutcome: updateResp.outcome ?? undefined,
+        updateTypeInfo: input.updateTypeInfo,
       };
     } catch (thrownError) {
       let err = thrownError;
@@ -1305,7 +1332,8 @@ export class WorkflowClient extends BaseClient {
     updateId: string,
     workflowId: string,
     workflowRunId?: string,
-    outcome?: temporal.api.update.v1.IOutcome
+    outcome?: temporal.api.update.v1.IOutcome,
+    typeInfo?: TypeInfo<Ret, unknown>
   ): WorkflowUpdateHandle<Ret> {
     const dataConverter = this.dataConverter;
     const context = this.workflowSerializationContext(workflowId);
@@ -1322,7 +1350,13 @@ export class WorkflowClient extends BaseClient {
             await decodeOptionalFailureToOptionalError(dataConverter, completedOutcome.failure, context)
           );
         } else {
-          return await decodeFromPayloadsAtIndex<Ret>(dataConverter, 0, completedOutcome.success?.payloads, context);
+          return await decodeFromPayloadsAtIndex<Ret, unknown>(
+            dataConverter,
+            0,
+            completedOutcome.success?.payloads,
+            context,
+            typeInfo
+          );
         }
       },
     };
@@ -1685,12 +1719,19 @@ export class WorkflowClient extends BaseClient {
     ): Promise<WorkflowUpdateHandle<Ret>> => {
       const next = this._startUpdateHandler.bind(this, waitForStage);
       const fn = composeInterceptors(interceptors, 'startUpdate', next);
-      const { args, ...opts } = options ?? {};
+      const { args, typeInfo: callSiteTypeInfo, ...opts } = options ?? {};
+      if (typeof def !== 'string' && callSiteTypeInfo !== undefined) {
+        throw new TypeError(
+          'Cannot provide call-site Update TypeInfo with an Update definition. ' +
+            'Define TypeInfo when creating the Update definition instead.'
+        );
+      }
       const input = {
         workflowExecution: { workflowId, runId },
         firstExecutionRunId,
         updateName: typeof def === 'string' ? def : def.name,
         args: args ?? [],
+        typeInfo: typeof def === 'string' ? callSiteTypeInfo : def.typeInfo,
         waitForStage,
         headers: {},
         options: opts,
@@ -1700,7 +1741,8 @@ export class WorkflowClient extends BaseClient {
         output.updateId,
         input.workflowExecution.workflowId,
         output.workflowRunId,
-        output.outcome
+        output.outcome,
+        output.typeInfo?.outputType as TypeInfo<Ret, unknown> | undefined
       );
       if (!output.outcome && waitForStage === WorkflowUpdateStage.COMPLETED) {
         await this._pollForUpdateOutcome(handle.updateId, input.workflowExecution);
@@ -1811,17 +1853,23 @@ export class WorkflowClient extends BaseClient {
           waitForStage: typeof WorkflowUpdateStage.ACCEPTED;
         }
       ): Promise<WorkflowUpdateHandle<Ret>> {
-        return await _startUpdate(def, options.waitForStage, options);
+        return await _startUpdate<Ret, Args>(def, options.waitForStage, options);
       },
       async executeUpdate<Ret, Args extends any[]>(
         def: UpdateDefinition<Ret, Args> | string,
         options?: WorkflowUpdateOptions & { args?: Args }
       ): Promise<Ret> {
-        const handle = await _startUpdate(def, WorkflowUpdateStage.COMPLETED, options);
+        const handle = await _startUpdate<Ret, Args>(def, WorkflowUpdateStage.COMPLETED, options);
         return await handle.result();
       },
-      getUpdateHandle<Ret>(updateId: string): WorkflowUpdateHandle<Ret> {
-        return this.client.createWorkflowUpdateHandle(updateId, workflowId, runId);
+      getUpdateHandle<Ret>(updateId: string, options?: GetWorkflowUpdateHandleOptions): WorkflowUpdateHandle<Ret> {
+        return this.client.createWorkflowUpdateHandle<Ret>(
+          updateId,
+          workflowId,
+          options?.workflowRunId ?? runId,
+          undefined,
+          options?.typeInfo?.outputType as TypeInfo<Ret, unknown> | undefined
+        );
       },
       async signal<Args extends any[]>(def: SignalDefinition<Args> | string, ...args: Args): Promise<void> {
         if (typeof def === 'string') {

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -1358,7 +1358,8 @@ export class WorkflowClient extends BaseClient {
             await decodeOptionalFailureToOptionalError(dataConverter, completedOutcome.failure, context)
           );
         } else {
-          // Interceptor metadata erases its application type; the handle's result type restores it at this boundary.
+          // PayloadTypeInfo stores output metadata without its application type, so TypeScript cannot know that this
+          // TypeInfo produces the Ret promised by the handle. Assert that relationship once, immediately before decoding.
           return await decodeFromPayloadsAtIndex<Ret, unknown>(
             dataConverter,
             0,

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -106,6 +106,13 @@ export interface WorkflowUpdateOptions {
    * Update.
    */
   readonly updateId?: string;
+
+  /**
+   * Type information used to convert Update arguments and results when the Update is referenced by name.
+   *
+   * @experimental
+   */
+  typeInfo?: PayloadTypeInfo;
 }
 
 type WorkflowSignalWithStartOptionsBase<SignalArgs extends any[]> = SignalArgs extends [any, ...any[]]

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -12,6 +12,7 @@ export type WorkflowUpdateAnnotatedType = {
   unfinishedPolicy: HandlerUnfinishedPolicy;
   validator?: WorkflowUpdateValidatorType;
   description?: string;
+  typeInfo?: PayloadTypeInfo;
 };
 export type WorkflowSignalType = (...args: any[]) => Promise<void> | void;
 export type WorkflowSignalAnnotatedType = {
@@ -39,6 +40,16 @@ declare const argsBrand: unique symbol;
 declare const retBrand: unique symbol;
 
 /**
+ * Options for {@link UpdateDefinition}.
+ *
+ * @experimental
+ */
+export interface UpdateDefinitionOptions {
+  /** Type information used to convert Update arguments and results. */
+  typeInfo?: PayloadTypeInfo;
+}
+
+/**
  * An interface representing a Workflow update definition, as returned from {@link defineUpdate}
  *
  * @remarks `Args` can be used for parameter type inference in handler functions and WorkflowHandle methods.
@@ -47,6 +58,8 @@ declare const retBrand: unique symbol;
 export interface UpdateDefinition<Ret, Args extends any[] = [], Name extends string = string> {
   type: 'update';
   name: Name;
+  /** Type information used to convert Update arguments and results. */
+  typeInfo?: PayloadTypeInfo;
   /**
    * Virtual type brand to maintain a distinction between {@link UpdateDefinition} types with different args.
    * This field is not present at run-time.

--- a/packages/test/src/test-type-info.ts
+++ b/packages/test/src/test-type-info.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto';
 import type { ExecutionContext } from 'ava';
-import type { WorkflowSignalWithStartOptions } from '@temporalio/client';
+import type { WorkflowClientInterceptor, WorkflowSignalWithStartOptions } from '@temporalio/client';
 import { Client, WithStartWorkflowOperation, WorkflowFailedError } from '@temporalio/client';
 import { workflowInterceptorModules } from '@temporalio/testing';
 import { executeChild } from '@temporalio/workflow';
@@ -18,6 +18,7 @@ import {
   orderQueryTypeInfo,
   orderSignal,
   orderSignalTypeInfo,
+  orderUpdate,
   parentWorkflowChildString,
   Receipt,
   signalChildTarget,
@@ -26,6 +27,7 @@ import {
   signalExternalTargetWithCallSiteTypeInfo,
   signalTarget,
   queryTarget,
+  updateTarget,
   workflowTypeInfo,
   workflowWithSignalStart,
   workflowWithTypeInfo,
@@ -388,6 +390,158 @@ test('Workflow Query interceptor uses output TypeInfo from the retargeted handle
     );
     await handle.signal(finishSignal);
     await handle.result();
+  });
+});
+
+// Updates
+
+test('Update definition converts input and result', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker();
+
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(updateTarget, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+    });
+    const update = await handle.startUpdate(orderUpdate, {
+      args: [new Order('order-1', 12345n)],
+      waitForStage: 'ACCEPTED',
+    });
+    assertReceipt(t, await update.result());
+    await handle.result();
+  });
+});
+
+test('String Update uses call-site TypeInfo for start and execute', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker();
+
+  await worker.runUntil(async () => {
+    const startHandle = await client.workflow.start(updateTarget, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+    });
+    const started = await startHandle.startUpdate<Receipt, [Order]>('order', {
+      args: [new Order('order-1', 12345n)],
+      waitForStage: 'ACCEPTED',
+      typeInfo: workflowTypeInfo,
+    });
+    assertReceipt(t, await started.result());
+    await startHandle.result();
+
+    const executeHandle = await client.workflow.start(updateTarget, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+    });
+    assertReceipt(
+      t,
+      await executeHandle.executeUpdate<Receipt, [Order]>('order', {
+        args: [new Order('order-1', 12345n)],
+        typeInfo: workflowTypeInfo,
+      })
+    );
+    await executeHandle.result();
+  });
+});
+
+test('Update-with-Start uses definition and string TypeInfo', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker();
+
+  await worker.runUntil(async () => {
+    const definitionStart = new WithStartWorkflowOperation(updateTarget, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+      workflowIdConflictPolicy: 'USE_EXISTING',
+    });
+    assertReceipt(
+      t,
+      await client.workflow.executeUpdateWithStart(orderUpdate, {
+        args: [new Order('order-1', 12345n)],
+        startWorkflowOperation: definitionStart,
+      })
+    );
+    await (await definitionStart.workflowHandle()).result();
+
+    const stringStart = new WithStartWorkflowOperation(updateTarget, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+      workflowIdConflictPolicy: 'USE_EXISTING',
+    });
+    const update = await client.workflow.startUpdateWithStart<typeof updateTarget, Receipt, [Order]>('order', {
+      args: [new Order('order-1', 12345n)],
+      waitForStage: 'ACCEPTED',
+      typeInfo: workflowTypeInfo,
+      startWorkflowOperation: stringStart,
+    });
+    assertReceipt(t, await update.result());
+    await (await stringStart.workflowHandle()).result();
+  });
+});
+
+test('Detached Update handle decodes with call-site output TypeInfo', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker();
+
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(updateTarget, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+    });
+    const update = await handle.startUpdate(orderUpdate, {
+      args: [new Order('order-1', 12345n)],
+      waitForStage: 'ACCEPTED',
+    });
+    assertReceipt(
+      t,
+      await handle
+        .getUpdateHandle<Receipt>(update.updateId, { typeInfo: { outputType: workflowTypeInfo.outputType } })
+        .result()
+    );
+    await handle.result();
+  });
+});
+
+test('Update handle uses TypeInfo resolved by an interceptor', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const interceptor: WorkflowClientInterceptor = {
+    async startUpdate(input, next) {
+      return await next({ ...input, typeInfo: workflowTypeInfo });
+    },
+  };
+  const client = new Client({
+    connection: t.context.env.client.connection,
+    namespace: t.context.env.client.options.namespace,
+    interceptors: { workflow: [interceptor] },
+  });
+  const worker = await h.createWorker();
+
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(updateTarget, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+    });
+    assertReceipt(t, await handle.executeUpdate('order', { args: [new Order('order-1', 12345n)] }));
+    await handle.result();
+  });
+});
+
+test('Update definition rejects call-site TypeInfo at runtime', async (t) => {
+  const client = makeClient(t.context.env);
+  const options = {
+    args: [new Order('order-1', 12345n)],
+    waitForStage: 'ACCEPTED' as const,
+    typeInfo: workflowTypeInfo,
+  } as any;
+  const handle = client.workflow.getHandle('unused');
+  await t.throwsAsync(handle.startUpdate(orderUpdate, options), {
+    instanceOf: TypeError,
+    message: /Cannot provide call-site Update TypeInfo with an Update definition/,
   });
 });
 

--- a/packages/test/src/workflows/type-info/messages.ts
+++ b/packages/test/src/workflows/type-info/messages.ts
@@ -110,6 +110,22 @@ export async function workflowWithSignalStart(order: Order): Promise<Receipt> {
 
 export const finishUpdate = defineUpdate('finish');
 
+export const orderUpdate = defineUpdate<Receipt, [Order]>('order', { typeInfo: workflowTypeInfo });
+
+export async function updateTarget(): Promise<void> {
+  let finished = false;
+  setHandler(
+    orderUpdate,
+    (order) => {
+      assertOrder(order);
+      finished = true;
+      return new Receipt(order.id, order.totalCents);
+    },
+    { validator: assertOrder }
+  );
+  await condition(() => finished);
+}
+
 defineWorkflowOptions(workflowWithUpdateStart, {
   staticOptions: { typeInfo: workflowTypeInfo },
 });

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -944,6 +944,7 @@ export class Activator implements ActivationHandler {
         ? {
             handler: this.defaultUpdateHandler.bind(undefined, name),
             validator: undefined,
+            typeInfo: undefined,
             // Default to a warning policy.
             unfinishedPolicy: HandlerUnfinishedPolicy.WARN_AND_ABANDON,
           }
@@ -959,7 +960,7 @@ export class Activator implements ActivationHandler {
       const context = this.workflowSerializationContext();
       return {
         updateId,
-        args: arrayFromPayloads(this.payloadConverter, activation.input, context),
+        args: arrayFromPayloads(this.payloadConverter, activation.input, context, entry.typeInfo?.inputTypes),
         name,
         headers: headers ?? {},
       };
@@ -1031,7 +1032,7 @@ export class Activator implements ActivationHandler {
       const { unfinishedPolicy } = entry;
       this.inProgressUpdates.set(updateId, { name, unfinishedPolicy, id: updateId });
       const res = execute(input)
-        .then((result) => this.completeUpdate(protocolInstanceId, result))
+        .then((result) => this.completeUpdate(protocolInstanceId, result, entry.typeInfo?.outputType))
         .catch((error) => {
           if (error instanceof TemporalFailure) {
             this.rejectUpdate(protocolInstanceId, error);
@@ -1418,10 +1419,10 @@ export class Activator implements ActivationHandler {
     this.pushCommand({ updateResponse: { protocolInstanceId, accepted: {} } });
   }
 
-  private completeUpdate(protocolInstanceId: string, result: unknown): void {
+  private completeUpdate(protocolInstanceId: string, result: unknown, typeInfo?: TypeInfo): void {
     const context = this.workflowSerializationContext();
     this.pushCommand({
-      updateResponse: { protocolInstanceId, completed: this.payloadConverter.toPayload(result, context) },
+      updateResponse: { protocolInstanceId, completed: toPayloadWithTypeInfo(this.payloadConverter, result, context, typeInfo) },
     });
   }
 

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -1422,7 +1422,10 @@ export class Activator implements ActivationHandler {
   private completeUpdate(protocolInstanceId: string, result: unknown, typeInfo?: TypeInfo): void {
     const context = this.workflowSerializationContext();
     this.pushCommand({
-      updateResponse: { protocolInstanceId, completed: toPayloadWithTypeInfo(this.payloadConverter, result, context, typeInfo) },
+      updateResponse: {
+        protocolInstanceId,
+        completed: toPayloadWithTypeInfo(this.payloadConverter, result, context, typeInfo),
+      },
     });
   }
 

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1480,7 +1480,13 @@ export function setHandler<
 
       const validator = updateOptions?.validator as WorkflowUpdateValidatorType | undefined;
       const unfinishedPolicy = updateOptions?.unfinishedPolicy ?? HandlerUnfinishedPolicy.WARN_AND_ABANDON;
-      activator.updateHandlers.set(def.name, { handler, validator, description, unfinishedPolicy, typeInfo: def.typeInfo });
+      activator.updateHandlers.set(def.name, {
+        handler,
+        validator,
+        description,
+        unfinishedPolicy,
+        typeInfo: def.typeInfo,
+      });
       activator.dispatchBufferedUpdates();
     } else if (handler == null) {
       activator.updateHandlers.delete(def.name);

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -12,6 +12,7 @@ import type {
   SignalTypeInfo,
   UntypedActivities,
   UpdateDefinition,
+  UpdateDefinitionOptions,
   WithWorkflowArgs,
   Workflow,
   WorkflowSerializationContext,
@@ -1307,11 +1308,13 @@ function conditionInner(fn: () => boolean): Promise<void> {
  * A definition can be reused in multiple Workflows.
  */
 export function defineUpdate<Ret, Args extends any[] = [], Name extends string = string>(
-  name: Name
+  name: Name,
+  options: UpdateDefinitionOptions = {}
 ): UpdateDefinition<Ret, Args, Name> {
   return {
     type: 'update',
     name,
+    ...options,
   } as UpdateDefinition<Ret, Args, Name>;
 }
 
@@ -1477,7 +1480,7 @@ export function setHandler<
 
       const validator = updateOptions?.validator as WorkflowUpdateValidatorType | undefined;
       const unfinishedPolicy = updateOptions?.unfinishedPolicy ?? HandlerUnfinishedPolicy.WARN_AND_ABANDON;
-      activator.updateHandlers.set(def.name, { handler, validator, description, unfinishedPolicy });
+      activator.updateHandlers.set(def.name, { handler, validator, description, unfinishedPolicy, typeInfo: def.typeInfo });
       activator.dispatchBufferedUpdates();
     } else if (handler == null) {
       activator.updateHandlers.delete(def.name);


### PR DESCRIPTION
## What was changed

Added TypeInfo to Update definitions, string-named Update calls, Update-with-Start, returned Update handles, and detached Update handles. Runtime validation prevents combining definition and call-site metadata, while interceptor-resolved TypeInfo is retained for result decoding.

Reviewing commit-by-commit separates the definition, call-site, test, and changelog changes.

## Why?

Update arguments and results cross serialization boundaries independently of their Workflow. TypeInfo preserves application runtime types for both direct and reconstructed Update handles without changing existing Update call signatures.

Existing Update calls without TypeInfo retain their current behavior. There is no rollout step or manual action required.

## Checklist

1. Closes: N/A

2. How was this tested: Proto, Common, Client, Workflow, Test, and contrib interceptor builds; all 32 TypeInfo tests; ESLint; Prettier; `ts-prune`; and `git diff --check`.

3. Any docs updates needed? No; documentation will accompany the completed experimental API.
