### PR TITLE
chore(langsmith): bump up ava concurrency

### DIFF
--- a/contrib/langsmith/package.json
+++ b/contrib/langsmith/package.json
@@ -20,7 +20,7 @@
       "./lib/__tests__/test-*.js"
     ],
     "timeout": "120s",
-    "concurrency": 1,
+    "concurrency": 4,
     "workerThreads": false
   },
   "exports": {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Bump up ava concurrency to 4 for langsmith

## Why?
Minor speedup for running tests

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io --> 