### PR TITLE
fix(google-adk-agents): surface the model failures ADK absorbs

### DIFF
--- a/contrib/google-adk-agents/README.md
+++ b/contrib/google-adk-agents/README.md
@@ -115,6 +115,12 @@ const agent = new LlmAgent({
 });
 ```
 
+A model failure is non-retryable unless its status says a retry could succeed,
+so a bad request fails the Workflow on the first attempt no matter the retry
+policy. To opt out, handle the error in an ADK `onModelErrorCallback`, pass
+that same error to `markModelFailureHandled`, and return a substitute event
+built with ADK's `createEvent`.
+
 ### MCP tools
 
 Use `TemporalMCPToolset` in Workflow code and register the matching MCP factory

--- a/contrib/google-adk-agents/src/__tests__/absorbed-failure.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/absorbed-failure.test.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Terminal-outcome tests for model failures that `@google/adk` absorbs. Because the
  * absorbed failure lets the run finish normally, every case here asserts the
  * *execution's* status, not just what the Workflow returned: a failed model call must

--- a/contrib/google-adk-agents/src/__tests__/absorbed-failure.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/absorbed-failure.test.ts
@@ -1,0 +1,342 @@
+/**
+ * @license
+ * Copyright 2025 Temporal Technologies Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * Terminal-outcome tests for model failures that `@google/adk` absorbs. Because the
+ * absorbed failure lets the run finish normally, every case here asserts the
+ * *execution's* status, not just what the Workflow returned: a failed model call must
+ * FAIL the execution, a cancel must end it CANCELLED, and a failure the caller
+ * handled must leave it COMPLETED.
+ */
+
+import test from 'ava';
+
+import { ApplicationFailure, TimeoutFailure } from '@temporalio/common';
+
+import { GoogleAdkPlugin } from '../index';
+import {
+  countScheduledActivities,
+  defaultTestProvider,
+  findInCauseChain,
+  setupTestEnv,
+  uid,
+  waitForScheduledActivities,
+  withWorker,
+} from './helpers';
+import {
+  adkAwaitSignal,
+  adkChatUpdate,
+  adkContinueUpdate,
+  adkDoneSignal,
+  adkRecoverSignal,
+  adkStartSignal,
+  agentRunnerAwaitedSignalTurn,
+  agentRunnerContinueAsNew,
+  agentRunnerContinueAsNewFromUpdate,
+  agentRunnerFailThenSlowModel,
+  agentRunnerFailureAfterTimeoutScope,
+  agentRunnerFailureThenRecoveringSignal,
+  agentRunnerFailureWithCompensation,
+  agentRunnerOneTurn,
+  agentRunnerRecoversFromCancelledModel,
+  agentRunnerRecoversFromModelError,
+  agentRunnerRecoversOnlyTheSecondFailure,
+  agentRunnerThrowingSummary,
+  agentRunnerTurnUnderTimeoutScope,
+  agentRunnerUnawaitedSignalTurn,
+  agentRunnerUpdateDriven,
+  caughtModelCallError,
+} from './workflows';
+
+const getEnv = setupTestEnv(test);
+
+function adkPlugin(): GoogleAdkPlugin {
+  return new GoogleAdkPlugin({ modelProvider: defaultTestProvider() });
+}
+
+test.serial('modelFailureThroughTheRunnerFailsTheWorkflow', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-fail');
+  const workflowId = uid('wf-agent-fail');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const handle = await env.client.workflow.start(agentRunnerOneTurn, {
+      taskQueue,
+      workflowId,
+      args: ['boom', 'explode'],
+    });
+    const caught = await t.throwsAsync(handle.result());
+    const appFailure = findInCauseChain(caught, ApplicationFailure);
+    t.is(appFailure?.type, 'GoogleAdkModelError.400');
+    t.is((await handle.describe()).status.name, 'FAILED');
+  });
+});
+
+test.serial('cancellingARunnerDrivenAgentEndsCancelled', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-cancel');
+  const workflowId = uid('wf-agent-cancel');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const handle = await env.client.workflow.start(agentRunnerOneTurn, {
+      taskQueue,
+      workflowId,
+      args: ['slow-model', 'wait'],
+    });
+    // Cancel only once the model Activity is scheduled, so it rejects with an
+    // `ActivityFailure` carrying a `CancelledFailure` cause.
+    await waitForScheduledActivities(env, workflowId, 'adk-invokeModel');
+    await handle.cancel();
+    await t.throwsAsync(handle.result());
+    t.is((await handle.describe()).status.name, 'CANCELLED');
+  });
+});
+
+test.serial('cancellingAfterAnAbsorbedFailureStillEndsCancelled', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-fail-cancel');
+  const workflowId = uid('wf-agent-fail-cancel');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const handle = await env.client.workflow.start(agentRunnerFailThenSlowModel, {
+      taskQueue,
+      workflowId,
+      args: ['go'],
+    });
+    // Two scheduled model Activities means the failing turn is behind us, so the
+    // cancellation arrives with a failure already absorbed.
+    await waitForScheduledActivities(env, workflowId, 'adk-invokeModel', 2);
+    await handle.cancel();
+    await t.throwsAsync(handle.result());
+    t.is((await handle.describe()).status.name, 'CANCELLED');
+  });
+});
+
+test.serial('onModelErrorRecoveryLeavesTheWorkflowCompleted', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-recover');
+  const workflowId = uid('wf-agent-recover');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const result = await env.client.workflow.execute(agentRunnerRecoversFromModelError, {
+      taskQueue,
+      workflowId,
+      args: ['explode'],
+    });
+    t.is(result, 'recovered');
+    t.is((await env.client.workflow.getHandle(workflowId).describe()).status.name, 'COMPLETED');
+  });
+});
+
+test.serial('onModelErrorRecoveryLeavesAnEarlierFailureStanding', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-recover-second');
+  const workflowId = uid('wf-agent-recover-second');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const handle = await env.client.workflow.start(agentRunnerRecoversOnlyTheSecondFailure, {
+      taskQueue,
+      workflowId,
+      args: ['explode'],
+    });
+    const caught = await t.throwsAsync(handle.result());
+    t.is(findInCauseChain(caught, ApplicationFailure)?.type, 'GoogleAdkModelError.400');
+    t.is((await handle.describe()).status.name, 'FAILED');
+  });
+});
+
+test.serial('cancellingARunnerWhoseCallbackRecoversStillEndsCancelled', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-cancel-recover');
+  const workflowId = uid('wf-agent-cancel-recover');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const handle = await env.client.workflow.start(agentRunnerRecoversFromCancelledModel, {
+      taskQueue,
+      workflowId,
+      args: ['wait'],
+    });
+    // The cancel reaches `onModelErrorCallback` as any other model failure does, and that
+    // callback recovers from it — but a cancelled execution is not the caller's to absorb.
+    await waitForScheduledActivities(env, workflowId, 'adk-invokeModel');
+    await handle.cancel();
+    await t.throwsAsync(handle.result());
+    t.is((await handle.describe()).status.name, 'CANCELLED');
+  });
+});
+
+test.serial('throwingSummaryCallbackFailsTheWorkflow', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-summary');
+  const workflowId = uid('wf-agent-summary');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const handle = await env.client.workflow.start(agentRunnerThrowingSummary, {
+      taskQueue,
+      workflowId,
+      args: ['hi'],
+    });
+    const caught = await t.throwsAsync(handle.result());
+    t.is(findInCauseChain(caught, ApplicationFailure)?.type, 'TestSummaryFailure');
+    t.is((await handle.describe()).status.name, 'FAILED');
+  });
+});
+
+test.serial('handledDirectModelFailureLeavesTheWorkflowCompleted', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-direct-caught');
+  const workflowId = uid('wf-direct-caught');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const result = await env.client.workflow.execute(caughtModelCallError, { taskQueue, workflowId });
+    t.is(result, 'GoogleAdkModelError.400');
+    t.is((await env.client.workflow.getHandle(workflowId).describe()).status.name, 'COMPLETED');
+  });
+});
+
+test.serial('aTimeoutScopeAroundAnAgentTurnLeavesTheWorkflowCompleted', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-timeout-uncaught');
+  const workflowId = uid('wf-agent-timeout-uncaught');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const result = await env.client.workflow.execute(agentRunnerTurnUnderTimeoutScope, {
+      taskQueue,
+      workflowId,
+      args: ['wait'],
+    });
+    t.is(result, 'timed out');
+    t.is((await env.client.workflow.getHandle(workflowId).describe()).status.name, 'COMPLETED');
+  });
+});
+
+test.serial('modelFailureAfterATimeoutScopedTurnFailsTheWorkflow', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-fail-after-scope');
+  const workflowId = uid('wf-agent-fail-after-scope');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const handle = await env.client.workflow.start(agentRunnerFailureAfterTimeoutScope, {
+      taskQueue,
+      workflowId,
+      args: ['wait'],
+    });
+    const caught = await t.throwsAsync(handle.result());
+    t.is(findInCauseChain(caught, ApplicationFailure)?.type, 'GoogleAdkModelError.400');
+    t.is((await handle.describe()).status.name, 'FAILED');
+  });
+});
+
+test.serial('modelFailureInAnUpdateRejectsThatUpdateOnly', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-update');
+  const workflowId = uid('wf-agent-update');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const handle = await env.client.workflow.start(agentRunnerUpdateDriven, { taskQueue, workflowId });
+
+    const caught = await t.throwsAsync(handle.executeUpdate(adkChatUpdate, { args: ['boom'] }));
+    t.is(findInCauseChain(caught, ApplicationFailure)?.type, 'GoogleAdkModelError.400');
+
+    // The rejected Update's frame consumed its own failure: it leaked into neither the
+    // next Update's frame nor the main function's frame.
+    t.is(await handle.executeUpdate(adkChatUpdate, { args: ['fake-model'] }), 'fake-response:fake-model');
+    await handle.signal(adkDoneSignal);
+    await handle.result();
+    t.is((await handle.describe()).status.name, 'COMPLETED');
+  });
+});
+
+test.serial('modelFailureBeforeContinueAsNewFailsTheWorkflow', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-can');
+  const workflowId = uid('wf-agent-can');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    // The next run would use a model that answers, so a Workflow that continues as new
+    // here would otherwise reach a green terminal state despite the failed turn.
+    const handle = await env.client.workflow.start(agentRunnerContinueAsNew, {
+      taskQueue,
+      workflowId,
+      args: ['boom', 'fake-model'],
+    });
+    const caught = await t.throwsAsync(handle.result());
+    t.is(findInCauseChain(caught, ApplicationFailure)?.type, 'GoogleAdkModelError.400');
+    t.is((await handle.describe()).status.name, 'FAILED');
+  });
+});
+
+test.serial('modelFailureRecoveredInASignalLeavesTheMainFunctionsStanding', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-signal-recover');
+  const workflowId = uid('wf-agent-signal-recover');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const handle = await env.client.workflow.start(agentRunnerFailureThenRecoveringSignal, {
+      taskQueue,
+      workflowId,
+    });
+    // Two scheduled model Activities means the main function's failing turn is behind us,
+    // so the Signal's own turn is what the recovery in it applies to.
+    await waitForScheduledActivities(env, workflowId, 'adk-invokeModel', 2);
+    await handle.signal(adkRecoverSignal);
+    const caught = await t.throwsAsync(handle.result());
+    // A timeout is the main function's own failure; the turn its Signal recovered was a 400.
+    t.truthy(findInCauseChain(caught, TimeoutFailure));
+    t.is((await handle.describe()).status.name, 'FAILED');
+  });
+});
+
+test.serial('modelFailureInAnAwaitedSignalTurnFailsTheWorkflow', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-signal-awaited');
+  const workflowId = uid('wf-agent-signal-awaited');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const handle = await env.client.workflow.start(agentRunnerAwaitedSignalTurn, { taskQueue, workflowId });
+    await handle.signal(adkAwaitSignal);
+    const caught = await t.throwsAsync(handle.result());
+    t.is(findInCauseChain(caught, ApplicationFailure)?.type, 'GoogleAdkModelError.400');
+    t.is((await handle.describe()).status.name, 'FAILED');
+  });
+});
+
+test.serial('modelFailureFromAnUnawaitedSignalTurnFailsTheWorkflow', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-signal-unawaited');
+  const workflowId = uid('wf-agent-signal-unawaited');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const handle = await env.client.workflow.start(agentRunnerUnawaitedSignalTurn, { taskQueue, workflowId });
+    await handle.signal(adkStartSignal);
+    const caught = await t.throwsAsync(handle.result());
+    t.is(findInCauseChain(caught, ApplicationFailure)?.type, 'GoogleAdkModelError.400');
+    t.is((await handle.describe()).status.name, 'FAILED');
+  });
+});
+
+test.serial('anUnrelatedSignalLeavesTheMainFunctionToCompensate', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-signal-compensate');
+  const workflowId = uid('wf-agent-signal-compensate');
+  const activities = { compensate: async () => undefined };
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()], activities }, async () => {
+    const handle = await env.client.workflow.start(agentRunnerFailureWithCompensation, { taskQueue, workflowId });
+    await waitForScheduledActivities(env, workflowId, 'adk-invokeModel', 2);
+    await handle.signal(adkDoneSignal);
+    const caught = await t.throwsAsync(handle.result());
+    t.is(findInCauseChain(caught, ApplicationFailure)?.type, 'GoogleAdkModelError.400');
+    t.is((await handle.describe()).status.name, 'FAILED');
+    // The Signal absorbed nothing, so the failure stayed in the main function's frame and
+    // that function reached its `finally` before the execution failed.
+    const { events } = await handle.fetchHistory();
+    t.is(countScheduledActivities(events ?? [], 'compensate'), 1);
+  });
+});
+
+test.serial('continueAsNewFromAnUpdateFailsOnTheMainFunctionsFailure', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-agent-can-update');
+  const workflowId = uid('wf-agent-can-update');
+  await withWorker(env, { taskQueue, plugins: [adkPlugin()] }, async () => {
+    const handle = await env.client.workflow.start(agentRunnerContinueAsNewFromUpdate, {
+      taskQueue,
+      workflowId,
+      args: ['boom'],
+    });
+    await waitForScheduledActivities(env, workflowId, 'adk-invokeModel', 2);
+    const rejected = await t.throwsAsync(handle.executeUpdate(adkContinueUpdate));
+    t.is(findInCauseChain(rejected, ApplicationFailure)?.type, 'GoogleAdkModelError.400');
+
+    await handle.signal(adkDoneSignal);
+    const caught = await t.throwsAsync(handle.result());
+    t.is(findInCauseChain(caught, ApplicationFailure)?.type, 'GoogleAdkModelError.400');
+    t.is((await handle.describe()).status.name, 'FAILED');
+  });
+});

--- a/contrib/google-adk-agents/src/__tests__/adk-converter.ts
+++ b/contrib/google-adk-agents/src/__tests__/adk-converter.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * A custom payload-converter module that imports `@google/adk`, following the
  * documented workaround: converter modules evaluate before interceptor modules
  * (so before the plugin's polyfill loader), and must therefore import

--- a/contrib/google-adk-agents/src/__tests__/adk-first-interceptor.ts
+++ b/contrib/google-adk-agents/src/__tests__/adk-first-interceptor.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * A user `interceptors.workflowModules` entry that imports `@google/adk`.
  * Interceptor modules all evaluate before any interceptor factory runs, so
  * this makes ADK's `telemetry/tracing.js` cache its tracer at module load —

--- a/contrib/google-adk-agents/src/__tests__/agent.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/agent.test.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Native-runtime integration test — the load-bearing proof that an existing
  * ADK agent becomes durable with no rewrite. A vanilla `LlmAgent` is driven by
  * the SDK's own `InMemoryRunner.runEphemeral` loop inside a Workflow; the only

--- a/contrib/google-adk-agents/src/__tests__/compiled-cjs.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/compiled-cjs.test.ts
@@ -16,11 +16,12 @@
 import path from 'node:path';
 
 import test from 'ava';
+import { ApplicationFailure } from '@temporalio/common';
 import { Worker } from '@temporalio/worker';
 
 import { GoogleAdkPlugin } from '../index';
-import { defaultTestProvider, REUSE_V8_CONTEXT, setupTestEnv, uid, workflowsPath } from './helpers';
-import { singleModelCall } from './workflows';
+import { defaultTestProvider, findInCauseChain, REUSE_V8_CONTEXT, setupTestEnv, uid, workflowsPath } from './helpers';
+import { agentRunnerOneTurn, singleModelCall } from './workflows';
 
 const getEnv = setupTestEnv(test);
 
@@ -74,4 +75,35 @@ test.serial('converterModuleImportingAdkRunsWithWorkaround', async (t) => {
     })
   );
   t.is(result, 'fake-response:fake-model');
+});
+
+// An absorbed model failure fails the Workflow when the bundle holds ONE copy of the
+// absorbed-failure module (E2E)
+test.serial('compiledCjsBundleSurfacesAnAbsorbedModelFailure', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-cjs-fail');
+  const workflowId = uid('wf-cjs-fail');
+  // Both the plugin's interceptor-module entry and the Workflow's own import of
+  // `TemporalModel` resolve to the compiled `lib/`, so the bundle holds a single copy of
+  // the absorbed-failure module — the topology a published consumer gets, where the
+  // TypeScript-source bundle the other tests build holds two.
+  const worker = await Worker.create({
+    connection: env.nativeConnection,
+    taskQueue,
+    workflowsPath: compiledWorkflowsPath,
+    reuseV8Context: REUSE_V8_CONTEXT,
+    plugins: [new GoogleAdkPlugin({ modelProvider: defaultTestProvider() })],
+  });
+  await worker.runUntil(
+    (async () => {
+      const handle = await env.client.workflow.start(agentRunnerOneTurn, {
+        taskQueue,
+        workflowId,
+        args: ['boom', 'explode'],
+      });
+      const caught = await t.throwsAsync(handle.result());
+      t.is(findInCauseChain(caught, ApplicationFailure)?.type, 'GoogleAdkModelError.400');
+      t.is((await handle.describe()).status.name, 'FAILED');
+    })()
+  );
 });

--- a/contrib/google-adk-agents/src/__tests__/compiled-cjs.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/compiled-cjs.test.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Regression coverage for workflow-bundle module layouts that evaluate ADK's
  * telemetry chain (`@opentelemetry/sdk-trace-base` → `@opentelemetry/core`,
  * whose browser build dereferences the `performance` global at module load)

--- a/contrib/google-adk-agents/src/__tests__/errors.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/errors.test.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Unit tests for `toApplicationFailure`'s status-based retry classification,
  * covering statuses carried on the wrapped `err.response.status` (not just the
  * top-level `err.status`), plus the header-driven retry contract

--- a/contrib/google-adk-agents/src/__tests__/helpers.ts
+++ b/contrib/google-adk-agents/src/__tests__/helpers.ts
@@ -224,6 +224,7 @@ export interface WithWorkerOptions {
   taskQueue: string;
   plugins: Array<WorkerPlugin & BundlerPlugin>;
   activities?: object;
+  /** Defaults to 0, so every Workflow task replays the full history. */
   maxCachedWorkflows?: number;
   /**
    * User workflow-interceptor modules to bundle; the plugin's polyfill loader
@@ -294,7 +295,7 @@ export async function withWorker<T>(
     reuseV8Context: REUSE_V8_CONTEXT,
     plugins: options.plugins,
     activities: options.activities,
-    maxCachedWorkflows: options.maxCachedWorkflows,
+    maxCachedWorkflows: options.maxCachedWorkflows ?? 0,
   });
   return worker.runUntil(fn());
 }

--- a/contrib/google-adk-agents/src/__tests__/helpers.ts
+++ b/contrib/google-adk-agents/src/__tests__/helpers.ts
@@ -307,6 +307,27 @@ export function countScheduledActivities(
   return events.filter((e) => e.activityTaskScheduledEventAttributes?.activityType?.name === activityTypeName).length;
 }
 
+/**
+ * Resolves once history shows at least `count` `ActivityTaskScheduled` events for
+ * `activityTypeName`.
+ */
+export async function waitForScheduledActivities(
+  env: TestWorkflowEnvironment,
+  workflowId: string,
+  activityTypeName: string,
+  count = 1
+): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    const { events } = await env.client.workflow.getHandle(workflowId).fetchHistory();
+    if (countScheduledActivities(events ?? [], activityTypeName) >= count) return;
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${count} ${activityTypeName} Activities to be scheduled`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
 /** An `ActivityTaskScheduled` history event, narrowed to what the helpers below read. */
 type ScheduledActivityEvent = {
   activityTaskScheduledEventAttributes?: { activityType?: { name?: string | null } | null } | null;

--- a/contrib/google-adk-agents/src/__tests__/hitl.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/hitl.test.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * E2E test for human-in-the-loop. Because the ADK agent loop runs in the
  * Workflow body, a `LongRunningFunctionTool.execute` can `await` a Temporal
  * Signal or Update carrying the human's decision. Both variants are exercised.

--- a/contrib/google-adk-agents/src/__tests__/mcp.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/mcp.test.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- */
-
 import { readFileSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';

--- a/contrib/google-adk-agents/src/__tests__/model.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/model.test.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * E2E tests for the `TemporalModel` model boundary. Each test boots a local
  * Temporal server + worker (with the plugin), runs a real ADK `TemporalModel`
  * inside the Workflow, and asserts on observable behavior (return values,

--- a/contrib/google-adk-agents/src/__tests__/net-shim.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/net-shim.test.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Coverage for the `net` builtin shim. `@google/adk` >= 1.5.0 ships
  * `tools/load_web_page.js` on the barrel path, which parses its blocked-CIDR
  * tables at module load, calling `isIP` from `node:net` in the process — with

--- a/contrib/google-adk-agents/src/__tests__/plugin.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/plugin.test.ts
@@ -58,16 +58,19 @@ test('configureBundler stubs ADK node-only packages and disallowed builtins', (t
   }
 });
 
-test('configureBundler prepends the polyfill loader to workflowInterceptorModules', (t) => {
+test('configureBundler brackets the user modules with the polyfill loader and failure interceptor', (t) => {
   const plugin = new GoogleAdkPlugin();
   const { workflowInterceptorModules } = plugin.configureBundler({
     workflowsPath: 'wf',
     workflowInterceptorModules: ['user-interceptors'],
   } as BundleOptions);
-  // Must be first so the web-global polyfills install before any other
+  // The polyfill loader must be first so the web globals install before any other
   // per-workflow module (interceptors, then the user's workflows) evaluates.
-  t.is(workflowInterceptorModules?.[0], require.resolve('../load-polyfills'));
-  t.deepEqual(workflowInterceptorModules?.slice(1), ['user-interceptors']);
+  t.deepEqual(workflowInterceptorModules, [
+    require.resolve('../load-polyfills'),
+    'user-interceptors',
+    require.resolve('../absorbed-failure'),
+  ]);
   // The module satisfies the documented interceptor-module contract (exports
   // an `interceptors` factory) while registering nothing.
   t.deepEqual(polyfillInterceptors(), {});

--- a/contrib/google-adk-agents/src/__tests__/plugin.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/plugin.test.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Server-free unit tests that assert the shape of `configureBundler` /
  * `configureWorker` output without bundling or executing a Workflow.
  */

--- a/contrib/google-adk-agents/src/__tests__/published-artifact.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/published-artifact.test.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Regression test that consumes the COMPILED `lib` the way a published-package
  * user does: resolved BY PACKAGE NAME (`@temporalio/google-adk-agents` and its
  * `/workflow` and `/testing` subpaths) via Node package self-reference, never

--- a/contrib/google-adk-agents/src/__tests__/published-artifact.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/published-artifact.test.ts
@@ -24,6 +24,7 @@ test('cjsRequireExposesPublicExports', (t) => {
   t.is(typeof workflow.TemporalModel, 'function');
   t.is(typeof workflow.TemporalMCPToolset, 'function');
   t.is(typeof workflow.activityAsTool, 'function');
+  t.is(typeof workflow.markModelFailureHandled, 'function');
   t.is(workflow.MODEL_ERROR_FAILURE_TYPE, 'GoogleAdkModelError');
   t.is(workflow.MCP_TOOL_NOT_FOUND_FAILURE_TYPE, 'GoogleAdkMCPToolNotFound');
   t.is(workflow.MCP_ERROR_FAILURE_TYPE, 'GoogleAdkMCPError');

--- a/contrib/google-adk-agents/src/__tests__/replay.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/replay.test.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Replay determinism. Runs a combined scenario (two model calls + an MCP
  * discovery + call) to produce a real history, then replays that history with
  * the plugin registered. ADK's event IDs / timestamps funnel through

--- a/contrib/google-adk-agents/src/__tests__/streaming.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/streaming.test.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * E2E tests for SSE streaming. With `streamingTopic` set, a streamed model call
  * publishes incremental `LlmResponse` chunks via `@temporalio/workflow-streams`
  * while the Workflow still receives the full, ordered transcript via the

--- a/contrib/google-adk-agents/src/__tests__/stub-mcp-server.ts
+++ b/contrib/google-adk-agents/src/__tests__/stub-mcp-server.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * A stdio MCP server exposing one `echo` tool, recording its session boundaries and
  * tool requests to the file named by `MCP_STUB_LOG`. An unknown tool gets the reply a
  * real `McpServer` sends: a successful result carrying `isError: true`, never a

--- a/contrib/google-adk-agents/src/__tests__/telemetry.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/telemetry.test.ts
@@ -16,14 +16,14 @@
 import path from 'node:path';
 
 import test, { type ExecutionContext } from 'ava';
-import { trace } from '@opentelemetry/api';
+import { SpanStatusCode, trace } from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
 import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { OpenTelemetryPlugin } from '@temporalio/interceptors-opentelemetry';
 
 import { GoogleAdkPlugin } from '../index';
 import { defaultTestProvider, setupTestEnv, uid, withWorker } from './helpers';
-import { agentRunnerTwoTurnsWorkflow } from './workflows';
+import { agentRunnerOneTurn, agentRunnerTwoTurnsWorkflow } from './workflows';
 
 const getEnv = setupTestEnv(test);
 
@@ -210,4 +210,28 @@ test.serial('adkSpansDoNotLeakToProcessGlobalProvider', async (t) => {
     trace.disable();
     await provider.shutdown();
   }
+});
+
+// A composed observability interceptor sees the absorbed failure as a failure (E2E)
+test.serial('absorbedModelFailureMarksTheComposedWorkflowSpanAsError', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-otel-fail');
+  const workflowId = uid('wf-otel-fail');
+  const exporter = new InMemorySpanExporter();
+  const otelPlugin = new OpenTelemetryPlugin({
+    resource: new Resource({ 'service.name': 'adk-telemetry-test' }),
+    spanProcessor: new SimpleSpanProcessor(exporter),
+  });
+
+  await withWorker(env, { taskQueue, plugins: [otelPlugin, makeAdkPlugin()] }, async () => {
+    const handle = await env.client.workflow.start(agentRunnerOneTurn, {
+      taskQueue,
+      workflowId,
+      args: ['boom', 'explode'],
+    });
+    await t.throwsAsync(handle.result());
+  });
+
+  const executeSpan = exporter.getFinishedSpans().find((span) => span.name === 'RunWorkflow:agentRunnerOneTurn');
+  t.is(executeSpan?.status.code, SpanStatusCode.ERROR);
 });

--- a/contrib/google-adk-agents/src/__tests__/telemetry.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/telemetry.test.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Telemetry replay-safety. ADK creates OpenTelemetry spans (tracer
  * `gcp.vertex.agent`: `invocation`, `invoke_agent <name>`, `call_llm`, …)
  * inside the Workflow sandbox. Composing this plugin with the SDK's

--- a/contrib/google-adk-agents/src/__tests__/tools.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/tools.test.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * E2E test for `activityAsTool`: an existing Temporal Activity, registered on
  * the worker, is exposed to the ADK agent as a `BaseTool`. The agent's model
  * asks for it by name, ADK dispatches the call as an Activity, and the result

--- a/contrib/google-adk-agents/src/__tests__/workflows.ts
+++ b/contrib/google-adk-agents/src/__tests__/workflows.ts
@@ -12,19 +12,38 @@
 import { isIP } from 'node:net';
 
 import {
+  BasePlugin,
+  createEvent,
   InMemoryRunner,
   isFinalResponse,
   LlmAgent,
   LongRunningFunctionTool,
   stringifyContent,
   type LlmRequest,
+  type LlmResponse,
 } from '@google/adk';
 import { Type } from '@google/genai';
-import type { Duration } from '@temporalio/common';
-import { condition, defineSignal, defineUpdate, proxyActivities, setHandler } from '@temporalio/workflow';
+import { ActivityFailure, ApplicationFailure, type Duration } from '@temporalio/common';
+import {
+  CancellationScope,
+  condition,
+  continueAsNew,
+  defineSignal,
+  defineUpdate,
+  proxyActivities,
+  setHandler,
+  sleep,
+} from '@temporalio/workflow';
 import { WorkflowStream } from '@temporalio/workflow-streams/workflow';
 
-import { TemporalModel, TemporalMCPToolset, activityAsTool, type TemporalMCPToolsetOptions } from '../workflow';
+import {
+  markModelFailureHandled,
+  TemporalModel,
+  TemporalMCPToolset,
+  activityAsTool,
+  type TemporalMCPToolsetOptions,
+  type TemporalModelOptions,
+} from '../workflow';
 
 // Mirrors `@google/adk` >= 1.5.0 `tools/load_web_page.js` (on the barrel
 // path), which parses its blocked-CIDR tables at module load, calling
@@ -402,6 +421,265 @@ export async function agentRunnerTwoTurnsWorkflow(prompt: string): Promise<strin
     }
   }
   return texts.join('|');
+}
+
+/** Per-turn Activity options for the runner fixtures below: fail on the first attempt. */
+const SINGLE_ATTEMPT: TemporalModelOptions = { activity: { retry: { maximumAttempts: 1 } } };
+
+/**
+ * One runner-driven agent turn through `model`, returning the turn's final text —
+ * empty when the turn produced none.
+ */
+async function runAgentTurn(model: TemporalModel, prompt: string, plugins?: BasePlugin[]): Promise<string> {
+  const agent = new LlmAgent({
+    name: 'assistant',
+    model,
+    instruction: 'You are a helpful assistant.',
+  });
+  const runner = new InMemoryRunner({ agent, plugins });
+
+  let finalText = '';
+  for await (const event of runner.runEphemeral({
+    userId: 'test-user',
+    newMessage: { role: 'user', parts: [{ text: prompt }] },
+  })) {
+    if (isFinalResponse(event)) {
+      finalText = stringifyContent(event);
+    }
+  }
+  return finalText;
+}
+
+/** One runner turn through `model`, retries off. */
+export async function agentRunnerOneTurn(model: string, prompt: string): Promise<string> {
+  return runAgentTurn(new TemporalModel(model, SINGLE_ATTEMPT), prompt);
+}
+
+/** A failing runner turn, then a slow one, so a cancellation lands after an absorbed failure. */
+export async function agentRunnerFailThenSlowModel(prompt: string): Promise<string> {
+  const failed = await runAgentTurn(new TemporalModel('boom', SINGLE_ATTEMPT), prompt);
+  const cancelled = await runAgentTurn(new TemporalModel('slow-model', SINGLE_ATTEMPT), prompt);
+  return `${failed}|${cancelled}`;
+}
+
+/** An ADK plugin that substitutes a response for a failed model call. */
+class RecoveringPlugin extends BasePlugin {
+  constructor() {
+    super('recovering');
+  }
+
+  override async onModelErrorCallback({ error }: { error: Error }): Promise<LlmResponse | undefined> {
+    markModelFailureHandled(error);
+    return createEvent({
+      author: 'assistant',
+      content: { role: 'model', parts: [{ text: 'recovered' }] },
+      turnComplete: true,
+    });
+  }
+}
+
+/** A failing runner turn whose `onModelErrorCallback` recovers from the failure. */
+export async function agentRunnerRecoversFromModelError(prompt: string): Promise<string> {
+  return runAgentTurn(new TemporalModel('boom', SINGLE_ATTEMPT), prompt, [new RecoveringPlugin()]);
+}
+
+/** A failing runner turn nothing recovers, then one whose `onModelErrorCallback` does. */
+export async function agentRunnerRecoversOnlyTheSecondFailure(prompt: string): Promise<string> {
+  const unrecovered = await runAgentTurn(new TemporalModel('boom', SINGLE_ATTEMPT), prompt);
+  const recovered = await runAgentTurn(new TemporalModel('boom', SINGLE_ATTEMPT), prompt, [new RecoveringPlugin()]);
+  return `${unrecovered}|${recovered}`;
+}
+
+/**
+ * A runner turn whose `onModelErrorCallback` recovers, against a model slow enough that
+ * the failure it recovers from is the Workflow's own cancellation.
+ */
+export async function agentRunnerRecoversFromCancelledModel(prompt: string): Promise<string> {
+  return runAgentTurn(new TemporalModel('slow-model', SINGLE_ATTEMPT), prompt, [new RecoveringPlugin()]);
+}
+
+/** A runner turn whose caller-supplied `summary` callback throws before the Activity. */
+export async function agentRunnerThrowingSummary(prompt: string): Promise<string> {
+  const model = new TemporalModel('fake-model', {
+    ...SINGLE_ATTEMPT,
+    summary: () => {
+      throw ApplicationFailure.nonRetryable('summary callback exploded', 'TestSummaryFailure');
+    },
+  });
+  return runAgentTurn(model, prompt);
+}
+
+/**
+ * A runner turn against a model too slow for its 1-second timeout scope. ADK absorbs the
+ * scope's cancellation, so the turn returns no text rather than throwing, and the Workflow
+ * falls back to its own value.
+ */
+export async function agentRunnerTurnUnderTimeoutScope(prompt: string): Promise<string> {
+  const text = await CancellationScope.withTimeout('1 second', () =>
+    runAgentTurn(new TemporalModel('slow-model', SINGLE_ATTEMPT), prompt)
+  );
+  return text || 'timed out';
+}
+
+/** A turn aborted by its timeout scope, then a turn that really fails. */
+export async function agentRunnerFailureAfterTimeoutScope(prompt: string): Promise<string> {
+  const aborted = await CancellationScope.withTimeout('1 second', () =>
+    runAgentTurn(new TemporalModel('slow-model', SINGLE_ATTEMPT), prompt)
+  );
+  const failed = await runAgentTurn(new TemporalModel('boom', SINGLE_ATTEMPT), prompt);
+  return `${aborted}|${failed}`;
+}
+
+/**
+ * A direct (non-runner) model call whose Activity fails and whose caller handles it.
+ * Returns the caught failure's type, so the Workflow's result witnesses what it caught.
+ */
+export async function caughtModelCallError(): Promise<string> {
+  const llm = new TemporalModel('boom', SINGLE_ATTEMPT);
+  let text = '';
+  try {
+    for await (const response of llm.generateContentAsync(makeRequest('explode'))) {
+      text += collectText(response.content?.parts);
+    }
+  } catch (err) {
+    if (err instanceof ActivityFailure && err.cause instanceof ApplicationFailure) {
+      return err.cause.type ?? 'untyped';
+    }
+    throw err;
+  }
+  return text;
+}
+
+export const adkChatUpdate = defineUpdate<string, [string]>('adkChat');
+export const adkDoneSignal = defineSignal<[]>('adkDone');
+
+/**
+ * The update-driven agent shape: the main function parks while each Update runs one
+ * agent turn against the model it names.
+ */
+export async function agentRunnerUpdateDriven(): Promise<void> {
+  let done = false;
+  setHandler(adkChatUpdate, (model) => runAgentTurn(new TemporalModel(model, SINGLE_ATTEMPT), 'hi'));
+  setHandler(adkDoneSignal, () => {
+    done = true;
+  });
+  await condition(() => done);
+}
+
+/**
+ * A runner turn followed by `continueAsNew` to `nextModel` — the shape a long-running
+ * agent uses to trim its history.
+ */
+export async function agentRunnerContinueAsNew(model: string, nextModel?: string): Promise<string> {
+  const text = await runAgentTurn(new TemporalModel(model, SINGLE_ATTEMPT), 'hi');
+  if (nextModel !== undefined) {
+    await continueAsNew<typeof agentRunnerContinueAsNew>(nextModel);
+  }
+  return text;
+}
+
+export const adkRecoverSignal = defineSignal<[]>('adkRecover');
+
+/**
+ * A turn against a model that answers, so it emits the second `adk-invokeModel` Activity
+ * the tests wait on to know the failing turn is behind them.
+ */
+async function answeringTurn(): Promise<string> {
+  return runAgentTurn(new TemporalModel('fake-model'), 'hi');
+}
+
+/**
+ * A failing main-function turn nothing recovers, plus a Signal handler that runs its own
+ * failing turn and recovers from that one.
+ */
+export async function agentRunnerFailureThenRecoveringSignal(): Promise<string> {
+  let recovered = false;
+  setHandler(adkRecoverSignal, async () => {
+    await runAgentTurn(new TemporalModel('boom', SINGLE_ATTEMPT), 'hi', [new RecoveringPlugin()]);
+    recovered = true;
+  });
+  await runAgentTurn(
+    new TemporalModel('slow-model', { activity: { startToCloseTimeout: '1 second', retry: { maximumAttempts: 1 } } }),
+    'hi'
+  );
+  const answered = await answeringTurn();
+  await condition(() => recovered);
+  return answered;
+}
+
+export const adkStartSignal = defineSignal<[]>('adkStart');
+
+/**
+ * A Signal handler that starts a failing turn without awaiting it, so the handler returns
+ * before the failure lands, while the main function stays parked until the turn is over.
+ */
+export async function agentRunnerUnawaitedSignalTurn(): Promise<string> {
+  let finished = false;
+  setHandler(adkStartSignal, () => {
+    void runAgentTurn(new TemporalModel('boom', SINGLE_ATTEMPT), 'hi').then(() => {
+      finished = true;
+    });
+  });
+  await condition(() => finished);
+  return 'joined';
+}
+
+export const adkAwaitSignal = defineSignal<[]>('adkAwait');
+
+/**
+ * A Signal handler that awaits its own failing turn while the main function parks for good,
+ * so the Signal's frame is the only one that can raise what that turn absorbed.
+ */
+export async function agentRunnerAwaitedSignalTurn(): Promise<void> {
+  setHandler(adkAwaitSignal, async () => {
+    await runAgentTurn(new TemporalModel('boom', SINGLE_ATTEMPT), 'hi');
+  });
+  await condition(() => false);
+}
+
+interface CompensationActivities {
+  compensate(): Promise<void>;
+}
+
+/**
+ * A failing main-function turn inside a `try`/`finally` that compensates through an
+ * Activity, then a park long enough to take a Signal while the main function still runs.
+ */
+export async function agentRunnerFailureWithCompensation(): Promise<string> {
+  let nudged = false;
+  setHandler(adkDoneSignal, () => {
+    nudged = true;
+  });
+  const { compensate } = proxyActivities<CompensationActivities>({ startToCloseTimeout: '10 seconds' });
+  try {
+    await runAgentTurn(new TemporalModel('boom', SINGLE_ATTEMPT), 'hi');
+    await answeringTurn();
+    await sleep('2 seconds');
+    return nudged ? 'nudged' : 'quiet';
+  } finally {
+    await compensate();
+  }
+}
+
+export const adkContinueUpdate = defineUpdate<string, []>('adkContinue');
+
+/**
+ * A failing main-function turn, then a park, while an Update continues as new to a model
+ * that answers.
+ */
+export async function agentRunnerContinueAsNewFromUpdate(model: string): Promise<string> {
+  let done = false;
+  setHandler(adkContinueUpdate, async () => {
+    await continueAsNew<typeof agentRunnerContinueAsNewFromUpdate>('fake-model');
+    return 'continued';
+  });
+  setHandler(adkDoneSignal, () => {
+    done = true;
+  });
+  const failed = await runAgentTurn(new TemporalModel(model, SINGLE_ATTEMPT), 'hi');
+  const answered = await answeringTurn();
+  await condition(() => done);
+  return `${failed}|${answered}`;
 }
 
 /** `net` shim classifications computed at module load and at run time. */

--- a/contrib/google-adk-agents/src/absorbed-failure.ts
+++ b/contrib/google-adk-agents/src/absorbed-failure.ts
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2025 Temporal Technologies Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * Surfaces the failures `@google/adk` absorbs before Workflow code can see them.
+ * `LlmAgent.runAndHandleError` turns any `Error` escaping a model call into an event
+ * and lets the run finish, so a Workflow whose model Activity failed returns
+ * normally. `TemporalModel` records such a failure here, and the inbound interceptor
+ * below re-raises it once the Workflow or handler frame that recorded it returns.
+ *
+ * Await an agent turn in the frame that started it: a failure recorded while that frame
+ * is open surfaces there, and one recorded after a handler frame returned surfaces in the
+ * main function's. One recorded after the main function returned never surfaces —
+ * completing with unfinished handlers is a user error Temporal already warns about.
+ */
+
+import type { AsyncLocalStorage as ALS } from 'node:async_hooks';
+
+import {
+  AsyncLocalStorage,
+  CancellationScope,
+  ContinueAsNew,
+  inWorkflowContext,
+  isCancellation,
+  type WorkflowInterceptorsFactory,
+} from '@temporalio/workflow';
+
+// Held on the per-execution sandbox `globalThis` rather than in module scope: a
+// bundle can hold two copies of this module (the interceptor list registers its
+// compiled path, while a Workflow reaches it through its own import of
+// `TemporalModel`), and both have to reach the same recordings.
+const ABSORBED = '__temporal_googleAdkAbsorbedFailures';
+
+/** What one inbound frame — the main function, a Signal handler, an Update handler — absorbed. */
+interface Frame {
+  /** Failures no caller has marked handled, in the order they were absorbed. */
+  pending: unknown[];
+  /**
+   * The frame's first absorbed cancellation, held apart from `pending`: whether it is
+   * the execution's outcome is only knowable once the frame returns, and it outranks
+   * anything else the frame absorbed.
+   */
+  cancellation?: unknown;
+  /** Whether the frame has returned, spending its one chance to raise; it never takes another. */
+  surfaced: boolean;
+}
+
+interface AbsorbedFailures {
+  /** The frame the running code belongs to. */
+  frames: ALS<Frame>;
+  /** The main function's frame, which owns whatever is absorbed outside a handler frame. */
+  main?: Frame;
+}
+
+function recorded(): AbsorbedFailures {
+  const global = globalThis as Record<string, unknown>;
+  let state = global[ABSORBED] as AbsorbedFailures | undefined;
+  if (state === undefined) {
+    state = { frames: new AsyncLocalStorage<Frame>() };
+    global[ABSORBED] = state;
+  }
+  return state;
+}
+
+function openFrame(): Frame | undefined {
+  const { frames, main } = recorded();
+  const frame = frames.getStore() ?? main;
+  if (frame?.surfaced === false) return frame;
+  // A surfaced frame is never read again; only the main function's can still raise a failure.
+  return main?.surfaced === false ? main : undefined;
+}
+
+/** @internal */
+export function recordAbsorbedFailure(err: unknown): void {
+  const frame = openFrame();
+  if (frame === undefined) return;
+  if (isCancellation(err)) {
+    frame.cancellation ??= err;
+  } else {
+    frame.pending.push(err);
+  }
+}
+
+/**
+ * Declares that the caller handled `error` from a failed `TemporalModel` call, so it must
+ * not fail the Workflow or reject the Update it happened in. Other failures absorbed by the
+ * same Workflow invocation — the main function, or the Signal or Update handler that ran
+ * the turn — still surface. Does nothing outside a Workflow.
+ *
+ * Call it from an ADK `onModelErrorCallback`, passing the `error` that callback received,
+ * and return the substitute response from that callback — built with ADK's `createEvent`,
+ * because ADK yields the callback's return value untouched and `isFinalResponse` then
+ * dereferences the `actions` a bare `LlmResponse` does not carry. ADK finishes the run on
+ * the substitute, and without this call the Workflow fails anyway and the recovery is
+ * discarded. A cancellation cannot be handled this way: an execution whose cancel a model
+ * call absorbed still ends CANCELLED.
+ */
+export function markModelFailureHandled(error: unknown): void {
+  if (!inWorkflowContext()) return;
+  const frame = openFrame();
+  if (frame === undefined) return;
+  const at = frame.pending.indexOf(error);
+  if (at !== -1) frame.pending.splice(at, 1);
+}
+
+function raiseAbsorbed(frame: Frame): void {
+  // Only a cancel a model call absorbed lands here, and it decides the outcome only if
+  // the execution itself was cancelled. An inner scope's cancel
+  // (`CancellationScope.withTimeout`) is the consumer's own doing and is not raised at all.
+  if (frame.cancellation !== undefined && CancellationScope.current().consideredCancelled) {
+    // Re-raised as caught: CANCELLED is read off the original `ActivityFailure` /
+    // `CancelledFailure` pair, which any wrapper would hide.
+    throw frame.cancellation;
+  }
+  if (frame.pending.length > 0) throw frame.pending[0];
+}
+
+async function surfaceAbsorbedFailure<T>(frame: Frame, next: () => Promise<T>): Promise<T> {
+  let result: T;
+  try {
+    result = await recorded().frames.run(frame, next);
+  } catch (err) {
+    // `continueAsNew()` ends the run without surfacing what was absorbed, so the chain
+    // would reach a successful terminal state; it ends the execution wherever it is called
+    // from, so the main function's failures count too.
+    if (err instanceof ContinueAsNew) {
+      raiseAbsorbed(frame);
+      const { main } = recorded();
+      if (main !== undefined && main !== frame) raiseAbsorbed(main);
+    }
+    throw err;
+  } finally {
+    frame.surfaced = true;
+  }
+  raiseAbsorbed(frame);
+  return result;
+}
+
+// ts-prune-ignore-next (loaded by path from workflowInterceptorModules)
+export const interceptors: WorkflowInterceptorsFactory = () => ({
+  inbound: [
+    {
+      execute: (input, next) => {
+        const frame: Frame = { pending: [], surfaced: false };
+        recorded().main = frame;
+        return surfaceAbsorbedFailure(frame, () => next(input));
+      },
+      handleUpdate: (input, next) => surfaceAbsorbedFailure({ pending: [], surfaced: false }, () => next(input)),
+      handleSignal: (input, next) => surfaceAbsorbedFailure({ pending: [], surfaced: false }, () => next(input)),
+    },
+  ],
+});

--- a/contrib/google-adk-agents/src/absorbed-failure.ts
+++ b/contrib/google-adk-agents/src/absorbed-failure.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Surfaces the failures `@google/adk` absorbs before Workflow code can see them.
  * `LlmAgent.runAndHandleError` turns any `Error` escaping a model call into an event
  * and lets the run finish, so a Workflow whose model Activity failed returns

--- a/contrib/google-adk-agents/src/activities.ts
+++ b/contrib/google-adk-agents/src/activities.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Worker-side Activity implementations for the Google ADK Temporal plugin — no
  * module in the `./workflow` import graph reaches this one, so the
  * worker-runtime packages it pulls in (`@temporalio/activity`,

--- a/contrib/google-adk-agents/src/error-types.ts
+++ b/contrib/google-adk-agents/src/error-types.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * The `ApplicationFailure.type` values this plugin raises.
  */
 

--- a/contrib/google-adk-agents/src/error-types.ts
+++ b/contrib/google-adk-agents/src/error-types.ts
@@ -40,8 +40,12 @@ export const MCP_TOOL_NOT_FOUND_FAILURE_TYPE = 'GoogleAdkMCPToolNotFound';
 
 /**
  * Error type for a failed model call. Raised inside an Activity, so it arrives
- * wrapped in an `ActivityFailure`: match it through the `.cause` chain. It reaches
- * code that awaits `TemporalModel.generateContentAsync` itself.
+ * wrapped in an `ActivityFailure`: match it through the `.cause` chain. A request
+ * carrying an `adk_agent_name` label, as an ADK agent run's requests do, has its
+ * failure recorded: it fails the Workflow — or rejects the Update whose handler ran
+ * the turn — unless an `onModelErrorCallback` recovers and calls
+ * `markModelFailureHandled(error)`. A hand-built request ordinarily carries none, and
+ * then only throws at the call site.
  *
  * A failure that carries an HTTP status has it appended as `.<status>`, for example
  * `GoogleAdkModelError.429`, so match with `startsWith`, not `===`; such a failure is

--- a/contrib/google-adk-agents/src/index.ts
+++ b/contrib/google-adk-agents/src/index.ts
@@ -4,10 +4,6 @@
  * @experimental The Google ADK plugin is an experimental feature; APIs may change without notice.
  *
  * @module
- *
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
  */
 
 export { GoogleAdkPlugin } from './plugin';

--- a/contrib/google-adk-agents/src/load-polyfills.ts
+++ b/contrib/google-adk-agents/src/load-polyfills.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Web/Node global polyfills for the Temporal Workflow sandbox.
  *
  * `@google/adk` and `@google/genai` reference `Headers`, `structuredClone`,

--- a/contrib/google-adk-agents/src/mcp.ts
+++ b/contrib/google-adk-agents/src/mcp.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Workflow-side MCP boundary for the Google ADK Temporal plugin.
  *
  * MCP is ADK's primary external-tool protocol. `TemporalMCPToolset` is a

--- a/contrib/google-adk-agents/src/model.ts
+++ b/contrib/google-adk-agents/src/model.ts
@@ -25,6 +25,7 @@ import type { ActivityOptions, Duration } from '@temporalio/common';
 import { ApplicationFailure } from '@temporalio/common';
 import { inWorkflowContext, proxyActivities } from '@temporalio/workflow';
 
+import { recordAbsorbedFailure } from './absorbed-failure';
 import { STREAMING_TOPIC_REQUIRED_FAILURE_TYPE, UNSUPPORTED_FAILURE_TYPE } from './error-types';
 
 export interface TemporalModelOptions {
@@ -90,6 +91,8 @@ export interface ModelActivities {
 
 const DEFAULT_MODEL_START_TO_CLOSE: Duration = '1 minute';
 
+const ADK_AGENT_NAME_LABEL = 'adk_agent_name';
+
 /**
  * A {@link BaseLlm} whose inference is durable under Temporal.
  *
@@ -127,32 +130,40 @@ export class TemporalModel extends BaseLlm {
       return;
     }
 
-    const activities = proxyActivities<ModelActivities>({
-      ...this.options.activity,
-      startToCloseTimeout: this.options.activity?.startToCloseTimeout ?? DEFAULT_MODEL_START_TO_CLOSE,
-      summary: this.resolveSummary(llmRequest),
-    });
-
-    const wire = toWireRequest(llmRequest);
     const streamingTopic = this.options.streamingTopic;
+    // ADK's agent flow stamps this label on every request just before calling the
+    // model, and a request built by hand for a direct call carries none. Only that
+    // flow absorbs a throw, so only it needs the failure recorded.
+    const throughAgentRun = llmRequest.config?.labels?.[ADK_AGENT_NAME_LABEL] !== undefined;
 
     let responses: LlmResponse[];
-    if (stream) {
-      if (!streamingTopic) {
-        throw ApplicationFailure.nonRetryable(
-          `TemporalModel('${this.model}'): streaming was requested but no 'streamingTopic' is ` +
-            'configured. Set TemporalModelOptions.streamingTopic to publish incremental chunks.',
-          STREAMING_TOPIC_REQUIRED_FAILURE_TYPE
-        );
-      }
-      responses = await activities['adk-invokeModelStreaming']({
-        model: this.model,
-        request: wire,
-        streamingTopic,
-        batchInterval: this.options.streamingBatchInterval,
+    try {
+      const activities = proxyActivities<ModelActivities>({
+        ...this.options.activity,
+        startToCloseTimeout: this.options.activity?.startToCloseTimeout ?? DEFAULT_MODEL_START_TO_CLOSE,
+        summary: this.resolveSummary(llmRequest),
       });
-    } else {
-      responses = await activities['adk-invokeModel']({ model: this.model, request: wire });
+      const wire = toWireRequest(llmRequest);
+      if (stream) {
+        if (!streamingTopic) {
+          throw ApplicationFailure.nonRetryable(
+            `TemporalModel('${this.model}'): streaming was requested but no 'streamingTopic' is ` +
+              'configured. Set TemporalModelOptions.streamingTopic to publish incremental chunks.',
+            STREAMING_TOPIC_REQUIRED_FAILURE_TYPE
+          );
+        }
+        responses = await activities['adk-invokeModelStreaming']({
+          model: this.model,
+          request: wire,
+          streamingTopic,
+          batchInterval: this.options.streamingBatchInterval,
+        });
+      } else {
+        responses = await activities['adk-invokeModel']({ model: this.model, request: wire });
+      }
+    } catch (err) {
+      if (throughAgentRun) recordAbsorbedFailure(err);
+      throw err;
     }
 
     for (const response of responses) {
@@ -189,7 +200,7 @@ export class TemporalModel extends BaseLlm {
     if (this.options.activity?.summary !== undefined) {
       return this.options.activity.summary;
     }
-    const agentName = req.config?.labels?.['adk_agent_name'];
+    const agentName = req.config?.labels?.[ADK_AGENT_NAME_LABEL];
     if (agentName) {
       return agentName;
     }

--- a/contrib/google-adk-agents/src/model.ts
+++ b/contrib/google-adk-agents/src/model.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Workflow-side model boundary for the Google ADK Temporal plugin.
  *
  * `TemporalModel` is a drop-in `BaseLlm` (from `@google/adk`) that a user places

--- a/contrib/google-adk-agents/src/plugin.ts
+++ b/contrib/google-adk-agents/src/plugin.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- */
-
 import { builtinModules, createRequire } from 'node:module';
 
 import type { BaseLlm } from '@google/adk';

--- a/contrib/google-adk-agents/src/plugin.ts
+++ b/contrib/google-adk-agents/src/plugin.ts
@@ -479,7 +479,7 @@ export class GoogleAdkPlugin extends SimplePlugin {
    * recipe applies identically on both paths and there is no separate
    * `configureWorker`/`configureReplayWorker` bundler override.
    *
-   * The recipe has three parts, all required:
+   * The recipe has four parts, all required:
    *
    *  1. **`webpackConfigHook`** adds {@link googleAdkSandboxCompatPlugin} (the
    *     `node:` strip, shim redirects, and `process` provide) and the
@@ -513,6 +513,14 @@ export class GoogleAdkPlugin extends SimplePlugin {
    *     `@google/adk`/`@google/genai` must import
    *     `@temporalio/google-adk-agents/workflow` (or `./load-polyfills`) first
    *     to install the polyfills.
+   *  4. **`workflowInterceptorModules`** also gets the `absorbed-failure` module
+   *     appended last — the module that re-raises a model failure ADK absorbed
+   *     (`markModelFailureHandled` opts one back out). Interceptor modules compose
+   *     first-is-outermost, so last means innermost, and the re-raise rejects
+   *     *through* the outer interceptors rather than past them: an observability
+   *     interceptor must not close its span OK on a Workflow about to fail. Being
+   *     last is order-dependent, not structural — so list `GoogleAdkPlugin` last in
+   *     `plugins`.
    *
    * Tradeoff: putting **all** disallowed builtins in `ignoreModules` suppresses
    * the bundler's friendly "you imported a Node builtin in your Workflow"
@@ -526,7 +534,11 @@ export class GoogleAdkPlugin extends SimplePlugin {
     return {
       ...base,
       ignoreModules,
-      workflowInterceptorModules: [require.resolve('./load-polyfills'), ...(base.workflowInterceptorModules ?? [])],
+      workflowInterceptorModules: [
+        require.resolve('./load-polyfills'),
+        ...(base.workflowInterceptorModules ?? []),
+        require.resolve('./absorbed-failure'),
+      ],
       webpackConfigHook: addSandboxCompat(base.webpackConfigHook),
     };
   }

--- a/contrib/google-adk-agents/src/testing.ts
+++ b/contrib/google-adk-agents/src/testing.ts
@@ -1,8 +1,4 @@
 /**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- *
  * Test helpers for users adopting the Google ADK Temporal plugin.
  *
  * These let you unit-test Workflows that use `TemporalModel` / `TemporalMCPToolset`

--- a/contrib/google-adk-agents/src/tools.ts
+++ b/contrib/google-adk-agents/src/tools.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
- */
-
 import { type FunctionDeclaration, type Schema, Type } from '@google/genai';
 import { BaseTool, type RunAsyncToolRequest } from '@google/adk';
 import { ApplicationFailure, type ActivityOptions } from '@temporalio/common';

--- a/contrib/google-adk-agents/src/workflow.ts
+++ b/contrib/google-adk-agents/src/workflow.ts
@@ -5,10 +5,6 @@
  * @experimental The Google ADK plugin is an experimental feature; APIs may change without notice.
  *
  * @module
- *
- * @license
- * Copyright 2025 Temporal Technologies Inc.
- * SPDX-License-Identifier: MIT
  */
 
 // Side-effect import: install Workflow-sandbox polyfills (gated internally on

--- a/contrib/google-adk-agents/src/workflow.ts
+++ b/contrib/google-adk-agents/src/workflow.ts
@@ -19,6 +19,8 @@ import './load-polyfills';
 export { TemporalModel } from './model';
 export type { TemporalModelOptions } from './model';
 
+export { markModelFailureHandled } from './absorbed-failure';
+
 export { TemporalMCPToolset } from './mcp';
 export type { TemporalMCPToolsetOptions, MCPToolsetFactory } from './mcp';
 


### PR DESCRIPTION
A Workflow whose model Activity had permanently failed was completing successfully. `LlmAgent.runAndHandleError` catches any `Error` escaping a model call, turns it into an event carrying `errorCode`/`errorMessage` and no content, and lets the run finish, so nothing ever reaches Workflow code to fail on. A cancelled in-flight model call went the same way.

`TemporalModel` now records such a failure against the inbound frame it was thrown in (the main function, or the Signal or Update handler that ran the turn), and an interceptor re-raises it when that frame returns. Recording is keyed on ADK's `adk_agent_name` request label, so a request without that label still just throws at the call site where the caller can catch it. A consumer who recovers in an ADK `onModelErrorCallback` calls `markModelFailureHandled(error)`, the only public API addition, to drop that one failure and keep their recovery.

The guarantee is scoped to one rule: await an agent turn in the frame that started it. An Update handler's failed turn rejects that Update rather than the Workflow, a Signal handler that awaits its turn fails the execution, and an operator cancel still ends CANCELLED, while a `CancellationScope.withTimeout` the consumer imposed is their own decision and leaves the Workflow to complete on its fallback. A pending failure also wins over `continueAsNew()`, which would otherwise let the chain reach a successful terminal state. One recorded after the main function returned never surfaces, and that case is documented rather than fixed, since such a Workflow is completing with unfinished handlers and Temporal already warns about it (TMPRL1102).

Note: the interceptor module is appended last, hence innermost, so the re-raise rejects through the outer interceptors rather than past them (a composed observability interceptor must not close its span OK on a Workflow that is about to fail). That position depends on plugin order, so `configureBundler`'s TSDoc now says to list `GoogleAdkPlugin` last in `plugins`.
