### PR TITLE
chore(deps): update nexus-rpc to 0.0.3

### DIFF
--- a/contrib/interceptors-opentelemetry-v2/package.json
+++ b/contrib/interceptors-opentelemetry-v2/package.json
@@ -36,7 +36,7 @@
     "@temporalio/worker": "workspace:*",
     "@temporalio/workflow": "workspace:*",
     "ava": "^5.3.1",
-    "nexus-rpc": "^0.0.2",
+    "nexus-rpc": "^0.0.3",
     "rxjs": "7.8.1",
     "uuid": "^11.1.0"
   },

--- a/contrib/interceptors-opentelemetry/package.json
+++ b/contrib/interceptors-opentelemetry/package.json
@@ -36,7 +36,7 @@
     "@temporalio/worker": "workspace:*",
     "@temporalio/workflow": "workspace:*",
     "ava": "^5.3.1",
-    "nexus-rpc": "^0.0.2",
+    "nexus-rpc": "^0.0.3",
     "rxjs": "7.8.1"
   },
   "peerDependencies": {

--- a/contrib/langsmith/package.json
+++ b/contrib/langsmith/package.json
@@ -62,7 +62,7 @@
     "@temporalio/testing": "workspace:*",
     "ava": "^5.3.1",
     "langsmith": "^0.7.9",
-    "nexus-rpc": "^0.0.2"
+    "nexus-rpc": "^0.0.3"
   },
   "engines": {
     "node": ">= 20.3.0"

--- a/contrib/openai-agents/package.json
+++ b/contrib/openai-agents/package.json
@@ -102,7 +102,7 @@
     "@temporalio/test-helpers": "workspace:*",
     "@temporalio/testing": "workspace:*",
     "ava": "^5.3.1",
-    "nexus-rpc": "^0.0.2",
+    "nexus-rpc": "^0.0.3",
     "openai": "^6.35.0"
   },
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -20,7 +20,7 @@
     "@temporalio/proto": "workspace:*",
     "abort-controller": "^3.0.0",
     "long": "^5.3.2",
-    "nexus-rpc": "^0.0.2",
+    "nexus-rpc": "^0.0.3",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,7 +15,7 @@
     "@temporalio/proto": "workspace:*",
     "long": "^5.3.2",
     "ms": "3.0.0-canary.1",
-    "nexus-rpc": "^0.0.2",
+    "nexus-rpc": "^0.0.3",
     "protobufjs": "^8.7.1"
   },
   "scripts": {

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -26,7 +26,7 @@
     "@temporalio/common": "workspace:*",
     "@temporalio/proto": "workspace:*",
     "long": "^5.3.2",
-    "nexus-rpc": "^0.0.2"
+    "nexus-rpc": "^0.0.3"
   },
   "devDependencies": {
     "ava": "^5.3.1"

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -19,7 +19,7 @@
     "@temporalio/client": "workspace:*",
     "@temporalio/common": "workspace:*",
     "@temporalio/worker": "workspace:*",
-    "nexus-rpc": "^0.0.2"
+    "nexus-rpc": "^0.0.3"
   },
   "bugs": {
     "url": "https://github.com/temporalio/sdk-typescript/issues"

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -57,7 +57,7 @@
     "istanbul-lib-coverage": "^3.2.2",
     "long": "^5.3.2",
     "ms": "3.0.0-canary.1",
-    "nexus-rpc": "^0.0.2",
+    "nexus-rpc": "^0.0.3",
     "pidusage": "^3.0.2",
     "protobufjs": "^8.7.1",
     "protobufjs-cli": "^2.6.1",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -27,7 +27,7 @@
     "@temporalio/workflow": "workspace:*",
     "heap-js": "^2.6.0",
     "memfs": "^4.6.0",
-    "nexus-rpc": "^0.0.2",
+    "nexus-rpc": "^0.0.3",
     "protobufjs": "^8.7.1",
     "rxjs": "^7.8.1",
     "source-map": "^0.7.4",

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@temporalio/common": "workspace:*",
     "@temporalio/proto": "workspace:*",
-    "nexus-rpc": "^0.0.2"
+    "nexus-rpc": "^0.0.3"
   },
   "devDependencies": {
     "ava": "^5.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,8 +327,8 @@ importers:
         specifier: ^5.3.1
         version: 5.3.1(supports-color@8.1.1)
       nexus-rpc:
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
       rxjs:
         specifier: 7.8.1
         version: 7.8.1
@@ -388,8 +388,8 @@ importers:
         specifier: ^5.3.1
         version: 5.3.1(supports-color@8.1.1)
       nexus-rpc:
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
       rxjs:
         specifier: 7.8.1
         version: 7.8.1
@@ -428,8 +428,8 @@ importers:
         specifier: ^0.7.9
         version: 0.7.10(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.36.0(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
       nexus-rpc:
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
 
   contrib/openai-agents:
     dependencies:
@@ -498,8 +498,8 @@ importers:
         specifier: ^5.3.1
         version: 5.3.1(supports-color@8.1.1)
       nexus-rpc:
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
       openai:
         specifier: ^6.35.0
         version: 6.36.0(ws@8.21.1)(zod@4.4.3)
@@ -617,8 +617,8 @@ importers:
         specifier: ^5.3.2
         version: 5.3.2
       nexus-rpc:
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -658,8 +658,8 @@ importers:
         specifier: 3.0.0-canary.1
         version: 3.0.0-canary.1
       nexus-rpc:
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
       protobufjs:
         specifier: ^8.7.1
         version: 8.7.1
@@ -870,8 +870,8 @@ importers:
         specifier: ^5.3.2
         version: 5.3.2
       nexus-rpc:
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
     devDependencies:
       ava:
         specifier: ^5.3.1
@@ -932,8 +932,8 @@ importers:
         specifier: workspace:*
         version: link:../worker
       nexus-rpc:
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
 
   packages/proto:
     dependencies:
@@ -1050,8 +1050,8 @@ importers:
         specifier: 3.0.0-canary.1
         version: 3.0.0-canary.1
       nexus-rpc:
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
       pidusage:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1179,8 +1179,8 @@ importers:
         specifier: ^4.6.0
         version: 4.6.0(quill-delta@5.1.0)(rxjs@7.8.1)(tslib@2.6.2)
       nexus-rpc:
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
       protobufjs:
         specifier: ^8.7.1
         version: 8.7.1
@@ -1219,8 +1219,8 @@ importers:
         specifier: workspace:*
         version: link:../proto
       nexus-rpc:
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
     devDependencies:
       ava:
         specifier: ^5.3.1
@@ -5746,8 +5746,8 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  nexus-rpc@0.0.2:
-    resolution: {integrity: sha512-IWjIExdVYlmwXuzHdY/Q3lXCv1gbqoAXPazQhy2w4Xgtgha3H0OOujEESVPQcFUFMWm+pAk2gKnb57g8S41JZg==}
+  nexus-rpc@0.0.3:
+    resolution: {integrity: sha512-ksIBeYHDv6FHAR1h3Vwk0kQ6REhdo1STqDHXMzu/yn/VN/XzgOor2IUjewG6paoA7IgxlIPZoOU/PD78PC6HTg==}
     engines: {node: '>= 20.0.0'}
 
   node-abi@3.94.0:
@@ -12741,7 +12741,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nexus-rpc@0.0.2: {}
+  nexus-rpc@0.0.3: {}
 
   node-abi@3.94.0:
     dependencies:


### PR DESCRIPTION
## What was changed

Updated every existing sdk-typescript workspace dependency on `nexus-rpc` from `^0.0.2` to the stable `^0.0.3` release and updated only the corresponding lockfile importer, package, and snapshot entries.

## Why?

`nexus-rpc@0.0.3` adds operation input and output type information required by the upcoming Nexus TypeInfo integration. Landing the stable dependency independently keeps the Nexus feature PRs focused and removes their temporary `0.0.3-rc.0` dependency changes.

This is a dependency-only change with no rollout steps or manual configuration.

## Checklist

1. Closes: N/A

2. How was this tested: Node 20 and pnpm 10.27.0 frozen install; Proto, Common, Workflow, Client, Worker, Nexus, Plugin, and Test builds; all 43 Common tests; all 47 Nexus tests; Prettier; `ts-prune`; and `git diff --check`.

3. Any docs updates needed? No.
