### PR TITLE
feat(client): add TypeInfo to async Activity completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ to docs, or any other relevant information.
 - **Experimental**: Standalone Activity Clients can use `TypeInfo` to convert Activity inputs and results.
 - **Experimental**: Activities can use `TypeInfo` to convert inputs and results when called through Workflow Activity
   proxies and handled by Workers.
+- **Experimental**: Async Activity completion can use `TypeInfo` to convert successful Activity results.
 - Core logs written directly to the console can now use compact, pretty, or newline-delimited JSON
   output via `telemetryOptions.logging.console.format`.
 - **Experimental**: Workflow Clients can now use `TypeInfo` to encode Workflow inputs and decode Workflow results.

--- a/packages/client/src/async-completion-client.ts
+++ b/packages/client/src/async-completion-client.ts
@@ -1,5 +1,5 @@
 import { status as grpcStatus } from '@grpc/grpc-js';
-import type { ActivitySerializationContext, StorageDriverTargetInfo } from '@temporalio/common';
+import type { ActivitySerializationContext, PayloadTypeInfo, StorageDriverTargetInfo } from '@temporalio/common';
 import { ensureTemporalFailure } from '@temporalio/common';
 import {
   encodeErrorToFailure,
@@ -53,6 +53,20 @@ export interface AsyncCompletionOperationOptions {
    * @experimental Serialization context is an experimental feature and may change.
    */
   serializationContext?: ActivitySerializationContext;
+}
+
+/**
+ * Options for successfully completing an Activity asynchronously.
+ *
+ * @experimental
+ */
+export interface AsyncCompletionCompleteOptions extends AsyncCompletionOperationOptions {
+  /**
+   * Type information used to encode the Activity result.
+   *
+   * @experimental
+   */
+  typeInfo?: Pick<PayloadTypeInfo, 'outputType'>;
 }
 
 /**
@@ -170,21 +184,27 @@ export class AsyncCompletionClient extends BaseClient {
   /**
    * Complete an Activity by task token
    */
-  async complete(taskToken: Uint8Array, result: unknown, options?: AsyncCompletionOperationOptions): Promise<void>;
+  async complete(taskToken: Uint8Array, result: unknown, options?: AsyncCompletionCompleteOptions): Promise<void>;
   /**
    * Complete an Activity by full ID
    */
-  async complete(fullActivityId: FullActivityId, result: unknown): Promise<void>;
+  async complete(
+    fullActivityId: FullActivityId,
+    result: unknown,
+    options?: AsyncCompletionCompleteOptions
+  ): Promise<void>;
 
   async complete(
     taskTokenOrFullActivityId: Uint8Array | FullActivityId,
     result: unknown,
-    options?: AsyncCompletionOperationOptions
+    options?: AsyncCompletionCompleteOptions
   ): Promise<void> {
+    const outputType = options?.typeInfo?.outputType;
     const payloads = await encodeToPayloadsWithContext(
       this.dataConverter,
       this.serializationContextFor(taskTokenOrFullActivityId, options),
-      [result]
+      [result],
+      outputType === undefined ? undefined : [outputType]
     );
     const externalStorage = this.dataConverter.externalStorage;
     try {

--- a/packages/test/src/test-standalone-activities.cloud-pending.ts
+++ b/packages/test/src/test-standalone-activities.cloud-pending.ts
@@ -19,12 +19,13 @@ import {
 } from '@temporalio/client';
 import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
 import { activityInfo } from '@temporalio/activity';
+import type { Info } from '@temporalio/activity';
 import type { TestWorkflowEnvironment } from './helpers';
 import { RUN_INTEGRATION_TESTS, waitUntil, Worker } from './helpers';
 import { echo, throwAnError } from './activities';
 import { heartbeatCancellationDetailsActivity } from './activities/heartbeat-cancellation-details';
 import { createTestWorkflowEnvironment } from './helpers-integration';
-import { convertOrder } from './workflows/type-info/activities';
+import { convertOrder, createAsyncOrderActivities } from './workflows/type-info/activities';
 import { Order, Receipt, receiptTypeInfo, workflowTypeInfo } from './workflows/type-info/models';
 
 // Use a reduced server long-poll expiration timeout, in order to confirm that client
@@ -37,6 +38,7 @@ export interface Context {
   runPromise: Promise<void>;
   activityStartedSubject: rxjs.Subject<string>;
   activitySignalSubject: rxjs.Subject<string>;
+  asyncActivityStartedSubject: rxjs.Subject<Info>;
 }
 
 const activities = {
@@ -118,10 +120,12 @@ if (RUN_INTEGRATION_TESTS) {
 
     const activityStartedSubject = new rxjs.Subject<string>();
     const activitySignalSubject = new rxjs.Subject<string>();
+    const asyncActivityStartedSubject = new rxjs.Subject<Info>();
 
     const worker = await Worker.create({
       activities: {
         ...activities,
+        ...createAsyncOrderActivities(asyncActivityStartedSubject),
         waitForSignal: async () => {
           const activityId = activityInfo().activityId;
           const wait = waitForValue(activitySignalSubject, activityId);
@@ -145,6 +149,7 @@ if (RUN_INTEGRATION_TESTS) {
       runPromise,
       activityStartedSubject,
       activitySignalSubject,
+      asyncActivityStartedSubject,
     };
   });
 
@@ -213,6 +218,21 @@ if (RUN_INTEGRATION_TESTS) {
     });
 
     assertReceipt(t, result);
+  });
+
+  test('Async Activity completion by full ID preserves a rich result', async (t) => {
+    const client = t.context.env.client.activity;
+    const handle = await client.start<Receipt>('completeOrderAsync', {
+      ...defaultOptions,
+      id: randomUUID(),
+      args: [new Order('order-1', 12345n)],
+      typeInfo: workflowTypeInfo,
+    });
+    const info = await rxjs.firstValueFrom(t.context.asyncActivityStartedSubject);
+    await client.complete({ activityId: info.activityId, runId: info.activityRunId }, new Receipt('order-1', 12345n), {
+      typeInfo: { outputType: receiptTypeInfo },
+    });
+    assertReceipt(t, await handle.result());
   });
 
   test('Detached Activity handle decodes its result with output TypeInfo', async (t) => {

--- a/packages/test/src/test-type-info.ts
+++ b/packages/test/src/test-type-info.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'crypto';
 import type { ExecutionContext } from 'ava';
+import type { Info } from '@temporalio/activity';
+import { firstValueFrom, ReplaySubject } from 'rxjs';
 import type { WorkflowClientInterceptor, WorkflowSignalWithStartOptions } from '@temporalio/client';
 import { Client, WithStartWorkflowOperation, WorkflowFailedError } from '@temporalio/client';
 import { workflowInterceptorModules } from '@temporalio/testing';
@@ -36,11 +38,16 @@ import {
   workflowWithTypedActivity,
   workflowWithTypedLocalActivity,
   workflowWithActivityWithoutTypeInfo,
+  workflowWithAsyncTypedActivity,
   workflowWithDefaultTypedActivity,
   workflowWithInterceptorTypedActivity,
   workflowWithInterceptorTypedLocalActivity,
 } from './workflows/type-info';
-import { convertOrder, convertOrderWithoutTypeInfo } from './workflows/type-info/activities';
+import {
+  convertOrder,
+  convertOrderWithoutTypeInfo,
+  createAsyncOrderActivities,
+} from './workflows/type-info/activities';
 
 function assertReceipt(t: ExecutionContext, receipt: Receipt): void {
   t.true(receipt instanceof Receipt);
@@ -239,6 +246,26 @@ test('Worker default Activity uses TypeInfo attached to the selected fallback fu
       args: [new Order('order-1', 12345n)],
     });
     assertReceipt(t, result);
+  });
+});
+
+test('Async Activity completion by task token preserves a rich result', async (t) => {
+  const h = configurableHelpers(t, t.context.workflowBundle, t.context.env);
+  const client = makeClient(t.context.env);
+  const activityStarted = new ReplaySubject<Info>(1);
+  const worker = await h.createWorker({ activities: createAsyncOrderActivities(activityStarted) });
+
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(workflowWithAsyncTypedActivity, {
+      workflowId: `wf-${randomUUID()}`,
+      taskQueue: h.taskQueue,
+      args: [new Order('order-1', 12345n)],
+    });
+    const info = await firstValueFrom(activityStarted);
+    await client.activity.complete(info.taskToken, new Receipt('order-1', 12345n), {
+      typeInfo: { outputType: workflowTypeInfo.outputType },
+    });
+    assertReceipt(t, await handle.result());
   });
 });
 

--- a/packages/test/src/workflows/type-info/activities.ts
+++ b/packages/test/src/workflows/type-info/activities.ts
@@ -1,4 +1,6 @@
-import { setActivityOptions } from '@temporalio/activity';
+import type { Info } from '@temporalio/activity';
+import { CompleteAsyncError, Context, setActivityOptions } from '@temporalio/activity';
+import type { Observer } from 'rxjs';
 import { assertOrder, Order, Receipt, workflowTypeInfo } from './models';
 
 export async function convertOrder(order: Order): Promise<Receipt> {
@@ -7,6 +9,21 @@ export async function convertOrder(order: Order): Promise<Receipt> {
 }
 
 setActivityOptions({ typeInfo: workflowTypeInfo }, convertOrder);
+
+export interface AsyncOrderActivities {
+  completeOrderAsync(order: Order): Promise<Receipt>;
+}
+
+export function createAsyncOrderActivities(observer: Observer<Info>): AsyncOrderActivities {
+  async function completeOrderAsync(order: Order): Promise<Receipt> {
+    assertOrder(order);
+    observer.next(Context.current().info);
+    throw new CompleteAsyncError();
+  }
+
+  setActivityOptions({ typeInfo: workflowTypeInfo }, completeOrderAsync);
+  return { completeOrderAsync };
+}
 
 export async function convertOrderWithoutTypeInfo(order: unknown): Promise<string> {
   if (order instanceof Order) {

--- a/packages/test/src/workflows/type-info/workflows.ts
+++ b/packages/test/src/workflows/type-info/workflows.ts
@@ -88,6 +88,21 @@ const typedActivities = proxyActivities<typeof activities>({
   activityTypeInfo: { convertOrder: workflowTypeInfo },
 });
 
+const asyncTypedActivities = proxyActivities<activities.AsyncOrderActivities>({
+  startToCloseTimeout: '1 minute',
+  activityTypeInfo: { completeOrderAsync: workflowTypeInfo },
+});
+
+defineWorkflowOptions(workflowWithAsyncTypedActivity, {
+  staticOptions: { typeInfo: workflowTypeInfo },
+});
+export async function workflowWithAsyncTypedActivity(order: Order): Promise<Receipt> {
+  assertOrder(order);
+  const receipt = await asyncTypedActivities.completeOrderAsync(order);
+  assertReceipt(receipt);
+  return receipt;
+}
+
 const typedLocalActivities = proxyLocalActivities<typeof activities>({
   startToCloseTimeout: '1 minute',
   activityTypeInfo: { convertOrder: workflowTypeInfo },


### PR DESCRIPTION
## What was changed

Async Activity completion can now use experimental `TypeInfo` to encode a successful result. `complete` accepts an optional output TypeInfo for both task-token and full-Activity-ID calls; failure, cancellation, and heartbeat APIs remain unchanged.

This completes the asynchronous-completion portion of the Activity TypeInfo stack. A Worker or Activity client can now return a rich value, such as a class containing a `bigint`, after an Activity elects asynchronous completion.

This draft is stacked on the standalone Activity Client TypeInfo PR.

## Why?

Activity TypeInfo already covers normal Workflow and Standalone Activity results. Asynchronous completion is a separate Client serialization boundary, so without this change the later completion result bypasses the output conversion supplied to the calling Activity API.

## Checklist

1. Closes: N/A

2. How was this tested: Client build, Prettier, and `git diff --check`. Focused task-token and full-ID runtime coverage is included but remains pending the parent draft's test fix.

3. Any docs updates needed? No; this is an experimental API and the CHANGELOG records it.
