### PR TITLE
chore(otel): minor speedup of otel test

### DIFF
--- a/contrib/interceptors-opentelemetry-v2/src/__tests__/test-otel.ts
+++ b/contrib/interceptors-opentelemetry-v2/src/__tests__/test-otel.ts
@@ -199,11 +199,17 @@ if (RUN_INTEGRATION_TESTS) {
       const client = new Client({
         plugins: [plugin],
       });
+      const workflowType = workflows.interceptorTest.name;
       await worker.runUntil(
-        client.workflow.execute(workflows.smorgasbord, { taskQueue: 'test-otel-v2', workflowId: uuid4() })
+        client.workflow.execute(workflows.interceptorTest, {
+          taskQueue: 'test-otel-v2',
+          workflowId: uuid4(),
+        })
       );
       await otel.shutdown();
-      const originalSpan = spans.find(({ name }) => name === `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}smorgasbord`);
+      const originalSpan = spans.find(
+        ({ name }) => name === `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}${workflowType}`
+      );
       t.true(originalSpan !== undefined);
       t.log(
         spans.map((span) => ({
@@ -215,7 +221,7 @@ if (RUN_INTEGRATION_TESTS) {
 
       const firstExecuteSpan = spans.find(
         ({ name, parentSpanContext }) =>
-          name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}smorgasbord` &&
+          name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}${workflowType}` &&
           parentSpanContext?.spanId === originalSpan?.spanContext().spanId
       );
       t.true(firstExecuteSpan !== undefined);
@@ -223,7 +229,7 @@ if (RUN_INTEGRATION_TESTS) {
 
       const continueAsNewSpan = spans.find(
         ({ name, parentSpanContext }) =>
-          name === `${SpanName.CONTINUE_AS_NEW}${SPAN_DELIMITER}smorgasbord` &&
+          name === `${SpanName.CONTINUE_AS_NEW}${SPAN_DELIMITER}${workflowType}` &&
           parentSpanContext?.spanId === firstExecuteSpan?.spanContext().spanId
       );
       t.true(continueAsNewSpan !== undefined);
@@ -231,7 +237,7 @@ if (RUN_INTEGRATION_TESTS) {
 
       const parentExecuteSpan = spans.find(
         ({ name, parentSpanContext }) =>
-          name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}smorgasbord` &&
+          name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}${workflowType}` &&
           parentSpanContext?.spanId === continueAsNewSpan?.spanContext().spanId
       );
       t.true(parentExecuteSpan !== undefined);
@@ -810,19 +816,23 @@ if (RUN_INTEGRATION_TESTS) {
       const client = new Client({
         plugins: [plugin],
       });
+      const workflowType = workflows.interceptorTest.name;
       await worker.runUntil(
-        client.workflow.execute(workflows.smorgasbord, { taskQueue: 'test-otel-v2-prebundled', workflowId: uuid4() })
+        client.workflow.execute(workflows.interceptorTest, {
+          taskQueue: 'test-otel-v2-prebundled',
+          workflowId: uuid4(),
+        })
       );
       await provider.shutdown();
 
       // Verify that workflow spans were created
       const workflowStartSpan = spans.find(
-        ({ name }) => name === `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}smorgasbord`
+        ({ name }) => name === `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}${workflowType}`
       );
       t.true(workflowStartSpan !== undefined, 'WORKFLOW_START span should exist');
 
       const workflowExecuteSpan = spans.find(
-        ({ name }) => name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}smorgasbord`
+        ({ name }) => name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}${workflowType}`
       );
       t.true(workflowExecuteSpan !== undefined, 'WORKFLOW_EXECUTE span should exist');
 

--- a/contrib/interceptors-opentelemetry-v2/src/__tests__/workflows/index.ts
+++ b/contrib/interceptors-opentelemetry-v2/src/__tests__/workflows/index.ts
@@ -3,6 +3,7 @@ export * from './definitions';
 export * from './nexus-caller-otel';
 export * from './signal-target';
 export * from './smorgasbord';
+export * from './interceptor-test';
 export * from './success-string';
 export * from './throw-maybe-benign';
 export * from './update-start-otel';

--- a/contrib/interceptors-opentelemetry-v2/src/__tests__/workflows/interceptor-test.ts
+++ b/contrib/interceptors-opentelemetry-v2/src/__tests__/workflows/interceptor-test.ts
@@ -1,0 +1,33 @@
+import { condition, continueAsNew, defineQuery, proxyActivities, proxyLocalActivities, setHandler, startChild } from '@temporalio/workflow';
+
+import type * as activities from '../activities';
+import { activityStartedSignal, unblockSignal } from './definitions';
+import { signalTarget } from './signal-target';
+
+const { fakeProgress, queryOwnWf } = proxyActivities<typeof activities>({ startToCloseTimeout: '1m' });
+const { echo } = proxyLocalActivities<typeof activities>({ startToCloseTimeout: '1m' });
+
+const stepQuery = defineQuery<number>('step');
+
+export async function interceptorTest(iteration = 0): Promise<void> {
+  let activityStarted = false;
+  setHandler(stepQuery, () => iteration);
+  setHandler(activityStartedSignal, () => void (activityStarted = true));
+
+  const child = (async () => {
+    const handle = await startChild(signalTarget);
+    await handle.signal(unblockSignal);
+    await handle.result();
+  })();
+  await Promise.all([
+    fakeProgress(100, 0),
+    queryOwnWf(stepQuery),
+    child,
+    echo('local-activity'),
+    condition(() => activityStarted),
+  ]);
+
+  if (iteration === 0) {
+    await continueAsNew<typeof interceptorTest>(iteration + 1);
+  }
+}

--- a/contrib/interceptors-opentelemetry-v2/src/__tests__/workflows/interceptor-test.ts
+++ b/contrib/interceptors-opentelemetry-v2/src/__tests__/workflows/interceptor-test.ts
@@ -1,4 +1,12 @@
-import { condition, continueAsNew, defineQuery, proxyActivities, proxyLocalActivities, setHandler, startChild } from '@temporalio/workflow';
+import {
+  condition,
+  continueAsNew,
+  defineQuery,
+  proxyActivities,
+  proxyLocalActivities,
+  setHandler,
+  startChild,
+} from '@temporalio/workflow';
 
 import type * as activities from '../activities';
 import { activityStartedSignal, unblockSignal } from './definitions';

--- a/contrib/interceptors-opentelemetry/src/__tests__/test-otel.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/test-otel.ts
@@ -177,11 +177,15 @@ if (RUN_INTEGRATION_TESTS) {
       const client = new Client({
         plugins: [plugin],
       });
+      const workflowType = workflows.interceptorTest.name;
       await worker.runUntil(
-        client.workflow.execute(workflows.smorgasbord, { taskQueue: 'test-otel', workflowId: randomUUID() })
+        client.workflow.execute(workflows.interceptorTest, {
+          taskQueue: 'test-otel',
+          workflowId: randomUUID(),
+        })
       );
       await otel.shutdown();
-      const originalSpan = spans.find(({ name }) => name === `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}smorgasbord`);
+      const originalSpan = spans.find(({ name }) => name === `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}${workflowType}`);
       t.true(originalSpan !== undefined);
       t.log(
         spans.map((span) => ({ name: span.name, parentSpanId: span.parentSpanId, spanId: span.spanContext().spanId }))
@@ -189,7 +193,7 @@ if (RUN_INTEGRATION_TESTS) {
 
       const firstExecuteSpan = spans.find(
         ({ name, parentSpanId }) =>
-          name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}smorgasbord` &&
+          name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}${workflowType}` &&
           parentSpanId === originalSpan?.spanContext().spanId
       );
       t.true(firstExecuteSpan !== undefined);
@@ -197,7 +201,7 @@ if (RUN_INTEGRATION_TESTS) {
 
       const continueAsNewSpan = spans.find(
         ({ name, parentSpanId }) =>
-          name === `${SpanName.CONTINUE_AS_NEW}${SPAN_DELIMITER}smorgasbord` &&
+          name === `${SpanName.CONTINUE_AS_NEW}${SPAN_DELIMITER}${workflowType}` &&
           parentSpanId === firstExecuteSpan?.spanContext().spanId
       );
       t.true(continueAsNewSpan !== undefined);
@@ -205,7 +209,7 @@ if (RUN_INTEGRATION_TESTS) {
 
       const parentExecuteSpan = spans.find(
         ({ name, parentSpanId }) =>
-          name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}smorgasbord` &&
+          name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}${workflowType}` &&
           parentSpanId === continueAsNewSpan?.spanContext().spanId
       );
       t.true(parentExecuteSpan !== undefined);
@@ -810,19 +814,23 @@ if (RUN_INTEGRATION_TESTS) {
       const client = new Client({
         plugins: [plugin],
       });
+      const workflowType = workflows.interceptorTest.name;
       await worker.runUntil(
-        client.workflow.execute(workflows.smorgasbord, { taskQueue: 'test-otel-prebundled', workflowId: randomUUID() })
+        client.workflow.execute(workflows.interceptorTest, {
+          taskQueue: 'test-otel-prebundled',
+          workflowId: randomUUID(),
+        })
       );
       await provider.shutdown();
 
       // Verify that workflow spans were created
       const workflowStartSpan = spans.find(
-        ({ name }) => name === `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}smorgasbord`
+        ({ name }) => name === `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}${workflowType}`
       );
       t.true(workflowStartSpan !== undefined, 'WORKFLOW_START span should exist');
 
       const workflowExecuteSpan = spans.find(
-        ({ name }) => name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}smorgasbord`
+        ({ name }) => name === `${SpanName.WORKFLOW_EXECUTE}${SPAN_DELIMITER}${workflowType}`
       );
       t.true(workflowExecuteSpan !== undefined, 'WORKFLOW_EXECUTE span should exist');
 

--- a/contrib/interceptors-opentelemetry/src/__tests__/test-otel.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/test-otel.ts
@@ -185,7 +185,9 @@ if (RUN_INTEGRATION_TESTS) {
         })
       );
       await otel.shutdown();
-      const originalSpan = spans.find(({ name }) => name === `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}${workflowType}`);
+      const originalSpan = spans.find(
+        ({ name }) => name === `${SpanName.WORKFLOW_START}${SPAN_DELIMITER}${workflowType}`
+      );
       t.true(originalSpan !== undefined);
       t.log(
         spans.map((span) => ({ name: span.name, parentSpanId: span.parentSpanId, spanId: span.spanContext().spanId }))

--- a/contrib/interceptors-opentelemetry/src/__tests__/workflows/index.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/workflows/index.ts
@@ -4,6 +4,7 @@ export * from './metric-trace-tags';
 export * from './nexus-caller-otel';
 export * from './signal-target';
 export * from './smorgasbord';
+export * from './interceptor-test';
 export * from './success-string';
 export * from './throw-maybe-benign';
 export * from './update-start-otel';

--- a/contrib/interceptors-opentelemetry/src/__tests__/workflows/interceptor-test.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/workflows/interceptor-test.ts
@@ -1,0 +1,33 @@
+import { condition, continueAsNew, defineQuery, proxyActivities, proxyLocalActivities, setHandler, startChild } from '@temporalio/workflow';
+
+import type * as activities from '../activities';
+import { activityStartedSignal, unblockSignal } from './definitions';
+import { signalTarget } from './signal-target';
+
+const { fakeProgress, queryOwnWf } = proxyActivities<typeof activities>({ startToCloseTimeout: '1m' });
+const { echo } = proxyLocalActivities<typeof activities>({ startToCloseTimeout: '1m' });
+
+const stepQuery = defineQuery<number>('step');
+
+export async function interceptorTest(iteration = 0): Promise<void> {
+  let activityStarted = false;
+  setHandler(stepQuery, () => iteration);
+  setHandler(activityStartedSignal, () => void (activityStarted = true));
+
+  const child = (async () => {
+    const handle = await startChild(signalTarget);
+    await handle.signal(unblockSignal);
+    await handle.result();
+  })();
+  await Promise.all([
+    fakeProgress(100, 0),
+    queryOwnWf(stepQuery),
+    child,
+    echo('local-activity'),
+    condition(() => activityStarted),
+  ]);
+
+  if (iteration === 0) {
+    await continueAsNew<typeof interceptorTest>(iteration + 1);
+  }
+}

--- a/contrib/interceptors-opentelemetry/src/__tests__/workflows/interceptor-test.ts
+++ b/contrib/interceptors-opentelemetry/src/__tests__/workflows/interceptor-test.ts
@@ -1,4 +1,12 @@
-import { condition, continueAsNew, defineQuery, proxyActivities, proxyLocalActivities, setHandler, startChild } from '@temporalio/workflow';
+import {
+  condition,
+  continueAsNew,
+  defineQuery,
+  proxyActivities,
+  proxyLocalActivities,
+  setHandler,
+  startChild,
+} from '@temporalio/workflow';
 
 import type * as activities from '../activities';
 import { activityStartedSignal, unblockSignal } from './definitions';


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Basically all this PR did is move some of the OTel tests to not use the base smorgasbord workflow when not replaying as it isn't necessarily a fast one. We really just need to verify spans get emitted for these various commands so all we need is a workflow that generates them.

## Why?
Our CI has gotten crazy long now. Doing my part to shave some time off.

Local results:
```
Before
  Time (mean ± σ):     14.537 s ±  0.526 s    [User: 12.127 s, System: 2.546 s]
  Range (min … max):   14.127 s … 15.890 s    10 runs

After
  Time (mean ± σ):     10.726 s ±  0.514 s    [User: 11.937 s, System: 2.625 s]
  Range (min … max):   10.269 s … 11.698 s    10 runs
```

Sadly doesn't correspond to a larger win in CI, but you gotta start somewhere.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
