### PR TITLE
feat(nexus): apply TypeInfo in the standalone Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ to docs, or any other relevant information.
   `undefined` produces a failure without details.
 - **Experimental**: Nexus operation definitions can provide `TypeInfo` for Workflow callers and operation handlers.
   Workflow-backed asynchronous handlers must configure matching TypeInfo on the backing Workflow.
+- **Experimental**: Standalone Nexus Clients can use operation `TypeInfo`, including output conversion on detached
+  operation handles.
 - Core logs written directly to the console can now use compact, pretty, or newline-delimited JSON
   output via `telemetryOptions.logging.console.format`.
 - **Experimental**: Workflow Clients can now use `TypeInfo` to encode Workflow inputs and decode Workflow results.

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -315,12 +315,15 @@ export interface StartNexusOperationInput {
   readonly idConflictPolicy?: NexusOperationIdConflictPolicy;
   readonly searchAttributes?: SearchAttributePair[] | TypedSearchAttributes;
   readonly headers?: Record<string, string>;
+  readonly inputType?: TypeInfo;
+  readonly outputType?: TypeInfo;
 }
 
 /** Input for {@link NexusClientInterceptor.getResult}. */
 export interface GetNexusOperationResultInput {
   readonly operationId: string;
   readonly runId?: string;
+  readonly outputType?: TypeInfo;
 }
 
 /** Input for {@link NexusClientInterceptor.describe}. */

--- a/packages/client/src/nexus-client.ts
+++ b/packages/client/src/nexus-client.ts
@@ -24,7 +24,7 @@ import {
 import { filterNullAndUndefined } from '@temporalio/common/lib/internal-workflow';
 import { msOptionalToTs, optionalTsToDate, optionalTsToMs } from '@temporalio/common/lib/time';
 import { temporal } from '@temporalio/proto';
-import type { LoadedDataConverter } from '@temporalio/common';
+import type { LoadedDataConverter, TypeInfo } from '@temporalio/common';
 import type { SearchAttributeType, TypedSearchAttributeValue } from '@temporalio/common/lib/search-attributes';
 import { decode } from '@temporalio/common/lib/encoding';
 import type { BaseClientOptions, LoadedWithDefaults, WithDefaults } from './base-client';
@@ -241,9 +241,11 @@ export class NexusClient extends BaseClient {
       options: StartNexusOperationOptions
     ): Promise<NexusOperationHandle<OperationOutput<T, Op>>> => {
       let operationName: string;
+      let inputType: TypeInfo | undefined;
+      let outputType: TypeInfo | undefined;
       if (typeof operation === 'string') {
-        const op = service.operations[operation];
-        if (op == null) {
+        const definition = service.operations[operation];
+        if (definition == null) {
           // The OperationReference<T> type guarantees that if operation is
           // a string then it is a key of service.operations. This runtime
           // check is for extra safety.
@@ -251,9 +253,13 @@ export class NexusClient extends BaseClient {
             `Unable to resolve Nexus operation name from key ${operation} for service ${service.name}`
           );
         }
-        operationName = op.name;
+        operationName = definition.name;
+        inputType = definition.inputType;
+        outputType = definition.outputType;
       } else {
         operationName = operation.name;
+        inputType = operation.inputType;
+        outputType = operation.outputType;
       }
 
       const handle = await this.startNexusOperation({
@@ -270,10 +276,12 @@ export class NexusClient extends BaseClient {
         idConflictPolicy: options.idConflictPolicy,
         searchAttributes: options.searchAttributes,
         headers: options.headers,
+        inputType,
+        outputType,
       });
 
-      // The interceptor layer returns NexusOperationHandle<unknown>, so reapply
-      // the output type here to match the OperationDefinition contract.
+      // NexusClientInterceptor is not generic in the operation definition, so its handle result type is unknown.
+      // Rebind that result to the output type promised by this typed service-client call.
       return handle as NexusOperationHandle<OperationOutput<T, Op>>;
     };
 
@@ -310,6 +318,7 @@ export class NexusClient extends BaseClient {
     return this.createNexusOperationHandle({
       operationId,
       runId: options?.runId,
+      outputType: options?.typeInfo?.outputType,
     });
   }
 
@@ -373,7 +382,7 @@ export class NexusClient extends BaseClient {
   }
 
   protected async startNexusOperationHandler(input: StartNexusOperationInput): Promise<NexusOperationHandle> {
-    const inputPayload = await encodeToPayload(this.dataConverter, input.arg);
+    const inputPayload = await encodeToPayload(this.dataConverter, input.arg, undefined, input.inputType);
     const searchAttributes =
       input.searchAttributes != null
         ? { indexedFields: encodeUnifiedSearchAttributes(undefined, input.searchAttributes) }
@@ -416,10 +425,15 @@ export class NexusClient extends BaseClient {
     return this.createNexusOperationHandle({
       operationId: input.id,
       runId: res.runId ?? undefined,
+      outputType: input.outputType,
     });
   }
 
-  protected createNexusOperationHandle<O>(opts: { operationId: string; runId?: string }): NexusOperationHandle<O> {
+  protected createNexusOperationHandle<O>(opts: {
+    operationId: string;
+    runId?: string;
+    outputType?: TypeInfo;
+  }): NexusOperationHandle<O> {
     let cachedResult:
       | { state: 'not-requested' }
       | { state: 'success'; value: O }
@@ -434,6 +448,7 @@ export class NexusClient extends BaseClient {
             const result = (await this.client.getNexusOperationResult({
               operationId: this.operationId,
               runId: this.runId,
+              outputType: opts.outputType,
             })) as O;
             cachedResult = { state: 'success', value: result };
             return result;
@@ -492,7 +507,7 @@ export class NexusClient extends BaseClient {
 
       // The operation is closed if we have a result or failure
       if (res.result) {
-        return await decodeFromPayloadsAtIndex(this.dataConverter, 0, [res.result]);
+        return await decodeFromPayloadsAtIndex(this.dataConverter, 0, [res.result], undefined, input.outputType);
       }
       if (res.failure) {
         const cause = await decodeOptionalFailureToOptionalError(this.dataConverter, res.failure);

--- a/packages/client/src/nexus-types.ts
+++ b/packages/client/src/nexus-types.ts
@@ -1,4 +1,10 @@
-import type { Duration, SearchAttributePair, SearchAttributeType, TypedSearchAttributes } from '@temporalio/common';
+import type {
+  Duration,
+  PayloadTypeInfo,
+  SearchAttributePair,
+  SearchAttributeType,
+  TypedSearchAttributes,
+} from '@temporalio/common';
 import type { TypedSearchAttributeValue } from '@temporalio/common/lib/search-attributes';
 import { makeProtoEnumConverters } from '@temporalio/common/lib/internal-workflow';
 import type { temporal } from '@temporalio/proto';
@@ -450,6 +456,11 @@ export interface GetNexusOperationHandleOptions {
    * If provided, targets this specific run of the operation. If absent, targets the latest run.
    */
   runId?: string;
+
+  /**
+   * Type information for decoding the operation result.
+   */
+  typeInfo?: Pick<PayloadTypeInfo, 'outputType'>;
 }
 
 /**

--- a/packages/test/src/test-nexus-standalone.cloud-unavailable.ts
+++ b/packages/test/src/test-nexus-standalone.cloud-unavailable.ts
@@ -25,6 +25,14 @@ import { generateWorkflowRunOperationToken } from '@temporalio/nexus/lib/token';
 import type { Context } from './helpers-integration';
 import { helpers, makeTestFunction } from './helpers-integration';
 import { waitUntil } from './helpers';
+import {
+  assertOrder,
+  assertReceipt,
+  Order,
+  orderTypeInfo,
+  Receipt,
+  receiptTypeInfo,
+} from './workflows/type-info/models';
 
 const { EventType } = temporal.api.enums.v1;
 
@@ -64,6 +72,17 @@ const testService = nexus.service('testService', {
   blockingAsync: nexus.operation<{ echo: string; wfId?: string }, string>(),
 });
 
+const standaloneTypeInfoService = nexus.service('standaloneTypeInfoService', {
+  convert: nexus.operation<Order, Receipt>({
+    inputType: orderTypeInfo,
+    outputType: receiptTypeInfo,
+  }),
+});
+
+const standaloneTypeInfoServiceWithoutMetadata = nexus.service('standaloneTypeInfoService', {
+  convert: nexus.operation<Order, Receipt>(),
+});
+
 // Creates a test handler and a promise that can be used to wait until the workflow
 // started by blockingAsync has been started.
 function makeTestHandler() {
@@ -100,6 +119,15 @@ function makeTestHandler() {
       ),
     }),
   };
+}
+
+function makeStandaloneTypeInfoHandler() {
+  return nexus.serviceHandler(standaloneTypeInfoService, {
+    async convert(_ctx, input) {
+      assertOrder(input);
+      return new Receipt(input.id, input.totalCents + 1n);
+    },
+  });
 }
 
 function assertWorkflowCallbackLinksToNexusOperation(
@@ -148,6 +176,113 @@ test('start sync operation and get result', async (t) => {
     t.is(typeof handle.operationId, 'string');
     const result = await handle.result();
     t.is(result.value, 'hello');
+  });
+});
+
+test('TypeInfo hydrates standalone start input and retained handle result', async (t) => {
+  const { createWorker, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+  const worker = await createWorker({ nexusServices: [makeStandaloneTypeInfoHandler()] });
+
+  await worker.runUntil(async () => {
+    const service = t.context.env.client.nexus.createServiceClient({
+      endpoint: endpointName,
+      service: standaloneTypeInfoService,
+    });
+    const handle = await service.startOperation(
+      standaloneTypeInfoService.operations.convert,
+      new Order('order-1', 41n),
+      {
+        id: `type-info-start-${randomUUID()}`,
+        scheduleToCloseTimeout: '10s',
+      }
+    );
+    const result = await handle.result();
+    assertReceipt(result);
+    t.is(result.summary(), 'order-1:42');
+  });
+});
+
+test('Detached standalone Nexus handle hydrates result using output TypeInfo', async (t) => {
+  const { createWorker, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+  const worker = await createWorker({ nexusServices: [makeStandaloneTypeInfoHandler()] });
+
+  await worker.runUntil(async () => {
+    const client = t.context.env.client;
+    const service = client.nexus.createServiceClient({ endpoint: endpointName, service: standaloneTypeInfoService });
+    const id = `type-info-detached-${randomUUID()}`;
+    const handle = await service.startOperation(
+      standaloneTypeInfoService.operations.convert,
+      new Order('order-1', 41n),
+      { id, scheduleToCloseTimeout: '10s' }
+    );
+
+    const detached = client.nexus.getHandle<Receipt>(id, {
+      runId: handle.runId,
+      typeInfo: { outputType: receiptTypeInfo },
+    });
+    const result = await detached.result();
+    assertReceipt(result);
+    t.is(result.summary(), 'order-1:42');
+  });
+});
+
+test('String standalone Nexus execute hydrates input and result using service TypeInfo', async (t) => {
+  const { createWorker, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+  const worker = await createWorker({ nexusServices: [makeStandaloneTypeInfoHandler()] });
+
+  await worker.runUntil(async () => {
+    const service = t.context.env.client.nexus.createServiceClient({
+      endpoint: endpointName,
+      service: standaloneTypeInfoService,
+    });
+    const result = await service.executeOperation('convert', new Order('order-1', 7n), {
+      id: `type-info-execute-${randomUUID()}`,
+      scheduleToCloseTimeout: '10s',
+    });
+    assertReceipt(result);
+    t.is(result.summary(), 'order-1:8');
+  });
+});
+
+test('Standalone Nexus interceptors can supply operation TypeInfo', async (t) => {
+  const { createWorker, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+  const worker = await createWorker({ nexusServices: [makeStandaloneTypeInfoHandler()] });
+
+  await worker.runUntil(async () => {
+    let startInterceptorCalled = false;
+    let resultInterceptorCalled = false;
+    const interceptor: NexusClientInterceptor = {
+      async startOperation(input, next) {
+        startInterceptorCalled = true;
+        return await next({ ...input, inputType: orderTypeInfo, outputType: receiptTypeInfo });
+      },
+      async getResult(input, next) {
+        resultInterceptorCalled = true;
+        return await next(input);
+      },
+    };
+    const client = new Client({
+      connection: t.context.env.connection,
+      namespace: t.context.env.namespace,
+      interceptors: { nexus: [interceptor] },
+    });
+    const service = client.nexus.createServiceClient({
+      endpoint: endpointName,
+      service: standaloneTypeInfoServiceWithoutMetadata,
+    });
+
+    const result = await service.executeOperation('convert', new Order('order-1', 7n), {
+      id: `type-info-interceptor-${randomUUID()}`,
+      scheduleToCloseTimeout: '10s',
+    });
+    assertReceipt(result);
+    t.is(result.summary(), 'order-1:8');
+    t.true(startInterceptorCalled);
+    t.true(resultInterceptorCalled);
   });
 });
 


### PR DESCRIPTION
## What was changed

Applied operation TypeInfo in the standalone Nexus Client for definition and key references, interceptor-modified conversion, retained start handles, execute calls, and detached result handles.

This PR follows merged #2334 and is based directly on `main`. It inherits stable `nexus-rpc@^0.0.3` and contains no dependency or lockfile changes.

## Why?

Standalone operation inputs and results otherwise lose application runtime types, particularly when a handle is reconstructed after the original start call.

Calls without TypeInfo retain their existing behavior. No rollout or manual steps are required.

## Checklist

1. Closes: N/A

2. How was this tested: Frozen install against stable `nexus-rpc@0.0.3`; Client, Nexus, Test, and full-workspace builds; ESLint; Prettier; `ts-prune`; `git diff --check`; and all 17 standalone Nexus tests with the CI-pinned Temporal CLI.

3. Any docs updates needed? No; documentation will accompany the completed experimental TypeInfo API.
