### PR TITLE
feat(nexus): apply TypeInfo in Workflow callers and handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ to docs, or any other relevant information.
 - Fixed issue where replaying a workflow with Local Activities scheduled from a nested Promise could
   trigger a nondeterminism error.
 - `msOptionalToTs()` was incorrectly converting durations of `0` to `undefined`, resulting in incorrect behaviors
-   in various places that takes optional durations where `0` is a legitimate value, e.g. `ApplicationFailure.nextRetryDelay()`. Durations of `0` are now properly preserved.
+  in various places that takes optional durations where `0` is a legitimate value, e.g. `ApplicationFailure.nextRetryDelay()`. Durations of `0` are now properly preserved.
 
 ## [1.22.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ to docs, or any other relevant information.
 - `createPayloadValidationError` in `@temporalio/common` creates a non-retryable
   `ApplicationFailure` with structured Payload validation details when provided. Passing `null` or
   `undefined` produces a failure without details.
+- **Experimental**: Nexus operation definitions can provide `TypeInfo` for Workflow callers and operation handlers.
+  Workflow-backed asynchronous handlers must configure matching TypeInfo on the backing Workflow.
 - Core logs written directly to the console can now use compact, pretty, or newline-delimited JSON
   output via `telemetryOptions.logging.console.format`.
 - **Experimental**: Workflow Clients can now use `TypeInfo` to encode Workflow inputs and decode Workflow results.

--- a/packages/common/src/__tests__/test-type-info.ts
+++ b/packages/common/src/__tests__/test-type-info.ts
@@ -8,12 +8,14 @@ import {
   type PayloadConverter,
 } from '../converter/payload-converter';
 import { ProtobufBinaryPayloadConverter } from '../converter/protobuf-payload-converters';
+import type { PayloadCodec } from '../converter/payload-codec';
 import type { SerializationContext } from '../converter/serialization-context';
 import { PayloadConverterError, ValueError } from '../errors';
 import type { Payload } from '../interfaces';
 import {
   decodeArrayFromPayloads,
   decodeFromPayloadsAtIndex,
+  encodeToPayload,
   encodeToPayloadsWithContext,
 } from '../internal-non-workflow/codec-helpers';
 import type { ConverterHint, TypeInfo } from '../type-info';
@@ -120,6 +122,52 @@ test('converts an application class to a transfer type around JSON payload conve
   t.is(result.balanceInCents, account.balanceInCents);
 });
 
+test('single-payload encoding applies transfer conversion before payload codecs', async (t) => {
+  const stages: string[] = [];
+  const account = new UserAccount('account-123', 123n);
+  const typeInfo: TypeInfo<UserAccount, UserAccountData> = {
+    transferTypeConverter: {
+      toTransferType(value) {
+        stages.push('transfer');
+        return toUserAccountData(value);
+      },
+      fromTransferType: fromUserAccountData,
+    },
+  };
+  const payloadConverter: PayloadConverter = {
+    toPayload(value, context, hint) {
+      stages.push('payload-converter');
+      return defaultPayloadConverter.toPayload(value, context, hint);
+    },
+    fromPayload(payload, context, hint) {
+      return defaultPayloadConverter.fromPayload(payload, context, hint);
+    },
+  };
+  const payloadCodec: PayloadCodec = {
+    async encode(payloads) {
+      stages.push('payload-codec');
+      return payloads;
+    },
+    async decode(payloads) {
+      return payloads;
+    },
+  };
+  const converter = { ...defaultDataConverter, payloadConverter, payloadCodecs: [payloadCodec] };
+
+  const payload = await encodeToPayload(converter, account, undefined, typeInfo);
+
+  t.deepEqual(payload, defaultPayloadConverter.toPayload(toUserAccountData(account)));
+  t.deepEqual(stages, ['transfer', 'payload-converter', 'payload-codec']);
+});
+
+test('single-payload encoding preserves best-effort conversion without TypeInfo', async (t) => {
+  const value = { value: '123' };
+
+  const payload = await encodeToPayload(defaultDataConverter, value);
+
+  t.deepEqual(payload, defaultPayloadConverter.toPayload(value));
+});
+
 test('uses a converter hint to serialize and deserialize a protobuf message', async (t) => {
   const messageType = new Type('HintedValue').add(new Field('value', 1, 'string'));
   const hint = {
@@ -135,8 +183,8 @@ test('uses a converter hint to serialize and deserialize a protobuf message', as
     ),
   };
 
-  const payloads = await encodeToPayloadsWithContext(converter, undefined, [{ value: '123' }], [typeInfo]);
-  const result = await decodeFromPayloadsAtIndex(converter, 0, payloads, undefined, typeInfo);
+  const payload = await encodeToPayload(converter, { value: '123' }, undefined, typeInfo);
+  const result = await decodeFromPayloadsAtIndex(converter, 0, [payload], undefined, typeInfo);
 
   t.is(result.value, '123');
 });

--- a/packages/common/src/internal-non-workflow/codec-helpers.ts
+++ b/packages/common/src/internal-non-workflow/codec-helpers.ts
@@ -4,6 +4,7 @@ import {
   arrayFromPayloads,
   convertOptionalToPayload,
   fromPayloadsAtIndex,
+  toPayloadWithTypeInfo,
   toPayloadsWithContext,
 } from '../converter/payload-converter';
 import { PayloadConverterError } from '../errors';
@@ -113,16 +114,15 @@ export async function decodeOptionalSinglePayload<T>(
   return payloadConverter.fromPayload(decoded, context);
 }
 
-/**
- * Run {@link PayloadConverter.toPayload} on value, and then encode it.
- */
-export async function encodeToPayload(
+/** Apply optional TypeInfo, run payload conversion, and then encode the resulting Payload. */
+export async function encodeToPayload<T>(
   converter: LoadedDataConverter,
-  value: unknown,
-  context?: SerializationContext
+  value: T,
+  context?: SerializationContext,
+  typeInfo?: TypeInfo<T, unknown>
 ): Promise<Payload> {
   const { payloadConverter, payloadCodecs } = converter;
-  return await encodeSingle(payloadCodecs, payloadConverter.toPayload(value, context), context);
+  return await encodeSingle(payloadCodecs, toPayloadWithTypeInfo(payloadConverter, value, context, typeInfo), context);
 }
 
 /**

--- a/packages/test/src/test-nexus-workflow-caller.cloud-unavailable.ts
+++ b/packages/test/src/test-nexus-workflow-caller.cloud-unavailable.ts
@@ -10,9 +10,24 @@ import * as workflow from '@temporalio/workflow';
 import { helpers, makeTestFunction } from './helpers-integration';
 import { unwrapHandlerErrorCause, innermostHandlerError } from './helpers-nexus';
 import { waitUntil } from './helpers';
+import {
+  assertOrder,
+  assertReceipt,
+  Order,
+  orderTypeInfo,
+  Receipt,
+  receiptTypeInfo,
+} from './workflows/type-info/models';
+import { workflowWithTypeInfo } from './workflows/type-info/workflows';
+
+export { workflowWithTypeInfo };
 
 const recordedLogs: { [key: string]: LogEntry[] } = {};
-const test = makeTestFunction({ workflowsPath: __filename, recordedLogs });
+const test = makeTestFunction({
+  workflowsPath: __filename,
+  recordedLogs,
+  workflowInterceptorModules: [require.resolve('./workflows/type-info/nexus-interceptors')],
+});
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Service definitions
@@ -76,6 +91,17 @@ const clientOperationTypeSafetyCheckerService = nexus.service('typeSafetyService
   explicit: nexus.operation<InputB, InputB>({ name: 'my-custom-operation-name' }),
 });
 
+const typeInfoService = nexus.service('typeInfoService', {
+  convert: nexus.operation<Order, Receipt>({
+    inputType: orderTypeInfo,
+    outputType: receiptTypeInfo,
+  }),
+});
+
+const typeInfoServiceWithoutMetadata = nexus.service('typeInfoService', {
+  convert: nexus.operation<Order, Receipt>(),
+});
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Caller workflows
 
@@ -109,6 +135,31 @@ export async function loggerOpCaller(endpoint: string): Promise<string> {
 export async function getClientCaller(endpoint: string): Promise<boolean> {
   const client = workflow.createNexusServiceClient({ endpoint, service: getClientService });
   return await client.executeOperation('getClientOp', undefined);
+}
+
+workflow.defineWorkflowOptions(typeInfoCaller, {
+  staticOptions: { typeInfo: { outputType: receiptTypeInfo } },
+});
+export async function typeInfoCaller(endpoint: string, useDefinition: boolean): Promise<Receipt> {
+  const client = workflow.createNexusServiceClient({ endpoint, service: typeInfoService });
+  let result: Receipt;
+  if (useDefinition) {
+    result = await client.executeOperation(typeInfoService.operations.convert, new Order('order-1', 123n));
+  } else {
+    result = await client.executeOperation('convert', new Order('order-1', 123n));
+  }
+  assertReceipt(result);
+  return result;
+}
+
+workflow.defineWorkflowOptions(interceptorTypeInfoCaller, {
+  staticOptions: { typeInfo: { outputType: receiptTypeInfo } },
+});
+export async function interceptorTypeInfoCaller(endpoint: string): Promise<Receipt> {
+  const client = workflow.createNexusServiceClient({ endpoint, service: typeInfoServiceWithoutMetadata });
+  const result = await client.executeOperation('convert', new Order('order-1', 123n));
+  assertReceipt(result);
+  return result;
 }
 
 export async function operationInfoCaller(
@@ -312,6 +363,76 @@ test('sync Operation Handler happy path - caller workflow', async (t) => {
       args: [endpointName],
     });
     t.is(result, 'hello');
+  });
+});
+
+test('Nexus TypeInfo hydrates synchronous handler input and caller result', async (t) => {
+  const { createWorker, executeWorkflow, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+
+  const worker = await createWorker({
+    nexusServices: [
+      nexus.serviceHandler(typeInfoService, {
+        async convert(_ctx, input) {
+          assertOrder(input);
+          return new Receipt(input.id, input.totalCents + 1n);
+        },
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const result = await executeWorkflow(typeInfoCaller, {
+      args: [endpointName, true],
+    });
+    assertReceipt(result);
+    t.is(result.summary(), 'order-1:124');
+  });
+});
+
+test('Nexus TypeInfo hydrates asynchronous backing Workflow input and caller result', async (t) => {
+  const { createWorker, executeWorkflow, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+
+  const worker = await createWorker({
+    nexusServices: [
+      nexus.serviceHandler(typeInfoService, {
+        convert: new temporalnexus.WorkflowRunOperationHandler<Order, Receipt>(async (ctx, input) => {
+          return await temporalnexus.startWorkflow(ctx, workflowWithTypeInfo, {
+            workflowId: randomUUID(),
+            args: [input],
+          });
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const result = await executeWorkflow(typeInfoCaller, { args: [endpointName, false] });
+    assertReceipt(result);
+    t.is(result.summary(), 'order-1:123');
+  });
+});
+
+test('Workflow Nexus interceptor can supply operation TypeInfo', async (t) => {
+  const { createWorker, executeWorkflow, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+
+  const worker = await createWorker({
+    nexusServices: [
+      nexus.serviceHandler(typeInfoService, {
+        async convert(_ctx, input) {
+          assertOrder(input);
+          return new Receipt(input.id, input.totalCents + 1n);
+        },
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const result = await executeWorkflow(interceptorTypeInfoCaller, { args: [endpointName] });
+    assertReceipt(result);
+    t.is(result.summary(), 'order-1:124');
   });
 });
 

--- a/packages/test/src/workflows/type-info/nexus-interceptors.ts
+++ b/packages/test/src/workflows/type-info/nexus-interceptors.ts
@@ -1,0 +1,16 @@
+import type { WorkflowInterceptors } from '@temporalio/workflow';
+import { workflowInfo } from '@temporalio/workflow';
+import { orderTypeInfo, receiptTypeInfo } from './models';
+
+export const interceptors = (): WorkflowInterceptors => ({
+  outbound: [
+    {
+      startNexusOperation(input, next) {
+        if (workflowInfo().workflowType !== 'interceptorTypeInfoCaller') {
+          return next(input);
+        }
+        return next({ ...input, inputType: orderTypeInfo, outputType: receiptTypeInfo });
+      },
+    },
+  ],
+});

--- a/packages/worker/src/nexus/conversions.ts
+++ b/packages/worker/src/nexus/conversions.ts
@@ -1,8 +1,8 @@
 import { status } from '@grpc/grpc-js';
 import * as nexus from 'nexus-rpc';
 import { isGrpcServiceError, ServiceError } from '@temporalio/client';
-import type { LoadedDataConverter, Payload, ProtoFailure } from '@temporalio/common';
-import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
+import type { LoadedDataConverter, Payload, ProtoFailure, TypeInfo } from '@temporalio/common';
+import { ApplicationFailure, CancelledFailure, fromPayloadWithTypeInfo } from '@temporalio/common';
 import { encodeErrorToFailure, decodeOptionalSingle } from '@temporalio/common/lib/internal-non-workflow';
 import type { temporal } from '@temporalio/proto';
 
@@ -27,9 +27,11 @@ function isPayloadValidationFailure(err: unknown): err is ApplicationFailure {
   return err instanceof ApplicationFailure && err.nonRetryable === true && err.type === PAYLOAD_VALIDATION_ERROR_TYPE;
 }
 
+/** Decode Payload Codecs and apply optional TypeInfo while translating invalid Nexus input errors. */
 export async function decodePayload(
   dataConverter: LoadedDataConverter,
-  payload: temporal.api.common.v1.IPayload | undefined
+  payload: temporal.api.common.v1.IPayload | undefined,
+  typeInfo?: TypeInfo
 ): Promise<unknown> {
   let decoded: Payload | undefined | null;
   try {
@@ -51,7 +53,7 @@ export async function decodePayload(
   }
 
   try {
-    return dataConverter.payloadConverter.fromPayload(decoded);
+    return fromPayloadWithTypeInfo(dataConverter.payloadConverter, decoded, undefined, typeInfo);
   } catch (err) {
     if (isPayloadValidationFailure(err)) {
       throw new nexus.HandlerError('BAD_REQUEST', `Invalid operation input`, {

--- a/packages/worker/src/nexus/index.ts
+++ b/packages/worker/src/nexus/index.ts
@@ -26,6 +26,10 @@ import { coerceToHandlerError, decodePayload, handlerErrorToProto, operationErro
 
 const UNINITIALIZED = Symbol();
 
+/** nexus-rpc compiles operation definition metadata and handler methods into one object. */
+type CompiledNexusOperationHandler = nexus.OperationDefinition<unknown, unknown> &
+  nexus.OperationHandler<unknown, unknown>;
+
 export class NexusHandler {
   /**
    * Logger bound to `sdkComponent: worker`, with metadata from this Nexus task.
@@ -94,7 +98,7 @@ export class NexusHandler {
     return composeInterceptors(this.interceptors.outbound, 'getMetricTags', (a) => a)(baseTags);
   }
 
-  private getOperationHandler(ctx: nexus.OperationContext): nexus.OperationHandler<unknown, unknown> {
+  private getOperationHandler(ctx: nexus.OperationContext): CompiledNexusOperationHandler {
     const serviceHandler = this.services.get(ctx.service);
     if (serviceHandler == null) {
       throw new nexus.HandlerError('NOT_FOUND', `No service handler registered for service name '${ctx.service}'`);
@@ -108,7 +112,7 @@ export class NexusHandler {
   ): Promise<coresdk.nexus.INexusTaskCompletion> {
     try {
       const handler = this.getOperationHandler(ctx);
-      const input = await decodePayload(this.dataConverter, payload);
+      const input = await decodePayload(this.dataConverter, payload, handler.inputType);
 
       const executeNextHandler = async (interceptorInput: NexusStartOperationInput) => {
         const result = await this.invokeUserCode(
@@ -142,7 +146,7 @@ export class NexusHandler {
           completed: {
             startOperation: {
               syncSuccess: {
-                payload: await encodeToPayload(this.dataConverter, result.value),
+                payload: await encodeToPayload(this.dataConverter, result.value, undefined, handler.outputType),
                 links: ctx.outboundLinks.map(nexusLinkToProtoLink),
               },
             },

--- a/packages/workflow/src/interceptors.ts
+++ b/packages/workflow/src/interceptors.ts
@@ -11,6 +11,7 @@ import type {
   MetricTags,
   SignalTypeInfo,
   Timestamp,
+  TypeInfo,
   WorkflowExecution,
 } from '@temporalio/common';
 import { Headers, Next } from '@temporalio/common';
@@ -264,6 +265,10 @@ export interface LocalActivityInput {
  */
 export interface StartNexusOperationInput {
   readonly input: unknown;
+  /** Type information used to encode the operation's single input value. */
+  readonly inputType?: TypeInfo;
+  /** Type information retained to decode the operation result. */
+  readonly outputType?: TypeInfo;
   readonly endpoint: string;
   readonly service: string;
   readonly options: StartNexusOperationOptions;

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -788,13 +788,14 @@ export class Activator implements ActivationHandler {
 
   public resolveNexusOperationStart(activation: coresdk.workflow_activation.IResolveNexusOperationStart): void {
     const seq = getSeq(activation);
-    const { resolve, reject } = this.consumeCompletion('nexusOperationStart', seq);
+    const { resolve, reject, outputTypeInfo } = this.consumeCompletion('nexusOperationStart', seq);
 
     if (!activation.failed) {
       const completePromise = new Promise((resolve, reject) => {
         this.completions.nexusOperationComplete.set(seq, {
           resolve,
           reject,
+          outputTypeInfo,
         });
       });
       untrackPromise(completePromise);
@@ -811,16 +812,26 @@ export class Activator implements ActivationHandler {
     const context = this.workflowSerializationContext();
 
     if (activation.result?.completed) {
-      const result = this.payloadConverter.fromPayload(activation.result.completed, context);
-
       // It is possible for ResolveNexusOperation to be received without a prior ResolveNexusOperationStart,
       // e.g. because the handler completed the Operation synchronously.
       const startCompletion = this.maybeConsumeCompletion('nexusOperationStart', seq);
+      let outputTypeInfo: TypeInfo | undefined;
+      let resolveResult: (result: unknown) => void;
       if (startCompletion) {
-        startCompletion.resolve({ result: Promise.resolve(result) });
+        outputTypeInfo = startCompletion.outputTypeInfo;
+        resolveResult = (result) => startCompletion.resolve({ result: Promise.resolve(result) });
       } else {
-        this.consumeCompletion('nexusOperationComplete', seq).resolve(result);
+        const completion = this.consumeCompletion('nexusOperationComplete', seq);
+        outputTypeInfo = completion.outputTypeInfo;
+        resolveResult = completion.resolve;
       }
+      const result = fromPayloadWithTypeInfo(
+        this.payloadConverter,
+        activation.result.completed,
+        context,
+        outputTypeInfo
+      );
+      resolveResult(result);
     } else {
       let err: Error;
       if (activation.result?.failed) {

--- a/packages/workflow/src/nexus.ts
+++ b/packages/workflow/src/nexus.ts
@@ -1,4 +1,5 @@
 import type * as nexus from 'nexus-rpc';
+import { toPayloadWithTypeInfo } from '@temporalio/common';
 import { msOptionalToTs } from '@temporalio/common/lib/time';
 import { userMetadataToPayload } from '@temporalio/common/lib/user-metadata';
 import { makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow/enums-helpers';
@@ -127,12 +128,15 @@ export function createNexusServiceClient<T extends nexus.ServiceDefinition>(
       input: nexus.OperationInput<T['operations'][nexus.OperationKey<T['operations']>]>,
       operationOptions?: StartNexusOperationOptions
     ) {
-      const opName =
-        typeof operation === 'string'
-          ? // Casting as string to cover up the fact that `opName` might be undefined.
-            // If this happens, then `execute` will produce a `NexusOperationFailure.NOT_FOUND`.
-            (options.service.operations[operation]?.name as string)
-          : operation.name;
+      let operationDefinition: nexus.OperationDefinition<any, any> | undefined;
+      if (typeof operation === 'string') {
+        operationDefinition = options.service.operations[operation];
+      } else {
+        operationDefinition = operation;
+      }
+      // Casting as string preserves the existing behavior for an unknown operation property name:
+      // the resulting command produces a NexusOperationFailure.NOT_FOUND.
+      const opName = operationDefinition?.name as string;
 
       const activator = getActivator();
       const seq = activator.nextSeqs.nexusOperation++;
@@ -158,6 +162,8 @@ export function createNexusServiceClient<T extends nexus.ServiceDefinition>(
         headers: {},
         seq,
         input,
+        inputType: operationDefinition?.inputType,
+        outputType: operationDefinition?.outputType,
       });
 
       return {
@@ -182,6 +188,8 @@ function startNexusOperationNextHandler({
   operation,
   seq,
   headers,
+  inputType,
+  outputType,
 }: StartNexusOperationInput): Promise<StartNexusOperationOutput> {
   const activator = getActivator();
   const context = {
@@ -221,7 +229,7 @@ function startNexusOperationNextHandler({
         service,
         operation,
         nexusHeader: headers,
-        input: activator.payloadConverter.toPayload(input, context),
+        input: toPayloadWithTypeInfo(activator.payloadConverter, input, context, inputType),
         scheduleToCloseTimeout: msOptionalToTs(options?.scheduleToCloseTimeout),
         scheduleToStartTimeout: msOptionalToTs(options?.scheduleToStartTimeout),
         startToCloseTimeout: msOptionalToTs(options?.startToCloseTimeout),
@@ -233,6 +241,7 @@ function startNexusOperationNextHandler({
     activator.completions.nexusOperationStart.set(seq, {
       resolve,
       reject,
+      outputTypeInfo: outputType,
     });
   });
 }

--- a/packages/workflow/src/nexus.ts
+++ b/packages/workflow/src/nexus.ts
@@ -134,8 +134,8 @@ export function createNexusServiceClient<T extends nexus.ServiceDefinition>(
       } else {
         operationDefinition = operation;
       }
-      // Casting as string preserves the existing behavior for an unknown operation property name:
-      // the resulting command produces a NexusOperationFailure.NOT_FOUND.
+      // Casting as string to cover up the fact that `opName` might be undefined.
+      // If this happens, then `execute` will produce a `NexusOperationFailure.NOT_FOUND`.
       const opName = operationDefinition?.name as string;
 
       const activator = getActivator();


### PR DESCRIPTION
## What was changed

Added experimental `TypeInfo` support to Nexus operation definitions used by Workflow callers and Worker handlers. Operation input and output metadata now flows through Workflow outbound interceptors and Worker handler conversion, including synchronous results and asynchronous Workflow-backed operations.

Workflow-backed asynchronous handlers must configure matching TypeInfo on the backing Workflow because that Workflow produces the eventual result payload. Calls without TypeInfo retain their existing best-effort conversion behavior.

## Why?

Without operation TypeInfo, Nexus serialization boundaries lose application runtime types such as class instances and `bigint` fields. Generated Nexus APIs need the operation definition to preserve those types across Workflow callers and handlers.

The stable `nexus-rpc@^0.0.3` dependency is inherited from `main`; this PR contains no dependency or lockfile changes. No rollout or manual steps are required.

## Checklist

1. Closes: N/A

2. How was this tested: Frozen install against stable `nexus-rpc@0.0.3`; Common, Workflow, Worker, Nexus, and Test builds; 4 focused Common TypeInfo tests; 19 Nexus Workflow/handler tests; ESLint; Prettier; `ts-prune`; and `git diff --check`.

3. Any docs updates needed? No; documentation will accompany the completed experimental TypeInfo API.
