### PR TITLE
ci: give Windows integration tests more time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
   # Run integration tests.
   # Uses the native binaries built in compile-native-binaries, but build `@temporalio/*` packages locally.
   integration-tests:
-    timeout-minutes: 30
+    timeout-minutes: ${{ matrix.platform == 'windows-x64' && 40 || 30 }}
     needs:
       - compile-native-binaries-debug
     strategy:


### PR DESCRIPTION
## What was changed

Raised the Windows integration-test job timeout from 30 to 40 minutes. Other platforms remain at 30 minutes.

## Why?

The Windows job is being cancelled at the timeout after its tests pass.

## Checklist

1. Closes: N/A

2. How was this tested: Prettier, `git diff --check`, and actionlint comparison against `main`.

3. Any docs updates needed? No.
