### PR TITLE
Add payload validation error factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ to docs, or any other relevant information.
 
 ### Added
 
+- `createPayloadValidationError` in `@temporalio/common` creates a non-retryable
+  `ApplicationFailure` with structured Payload validation violations.
 - Core logs written directly to the console can now use compact, pretty, or newline-delimited JSON
   output via `telemetryOptions.logging.console.format`.
 - **Experimental**: Workflow Clients can now use `TypeInfo` to encode Workflow inputs and decode Workflow results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ to docs, or any other relevant information.
 ### Added
 
 - `createPayloadValidationError` in `@temporalio/common` creates a non-retryable
-  `ApplicationFailure` with structured Payload validation violations.
+  `ApplicationFailure` with structured Payload validation details.
 - Core logs written directly to the console can now use compact, pretty, or newline-delimited JSON
   output via `telemetryOptions.logging.console.format`.
 - **Experimental**: Workflow Clients can now use `TypeInfo` to encode Workflow inputs and decode Workflow results.

--- a/packages/common/src/__tests__/test-failure.ts
+++ b/packages/common/src/__tests__/test-failure.ts
@@ -1,0 +1,25 @@
+import test from 'ava';
+import { ApplicationFailure, createPayloadValidationError, defaultFailureConverter, defaultPayloadConverter } from '..';
+
+test('createPayloadValidationError creates a serializable non-retryable ApplicationFailure', (t) => {
+  const options = {
+    violations: [
+      { path: 'user.age', reason: 'must be an int' },
+      { path: 'user.name', reason: 'must not be empty' },
+    ],
+  };
+
+  const error = createPayloadValidationError(options);
+
+  t.true(error instanceof ApplicationFailure);
+  t.is(error.message, 'Payload validation failed');
+  t.is(error.type, 'PayloadValidationError');
+  t.true(error.nonRetryable);
+  t.deepEqual(error.details, [options]);
+
+  const encoded = defaultFailureConverter.errorToFailure(error, defaultPayloadConverter);
+  const decoded = defaultFailureConverter.failureToError(encoded, defaultPayloadConverter);
+
+  t.true(decoded instanceof ApplicationFailure);
+  t.deepEqual((decoded as ApplicationFailure).details, [options]);
+});

--- a/packages/common/src/__tests__/test-failure.ts
+++ b/packages/common/src/__tests__/test-failure.ts
@@ -2,24 +2,24 @@ import test from 'ava';
 import { ApplicationFailure, createPayloadValidationError, defaultFailureConverter, defaultPayloadConverter } from '..';
 
 test('createPayloadValidationError creates a serializable non-retryable ApplicationFailure', (t) => {
-  const options = {
+  const details = {
     violations: [
       { path: 'user.age', reason: 'must be an int' },
       { path: 'user.name', reason: 'must not be empty' },
     ],
   };
 
-  const error = createPayloadValidationError(options);
+  const error = createPayloadValidationError(details);
 
   t.true(error instanceof ApplicationFailure);
   t.is(error.message, 'Payload validation failed');
   t.is(error.type, 'PayloadValidationError');
   t.true(error.nonRetryable);
-  t.deepEqual(error.details, [options]);
+  t.deepEqual(error.details, [details]);
 
   const encoded = defaultFailureConverter.errorToFailure(error, defaultPayloadConverter);
   const decoded = defaultFailureConverter.failureToError(encoded, defaultPayloadConverter);
 
   t.true(decoded instanceof ApplicationFailure);
-  t.deepEqual((decoded as ApplicationFailure).details, [options]);
+  t.deepEqual((decoded as ApplicationFailure).details, [details]);
 });

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -297,30 +297,18 @@ export interface ApplicationFailureOptions {
   category?: ApplicationFailureCategory;
 }
 
-/** Options for {@link createPayloadValidationError}. */
-export interface PayloadValidationErrorOptions {
-  /** Every validation violation found while converting a Payload. */
-  violations: ReadonlyArray<{
-    /** Path to the value that failed validation. */
-    path: string;
-
-    /** Human-readable reason that the value failed validation. */
-    reason: string;
-  }>;
-}
-
 /**
- * Create a non-retryable {@link ApplicationFailure} for reporting Payload validation violations.
+ * Create a non-retryable {@link ApplicationFailure} for reporting a Payload validation failure.
  *
  * Payload Converters and Payload Codecs can throw this failure when they understand a Payload but
- * reject it as invalid. The supplied options are stored as a single failure detail.
+ * reject it as invalid. The supplied value is stored as a single failure detail.
  */
-export function createPayloadValidationError(options: PayloadValidationErrorOptions): ApplicationFailure {
+export function createPayloadValidationError(details: unknown): ApplicationFailure {
   return ApplicationFailure.create({
     message: 'Payload validation failed',
     type: 'PayloadValidationError',
     nonRetryable: true,
-    details: [options],
+    details: [details],
   });
 }
 

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -297,6 +297,33 @@ export interface ApplicationFailureOptions {
   category?: ApplicationFailureCategory;
 }
 
+/** Options for {@link createPayloadValidationError}. */
+export interface PayloadValidationErrorOptions {
+  /** Every validation violation found while converting a Payload. */
+  violations: ReadonlyArray<{
+    /** Path to the value that failed validation. */
+    path: string;
+
+    /** Human-readable reason that the value failed validation. */
+    reason: string;
+  }>;
+}
+
+/**
+ * Create a non-retryable {@link ApplicationFailure} for reporting Payload validation violations.
+ *
+ * Payload Converters and Payload Codecs can throw this failure when they understand a Payload but
+ * reject it as invalid. The supplied options are stored as a single failure detail.
+ */
+export function createPayloadValidationError(options: PayloadValidationErrorOptions): ApplicationFailure {
+  return ApplicationFailure.create({
+    message: 'Payload validation failed',
+    type: 'PayloadValidationError',
+    nonRetryable: true,
+    details: [options],
+  });
+}
+
 /**
  * This error is thrown when Cancellation has been requested. To allow Cancellation to happen, let it propagate. To
  * ignore Cancellation, catch it and continue executing. Note that Cancellation can only be requested a single time, so

--- a/packages/test/src/payload-validation-failing-payload-converter.ts
+++ b/packages/test/src/payload-validation-failing-payload-converter.ts
@@ -1,5 +1,5 @@
 import type { Payload } from '@temporalio/common';
-import { ApplicationFailure, defaultPayloadConverter } from '@temporalio/common';
+import { createPayloadValidationError, defaultPayloadConverter } from '@temporalio/common';
 import type { PayloadConverter } from '@temporalio/common/lib/converter/payload-converter';
 
 export const payloadConverter: PayloadConverter = {
@@ -7,11 +7,8 @@ export const payloadConverter: PayloadConverter = {
     return defaultPayloadConverter.toPayload(value);
   },
   fromPayload<T>(_payload: Payload): T {
-    // The reserved type a converter uses to report that it understood the payload but rejects it.
-    throw ApplicationFailure.create({
-      message: 'Intentional payload validation failure for testing',
-      type: 'PayloadValidationError',
-      nonRetryable: true,
+    throw createPayloadValidationError({
+      violations: [{ path: 'input', reason: 'intentional payload validation failure for testing' }],
     });
   },
 };

--- a/packages/test/src/test-nexus-codec-converter-errors.cloud-unavailable.ts
+++ b/packages/test/src/test-nexus-codec-converter-errors.cloud-unavailable.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
 import * as nexus from 'nexus-rpc';
 import type { Payload } from '@temporalio/common';
-import { ApplicationFailure, NexusOperationFailure } from '@temporalio/common';
+import { ApplicationFailure, createPayloadValidationError, NexusOperationFailure } from '@temporalio/common';
 import { Client, WorkflowFailedError } from '@temporalio/client';
 import type { PayloadCodec } from '@temporalio/common/lib/converter/payload-codec';
 import * as workflow from '@temporalio/workflow';
@@ -235,11 +235,8 @@ test('Nexus operation codec PayloadValidationError is a non-retryable bad reques
       for (const payload of payloads) {
         if (payload.data != null && Buffer.from(payload.data).toString() === '"hello"') {
           decodeAttempts++;
-          // The reserved type a codec uses to report that it understood the payload but rejects it.
-          throw ApplicationFailure.create({
-            message: 'Intentional payload validation failure for testing',
-            type: 'PayloadValidationError',
-            nonRetryable: true,
+          throw createPayloadValidationError({
+            violations: [{ path: 'input', reason: 'intentional payload validation failure for testing' }],
           });
         }
       }
@@ -288,7 +285,7 @@ test('Nexus operation codec PayloadValidationError is a non-retryable bad reques
     t.true(handlerError.cause instanceof ApplicationFailure);
     const cause = handlerError.cause as ApplicationFailure;
     t.is(cause.type, 'PayloadValidationError');
-    t.regex(cause.message, /Intentional payload validation failure for testing/);
+    t.is(cause.message, 'Payload validation failed');
   });
 
   // Non-retryable, so the input is only decoded once.
@@ -336,6 +333,6 @@ test('Nexus operation converter PayloadValidationError is a non-retryable bad re
     t.true(handlerError.cause instanceof ApplicationFailure);
     const cause = handlerError.cause as ApplicationFailure;
     t.is(cause.type, 'PayloadValidationError');
-    t.regex(cause.message, /Intentional payload validation failure for testing/);
+    t.is(cause.message, 'Payload validation failed');
   });
 });

--- a/packages/test/src/test-nexus-handler.ts
+++ b/packages/test/src/test-nexus-handler.ts
@@ -13,6 +13,7 @@ import type { LoadedDataConverter, Payload, ProtoFailure } from '@temporalio/com
 import {
   ApplicationFailure,
   CancelledFailure,
+  createPayloadValidationError,
   defaultFailureConverter,
   defaultPayloadConverter,
   defaultDataConverter,
@@ -438,10 +439,8 @@ function codecFailingWith(err: unknown): LoadedDataConverter {
 }
 
 test('decodePayload maps non-retryable PayloadValidationError from converter to a bad request handler error', async (t) => {
-  const cause = ApplicationFailure.create({
-    message: 'input payload is invalid',
-    type: PAYLOAD_VALIDATION_ERROR_TYPE,
-    nonRetryable: true,
+  const cause = createPayloadValidationError({
+    violations: [{ path: 'input', reason: 'is invalid' }],
   });
 
   const err = await t.throwsAsync(() => decodePayload(converterFailingWith(cause), encodedInputPayload), {
@@ -455,14 +454,12 @@ test('decodePayload maps non-retryable PayloadValidationError from converter to 
   t.is(err?.cause, cause);
   t.is((err?.cause as ApplicationFailure).type, PAYLOAD_VALIDATION_ERROR_TYPE);
   t.true((err?.cause as ApplicationFailure).nonRetryable);
-  t.is((err?.cause as ApplicationFailure).message, 'input payload is invalid');
+  t.is((err?.cause as ApplicationFailure).message, 'Payload validation failed');
 });
 
 test('decodePayload maps non-retryable PayloadValidationError from codec to a bad request handler error', async (t) => {
-  const cause = ApplicationFailure.create({
-    message: 'input payload is invalid',
-    type: PAYLOAD_VALIDATION_ERROR_TYPE,
-    nonRetryable: true,
+  const cause = createPayloadValidationError({
+    violations: [{ path: 'input', reason: 'is invalid' }],
   });
 
   const err = await t.throwsAsync(() => decodePayload(codecFailingWith(cause), encodedInputPayload), {
@@ -476,7 +473,7 @@ test('decodePayload maps non-retryable PayloadValidationError from codec to a ba
   t.is(err?.cause, cause);
   t.is((err?.cause as ApplicationFailure).type, PAYLOAD_VALIDATION_ERROR_TYPE);
   t.true((err?.cause as ApplicationFailure).nonRetryable);
-  t.is((err?.cause as ApplicationFailure).message, 'input payload is invalid');
+  t.is((err?.cause as ApplicationFailure).message, 'Payload validation failed');
 });
 
 test('decodePayload leaves non-retryable ApplicationFailure of another type as an internal handler error', async (t) => {


### PR DESCRIPTION
## Summary

- add createPayloadValidationError to @temporalio/common using the separate factory API
- create a non-retryable PayloadValidationError ApplicationFailure with structured violations
- replace positive Nexus test constructions with the public factory while retaining retryable compatibility coverage

## Testing

- Prettier and ESLint
- @temporalio/common build and 43 tests
- worker and test package TypeScript builds
- 20 focused Nexus handler tests