### PR TITLE
feat(activity): add TypeInfo support for activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ to docs, or any other relevant information.
   Workflow-backed asynchronous handlers must configure matching TypeInfo on the backing Workflow.
 - **Experimental**: Standalone Nexus Clients can use operation `TypeInfo`, including output conversion on detached
   operation handles.
+- **Experimental**: Workflow and standalone Activities can use `TypeInfo` to convert inputs and results, including
+  Local Activities, retained and detached Client handles, and asynchronous completion.
 - Core logs written directly to the console can now use compact, pretty, or newline-delimited JSON
   output via `telemetryOptions.logging.console.format`.
 - **Experimental**: Workflow Clients can now use `TypeInfo` to encode Workflow inputs and decode Workflow results.

--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -117,6 +117,8 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type {
+  ActivityDefinitionOptions,
+  ActivityFunction,
   Logger,
   Duration,
   LogLevel,
@@ -133,13 +135,29 @@ import type { ActivityCancellationDetailsHolder } from '@temporalio/common/lib/a
 import type { Client } from '@temporalio/client';
 
 export {
+  ActivityDefinitionOptions,
   ActivityFunction,
   ActivityInterface, // eslint-disable-line @typescript-eslint/no-deprecated
+  ActivityTypeInfoMap,
   ApplicationFailure,
   CancelledFailure,
   CompleteAsyncError,
   UntypedActivities,
 } from '@temporalio/common';
+
+/**
+ * Attach static metadata to an Activity function.
+ *
+ * Type information is used by a Worker to decode the Activity arguments and encode its result.
+ *
+ * @experimental
+ */
+export function setActivityOptions<Args extends any[], ReturnType>(
+  options: ActivityDefinitionOptions,
+  fn: ActivityFunction<Args, ReturnType>
+): void {
+  Object.assign(fn, { activityDefinitionOptions: options });
+}
 
 // Make it safe to use @temporalio/activity with multiple versions installed.
 const asyncLocalStorageSymbol = Symbol.for('__temporal_activity_context_storage__');

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -4,10 +4,12 @@ import type {
   ActivityFunction,
   LoadedDataConverter,
   Next,
+  PayloadTypeInfo,
   Priority,
   RetryPolicy,
   SearchAttributePair,
   TypedSearchAttributes,
+  TypeInfo,
 } from '@temporalio/common';
 import {
   compilePriority,
@@ -25,10 +27,9 @@ import {
   searchAttributePayloadConverter,
 } from '@temporalio/common/lib/converter/payload-search-attributes';
 import {
-  decodeArrayFromPayloads,
   decodeFromPayloadsAtIndex,
   decodeOptionalFailureToOptionalError,
-  encodeToPayloads,
+  encodeToPayloadsWithContext,
   encodeUserMetadata,
   extstoreInboundOptions,
   extstoreStoreOptions,
@@ -177,6 +178,19 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
   }
 
   /**
+   * Creates an Activity handle using options that may include result TypeInfo.
+   *
+   * @param activityId ID of the Activity.
+   * @param options Options identifying the Activity run and describing its result type.
+   * @returns Handle to the specified Activity execution.
+   *
+   * @experimental Standalone Activities are experimental. APIs may be subject to change.
+   */
+  getHandleWithOptions<R = any>(activityId: string, options: GetActivityHandleOptions): ActivityHandle<R> {
+    return this.createHandle(activityId, options.runId, options.typeInfo?.outputType);
+  }
+
+  /**
    * Return a list of Activity executions matching the given `query`.
    *
    * Note that the list of Activity executions returned is approximate and eventually consistent.
@@ -210,7 +224,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
     });
   }
 
-  protected createHandle<R>(activityId: string, runId?: string): ActivityHandle<R> {
+  protected createHandle<R>(activityId: string, runId?: string, outputType?: TypeInfo): ActivityHandle<R> {
     if (!activityId) {
       throw new TypeError('activityId is required');
     }
@@ -224,6 +238,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
         return await this.client.interceptedHandlers.getResult({
           activityId: this.activityId,
           activityRunId: this.runId ?? '',
+          outputType,
           headers: {},
         });
       },
@@ -265,9 +280,12 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
     validateActivityOptions(input.options);
 
     const internalOptions = (input.options as InternalActivityStartOptions)[InternalActivityStartOptionsSymbol];
+    const inputTypes = input.options.typeInfo?.inputTypes;
+    const invocationInputTypes = inputTypes === undefined ? undefined : [...inputTypes];
+    const outputType = input.options.typeInfo?.outputType;
 
     try {
-      const req = await this.buildStartActivityExecutionRequest(input);
+      const req = await this.buildStartActivityExecutionRequest(input, invocationInputTypes);
       const externalStorage = this.dataConverter.externalStorage;
       if (externalStorage) {
         await visit(
@@ -288,7 +306,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       if (internalOptions != null) {
         internalOptions.responseLink = resp.link ?? undefined;
       }
-      return this.createHandle(input.options.id, resp.runId);
+      return this.createHandle(input.options.id, resp.runId, outputType);
     } catch (err) {
       if (isGrpcServiceError(err) && err.code === grpcStatus.ALREADY_EXISTS) {
         for (const entry of getGrpcStatusDetails(err) ?? []) {
@@ -312,7 +330,8 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
   }
 
   protected async buildStartActivityExecutionRequest(
-    input: ActivityStartInput
+    input: ActivityStartInput,
+    inputTypes: readonly TypeInfo[] | undefined
   ): Promise<temporal.api.workflowservice.v1.IStartActivityExecutionRequest> {
     const searchAttributes = input.options.typedSearchAttributes
       ? { indexedFields: encodeUnifiedSearchAttributes(undefined, input.options.typedSearchAttributes) }
@@ -332,7 +351,14 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       startToCloseTimeout: msOptionalToTs(input.options.startToCloseTimeout),
       heartbeatTimeout: msOptionalToTs(input.options.heartbeatTimeout),
       retryPolicy: input.options.retry ? compileRetryPolicy(input.options.retry) : undefined,
-      input: { payloads: await encodeToPayloads(this.dataConverter, ...(input.options.args || [])) },
+      input: {
+        payloads: await encodeToPayloadsWithContext(
+          this.dataConverter,
+          undefined,
+          [...(input.options.args ?? [])],
+          inputTypes
+        ),
+      },
       idReusePolicy: encodeActivityIdReusePolicy(input.options.idReusePolicy),
       idConflictPolicy: encodeActivityIdConflictPolicy(input.options.idConflictPolicy),
       searchAttributes,
@@ -364,8 +390,13 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
         const externalStorage = this.dataConverter.externalStorage;
         await visit(resp, walkPollActivityExecutionResponse, extstoreInboundOptions(externalStorage));
         if (resp.outcome?.result) {
-          const [result] = await decodeArrayFromPayloads(this.dataConverter, resp.outcome.result.payloads ?? []);
-          return result;
+          return await decodeFromPayloadsAtIndex(
+            this.dataConverter,
+            0,
+            resp.outcome.result.payloads,
+            undefined,
+            input.outputType
+          );
         } else if (resp.outcome?.failure) {
           // If error conversion throws an exception, we want it to be caught and handled by rethrowGrpcError().
           // If it succeeds, we want to throw the ActivityExecutionFailedError directly, so outside of try/catch.
@@ -554,6 +585,12 @@ export interface ActivityOptions {
    */
   args?: any[] | Readonly<any[]>;
   /**
+   * Type information used to encode Activity arguments and decode its result.
+   *
+   * @experimental
+   */
+  typeInfo?: PayloadTypeInfo;
+  /**
    * If set, specifies maximum time between successful heartbeats.
    */
   heartbeatTimeout?: Duration;
@@ -604,6 +641,25 @@ export interface ActivityOptions {
    * Search attributes for the activity.
    */
   typedSearchAttributes?: SearchAttributePair[] | TypedSearchAttributes;
+}
+
+/**
+ * Options for {@link ActivityClient.getHandleWithOptions}.
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
+export interface GetActivityHandleOptions {
+  /**
+   * If provided, targets this specific Activity run. If absent, the handle targets the latest run.
+   */
+  runId?: string;
+
+  /**
+   * Type information used to decode the Activity result.
+   *
+   * @experimental
+   */
+  typeInfo?: Pick<PayloadTypeInfo, 'outputType'>;
 }
 
 function validateActivityOptions(options: ActivityOptions): void {

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -1,5 +1,5 @@
 import { status as grpcStatus } from '@grpc/grpc-js';
-import type { ActivitySerializationContext, StorageDriverTargetInfo } from '@temporalio/common';
+import type { ActivitySerializationContext, PayloadTypeInfo, StorageDriverTargetInfo } from '@temporalio/common';
 import { ensureTemporalFailure } from '@temporalio/common';
 import {
   encodeErrorToFailure,
@@ -53,6 +53,20 @@ export interface AsyncCompletionOperationOptions {
    * @experimental Serialization context is an experimental feature and may change.
    */
   serializationContext?: ActivitySerializationContext;
+}
+
+/**
+ * Options for successfully completing an Activity asynchronously.
+ *
+ * @experimental
+ */
+export interface AsyncCompletionCompleteOptions {
+  /**
+   * Type information used to encode the Activity result.
+   *
+   * @experimental
+   */
+  typeInfo?: Pick<PayloadTypeInfo, 'outputType'>;
 }
 
 /**
@@ -170,21 +184,31 @@ export class AsyncCompletionClient extends BaseClient {
   /**
    * Complete an Activity by task token
    */
-  async complete(taskToken: Uint8Array, result: unknown, options?: AsyncCompletionOperationOptions): Promise<void>;
+  async complete(
+    taskToken: Uint8Array,
+    result: unknown,
+    options?: AsyncCompletionCompleteOptions & AsyncCompletionOperationOptions
+  ): Promise<void>;
   /**
    * Complete an Activity by full ID
    */
-  async complete(fullActivityId: FullActivityId, result: unknown): Promise<void>;
+  async complete(
+    fullActivityId: FullActivityId,
+    result: unknown,
+    options?: AsyncCompletionCompleteOptions
+  ): Promise<void>;
 
   async complete(
     taskTokenOrFullActivityId: Uint8Array | FullActivityId,
     result: unknown,
-    options?: AsyncCompletionOperationOptions
+    options?: AsyncCompletionCompleteOptions & AsyncCompletionOperationOptions
   ): Promise<void> {
+    const outputType = options?.typeInfo?.outputType;
     const payloads = await encodeToPayloadsWithContext(
       this.dataConverter,
       this.serializationContextFor(taskTokenOrFullActivityId, options),
-      [result]
+      [result],
+      outputType === undefined ? undefined : [outputType]
     );
     const externalStorage = this.dataConverter.externalStorage;
     try {

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -423,6 +423,8 @@ export interface ActivityStartInput {
 export interface ActivityGetResultInput {
   readonly activityId: string;
   readonly activityRunId: string;
+  /** Type information used to decode the Activity result. */
+  readonly outputType?: TypeInfo;
   readonly headers: Headers;
 }
 

--- a/packages/common/src/activity-definition-options.ts
+++ b/packages/common/src/activity-definition-options.ts
@@ -1,0 +1,40 @@
+import type { ActivityFunction } from './interfaces';
+import type { PayloadTypeInfo } from './type-info';
+
+/**
+ * Static metadata attached to an Activity function.
+ *
+ * @experimental
+ */
+export interface ActivityDefinitionOptions {
+  /** Type information used to decode Activity arguments and encode its result. */
+  typeInfo?: PayloadTypeInfo;
+}
+
+type ActivityKeys<A> = {
+  [K in keyof A & string]: A[K] extends ActivityFunction ? K : never;
+}[keyof A & string];
+
+/**
+ * Type information keyed only by Activity-valued properties of `A`.
+ *
+ * @experimental
+ */
+export type ActivityTypeInfoMap<A> = Partial<Record<ActivityKeys<A>, PayloadTypeInfo>>;
+
+/** @internal */
+export interface ActivityFunctionWithOptions<Args extends any[] = any[], ReturnType = any>
+  extends ActivityFunction<Args, ReturnType> {
+  activityDefinitionOptions: ActivityDefinitionOptions;
+}
+
+const activityDefinitionOptionsProperty = 'activityDefinitionOptions' satisfies keyof ActivityFunctionWithOptions;
+
+/** @internal */
+export function isActivityFunctionWithOptions(value: unknown): value is ActivityFunctionWithOptions<any[], any> {
+  if (typeof value !== 'function' || !Object.hasOwn(value, activityDefinitionOptionsProperty)) {
+    return false;
+  }
+  const { activityDefinitionOptions } = value as { activityDefinitionOptions?: unknown };
+  return typeof activityDefinitionOptions === 'object' && activityDefinitionOptions !== null;
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -8,6 +8,7 @@ import * as encoding from './encoding';
 import * as helpers from './type-helpers';
 
 export * from './activity-options';
+export * from './activity-definition-options';
 export { ActivityCancellationDetailsOptions, ActivityCancellationDetails } from './activity-cancellation-details';
 export { SuggestContinueAsNewReason } from './continue-as-new';
 export * from './converter/data-converter';

--- a/packages/test/src/test-standalone-activities.cloud-pending.ts
+++ b/packages/test/src/test-standalone-activities.cloud-pending.ts
@@ -19,13 +19,14 @@ import {
 } from '@temporalio/client';
 import type { Payload, PayloadCodec, PayloadTypeInfo } from '@temporalio/common';
 import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
+import type { Info } from '@temporalio/activity';
 import { activityInfo } from '@temporalio/activity';
 import type { TestWorkflowEnvironment } from './helpers';
 import { RUN_INTEGRATION_TESTS, waitUntil, Worker } from './helpers';
 import { echo, throwAnError } from './activities';
 import { heartbeatCancellationDetailsActivity } from './activities/heartbeat-cancellation-details';
 import { createTestWorkflowEnvironment } from './helpers-integration';
-import { convertOrder } from './workflows/type-info/activities';
+import { convertOrder, createAsyncOrderActivities } from './workflows/type-info/activities';
 import { activityTypeInfo } from './workflows/type-info/activity-type-info';
 import { Order, Receipt } from './workflows/type-info/models';
 
@@ -39,6 +40,7 @@ export interface Context {
   runPromise: Promise<void>;
   activityStartedSubject: rxjs.Subject<string>;
   activitySignalSubject: rxjs.Subject<string>;
+  asyncActivityStartedSubject: rxjs.Subject<Info>;
 }
 
 const activities = {
@@ -159,10 +161,12 @@ if (RUN_INTEGRATION_TESTS) {
 
     const activityStartedSubject = new rxjs.Subject<string>();
     const activitySignalSubject = new rxjs.Subject<string>();
+    const asyncActivityStartedSubject = new rxjs.Subject<Info>();
 
     const worker = await Worker.create({
       activities: {
         ...activities,
+        ...createAsyncOrderActivities(asyncActivityStartedSubject),
         waitForSignal: async () => {
           const activityId = activityInfo().activityId;
           const wait = waitForValue(activitySignalSubject, activityId);
@@ -186,6 +190,7 @@ if (RUN_INTEGRATION_TESTS) {
       runPromise,
       activityStartedSubject,
       activitySignalSubject,
+      asyncActivityStartedSubject,
     };
   });
 
@@ -254,6 +259,22 @@ if (RUN_INTEGRATION_TESTS) {
     });
 
     assertReceipt(t, result);
+  });
+
+  test('Async Activity completion by full ID preserves a rich result', async (t) => {
+    const client = t.context.env.client.activity;
+    const activityStarted = rxjs.firstValueFrom(t.context.asyncActivityStartedSubject);
+    const handle = await client.start<Receipt>('completeOrderAsync', {
+      ...typeInfoActivityOptions,
+      id: randomUUID(),
+      args: [new Order('order-1', 12345n)],
+      typeInfo: activityTypeInfo.convertOrder,
+    });
+    const info = await activityStarted;
+    await client.complete({ activityId: info.activityId, runId: info.activityRunId }, new Receipt('order-1', 12345n), {
+      typeInfo: { outputType: activityTypeInfo.convertOrder.outputType },
+    });
+    assertReceipt(t, await handle.result());
   });
 
   test('Detached Activity handle decodes its result with output TypeInfo', async (t) => {

--- a/packages/test/src/test-standalone-activities.cloud-pending.ts
+++ b/packages/test/src/test-standalone-activities.cloud-pending.ts
@@ -1,16 +1,23 @@
 import { randomUUID } from 'crypto';
-import type { TestFn } from 'ava';
+import type { ExecutionContext, TestFn } from 'ava';
 import anyTest from 'ava';
 import * as rxjs from 'rxjs';
-import type { ActivityHandle, TypedActivityClient, ActivityOptions } from '@temporalio/client';
+import type {
+  ActivityHandle,
+  ActivityOptions,
+  ActivityClientInterceptor,
+  TypedActivityClient,
+} from '@temporalio/client';
 import {
   ActivityExecutionStatus,
   ActivityExecutionAlreadyStartedError,
   ActivityExecutionFailedError,
+  Client,
   ServiceError,
   TerminatedFailure,
   isGrpcCancelledError,
 } from '@temporalio/client';
+import type { Payload, PayloadCodec, PayloadTypeInfo } from '@temporalio/common';
 import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
 import { activityInfo } from '@temporalio/activity';
 import type { TestWorkflowEnvironment } from './helpers';
@@ -18,6 +25,9 @@ import { RUN_INTEGRATION_TESTS, waitUntil, Worker } from './helpers';
 import { echo, throwAnError } from './activities';
 import { heartbeatCancellationDetailsActivity } from './activities/heartbeat-cancellation-details';
 import { createTestWorkflowEnvironment } from './helpers-integration';
+import { convertOrder } from './workflows/type-info/activities';
+import { activityTypeInfo } from './workflows/type-info/activity-type-info';
+import { Order, Receipt } from './workflows/type-info/models';
 
 // Use a reduced server long-poll expiration timeout, in order to confirm that client
 // polling/retry strategies result in the expected behavior
@@ -33,6 +43,7 @@ export interface Context {
 
 const activities = {
   echo,
+  convertOrder,
   throwAnError,
   heartbeatCancellationDetailsActivity,
   verifyStandaloneActivityInfo: async () => {
@@ -71,10 +82,66 @@ const defaultOptions: Omit<ActivityOptions, 'id' | 'args'> = {
   idReusePolicy: 'ALLOW_DUPLICATE',
 };
 
+const typeInfoActivityOptions = {
+  ...defaultOptions,
+  retry: { maximumAttempts: 1 },
+};
+
 const test = anyTest as TestFn<Context>;
 
 async function waitForValue<T>(subject: rxjs.Subject<T>, value: T) {
   await rxjs.firstValueFrom(subject.pipe(rxjs.first((v) => v === value)));
+}
+
+function assertReceipt(t: ExecutionContext, receipt: Receipt): void {
+  t.true(receipt instanceof Receipt);
+  t.is(receipt.summary(), 'order-1:12345');
+  t.is(typeof receipt.totalCents, 'bigint');
+}
+
+function makeClientWithActivityInterceptors(
+  env: TestWorkflowEnvironment,
+  interceptors: ActivityClientInterceptor[]
+): Client {
+  return new Client({
+    connection: env.client.connection,
+    namespace: env.client.options.namespace,
+    interceptors: { activity: interceptors },
+  });
+}
+
+class BlockingEncodePayloadCodec implements PayloadCodec {
+  readonly encodingStarted: Promise<void>;
+  private readonly continueEncoding: Promise<void>;
+  private resolveEncodingStarted!: () => void;
+  private resolveContinueEncoding!: () => void;
+  private blockNextEncode = true;
+
+  constructor() {
+    this.encodingStarted = new Promise((resolve) => {
+      this.resolveEncodingStarted = resolve;
+    });
+    this.continueEncoding = new Promise((resolve) => {
+      this.resolveContinueEncoding = resolve;
+    });
+  }
+
+  async encode(payloads: Payload[]): Promise<Payload[]> {
+    if (this.blockNextEncode) {
+      this.blockNextEncode = false;
+      this.resolveEncodingStarted();
+      await this.continueEncoding;
+    }
+    return payloads;
+  }
+
+  async decode(payloads: Payload[]): Promise<Payload[]> {
+    return payloads;
+  }
+
+  releaseEncoding(): void {
+    this.resolveContinueEncoding();
+  }
 }
 
 if (RUN_INTEGRATION_TESTS) {
@@ -163,6 +230,99 @@ if (RUN_INTEGRATION_TESTS) {
       args: ['hello'],
     });
     t.is(result, 'hello');
+  });
+
+  test('Start Activity preserves rich input and retained result with TypeInfo', async (t) => {
+    const client = t.context.env.client.activity;
+    const handle = await client.start<Receipt>('convertOrder', {
+      ...typeInfoActivityOptions,
+      id: randomUUID(),
+      args: [new Order('order-1', 12345n)],
+      typeInfo: activityTypeInfo.convertOrder,
+    });
+
+    assertReceipt(t, await handle.result());
+  });
+
+  test('Execute Activity preserves rich input and result with TypeInfo', async (t) => {
+    const client = t.context.env.client.activity;
+    const result = await client.execute<Receipt>('convertOrder', {
+      ...typeInfoActivityOptions,
+      id: randomUUID(),
+      args: [new Order('order-1', 12345n)],
+      typeInfo: activityTypeInfo.convertOrder,
+    });
+
+    assertReceipt(t, result);
+  });
+
+  test('Detached Activity handle decodes its result with output TypeInfo', async (t) => {
+    const client = t.context.env.client.activity;
+    const activityId = randomUUID();
+    const handle = await client.start<Receipt>('convertOrder', {
+      ...typeInfoActivityOptions,
+      id: activityId,
+      args: [new Order('order-1', 12345n)],
+      typeInfo: activityTypeInfo.convertOrder,
+    });
+
+    const detachedHandle = client.getHandleWithOptions<Receipt>(activityId, {
+      runId: handle.runId,
+      typeInfo: { outputType: activityTypeInfo.convertOrder.outputType },
+    });
+    assertReceipt(t, await detachedHandle.result());
+  });
+
+  test('Activity interceptors can provide input and result TypeInfo', async (t) => {
+    const client = makeClientWithActivityInterceptors(t.context.env, [
+      {
+        async start(input, next) {
+          return await next({
+            ...input,
+            options: {
+              ...input.options,
+              typeInfo: { inputTypes: activityTypeInfo.convertOrder.inputTypes },
+            },
+          });
+        },
+        async getResult(input, next) {
+          return await next({
+            ...input,
+            outputType: activityTypeInfo.convertOrder.outputType,
+          });
+        },
+      },
+    ]);
+
+    const result = await client.activity.execute<Receipt>('convertOrder', {
+      ...typeInfoActivityOptions,
+      id: randomUUID(),
+      args: [new Order('order-1', 12345n)],
+    });
+
+    assertReceipt(t, result);
+  });
+
+  test('Activity start snapshots output TypeInfo before asynchronous encoding', async (t) => {
+    const codec = new BlockingEncodePayloadCodec();
+    const client = new Client({
+      connection: t.context.env.client.connection,
+      namespace: t.context.env.client.options.namespace,
+      dataConverter: { payloadCodecs: [codec] },
+    });
+    const typeInfo: PayloadTypeInfo = { ...activityTypeInfo.convertOrder };
+    const start = client.activity.start<Receipt>('convertOrder', {
+      ...typeInfoActivityOptions,
+      id: randomUUID(),
+      args: [new Order('order-1', 12345n)],
+      typeInfo,
+    });
+
+    await codec.encodingStarted;
+    typeInfo.outputType = undefined;
+    codec.releaseEncoding();
+
+    assertReceipt(t, await (await start).result());
   });
 
   test('Execute activity - failure', async (t) => {

--- a/packages/test/src/test-type-info.ts
+++ b/packages/test/src/test-type-info.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'crypto';
 import type { ExecutionContext } from 'ava';
+import { firstValueFrom, ReplaySubject } from 'rxjs';
+import type { Info } from '@temporalio/activity';
 import type { WorkflowClientInterceptor, WorkflowSignalWithStartOptions } from '@temporalio/client';
 import { Client, WithStartWorkflowOperation, WorkflowFailedError } from '@temporalio/client';
 import { workflowInterceptorModules } from '@temporalio/testing';
@@ -34,10 +36,12 @@ import {
   workflowWithUpdateStart,
   workflowWithTypedActivity,
   workflowWithTypedLocalActivity,
+  workflowWithAsyncTypedActivity,
   workflowWithInterceptorTypedActivity,
   workflowWithInterceptorTypedLocalActivity,
 } from './workflows/type-info';
-import { convertOrder } from './workflows/type-info/activities';
+import { convertOrder, createAsyncOrderActivities } from './workflows/type-info/activities';
+import { activityTypeInfo } from './workflows/type-info/activity-type-info';
 
 function assertReceipt(t: ExecutionContext, receipt: Receipt): void {
   t.true(receipt instanceof Receipt);
@@ -221,6 +225,26 @@ test('Local Activity uses TypeInfo supplied by an outbound interceptor', async (
       args: [new Order('order-1', 12345n)],
     });
     assertReceipt(t, result);
+  });
+});
+
+test('Async Activity completion by task token preserves a rich result', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const activityStarted = new ReplaySubject<Info>(1);
+  const worker = await h.createWorker({ activities: createAsyncOrderActivities(activityStarted) });
+
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(workflowWithAsyncTypedActivity, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+      args: [new Order('order-1', 12345n)],
+    });
+    const info = await firstValueFrom(activityStarted);
+    await client.activity.complete(info.taskToken, new Receipt('order-1', 12345n), {
+      typeInfo: { outputType: activityTypeInfo.convertOrder.outputType },
+    });
+    assertReceipt(t, await handle.result());
   });
 });
 

--- a/packages/test/src/test-type-info.ts
+++ b/packages/test/src/test-type-info.ts
@@ -3,7 +3,7 @@ import type { ExecutionContext } from 'ava';
 import type { WorkflowClientInterceptor, WorkflowSignalWithStartOptions } from '@temporalio/client';
 import { Client, WithStartWorkflowOperation, WorkflowFailedError } from '@temporalio/client';
 import { workflowInterceptorModules } from '@temporalio/testing';
-import { executeChild } from '@temporalio/workflow';
+import { executeChild, proxyActivities } from '@temporalio/workflow';
 import type { TestWorkflowEnvironment } from './helpers';
 import { configurableHelpers, makeTestFunction } from './helpers-integration';
 import {
@@ -32,7 +32,12 @@ import {
   workflowWithSignalStart,
   workflowWithTypeInfo,
   workflowWithUpdateStart,
+  workflowWithTypedActivity,
+  workflowWithTypedLocalActivity,
+  workflowWithInterceptorTypedActivity,
+  workflowWithInterceptorTypedLocalActivity,
 } from './workflows/type-info';
+import { convertOrder } from './workflows/type-info/activities';
 
 function assertReceipt(t: ExecutionContext, receipt: Receipt): void {
   t.true(receipt instanceof Receipt);
@@ -155,6 +160,68 @@ test('Workflow execute rejects call-site TypeInfo for a Workflow definition at r
       message: /Workflow type information cannot be supplied at the call site when using a workflow function/,
     }
   );
+});
+
+// Activities
+
+test('Activity round-trips rich input and result using proxy and definition TypeInfo', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker({ activities: { convertOrder } });
+
+  await worker.runUntil(async () => {
+    const result = await client.workflow.execute(workflowWithTypedActivity, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+      args: [new Order('order-1', 12345n)],
+    });
+    assertReceipt(t, result);
+  });
+});
+
+test('Local Activity round-trips rich input and result using proxy and definition TypeInfo', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker({ activities: { convertOrder } });
+
+  await worker.runUntil(async () => {
+    const result = await client.workflow.execute(workflowWithTypedLocalActivity, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+      args: [new Order('order-1', 12345n)],
+    });
+    assertReceipt(t, result);
+  });
+});
+
+test('Activity uses TypeInfo supplied by an outbound interceptor', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker({ activities: { convertOrder } });
+
+  await worker.runUntil(async () => {
+    const result = await client.workflow.execute(workflowWithInterceptorTypedActivity, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+      args: [new Order('order-1', 12345n)],
+    });
+    assertReceipt(t, result);
+  });
+});
+
+test('Local Activity uses TypeInfo supplied by an outbound interceptor', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const worker = await h.createWorker({ activities: { convertOrder } });
+
+  await worker.runUntil(async () => {
+    const result = await client.workflow.execute(workflowWithInterceptorTypedLocalActivity, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+      args: [new Order('order-1', 12345n)],
+    });
+    assertReceipt(t, result);
+  });
 });
 
 // Workflow transitions
@@ -780,6 +847,26 @@ test('Signal-with-Start rejects call-site TypeInfo for non-string Signal referen
       signal: signalReference,
       signalArgs: [new Order('order-1', 12345n)],
       signalTypeInfo: orderSignalTypeInfo,
+    });
+  }
+
+  t.pass();
+});
+
+test('Activity TypeInfo keys must name proxied Activities', (t) => {
+  interface ActivityModuleWithNonActivityExport {
+    convertOrder: typeof convertOrder;
+    notAnActivity: string;
+  }
+
+  function _assertActivityTypeInfoKeys() {
+    void proxyActivities<ActivityModuleWithNonActivityExport>({
+      startToCloseTimeout: '1 minute',
+      activityTypeInfo: {
+        convertOrder: workflowTypeInfo,
+        // @ts-expect-error TypeInfo cannot be supplied for a non-Activity export.
+        notAnActivity: workflowTypeInfo,
+      },
     });
   }
 

--- a/packages/test/src/workflows/type-info/activities.ts
+++ b/packages/test/src/workflows/type-info/activities.ts
@@ -1,4 +1,6 @@
-import { setActivityOptions } from '@temporalio/activity';
+import type { Observer } from 'rxjs';
+import type { Info } from '@temporalio/activity';
+import { CompleteAsyncError, Context, setActivityOptions } from '@temporalio/activity';
 import { activityTypeInfo } from './activity-type-info';
 import type { Order } from './models';
 import { assertOrder, Receipt } from './models';
@@ -9,3 +11,14 @@ export async function convertOrder(order: Order): Promise<Receipt> {
 }
 
 setActivityOptions({ typeInfo: activityTypeInfo.convertOrder }, convertOrder);
+
+export function createAsyncOrderActivities(observer: Observer<Info>): { completeOrderAsync: typeof convertOrder } {
+  async function completeOrderAsync(order: Order): Promise<Receipt> {
+    assertOrder(order);
+    observer.next(Context.current().info);
+    throw new CompleteAsyncError();
+  }
+
+  setActivityOptions({ typeInfo: activityTypeInfo.convertOrder }, completeOrderAsync);
+  return { completeOrderAsync };
+}

--- a/packages/test/src/workflows/type-info/activities.ts
+++ b/packages/test/src/workflows/type-info/activities.ts
@@ -1,0 +1,11 @@
+import { setActivityOptions } from '@temporalio/activity';
+import { activityTypeInfo } from './activity-type-info';
+import type { Order } from './models';
+import { assertOrder, Receipt } from './models';
+
+export async function convertOrder(order: Order): Promise<Receipt> {
+  assertOrder(order);
+  return new Receipt(order.id, order.totalCents);
+}
+
+setActivityOptions({ typeInfo: activityTypeInfo.convertOrder }, convertOrder);

--- a/packages/test/src/workflows/type-info/activity-type-info.ts
+++ b/packages/test/src/workflows/type-info/activity-type-info.ts
@@ -1,0 +1,7 @@
+import type { ActivityTypeInfoMap } from '@temporalio/common';
+import type * as activities from './activities';
+import { workflowTypeInfo } from './models';
+
+export const activityTypeInfo = {
+  convertOrder: workflowTypeInfo,
+} satisfies ActivityTypeInfoMap<Pick<typeof activities, 'convertOrder'>>;

--- a/packages/test/src/workflows/type-info/interceptors.ts
+++ b/packages/test/src/workflows/type-info/interceptors.ts
@@ -27,6 +27,18 @@ export const interceptors = (): WorkflowInterceptors => ({
           },
         });
       },
+      scheduleActivity(input, next) {
+        if (workflowInfo().workflowType !== 'workflowWithInterceptorTypedActivity') {
+          return next(input);
+        }
+        return next({ ...input, typeInfo: workflowTypeInfo });
+      },
+      scheduleLocalActivity(input, next) {
+        if (workflowInfo().workflowType !== 'workflowWithInterceptorTypedLocalActivity') {
+          return next(input);
+        }
+        return next({ ...input, typeInfo: workflowTypeInfo });
+      },
     },
   ],
 });

--- a/packages/test/src/workflows/type-info/workflows.ts
+++ b/packages/test/src/workflows/type-info/workflows.ts
@@ -1,4 +1,14 @@
-import { continueAsNew, defineWorkflowOptions, executeChild, makeContinueAsNewFunc } from '@temporalio/workflow';
+import {
+  continueAsNew,
+  defineWorkflowOptions,
+  executeChild,
+  makeContinueAsNewFunc,
+  proxyActivities,
+  proxyLocalActivities,
+} from '@temporalio/workflow';
+import type { ActivityOptions } from '@temporalio/common';
+import type * as activities from './activities';
+import { activityTypeInfo } from './activity-type-info';
 import { assertOrder, assertReceipt, Order, Receipt, workflowTypeInfo } from './models';
 
 defineWorkflowOptions(workflowWithTypeInfo, {
@@ -73,4 +83,64 @@ export async function continueAsNewWithInterceptorTypeInfo(order: Order): Promis
     workflowType: 'workflowWithTypeInfo',
   });
   return await continueAsTypedWorkflow(order);
+}
+
+const boundedActivityOptions = {
+  startToCloseTimeout: '1 minute',
+  retry: { maximumAttempts: 1 },
+} satisfies ActivityOptions;
+
+const typeInfoActivityWorkflowConfig = {
+  workflowDefinitionOptions: { failureExceptionTypes: [Error] },
+  staticOptions: { typeInfo: workflowTypeInfo },
+};
+
+const typedActivities = proxyActivities<Pick<typeof activities, 'convertOrder'>>({
+  ...boundedActivityOptions,
+  activityTypeInfo,
+});
+
+const typedLocalActivities = proxyLocalActivities<Pick<typeof activities, 'convertOrder'>>({
+  ...boundedActivityOptions,
+  activityTypeInfo,
+});
+
+defineWorkflowOptions(workflowWithTypedActivity, typeInfoActivityWorkflowConfig);
+export async function workflowWithTypedActivity(order: Order): Promise<Receipt> {
+  assertOrder(order);
+  const receipt = await typedActivities.convertOrder.executeWithOptions({ startToCloseTimeout: '30 seconds' }, [order]);
+  assertReceipt(receipt);
+  return receipt;
+}
+
+defineWorkflowOptions(workflowWithTypedLocalActivity, typeInfoActivityWorkflowConfig);
+export async function workflowWithTypedLocalActivity(order: Order): Promise<Receipt> {
+  assertOrder(order);
+  const receipt = await typedLocalActivities.convertOrder.executeWithOptions({ startToCloseTimeout: '30 seconds' }, [
+    order,
+  ]);
+  assertReceipt(receipt);
+  return receipt;
+}
+
+// These proxies intentionally omit TypeInfo so the outbound interceptor is the only metadata source.
+const activitiesConfiguredByInterceptor =
+  proxyActivities<Pick<typeof activities, 'convertOrder'>>(boundedActivityOptions);
+const localActivitiesConfiguredByInterceptor =
+  proxyLocalActivities<Pick<typeof activities, 'convertOrder'>>(boundedActivityOptions);
+
+defineWorkflowOptions(workflowWithInterceptorTypedActivity, typeInfoActivityWorkflowConfig);
+export async function workflowWithInterceptorTypedActivity(order: Order): Promise<Receipt> {
+  assertOrder(order);
+  const receipt = await activitiesConfiguredByInterceptor.convertOrder(order);
+  assertReceipt(receipt);
+  return receipt;
+}
+
+defineWorkflowOptions(workflowWithInterceptorTypedLocalActivity, typeInfoActivityWorkflowConfig);
+export async function workflowWithInterceptorTypedLocalActivity(order: Order): Promise<Receipt> {
+  assertOrder(order);
+  const receipt = await localActivitiesConfiguredByInterceptor.convertOrder(order);
+  assertReceipt(receipt);
+  return receipt;
 }

--- a/packages/test/src/workflows/type-info/workflows.ts
+++ b/packages/test/src/workflows/type-info/workflows.ts
@@ -100,6 +100,19 @@ const typedActivities = proxyActivities<Pick<typeof activities, 'convertOrder'>>
   activityTypeInfo,
 });
 
+const asyncTypedActivities = proxyActivities<ReturnType<typeof activities.createAsyncOrderActivities>>({
+  ...boundedActivityOptions,
+  activityTypeInfo: { completeOrderAsync: activityTypeInfo.convertOrder },
+});
+
+defineWorkflowOptions(workflowWithAsyncTypedActivity, typeInfoActivityWorkflowConfig);
+export async function workflowWithAsyncTypedActivity(order: Order): Promise<Receipt> {
+  assertOrder(order);
+  const receipt = await asyncTypedActivities.completeOrderAsync(order);
+  assertReceipt(receipt);
+  return receipt;
+}
+
 const typedLocalActivities = proxyLocalActivities<Pick<typeof activities, 'convertOrder'>>({
   ...boundedActivityOptions,
   activityTypeInfo,

--- a/packages/testing/src/mocking-activity-environment.ts
+++ b/packages/testing/src/mocking-activity-environment.ts
@@ -56,6 +56,7 @@ export class MockActivityEnvironment extends events.EventEmitter {
         workflowId: activityInfo.workflowExecution?.workflowId,
         isLocal: activityInfo.isLocal,
       },
+      undefined,
       heartbeatCallback,
       opts?.client,
       LoggerWithComposedMetadata.compose(opts?.logger ?? new DefaultLogger(), { sdkComponent: SdkComponent.worker }),

--- a/packages/worker/src/activity.ts
+++ b/packages/worker/src/activity.ts
@@ -7,6 +7,7 @@ import type {
   LoadedDataConverter,
   MetricMeter,
   MetricTags,
+  TypeInfo,
 } from '@temporalio/common';
 import {
   ApplicationFailure,
@@ -70,6 +71,7 @@ export class Activity {
     public readonly fn: ActivityFunction<any[], any> | undefined,
     public readonly dataConverter: LoadedDataConverter,
     public readonly serializationContext: ActivitySerializationContext,
+    public readonly outputTypeInfo: TypeInfo | undefined,
     public readonly heartbeatCallback: Context['heartbeat'],
     private readonly _client: Client | undefined, // May be undefined in the case of MockActivityEnvironment
     workerLogger: Logger,
@@ -195,7 +197,11 @@ export class Activity {
       try {
         if (this.fn === undefined) throw new IllegalStateError('Activity function is not defined');
         const result = await this.executeWithClient(this.fn, input);
-        return { completed: { result: await encodeToPayload(this.dataConverter, result, this.serializationContext) } };
+        return {
+          completed: {
+            result: await encodeToPayload(this.dataConverter, result, this.serializationContext, this.outputTypeInfo),
+          },
+        };
       } catch (err) {
         if (err instanceof CompleteAsyncError) {
           return { willCompleteAsync: {} };

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -10,7 +10,13 @@ import { delay, filter, first, ignoreElements, last, map, mergeMap, takeUntil, t
 import type { RawSourceMap } from 'source-map';
 import * as nexus from 'nexus-rpc';
 import type { Info as ActivityInfo } from '@temporalio/activity';
-import type { LoadedDataConverter, Payload, MetricMeter, ActivitySerializationContext } from '@temporalio/common';
+import type {
+  LoadedDataConverter,
+  Payload,
+  MetricMeter,
+  ActivitySerializationContext,
+  PayloadTypeInfo,
+} from '@temporalio/common';
 import {
   DataConverter,
   decompileRetryPolicy,
@@ -24,6 +30,7 @@ import {
   CancelledFailure,
   ActivityCancellationDetails,
   convertDeploymentVersion,
+  isActivityFunctionWithOptions,
 } from '@temporalio/common';
 import type { Decoded } from '@temporalio/common/lib/internal-non-workflow';
 import {
@@ -1108,9 +1115,18 @@ export class Worker {
                         nonRetryable: false,
                       });
                     }
+                    const typeInfo: PayloadTypeInfo | undefined = isActivityFunctionWithOptions(fn)
+                      ? fn.activityDefinitionOptions.typeInfo
+                      : undefined;
+                    const outputTypeInfo = typeInfo?.outputType;
                     let args: unknown[];
                     try {
-                      args = await decodeArrayFromPayloads(loadedDataConverter, task.start?.input, context);
+                      args = await decodeArrayFromPayloads(
+                        loadedDataConverter,
+                        task.start?.input,
+                        context,
+                        typeInfo?.inputTypes
+                      );
                     } catch (err) {
                       throw ApplicationFailure.fromError(err, {
                         message: `Failed to parse activity args for activity ${activityType}: ${errorMessage(err)}`,
@@ -1130,6 +1146,7 @@ export class Worker {
                       fn,
                       loadedDataConverter,
                       context,
+                      outputTypeInfo,
                       (details) =>
                         this.activityHeartbeatSubject.next({
                           type: 'heartbeat',

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -86,6 +86,7 @@ export {
   ActivityCancellationType,
   ActivityFailure,
   ActivityOptions,
+  ActivityTypeInfoMap,
   ApplicationFailure,
   CancelledFailure,
   ChildWorkflowFailure,

--- a/packages/workflow/src/interceptors.ts
+++ b/packages/workflow/src/interceptors.ts
@@ -9,6 +9,7 @@ import type {
   Duration,
   LocalActivityOptions,
   MetricTags,
+  PayloadTypeInfo,
   SignalTypeInfo,
   Timestamp,
   TypeInfo,
@@ -244,6 +245,8 @@ export interface ActivityInput {
   readonly options: ActivityOptions;
   readonly headers: Headers;
   readonly seq: number;
+  /** TypeInfo selected for this invocation. Interceptors may replace it before calling `next`. */
+  readonly typeInfo?: PayloadTypeInfo;
 }
 
 /**
@@ -257,6 +260,8 @@ export interface LocalActivityInput {
   readonly seq: number;
   readonly originalScheduleTime?: Timestamp;
   readonly attempt: number;
+  /** TypeInfo selected for this invocation. Interceptors may replace it before calling `next`. */
+  readonly typeInfo?: PayloadTypeInfo;
 }
 
 /**

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -699,10 +699,12 @@ export class Activator implements ActivationHandler {
     if (!activation.result) {
       throw new TypeError('Got ResolveActivity activation with no result');
     }
-    const { resolve, reject, context } = this.consumeCompletion('activity', getSeq(activation));
+    const { resolve, reject, context, outputTypeInfo } = this.consumeCompletion('activity', getSeq(activation));
     if (activation.result.completed) {
       const completed = activation.result.completed;
-      const result = completed.result ? this.payloadConverter.fromPayload(completed.result, context) : undefined;
+      const result = completed.result
+        ? fromPayloadWithTypeInfo(this.payloadConverter, completed.result, context, outputTypeInfo)
+        : undefined;
       resolve(result);
     } else if (activation.result.failed) {
       const { failure } = activation.result.failed;

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -2,7 +2,9 @@ import type {
   ActivityFunction,
   ActivitySerializationContext,
   ActivityOptions,
+  ActivityTypeInfoMap,
   LocalActivityOptions,
+  PayloadTypeInfo,
   QueryDefinition,
   QueryDefinitionOptions,
   SearchAttributes,
@@ -210,7 +212,14 @@ const validateLocalActivityOptions = validateActivityOptions;
 /**
  * Push a scheduleActivity command into activator accumulator and register completion
  */
-function scheduleActivityNextHandler({ options, args, headers, seq, activityType }: ActivityInput): Promise<unknown> {
+function scheduleActivityNextHandler({
+  options,
+  args,
+  headers,
+  seq,
+  activityType,
+  typeInfo,
+}: ActivityInput): Promise<unknown> {
   const activator = getActivator();
   validateActivityOptions(options);
   const activityId = options.activityId ?? `${seq}`;
@@ -240,7 +249,7 @@ function scheduleActivityNextHandler({ options, args, headers, seq, activityType
         seq,
         activityId,
         activityType,
-        arguments: toPayloadsWithContext(activator.payloadConverter, context, args),
+        arguments: toPayloadsWithContext(activator.payloadConverter, context, args, typeInfo?.inputTypes),
         retryPolicy: options.retry ? compileRetryPolicy(options.retry) : undefined,
         taskQueue: options.taskQueue || activator.info.taskQueue,
         heartbeatTimeout: msOptionalToTs(options.heartbeatTimeout),
@@ -259,6 +268,7 @@ function scheduleActivityNextHandler({ options, args, headers, seq, activityType
       resolve,
       reject,
       context,
+      outputTypeInfo: typeInfo?.outputType,
     });
   });
 }
@@ -274,6 +284,7 @@ async function scheduleLocalActivityNextHandler({
   activityType,
   attempt,
   originalScheduleTime,
+  typeInfo,
 }: LocalActivityInput): Promise<unknown> {
   const activator = getActivator();
   const activityId = `${seq}`;
@@ -312,7 +323,7 @@ async function scheduleLocalActivityNextHandler({
         originalScheduleTime,
         activityId,
         activityType,
-        arguments: toPayloadsWithContext(activator.payloadConverter, context, args),
+        arguments: toPayloadsWithContext(activator.payloadConverter, context, args, typeInfo?.inputTypes),
         retryPolicy: options.retry ? compileRetryPolicy(options.retry) : undefined,
         scheduleToCloseTimeout: msOptionalToTs(options.scheduleToCloseTimeout),
         startToCloseTimeout: msOptionalToTs(options.startToCloseTimeout),
@@ -327,6 +338,7 @@ async function scheduleLocalActivityNextHandler({
       resolve,
       reject,
       context,
+      outputTypeInfo: typeInfo?.outputType,
     });
   });
 }
@@ -335,7 +347,12 @@ async function scheduleLocalActivityNextHandler({
  * Schedule an activity and run outbound interceptors
  * @hidden
  */
-export function scheduleActivity<R>(activityType: string, args: any[], options: ActivityOptions): Promise<R> {
+export function scheduleActivity<R>(
+  activityType: string,
+  args: any[],
+  options: ActivityOptions,
+  typeInfo?: PayloadTypeInfo
+): Promise<R> {
   const activator = assertInWorkflowContext(
     'Workflow.scheduleActivity(...) may only be used from a Workflow Execution'
   );
@@ -351,6 +368,7 @@ export function scheduleActivity<R>(activityType: string, args: any[], options: 
     options,
     args,
     seq,
+    typeInfo,
   }) as Promise<R>;
 }
 
@@ -361,7 +379,8 @@ export function scheduleActivity<R>(activityType: string, args: any[], options: 
 export async function scheduleLocalActivity<R>(
   activityType: string,
   args: any[],
-  options: LocalActivityOptions
+  options: LocalActivityOptions,
+  typeInfo?: PayloadTypeInfo
 ): Promise<R> {
   const activator = assertInWorkflowContext(
     'Workflow.scheduleLocalActivity(...) may only be used from a Workflow Execution'
@@ -390,6 +409,7 @@ export async function scheduleLocalActivity<R>(
         seq,
         attempt,
         originalScheduleTime,
+        typeInfo,
       })) as Promise<R>;
     } catch (err) {
       if (err instanceof LocalActivityDoBackoff) {
@@ -576,6 +596,16 @@ export type ActivityInterfaceFor<T> = {
   [K in keyof T]: T[K] extends ActivityFunction ? ActivityFunctionWithOptions<T[K]> : typeof NotAnActivityMethod;
 };
 
+/**
+ * Options for {@link proxyActivities}, including optional metadata for each proxied Activity.
+ *
+ * @experimental
+ */
+export interface ActivityProxyOptions<A = UntypedActivities> extends ActivityOptions {
+  /** Type information keyed by the Activity names exposed by this proxy. */
+  activityTypeInfo?: ActivityTypeInfoMap<A>;
+}
+
 export type ActivityFunctionWithOptions<T extends ActivityFunction> = T & {
   /**
    * Execute the activity, overriding its existing options with the
@@ -596,6 +626,16 @@ export type ActivityFunctionWithOptions<T extends ActivityFunction> = T & {
 export type LocalActivityInterfaceFor<T> = {
   [K in keyof T]: T[K] extends ActivityFunction ? LocalActivityFunctionWithOptions<T[K]> : typeof NotAnActivityMethod;
 };
+
+/**
+ * Options for {@link proxyLocalActivities}, including optional metadata for each proxied Local Activity.
+ *
+ * @experimental
+ */
+export interface LocalActivityProxyOptions<A = UntypedActivities> extends LocalActivityOptions {
+  /** Type information keyed by the Local Activity names exposed by this proxy. */
+  activityTypeInfo?: ActivityTypeInfoMap<A>;
+}
 
 export type LocalActivityFunctionWithOptions<T extends ActivityFunction> = T & {
   /**
@@ -668,7 +708,7 @@ export type LocalActivityFunctionWithOptions<T extends ActivityFunction> = T & {
  * }
  * ```
  */
-export function proxyActivities<A = UntypedActivities>(options: ActivityOptions): ActivityInterfaceFor<A> {
+export function proxyActivities<A = UntypedActivities>(options: ActivityProxyOptions<A>): ActivityInterfaceFor<A> {
   if (options === undefined) {
     throw new TypeError('options must be defined');
   }
@@ -680,16 +720,29 @@ export function proxyActivities<A = UntypedActivities>(options: ActivityOptions)
       if (typeof activityType !== 'string') {
         throw new TypeError(`Only strings are supported for Activity types, got: ${String(activityType)}`);
       }
+      const activityName = activityType;
 
       function activityProxyFunction(...args: unknown[]): Promise<unknown> {
-        return scheduleActivity(activityType as string, args, options);
+        const { activityTypeInfo, ...activityOptions } = options;
+        return scheduleActivity(
+          activityName,
+          args,
+          activityOptions,
+          activityTypeInfo?.[activityName as keyof A & string]
+        );
       }
 
       activityProxyFunction.executeWithOptions = function (
         overrideOptions: ActivityOptions,
         args: any[]
       ): Promise<unknown> {
-        return scheduleActivity(activityType, args, deepMerge(options, overrideOptions));
+        const { activityTypeInfo, ...activityOptions } = options;
+        return scheduleActivity(
+          activityName,
+          args,
+          deepMerge(activityOptions, overrideOptions),
+          activityTypeInfo?.[activityName as keyof A & string]
+        );
       };
 
       return activityProxyFunction;
@@ -708,7 +761,7 @@ export function proxyActivities<A = UntypedActivities>(options: ActivityOptions)
  * @see {@link proxyActivities} for examples
  */
 export function proxyLocalActivities<A = UntypedActivities>(
-  options: LocalActivityOptions
+  options: LocalActivityProxyOptions<A>
 ): LocalActivityInterfaceFor<A> {
   if (options === undefined) {
     throw new TypeError('options must be defined');
@@ -721,16 +774,29 @@ export function proxyLocalActivities<A = UntypedActivities>(
       if (typeof activityType !== 'string') {
         throw new TypeError(`Only strings are supported for Activity types, got: ${String(activityType)}`);
       }
+      const activityName = activityType;
 
       function localActivityProxyFunction(...args: unknown[]): Promise<unknown> {
-        return scheduleLocalActivity(activityType as string, args, options);
+        const { activityTypeInfo, ...activityOptions } = options;
+        return scheduleLocalActivity(
+          activityName,
+          args,
+          activityOptions,
+          activityTypeInfo?.[activityName as keyof A & string]
+        );
       }
 
       localActivityProxyFunction.executeWithOptions = function (
         overrideOptions: LocalActivityOptions,
         args: any[]
       ): Promise<unknown> {
-        return scheduleLocalActivity(activityType, args, deepMerge(options, overrideOptions));
+        const { activityTypeInfo, ...activityOptions } = options;
+        return scheduleLocalActivity(
+          activityName,
+          args,
+          deepMerge(activityOptions, overrideOptions),
+          activityTypeInfo?.[activityName as keyof A & string]
+        );
       };
 
       return localActivityProxyFunction;


### PR DESCRIPTION
## What was changed

Added experimental `TypeInfo` support across the complete Activity serialization surface.

Activity implementations can attach shared input and output metadata with `setActivityOptions`. Workflow and Local Activity proxies accept the same typed metadata map, and outbound interceptors may replace the selected metadata before conversion. Workers apply definition metadata when decoding arguments and encoding results, including default Activity handlers.

Standalone Activity Clients apply TypeInfo to start and execute calls, retain output metadata on returned handles, and accept output metadata when reconstructing detached handles. Async completion accepts output TypeInfo for task-token and full-ID completion without exposing ignored serialization-context options.

Calls without TypeInfo retain their existing behavior. Existing Activity registration and positional `getHandle(activityId, runId?)` calls remain unchanged; no rollout or manual steps are required.

## Why?

Without TypeInfo, Activity serialization boundaries lose application runtime types such as class instances and `bigint` fields. Activities require metadata on both the caller and Worker sides because Workflow isolates can import Activity types but not their implementations.

## Checklist

1. Closes: N/A

2. How was this tested: Common, Activity, Client, Workflow, Worker, Testing, and Test TypeScript builds; changed-file ESLint and Prettier; `ts-prune`; and `git diff --check`. The focused TypeInfo suite passed all 43 tests, and all 6 standalone/async Activity TypeInfo tests passed. The full standalone Activity file passed 23 tests and encountered one unrelated existing start-delay timing assertion.

3. Any docs updates needed? No; documentation will accompany the completed experimental TypeInfo API.
