### PR TITLE
fix(bun): support Bun 1.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,8 +239,6 @@ jobs:
 
       - name: Run Tests (Bun)
         if: matrix.node == 'bun'
-        # Run every workspace package's test script, as in the Node path above.
-        # AVA_RUNTIME=bun makes each AVA wrapper launch its tests under Bun.
         run: pnpm run test
         env:
           AVA_RUNTIME: bun

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,11 +239,9 @@ jobs:
 
       - name: Run Tests (Bun)
         if: matrix.node == 'bun'
-        working-directory: packages/test
-        # Same wrapper as the Node path, but AVA_RUNTIME=bun makes it launch ava
-        # under Bun (mirrors `bun run -b ava`), so Bun is still exercised. Bun runs
-        # the TypeScript wrapper directly (no tsx needed).
-        run: bun ../../scripts/ava-ci.ts ./lib/test-*.js
+        # Run every workspace package's test script, as in the Node path above.
+        # AVA_RUNTIME=bun makes each AVA wrapper launch its tests under Bun.
+        run: pnpm run test
         env:
           AVA_RUNTIME: bun
           RUN_INTEGRATION_TESTS: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
         uses: ./.github/actions/setup-bun-deps
         with:
           platform: ${{ matrix.platform }}
-          version: latest
+          bun-version: latest
 
       # On Windows, the 'runner.temp' variable uses backslashes as path separators, but
       # that may pose problems in later steps when we try to join that with subpaths;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
         uses: ./.github/actions/setup-bun-deps
         with:
           platform: ${{ matrix.platform }}
+          version: latest
 
       # On Windows, the 'runner.temp' variable uses backslashes as path separators, but
       # that may pose problems in later steps when we try to join that with subpaths;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,11 @@ to docs, or any other relevant information.
 
 - Updated Core to `65b25ada` (`temporal-core` 0.6.0)
 
+### Deprecated
+
+- **Experimental**: Bun versions older than 1.4.0 are deprecated and will not be supported in a future release. Please
+  upgrade to Bun 1.4.0 or later.
+
 ### Fixed
 
 - strands: Declare `zod` as a peer dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- **Experimental**: Fixed compatibility with Bun 1.4, including reusable VM context switching,
+  microtask handling, and Worker thread shutdown.
 - **Experimental**: The external storage S3 and GCS drivers now use `hash_algorithm` and `hash_value` instead of
   `hashAlgorithm` and `hashValue` in their claims. The GCS driver additionally uses `object_name` instead of
   `object`. Retrieval still accepts the old key names.

--- a/contrib/langsmith/src/__tests__/test-query-filter.ts
+++ b/contrib/langsmith/src/__tests__/test-query-filter.ts
@@ -31,7 +31,13 @@ test('internal-query filtering: traces user queries but not Temporal-internal qu
         workflowId: `qf-${Date.now()}`,
       });
       await handle.query(workflows.myQuery);
-      await handle.query('__stack_trace');
+      if ('bun' in process.versions) {
+        await t.throwsAsync(handle.query('__stack_trace'), {
+          message: /Workflow stack traces are not enabled on this worker/,
+        });
+      } else {
+        await handle.query('__stack_trace');
+      }
       await handle.signal(workflows.completeSignal);
       await handle.result();
     },

--- a/contrib/workflow-streams/src/__tests__/test-workflow-streams.ts
+++ b/contrib/workflow-streams/src/__tests__/test-workflow-streams.ts
@@ -8,6 +8,7 @@ import { randomUUID } from 'crypto';
 import { ApplicationFailure, defaultPayloadConverter, type Payload } from '@temporalio/common';
 import type { WorkflowHandle } from '@temporalio/client';
 import { WorkflowUpdateFailedError } from '@temporalio/client';
+import { isBun } from '@temporalio/test-helpers';
 import {
   FlushTimeoutError,
   WorkflowStreamClient,
@@ -949,7 +950,8 @@ test('flush_retry_preserves_items_after_failures — behavioral retry coverage',
   });
 });
 
-test('flush_raises_after_max_retry_duration — timeout surfaces, client resumes', async (t) => {
+// Retry running this test with Bun once https://github.com/oven-sh/bun/issues/36828 is resolved
+(isBun ? test.skip : test)('flush_raises_after_max_retry_duration — timeout surfaces, client resumes', async (t) => {
   // When the retry window expires, stop() must rethrow FlushTimeoutError;
   // the client stays usable and subsequent publishes succeed.
   const { env } = t.context;

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -97,6 +97,7 @@ import type {
 import { compileWorkerOptions, isCodeBundleOption, isPathBundleOption, toNativeWorkerOptions } from './worker-options';
 import { WorkflowCodecRunner } from './workflow-codec-runner';
 import { defaultWorkflowInterceptorModules, WorkflowCodeBundler } from './workflow/bundler';
+import { isBunPre1_4 } from './workflow/bun';
 import type { Workflow, WorkflowCreator } from './workflow/interface';
 import { ReusableVMWorkflowCreator } from './workflow/reusable-vm';
 import { ThreadedVMWorkflowCreator } from './workflow/threaded-vm';
@@ -521,6 +522,11 @@ export class Worker {
       sdkComponent: SdkComponent.worker,
       taskQueue: options.taskQueue ?? 'default',
     });
+    if (isBunPre1_4) {
+      logger.warn(
+        'Bun versions older than 1.4.0 are deprecated and will not be supported in a future release. Please upgrade to Bun 1.4.0 or later.'
+      );
+    }
     const metricMeter = runtime.metricMeter.withTags({
       namespace: options.namespace ?? 'default',
       taskQueue: options.taskQueue ?? 'default',

--- a/packages/worker/src/workflow/bun.ts
+++ b/packages/worker/src/workflow/bun.ts
@@ -9,6 +9,6 @@ const bun = (globalThis as typeof globalThis & { Bun?: BunGlobal }).Bun;
 
 export const isBun = bun !== undefined;
 
-// Bun supports vm.createContext({ microtaskMode: 'afterEvaluate' }) as of 1.4.0.
+// Bun versions before 1.4.0 need compatibility paths for VM microtask handling and Worker termination.
 // https://github.com/oven-sh/bun/pull/32018
-export const needsBunMicrotaskModeWorkaround = bun !== undefined && !bun.semver.satisfies(bun.version, '>=1.4.0');
+export const isBunPre1_4 = bun !== undefined && !bun.semver.satisfies(bun.version, '>=1.4.0');

--- a/packages/worker/src/workflow/bun.ts
+++ b/packages/worker/src/workflow/bun.ts
@@ -1,1 +1,14 @@
-export const isBun = typeof (globalThis as any).Bun !== 'undefined';
+interface BunGlobal {
+  version: string;
+  semver: {
+    satisfies(version: string, range: string): boolean;
+  };
+}
+
+const bun = (globalThis as typeof globalThis & { Bun?: BunGlobal }).Bun;
+
+export const isBun = bun !== undefined;
+
+// Bun supports vm.createContext({ microtaskMode: 'afterEvaluate' }) as of 1.4.0.
+// https://github.com/oven-sh/bun/pull/32018
+export const needsBunMicrotaskModeWorkaround = bun !== undefined && !bun.semver.satisfies(bun.version, '>=1.4.0');

--- a/packages/worker/src/workflow/reusable-vm.ts
+++ b/packages/worker/src/workflow/reusable-vm.ts
@@ -15,7 +15,7 @@ interface BagHolder {
 const callIntoVmScript = new vm.Script(`__TEMPORAL_CALL_INTO_SCOPE()`);
 const preloadModulesScript = new vm.Script(`__TEMPORAL__.preloadModules?.()`);
 
-function generateNodeCallIntoScopeScript(): string {
+function generateCallIntoScopeScript(): string {
   return `{
     const __TEMPORAL_CALL_INTO_SCOPE = () => {
       const [holder, fn, args] = globalThis.__temporal_args;
@@ -50,59 +50,46 @@ function generateNodeCallIntoScopeScript(): string {
   }`;
 }
 
-// This is a workaround for a bug in Bun where Object.getOwnPropertyDescriptor returns
-// stale values for numeric properties after modification. We must read/write numeric
-// properties directly.
-function generateBunCallIntoScopeScript(): string {
+/**
+ * Bun's contextified VM global does not preserve numeric properties across context switches.
+ * Bun 1.4.0 routes indexed reads through the contextified sandbox, but writes and deletes are
+ * still inconsistent. Route only numeric properties through a regular object instead.
+ *
+ * https://github.com/oven-sh/bun/pull/32018
+ */
+function generateBunNumericGlobalPropertiesWorkaroundScript(): string {
   return `{
     const __TEMPORAL_IS_NUMERIC_KEY = (key) => {
-      if (typeof key === 'number') return true;
-      if (typeof key === 'string') {
-        const num = Number(key);
-        return Number.isInteger(num) && num >= 0 && String(num) === key;
-      }
-      return false;
+      if (typeof key !== 'string') return false;
+      const num = Number(key);
+      return Number.isInteger(num) && num >= 0 && String(num) === key;
     };
 
-    const __TEMPORAL_CALL_INTO_SCOPE = () => {
-      const [holder, fn, args] = globalThis.__temporal_args;
-      delete globalThis.__temporal_args;
-
-      if (globalThis.__TEMPORAL_BAG_HOLDER__ !== holder) {
-        if (globalThis.__TEMPORAL_BAG_HOLDER__ !== undefined) {
-          const bag = Object.getOwnPropertyDescriptors(globalThis);
-          for (const prop of Reflect.ownKeys(bag)) {
-            if (__TEMPORAL_IS_NUMERIC_KEY(prop)) {
-              bag[prop].value = globalThis[prop];
-            }
-          }
-          globalThis.__TEMPORAL_BAG_HOLDER__.bag = bag;
-        }
-
-        const toBeDeleted = new Set(Reflect.ownKeys(globalThis));
-
-        for (const prop of Reflect.ownKeys(holder.bag)) {
-          if (holder.bag[prop].value !== globalThis[prop]) {
-            if (__TEMPORAL_IS_NUMERIC_KEY(prop)) {
-              globalThis[prop] = holder.bag[prop].value;
-            } else {
-              Object.defineProperty(globalThis, prop, holder.bag[prop]);
-            }
-          }
-          toBeDeleted.delete(prop);
-        }
-
-        for (const prop of toBeDeleted) {
-          delete globalThis[prop];
-        }
-
-        globalThis.__TEMPORAL_BAG_HOLDER__ = holder;
-      }
-
-      return __TEMPORAL__.api[fn](...args);
-    };
-    Object.defineProperty(globalThis, '__TEMPORAL_CALL_INTO_SCOPE', {
-      value: __TEMPORAL_CALL_INTO_SCOPE, writable: false, enumerable: false, configurable: false
+    const __TEMPORAL_NUMERIC_PROPERTIES = Object.create(null);
+    const __TEMPORAL_REAL_GLOBAL = globalThis;
+    __TEMPORAL_REAL_GLOBAL.globalThis = new Proxy(__TEMPORAL_REAL_GLOBAL, {
+      get: (target, prop, receiver) => __TEMPORAL_IS_NUMERIC_KEY(prop)
+        ? Reflect.get(__TEMPORAL_NUMERIC_PROPERTIES, prop)
+        : Reflect.get(target, prop, receiver),
+      set: (target, prop, value, receiver) => __TEMPORAL_IS_NUMERIC_KEY(prop)
+        ? Reflect.set(__TEMPORAL_NUMERIC_PROPERTIES, prop, value)
+        : Reflect.set(target, prop, value, receiver),
+      deleteProperty: (target, prop) => __TEMPORAL_IS_NUMERIC_KEY(prop)
+        ? Reflect.deleteProperty(__TEMPORAL_NUMERIC_PROPERTIES, prop)
+        : Reflect.deleteProperty(target, prop),
+      defineProperty: (target, prop, descriptor) => __TEMPORAL_IS_NUMERIC_KEY(prop)
+        ? Reflect.defineProperty(__TEMPORAL_NUMERIC_PROPERTIES, prop, descriptor)
+        : Reflect.defineProperty(target, prop, descriptor),
+      getOwnPropertyDescriptor: (target, prop) => __TEMPORAL_IS_NUMERIC_KEY(prop)
+        ? Reflect.getOwnPropertyDescriptor(__TEMPORAL_NUMERIC_PROPERTIES, prop)
+        : Reflect.getOwnPropertyDescriptor(target, prop),
+      has: (target, prop) => __TEMPORAL_IS_NUMERIC_KEY(prop)
+        ? Reflect.has(__TEMPORAL_NUMERIC_PROPERTIES, prop)
+        : Reflect.has(target, prop),
+      ownKeys: (target) => [
+        ...Reflect.ownKeys(target).filter((prop) => !__TEMPORAL_IS_NUMERIC_KEY(prop)),
+        ...Reflect.ownKeys(__TEMPORAL_NUMERIC_PROPERTIES),
+      ],
     });
   }`;
 }
@@ -139,7 +126,13 @@ export class ReusableVMWorkflowCreator implements WorkflowCreator {
     }
 
     this._context = vm.createContext({}, { microtaskMode: 'afterEvaluate' }) as vm.Context & typeof globalThis;
-    vm.runInContext(isBun ? generateBunCallIntoScopeScript() : generateNodeCallIntoScopeScript(), this._context, {
+    if (isBun) {
+      vm.runInContext(generateBunNumericGlobalPropertiesWorkaroundScript(), this._context, {
+        timeout: isolateExecutionTimeoutMs,
+        displayErrors: true,
+      });
+    }
+    vm.runInContext(generateCallIntoScopeScript(), this._context, {
       timeout: isolateExecutionTimeoutMs,
       displayErrors: true,
     });

--- a/packages/worker/src/workflow/reusable-vm.ts
+++ b/packages/worker/src/workflow/reusable-vm.ts
@@ -5,7 +5,7 @@ import { native } from '@temporalio/core-bridge';
 import type { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interface';
 import type { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
 import { BaseVMWorkflow, globalHandlers, injectGlobals, setUnhandledRejectionHandler } from './vm-shared';
-import { isBun, needsBunMicrotaskModeWorkaround } from './bun';
+import { isBun, isBunPre1_4 } from './bun';
 import type { WorkflowPatchActivationCallback } from './patch-activation-callback';
 
 interface BagHolder {
@@ -324,7 +324,7 @@ export class ReusableVMWorkflow extends BaseVMWorkflow {
     // automatically due to lack of proper microtaskMode: 'afterEvaluate' support.
     // Drain the microtask queue to prevent state leakage to the next workflow
     // that will reuse this VM context.
-    if (needsBunMicrotaskModeWorkaround) await new Promise(setImmediate);
+    if (isBunPre1_4) await new Promise(setImmediate);
     ReusableVMWorkflowCreator.workflowByRunId.delete(this.runId);
   }
 }

--- a/packages/worker/src/workflow/reusable-vm.ts
+++ b/packages/worker/src/workflow/reusable-vm.ts
@@ -5,7 +5,7 @@ import { native } from '@temporalio/core-bridge';
 import type { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interface';
 import type { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
 import { BaseVMWorkflow, globalHandlers, injectGlobals, setUnhandledRejectionHandler } from './vm-shared';
-import { isBun } from './bun';
+import { isBun, needsBunMicrotaskModeWorkaround } from './bun';
 import type { WorkflowPatchActivationCallback } from './patch-activation-callback';
 
 interface BagHolder {
@@ -320,11 +320,11 @@ type WorkflowModule = typeof internals;
 export class ReusableVMWorkflow extends BaseVMWorkflow {
   public async dispose(): Promise<void> {
     this.workflowModule.dispose();
-    // In Bun, microtasks scheduled inside the VM context may not be processed
+    // Before Bun 1.4.0, microtasks scheduled inside the VM context may not be processed
     // automatically due to lack of proper microtaskMode: 'afterEvaluate' support.
     // Drain the microtask queue to prevent state leakage to the next workflow
     // that will reuse this VM context.
-    if (isBun) await new Promise(setImmediate);
+    if (needsBunMicrotaskModeWorkaround) await new Promise(setImmediate);
     ReusableVMWorkflowCreator.workflowByRunId.delete(this.runId);
   }
 }

--- a/packages/worker/src/workflow/reusable-vm.ts
+++ b/packages/worker/src/workflow/reusable-vm.ts
@@ -51,11 +51,14 @@ function generateCallIntoScopeScript(): string {
 }
 
 /**
- * Bun's contextified VM global does not preserve numeric properties across context switches.
- * Bun 1.4.0 routes indexed reads through the contextified sandbox, but writes and deletes are
- * still inconsistent. Route only numeric properties through a regular object instead.
+ * Bun has inconsistent handling of numeric properties on the VM-context. In
+ * Bun 1.3.x, reads from the global in the VM may not see numeric properties present on the VM context
+ * object. Bun 1.4.0 fixes those reads, but writes and deletes from inside the VM
+ * global still do not update the VM context.
  *
- * https://github.com/oven-sh/bun/pull/32018
+ * To work around this we replace the `globalThis` value exposed inside the VM with a proxy.
+ * For numeric keys, route Object field operations to a special "numeric" properties object.
+ * Non-numeric keys pass through.
  */
 function generateBunNumericGlobalPropertiesWorkaroundScript(): string {
   return `{

--- a/packages/worker/src/workflow/threaded-vm.ts
+++ b/packages/worker/src/workflow/threaded-vm.ts
@@ -25,7 +25,7 @@ import type {
 } from './workflow-worker-thread/input';
 import type { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interface';
 import type { WorkerThreadOutput, WorkerThreadResponse } from './workflow-worker-thread/output';
-import { isBun, isBunPre1_4 } from './bun';
+import { isBunPre1_4 } from './bun';
 import {
   completePatchActivationCallback,
   invokePatchActivationCallbackWithSnapshot,
@@ -33,12 +33,9 @@ import {
   writePatchActivationCallbackResult,
 } from './patch-activation-callback';
 
-function isTerminatedExitCode(exitCode: number): boolean {
-  // Before Bun 1.4.0, 0 was used for a terminated worker thread.
-  // We still allow it to retain 1.3.4 compatibility.
-  // https://nodejs.org/api/worker_threads.html#event-exit
-  return exitCode === 1 || (isBun && exitCode === 0);
-}
+// https://nodejs.org/api/worker_threads.html#event-exit
+// Bun pre 1.4 exits with code 0 instead of 1
+export const TERMINATED_EXIT_CODE = isBunPre1_4 ? 0 : 1;
 
 interface Completion<T> {
   resolve(value: T): void;
@@ -184,7 +181,7 @@ export class WorkerThreadClient {
     await this.send({ type: 'destroy' });
 
     const exitCode = await (isBunPre1_4 ? this.terminateWithBunWorkaround() : this.workerThread.terminate());
-    if (exitCode !== null && !isTerminatedExitCode(exitCode)) {
+    if (exitCode !== null && exitCode !== TERMINATED_EXIT_CODE) {
       throw new UnexpectedError(`Failed to terminate Worker thread, exit code: ${exitCode}`);
     }
   }

--- a/packages/worker/src/workflow/threaded-vm.ts
+++ b/packages/worker/src/workflow/threaded-vm.ts
@@ -25,7 +25,7 @@ import type {
 } from './workflow-worker-thread/input';
 import type { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interface';
 import type { WorkerThreadOutput, WorkerThreadResponse } from './workflow-worker-thread/output';
-import { isBun } from './bun';
+import { isBun, isBunPre1_4 } from './bun';
 import {
   completePatchActivationCallback,
   invokePatchActivationCallbackWithSnapshot,
@@ -37,7 +37,7 @@ function isTerminatedExitCode(exitCode: number): boolean {
   // Before Bun 1.4.0, 0 was used for a terminated worker thread.
   // We still allow it to retain 1.3.4 compatibility.
   // https://nodejs.org/api/worker_threads.html#event-exit
-  return exitCode == 1 || (isBun && exitCode == 0);
+  return exitCode === 1 || (isBun && exitCode === 0);
 }
 
 interface Completion<T> {
@@ -183,7 +183,7 @@ export class WorkerThreadClient {
     this.shutDownRequested = true;
     await this.send({ type: 'destroy' });
 
-    const exitCode = await (isBun ? this.terminateWithBunWorkaround() : this.workerThread.terminate());
+    const exitCode = await (isBunPre1_4 ? this.terminateWithBunWorkaround() : this.workerThread.terminate());
     if (exitCode !== null && !isTerminatedExitCode(exitCode)) {
       throw new UnexpectedError(`Failed to terminate Worker thread, exit code: ${exitCode}`);
     }

--- a/packages/worker/src/workflow/threaded-vm.ts
+++ b/packages/worker/src/workflow/threaded-vm.ts
@@ -336,10 +336,10 @@ export class VMWorkflowThreadProxy implements Workflow {
   ): Promise<coresdk.workflow_completion.IWorkflowActivationCompletion> {
     const output = await this.workerThreadClient.send({
       type: 'activate-workflow',
-      // Some activation messages get silently dropped by Bun's postMessage.
+      // Before Bun 1.4.0, some activation messages get silently dropped by Bun's postMessage.
       // To work around this bug, we encode activations
       // An example of a failing activation can be found in test-payload-converter.ts 'Worker encodes/decodes a protobuf containing a binary array'
-      activation: isBun ? coresdk.workflow_activation.WorkflowActivation.encode(activation).finish() : activation,
+      activation: isBunPre1_4 ? coresdk.workflow_activation.WorkflowActivation.encode(activation).finish() : activation,
       runId: this.runId,
     });
     if (output?.type !== 'activation-completion') {

--- a/packages/worker/src/workflow/threaded-vm.ts
+++ b/packages/worker/src/workflow/threaded-vm.ts
@@ -33,9 +33,12 @@ import {
   writePatchActivationCallbackResult,
 } from './patch-activation-callback';
 
-// https://nodejs.org/api/worker_threads.html#event-exit
-// Bun exits with code 0 instead of 1
-export const TERMINATED_EXIT_CODE = isBun ? 0 : 1;
+function isTerminatedExitCode(exitCode: number): boolean {
+  // Before Bun 1.4.0, 0 was used for a terminated worker thread.
+  // We still allow it to retain 1.3.4 compatibility.
+  // https://nodejs.org/api/worker_threads.html#event-exit
+  return exitCode == 1 || (isBun && exitCode == 0);
+}
 
 interface Completion<T> {
   resolve(value: T): void;
@@ -181,7 +184,7 @@ export class WorkerThreadClient {
     await this.send({ type: 'destroy' });
 
     const exitCode = await (isBun ? this.terminateWithBunWorkaround() : this.workerThread.terminate());
-    if (exitCode !== null && exitCode !== TERMINATED_EXIT_CODE) {
+    if (exitCode !== null && !isTerminatedExitCode(exitCode)) {
       throw new UnexpectedError(`Failed to terminate Worker thread, exit code: ${exitCode}`);
     }
   }

--- a/packages/worker/src/workflow/vm-shared.ts
+++ b/packages/worker/src/workflow/vm-shared.ts
@@ -20,7 +20,7 @@ import type { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-t
 
 // We need this import for the ambient global extensions
 import '@temporalio/workflow/lib/global-attributes'; // eslint-disable-line import/no-unassigned-import
-import { needsBunMicrotaskModeWorkaround } from './bun';
+import { isBunPre1_4 } from './bun';
 
 // Best effort to catch unhandled rejections from workflow code.
 // We crash the thread if we cannot find the culprit.
@@ -419,7 +419,7 @@ export abstract class BaseVMWorkflow implements Workflow {
       const initWorkflowJob = activation.jobs.find((job) => job.initializeWorkflow != null)?.initializeWorkflow;
       if (initWorkflowJob) {
         this.workflowModule.initialize(initWorkflowJob);
-        if (needsBunMicrotaskModeWorkaround) await new Promise(setImmediate);
+        if (isBunPre1_4) await new Promise(setImmediate);
       }
 
       const hasSignals = activation.jobs.some(({ signalWorkflow }) => signalWorkflow != null);
@@ -441,7 +441,7 @@ export abstract class BaseVMWorkflow implements Workflow {
         this.workflowModule.activate(
           coresdk.workflow_activation.WorkflowActivation.fromObject({ ...activation, jobs: rest })
         );
-        if (needsBunMicrotaskModeWorkaround) {
+        if (isBunPre1_4) {
           await this.tryUnblockConditionsAndMicrotasksWithManualFlush();
         } else {
           this.tryUnblockConditionsAndMicrotasks();
@@ -461,7 +461,7 @@ export abstract class BaseVMWorkflow implements Workflow {
             coresdk.workflow_activation.WorkflowActivation.fromObject({ ...activation, jobs }),
             batchIndex++
           );
-          if (needsBunMicrotaskModeWorkaround) {
+          if (isBunPre1_4) {
             await this.tryUnblockConditionsAndMicrotasksWithManualFlush();
           } else {
             this.tryUnblockConditionsAndMicrotasks();
@@ -469,7 +469,7 @@ export abstract class BaseVMWorkflow implements Workflow {
         }
       }
 
-      if (needsBunMicrotaskModeWorkaround) await new Promise(setImmediate);
+      if (isBunPre1_4) await new Promise(setImmediate);
       const completion = this.workflowModule.concludeActivation();
 
       // Give unhandledRejection handler a chance to be triggered.
@@ -502,9 +502,9 @@ export abstract class BaseVMWorkflow implements Workflow {
       },
     }));
     this.workflowModule.activate(activation);
-    if (needsBunMicrotaskModeWorkaround) await new Promise(setImmediate);
+    if (isBunPre1_4) await new Promise(setImmediate);
     const completion = this.workflowModule.concludeActivation();
-    if (needsBunMicrotaskModeWorkaround) await new Promise(setImmediate);
+    if (isBunPre1_4) await new Promise(setImmediate);
     return completion;
   }
 

--- a/packages/worker/src/workflow/vm-shared.ts
+++ b/packages/worker/src/workflow/vm-shared.ts
@@ -20,7 +20,7 @@ import type { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-t
 
 // We need this import for the ambient global extensions
 import '@temporalio/workflow/lib/global-attributes'; // eslint-disable-line import/no-unassigned-import
-import { isBun } from './bun';
+import { needsBunMicrotaskModeWorkaround } from './bun';
 
 // Best effort to catch unhandled rejections from workflow code.
 // We crash the thread if we cannot find the culprit.
@@ -370,10 +370,9 @@ export abstract class BaseVMWorkflow implements Workflow {
   /**
    * Send request to the Workflow runtime's worker-interface
    *
-   * In order to properly work around Bun's lack of support for `microtaskMode: afterEvaluate` it is important to
-   * immediately schedule a task after each call into the `workflowModule`. This task ensures that any microtasks
-   * from a specific workflow will execute while the vm is still setup for said workflow.
-   * This is why there are `if (isBun) await new Promise(setImmediate)` scattered throughout this function.
+   * In Bun versions before 1.4.0, `microtaskMode: afterEvaluate` is not supported. On those versions, immediately
+   * schedule a task after each call into the `workflowModule` so that microtasks from a specific workflow execute
+   * while the VM is still set up for that workflow.
    */
   public async activate(
     activation: coresdk.workflow_activation.IWorkflowActivation
@@ -420,7 +419,7 @@ export abstract class BaseVMWorkflow implements Workflow {
       const initWorkflowJob = activation.jobs.find((job) => job.initializeWorkflow != null)?.initializeWorkflow;
       if (initWorkflowJob) {
         this.workflowModule.initialize(initWorkflowJob);
-        if (isBun) await new Promise(setImmediate);
+        if (needsBunMicrotaskModeWorkaround) await new Promise(setImmediate);
       }
 
       const hasSignals = activation.jobs.some(({ signalWorkflow }) => signalWorkflow != null);
@@ -442,7 +441,7 @@ export abstract class BaseVMWorkflow implements Workflow {
         this.workflowModule.activate(
           coresdk.workflow_activation.WorkflowActivation.fromObject({ ...activation, jobs: rest })
         );
-        if (isBun) {
+        if (needsBunMicrotaskModeWorkaround) {
           await this.tryUnblockConditionsAndMicrotasksWithManualFlush();
         } else {
           this.tryUnblockConditionsAndMicrotasks();
@@ -462,7 +461,7 @@ export abstract class BaseVMWorkflow implements Workflow {
             coresdk.workflow_activation.WorkflowActivation.fromObject({ ...activation, jobs }),
             batchIndex++
           );
-          if (isBun) {
+          if (needsBunMicrotaskModeWorkaround) {
             await this.tryUnblockConditionsAndMicrotasksWithManualFlush();
           } else {
             this.tryUnblockConditionsAndMicrotasks();
@@ -470,7 +469,7 @@ export abstract class BaseVMWorkflow implements Workflow {
         }
       }
 
-      if (isBun) await new Promise(setImmediate);
+      if (needsBunMicrotaskModeWorkaround) await new Promise(setImmediate);
       const completion = this.workflowModule.concludeActivation();
 
       // Give unhandledRejection handler a chance to be triggered.
@@ -503,9 +502,9 @@ export abstract class BaseVMWorkflow implements Workflow {
       },
     }));
     this.workflowModule.activate(activation);
-    if (isBun) await new Promise(setImmediate);
+    if (needsBunMicrotaskModeWorkaround) await new Promise(setImmediate);
     const completion = this.workflowModule.concludeActivation();
-    if (isBun) await new Promise(setImmediate);
+    if (needsBunMicrotaskModeWorkaround) await new Promise(setImmediate);
     return completion;
   }
 

--- a/packages/worker/src/workflow/vm.ts
+++ b/packages/worker/src/workflow/vm.ts
@@ -5,7 +5,7 @@ import type { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interfa
 import type { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
 import type { WorkflowModule } from './vm-shared';
 import { BaseVMWorkflow, globalHandlers, injectGlobals, setUnhandledRejectionHandler } from './vm-shared';
-import { isBun } from './bun';
+import { needsBunMicrotaskModeWorkaround } from './bun';
 import type { WorkflowPatchActivationCallback } from './patch-activation-callback';
 
 /**
@@ -134,11 +134,11 @@ export class VMWorkflowCreator implements WorkflowCreator {
 export class VMWorkflow extends BaseVMWorkflow {
   public async dispose(): Promise<void> {
     this.workflowModule.dispose();
-    if (isBun) await new Promise(setImmediate);
+    if (needsBunMicrotaskModeWorkaround) await new Promise(setImmediate);
 
     // This sandbox VM won't be reused, so we can destroy it now.
     this.workflowModule.destroy();
-    if (isBun) await new Promise(setImmediate);
+    if (needsBunMicrotaskModeWorkaround) await new Promise(setImmediate);
 
     VMWorkflowCreator.workflowByRunId.delete(this.runId);
     delete this.context;

--- a/packages/worker/src/workflow/vm.ts
+++ b/packages/worker/src/workflow/vm.ts
@@ -5,7 +5,7 @@ import type { Workflow, WorkflowCreateOptions, WorkflowCreator } from './interfa
 import type { WorkflowBundleWithSourceMapAndFilename } from './workflow-worker-thread/input';
 import type { WorkflowModule } from './vm-shared';
 import { BaseVMWorkflow, globalHandlers, injectGlobals, setUnhandledRejectionHandler } from './vm-shared';
-import { needsBunMicrotaskModeWorkaround } from './bun';
+import { isBunPre1_4 } from './bun';
 import type { WorkflowPatchActivationCallback } from './patch-activation-callback';
 
 /**
@@ -134,11 +134,11 @@ export class VMWorkflowCreator implements WorkflowCreator {
 export class VMWorkflow extends BaseVMWorkflow {
   public async dispose(): Promise<void> {
     this.workflowModule.dispose();
-    if (needsBunMicrotaskModeWorkaround) await new Promise(setImmediate);
+    if (isBunPre1_4) await new Promise(setImmediate);
 
     // This sandbox VM won't be reused, so we can destroy it now.
     this.workflowModule.destroy();
-    if (needsBunMicrotaskModeWorkaround) await new Promise(setImmediate);
+    if (isBunPre1_4) await new Promise(setImmediate);
 
     VMWorkflowCreator.workflowByRunId.delete(this.runId);
     delete this.context;

--- a/packages/worker/src/workflow/workflow-worker-thread.ts
+++ b/packages/worker/src/workflow/workflow-worker-thread.ts
@@ -7,7 +7,7 @@ import { ReusableVMWorkflowCreator } from './reusable-vm';
 import { VMWorkflowCreator } from './vm';
 import type { PatchActivationCallbackRequest, WorkerThreadRequest } from './workflow-worker-thread/input';
 import type { WorkerThreadResponse } from './workflow-worker-thread/output';
-import { isBun } from './bun';
+import { isBun, isBunPre1_4 } from './bun';
 import {
   makePatchActivationWorkflowInfoSnapshot,
   PATCH_ACTIVATION_CALLBACK_BUFFER_SIZE,
@@ -85,14 +85,14 @@ async function handleRequest({ requestId, input }: WorkerThreadRequest): Promise
       }
       let activation;
       if (input.activation instanceof Uint8Array) {
-        // Some activation messages get silently dropped by Bun's postMessage.
+        // Before Bun 1.4.0, some activation messages get silently dropped by Bun's postMessage.
         // To work around this bug, we encode activations
         activation = coresdk.workflow_activation.WorkflowActivation.decode(input.activation);
       } else {
         activation = coresdk.workflow_activation.WorkflowActivation.fromObject(input.activation);
       }
       const completion = await workflow.activate(activation);
-      const maybeEncodedCompletion = isBun
+      const maybeEncodedCompletion = isBunPre1_4
         ? coresdk.workflow_completion.WorkflowActivationCompletion.encode(completion).finish()
         : completion;
       return {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- For almost all of our `isBun` checks, move them to `isBunPre1_4` and gate them.
- There is new weirdness around numeric props on VM context. Was able to change our approach in a way that it works for both 1.3 and 1.4.
- Run *all* packages' tests using Bun, not just the `test` package.
- Add deprecation warning when starting a worker using Bun 1.4 or earlier

## Why?
Bun 1.4.0 introduced some changes that broke our previous workarounds. 

## Checklist
<!--- add/delete as needed --->

1. Closes #2348 

2. How was this tested:
Enabled running against latest Bun in CI

3. Any docs updates needed?
N/A
