### PR TITLE
feat(client): add TypeInfo to standalone Activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ to docs, or any other relevant information.
 
 ### Added
 
+- **Experimental**: Standalone Activity Clients can use `TypeInfo` to convert Activity inputs and results.
 - **Experimental**: Activities can use `TypeInfo` to convert inputs and results when called through Workflow Activity
   proxies and handled by Workers.
 - Core logs written directly to the console can now use compact, pretty, or newline-delimited JSON

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -4,10 +4,12 @@ import type {
   ActivityFunction,
   LoadedDataConverter,
   Next,
+  PayloadTypeInfo,
   Priority,
   RetryPolicy,
   SearchAttributePair,
   TypedSearchAttributes,
+  TypeInfo,
 } from '@temporalio/common';
 import {
   compilePriority,
@@ -25,10 +27,9 @@ import {
   searchAttributePayloadConverter,
 } from '@temporalio/common/lib/converter/payload-search-attributes';
 import {
-  decodeArrayFromPayloads,
   decodeFromPayloadsAtIndex,
   decodeOptionalFailureToOptionalError,
-  encodeToPayloads,
+  encodeToPayloadsWithContext,
   encodeUserMetadata,
   extstoreInboundOptions,
   extstoreStoreOptions,
@@ -167,13 +168,18 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
    * {@link ActivityHandle.describe} and read the `activityRunId` field of the returned {@link ActivityExecutionDescription}.
    *
    * @param activityId ID of the Activity.
-   * @param runId Optional run ID of the specific Activity execution.
+   * @param runIdOrOptions Optional run ID, or options containing a run ID and TypeInfo used to decode the result.
    * @returns Handle to the specified activity execution.
    *
    * @experimental Standalone Activities are experimental. APIs may be subject to change.
    */
-  getHandle<R = any>(activityId: string, runId?: string): ActivityHandle<R> {
-    return this.createHandle(activityId, runId);
+  getHandle<R = any>(activityId: string, runId?: string): ActivityHandle<R>;
+  getHandle<R = any>(activityId: string, options?: GetActivityHandleOptions): ActivityHandle<R>;
+  getHandle<R = any>(activityId: string, runIdOrOptions?: string | GetActivityHandleOptions): ActivityHandle<R> {
+    if (typeof runIdOrOptions === 'string') {
+      return this.createHandle(activityId, runIdOrOptions);
+    }
+    return this.createHandle(activityId, runIdOrOptions?.runId, runIdOrOptions?.typeInfo?.outputType);
   }
 
   /**
@@ -210,7 +216,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
     });
   }
 
-  protected createHandle<R>(activityId: string, runId?: string): ActivityHandle<R> {
+  protected createHandle<R>(activityId: string, runId?: string, outputType?: TypeInfo): ActivityHandle<R> {
     if (!activityId) {
       throw new TypeError('activityId is required');
     }
@@ -224,6 +230,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
         return await this.client.interceptedHandlers.getResult({
           activityId: this.activityId,
           activityRunId: this.runId ?? '',
+          outputType,
           headers: {},
         });
       },
@@ -288,7 +295,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       if (internalOptions != null) {
         internalOptions.responseLink = resp.link ?? undefined;
       }
-      return this.createHandle(input.options.id, resp.runId);
+      return this.createHandle(input.options.id, resp.runId, input.options.typeInfo?.outputType);
     } catch (err) {
       if (isGrpcServiceError(err) && err.code === grpcStatus.ALREADY_EXISTS) {
         for (const entry of getGrpcStatusDetails(err) ?? []) {
@@ -332,7 +339,14 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       startToCloseTimeout: msOptionalToTs(input.options.startToCloseTimeout),
       heartbeatTimeout: msOptionalToTs(input.options.heartbeatTimeout),
       retryPolicy: input.options.retry ? compileRetryPolicy(input.options.retry) : undefined,
-      input: { payloads: await encodeToPayloads(this.dataConverter, ...(input.options.args || [])) },
+      input: {
+        payloads: await encodeToPayloadsWithContext(
+          this.dataConverter,
+          undefined,
+          input.options.args ?? [],
+          input.options.typeInfo?.inputTypes
+        ),
+      },
       idReusePolicy: encodeActivityIdReusePolicy(input.options.idReusePolicy),
       idConflictPolicy: encodeActivityIdConflictPolicy(input.options.idConflictPolicy),
       searchAttributes,
@@ -364,8 +378,13 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
         const externalStorage = this.dataConverter.externalStorage;
         await visit(resp, walkPollActivityExecutionResponse, extstoreInboundOptions(externalStorage));
         if (resp.outcome?.result) {
-          const [result] = await decodeArrayFromPayloads(this.dataConverter, resp.outcome.result.payloads ?? []);
-          return result;
+          return await decodeFromPayloadsAtIndex(
+            this.dataConverter,
+            0,
+            resp.outcome.result.payloads,
+            undefined,
+            input.outputType
+          );
         } else if (resp.outcome?.failure) {
           // If error conversion throws an exception, we want it to be caught and handled by rethrowGrpcError().
           // If it succeeds, we want to throw the ActivityExecutionFailedError directly, so outside of try/catch.
@@ -554,6 +573,12 @@ export interface ActivityOptions {
    */
   args?: any[] | Readonly<any[]>;
   /**
+   * Type information used to encode Activity arguments and decode its result.
+   *
+   * @experimental
+   */
+  typeInfo?: PayloadTypeInfo;
+  /**
    * If set, specifies maximum time between successful heartbeats.
    */
   heartbeatTimeout?: Duration;
@@ -604,6 +629,25 @@ export interface ActivityOptions {
    * Search attributes for the activity.
    */
   typedSearchAttributes?: SearchAttributePair[] | TypedSearchAttributes;
+}
+
+/**
+ * Options for {@link ActivityClient.getHandle}.
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
+export interface GetActivityHandleOptions {
+  /**
+   * If provided, targets this specific Activity run. If absent, the handle targets the latest run.
+   */
+  runId?: string;
+
+  /**
+   * Type information used to decode the Activity result.
+   *
+   * @experimental
+   */
+  typeInfo?: Pick<PayloadTypeInfo, 'outputType'>;
 }
 
 function validateActivityOptions(options: ActivityOptions): void {

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -420,6 +420,8 @@ export interface ActivityStartInput {
 export interface ActivityGetResultInput {
   readonly activityId: string;
   readonly activityRunId: string;
+  /** Type information used to decode the Activity result. */
+  readonly outputType?: TypeInfo;
   readonly headers: Headers;
 }
 

--- a/packages/test/src/test-standalone-activities.cloud-pending.ts
+++ b/packages/test/src/test-standalone-activities.cloud-pending.ts
@@ -1,12 +1,18 @@
 import { randomUUID } from 'crypto';
-import type { TestFn } from 'ava';
+import type { ExecutionContext, TestFn } from 'ava';
 import anyTest from 'ava';
 import * as rxjs from 'rxjs';
-import type { ActivityHandle, TypedActivityClient, ActivityOptions } from '@temporalio/client';
+import type {
+  ActivityHandle,
+  ActivityOptions,
+  ActivityClientInterceptor,
+  TypedActivityClient,
+} from '@temporalio/client';
 import {
   ActivityExecutionStatus,
   ActivityExecutionAlreadyStartedError,
   ActivityExecutionFailedError,
+  Client,
   ServiceError,
   TerminatedFailure,
   isGrpcCancelledError,
@@ -18,6 +24,8 @@ import { RUN_INTEGRATION_TESTS, waitUntil, Worker } from './helpers';
 import { echo, throwAnError } from './activities';
 import { heartbeatCancellationDetailsActivity } from './activities/heartbeat-cancellation-details';
 import { createTestWorkflowEnvironment } from './helpers-integration';
+import { convertOrder } from './workflows/type-info/activities';
+import { Order, Receipt, receiptTypeInfo, workflowTypeInfo } from './workflows/type-info/models';
 
 // Use a reduced server long-poll expiration timeout, in order to confirm that client
 // polling/retry strategies result in the expected behavior
@@ -33,6 +41,7 @@ export interface Context {
 
 const activities = {
   echo,
+  convertOrder,
   throwAnError,
   heartbeatCancellationDetailsActivity,
   verifyStandaloneActivityInfo: async () => {
@@ -75,6 +84,23 @@ const test = anyTest as TestFn<Context>;
 
 async function waitForValue<T>(subject: rxjs.Subject<T>, value: T) {
   await rxjs.firstValueFrom(subject.pipe(rxjs.first((v) => v === value)));
+}
+
+function assertReceipt(t: ExecutionContext, receipt: Receipt): void {
+  t.true(receipt instanceof Receipt);
+  t.is(receipt.summary(), 'order-1:12345');
+  t.is(typeof receipt.totalCents, 'bigint');
+}
+
+function makeClientWithActivityInterceptors(
+  env: TestWorkflowEnvironment,
+  interceptors: ActivityClientInterceptor[]
+): Client {
+  return new Client({
+    connection: env.client.connection,
+    namespace: env.client.options.namespace,
+    interceptors: { activity: interceptors },
+  });
 }
 
 if (RUN_INTEGRATION_TESTS) {
@@ -163,6 +189,77 @@ if (RUN_INTEGRATION_TESTS) {
       args: ['hello'],
     });
     t.is(result, 'hello');
+  });
+
+  test('Start Activity preserves rich input and retained result with TypeInfo', async (t) => {
+    const client = t.context.env.client.activity;
+    const handle = await client.start<Receipt>('convertOrder', {
+      ...defaultOptions,
+      id: randomUUID(),
+      args: [new Order('order-1', 12345n)],
+      typeInfo: workflowTypeInfo,
+    });
+
+    assertReceipt(t, await handle.result());
+  });
+
+  test('Execute Activity preserves rich input and result with TypeInfo', async (t) => {
+    const client = t.context.env.client.activity;
+    const result = await client.execute<Receipt>('convertOrder', {
+      ...defaultOptions,
+      id: randomUUID(),
+      args: [new Order('order-1', 12345n)],
+      typeInfo: workflowTypeInfo,
+    });
+
+    assertReceipt(t, result);
+  });
+
+  test('Detached Activity handle decodes its result with output TypeInfo', async (t) => {
+    const client = t.context.env.client.activity;
+    const activityId = randomUUID();
+    const handle = await client.start<Receipt>('convertOrder', {
+      ...defaultOptions,
+      id: activityId,
+      args: [new Order('order-1', 12345n)],
+      typeInfo: workflowTypeInfo,
+    });
+
+    const detachedHandle = client.getHandle<Receipt>(activityId, {
+      runId: handle.runId,
+      typeInfo: { outputType: receiptTypeInfo },
+    });
+    assertReceipt(t, await detachedHandle.result());
+  });
+
+  test('Activity interceptors can provide input and result TypeInfo', async (t) => {
+    const client = makeClientWithActivityInterceptors(t.context.env, [
+      {
+        async start(input, next) {
+          return await next({
+            ...input,
+            options: {
+              ...input.options,
+              typeInfo: { inputTypes: workflowTypeInfo.inputTypes },
+            },
+          });
+        },
+        async getResult(input, next) {
+          return await next({
+            ...input,
+            outputType: receiptTypeInfo,
+          });
+        },
+      },
+    ]);
+
+    const result = await client.activity.execute<Receipt>('convertOrder', {
+      ...defaultOptions,
+      id: randomUUID(),
+      args: [new Order('order-1', 12345n)],
+    });
+
+    assertReceipt(t, result);
   });
 
   test('Execute activity - failure', async (t) => {


### PR DESCRIPTION
## What was changed

Standalone Activity Clients now accept experimental `TypeInfo` when starting or executing an Activity. The client applies input information before sending arguments, retains output information on the returned handle, and accepts output information when reconstructing a handle by ID. Activity Client interceptors can replace the metadata before the request is encoded.

## Why?

Activity TypeInfo already covers Workflow Activity proxies and Worker handlers. Standalone Activities need the same conversion boundary so rich application values can be preserved when an Activity is started directly from a Client.

Existing calls and positional `getHandle(activityId, runId?)` remain unchanged. This adds an options-object `getHandle` overload for result decoding; no rollout or manual steps are required.

This draft is stacked on the Workflow/Worker Activity TypeInfo PR.

## Checklist

1. Closes: N/A

2. How was this tested: Client build, Prettier, and `git diff --check`. Focused standalone Activity integration validation remains pending the parent draft's test fix.

3. Any docs updates needed? No; the experimental API is covered by TSDoc and the changelog.
