### PR TITLE
Nexus: raw ActivityClient starts inherit request ID and links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,9 @@ to docs, or any other relevant information.
 - Bumped the core-bridge HTTP/2 client stack (h2 0.4.13 → 0.4.19, hyper 1.8.1 → 1.11.0), picking up
   upstream fixes for stream-cancel flow-control leaks and missed wakeups on reset/trailers that can
   affect cancellation-heavy long-poll workloads.
+- **Experimental**: A Standalone Activity started from a Nexus operation handler directly through
+  `ActivityClient`, rather than through `TemporalNexusClient.startActivity()`'s guarded call, now
+  inherits the handler's Nexus request ID and inbound links.
 
 ## [1.22.0] - 2026-08-05
 

--- a/packages/nexus/src/activity-start-interceptor.ts
+++ b/packages/nexus/src/activity-start-interceptor.ts
@@ -1,0 +1,52 @@
+import type { ActivityClientInterceptor } from '@temporalio/client';
+import { type InternalActivityStartOptions, InternalActivityStartOptionsSymbol } from '@temporalio/client/lib/internal';
+import { getNexusStartOperationContext } from './context';
+import { pushResponseLink, requestLinksToTemporalLinks } from './operation-links';
+
+/**
+ * Adds the active Nexus operation's request ID and inbound links to Activities started through the
+ * Worker's Client. A no-op outside an active Nexus operation, or for a start that already carries
+ * its own SDK-internal options.
+ *
+ * @internal
+ * @hidden
+ */
+export const nexusActivityStartInterceptor: ActivityClientInterceptor = {
+  start: async (input, next) => {
+    const ctx = getNexusStartOperationContext();
+    if (ctx == null) {
+      return next(input);
+    }
+    const optionsWithInternal = input.options as InternalActivityStartOptions;
+    const existingInternalOptions = optionsWithInternal[InternalActivityStartOptionsSymbol];
+    if (existingInternalOptions != null) {
+      return next(input);
+    }
+    const links = requestLinksToTemporalLinks(ctx);
+    const internalOptions: NonNullable<InternalActivityStartOptions[typeof InternalActivityStartOptionsSymbol]> = {
+      requestId: ctx.requestId,
+      links,
+      onConflictOptions: links.length > 0 ? { attachLinks: true, attachRequestId: true } : undefined,
+    };
+    const options: InternalActivityStartOptions = {
+      ...input.options,
+      [InternalActivityStartOptionsSymbol]: internalOptions,
+    };
+    const handle = await next({ ...input, options });
+    if (internalOptions.responseLink != null) {
+      pushResponseLink(ctx, internalOptions.responseLink);
+    }
+    return handle;
+  },
+};
+
+/**
+ * Appends {@link nexusActivityStartInterceptor} to `interceptors`, so that Activities started
+ * through the resulting list are linked back to the current Nexus operation.
+ *
+ * @internal
+ * @hidden
+ */
+export function withNexusActivityLinking(interceptors: ActivityClientInterceptor[]): ActivityClientInterceptor[] {
+  return [...interceptors, nexusActivityStartInterceptor];
+}

--- a/packages/nexus/src/context.ts
+++ b/packages/nexus/src/context.ts
@@ -21,6 +21,27 @@ export function getHandlerContext(): HandlerContext {
 }
 
 /**
+ * The {@link TemporalStartOperationContext} of the {@link TemporalOperationHandler} start invocation
+ * currently in flight on this Nexus task, if any. Read by {@link nexusActivityStartInterceptor}.
+ *
+ * @internal
+ * @hidden
+ */
+export function getNexusStartOperationContext(): TemporalStartOperationContext | undefined {
+  return asyncLocalStorage.getStore()?.nexusStartOperationContext;
+}
+
+/**
+ * Runs `fn` with {@link getNexusStartOperationContext} set to `ctx` for its duration.
+ *
+ * @internal
+ * @hidden
+ */
+export function runWithNexusStartOperationContext<T>(ctx: TemporalStartOperationContext, fn: () => T): T {
+  return asyncLocalStorage.run({ ...getHandlerContext(), nexusStartOperationContext: ctx }, fn);
+}
+
+/**
  * Context used internally in the SDK to propagate information from the worker to the Temporal Nexus helpers.
  *
  * @internal
@@ -33,6 +54,7 @@ export interface HandlerContext {
   namespace: string;
   taskQueue: string;
   endpoint: string;
+  nexusStartOperationContext?: TemporalStartOperationContext;
 }
 
 /**

--- a/packages/nexus/src/operation-links.ts
+++ b/packages/nexus/src/operation-links.ts
@@ -1,0 +1,36 @@
+import type * as nexus from 'nexus-rpc';
+import type { temporal } from '@temporalio/proto';
+import { log } from './context';
+import { convertNexusLinkToTemporalLink, convertTemporalLinkToNexusLink } from './link-converter';
+
+/**
+ * Converts the request links carried on an operation start context into Temporal links so they can
+ * be forwarded onto an outgoing RPC (Workflow start/signal/update, Activity start). Links that fail
+ * to convert are logged and dropped.
+ */
+export function requestLinksToTemporalLinks(ctx: nexus.StartOperationContext): temporal.api.common.v1.ILink[] {
+  const links = Array<temporal.api.common.v1.ILink>();
+  if (ctx.inboundLinks?.length > 0) {
+    for (const l of ctx.inboundLinks) {
+      try {
+        links.push(convertNexusLinkToTemporalLink(l));
+      } catch (error) {
+        log.warn('failed to convert Nexus link to Workflow event link', { error });
+      }
+    }
+  }
+  return links;
+}
+
+/**
+ * Pushes a response link returned by an outbound RPC onto the operation's outbound links so the
+ * Nexus task handler attaches it to the StartOperationResponse, linking the caller's history event
+ * back to the callee's.
+ */
+export function pushResponseLink(ctx: nexus.StartOperationContext, responseLink: temporal.api.common.v1.ILink): void {
+  try {
+    ctx.outboundLinks.push(convertTemporalLinkToNexusLink(responseLink));
+  } catch (error) {
+    log.warn('failed to convert temporal link to Nexus link', { error });
+  }
+}

--- a/packages/nexus/src/workflow-helpers.ts
+++ b/packages/nexus/src/workflow-helpers.ts
@@ -19,7 +19,6 @@ import type {
   WorkflowSignalWithStartOptions as ClientWorkflowSignalWithStartOptions,
 } from '@temporalio/client';
 import { WorkflowUpdateStage, type WorkflowUpdateOptions } from '@temporalio/client';
-import { type temporal } from '@temporalio/proto';
 import type {
   InternalActivityStartOptions,
   InternalWorkflowHandle,
@@ -35,7 +34,6 @@ import {
   InternalWorkflowStartOptionsSymbol,
   InternalWorkflowUpdateOptionsSymbol,
 } from '@temporalio/client/lib/internal';
-import { convertNexusLinkToTemporalLink, convertTemporalLinkToNexusLink } from './link-converter';
 import {
   assertActivityOperationToken,
   assertUpdateWorkflowOperationToken,
@@ -51,10 +49,10 @@ import {
 import {
   getClient,
   getHandlerContext,
-  log,
   type TemporalCancelOperationContext,
   type TemporalStartOperationContext,
 } from './context';
+import { pushResponseLink, requestLinksToTemporalLinks } from './operation-links';
 
 declare const isNexusWorkflowHandle: unique symbol;
 declare const workflowResultType: unique symbol;
@@ -210,40 +208,6 @@ export async function startWorkflow<T extends Workflow>(
   // The Workflow run just started is this operation's async backing operation, so the handle's
   // `update()` must not be able to start another one.
   return createWorkflowHandle(ctx, handle.workflowId, handle.firstExecutionRunId, alreadyBackedReservation);
-}
-
-/**
- * Converts the request links carried on the operation start context into Temporal links so
- * they can be forwarded onto an outgoing Workflow RPC (signal, signalWithStart, start). Links that
- * fail to convert are logged and dropped.
- */
-function requestLinksToTemporalLinks(ctx: nexus.StartOperationContext): temporal.api.common.v1.ILink[] {
-  const links = Array<temporal.api.common.v1.ILink>();
-  if (ctx.inboundLinks?.length > 0) {
-    for (const l of ctx.inboundLinks) {
-      try {
-        links.push(convertNexusLinkToTemporalLink(l));
-      } catch (error) {
-        log.warn('failed to convert Nexus link to Workflow event link', { error });
-      }
-    }
-  }
-  return links;
-}
-
-/**
- * Pushes a response link returned by an outbound Workflow RPC onto the operation's outbound links so
- * the Nexus task handler attaches it to the StartOperationResponse, linking the caller Workflow's
- * NexusOperation history event back to the callee Workflow's event. Callers only invoke this when the
- * server returned a response link; older servers (or CHASM signal response links disabled) leave it
- * unset, in which case there is nothing to push.
- */
-function pushResponseLink(ctx: nexus.StartOperationContext, responseLink: temporal.api.common.v1.ILink) {
-  try {
-    ctx.outboundLinks.push(convertTemporalLinkToNexusLink(responseLink));
-  } catch (error) {
-    log.warn('failed to convert temporal link to Nexus link', { error });
-  }
 }
 
 /**
@@ -643,7 +607,9 @@ class TemporalNexusClientImpl implements TemporalNexusClient {
   };
 
   /**
-   * The Temporal Client for the active Nexus Operation.
+   * The Temporal Client for the active Nexus Operation. Activities started directly through
+   * `client.activity.start()` (rather than {@link startActivity}) are linked to this operation too,
+   * since a handler invocation may need to start more than one Activity.
    *
    * @experimental Temporal Operation handlers are experimental.
    */
@@ -791,11 +757,7 @@ async function updateWorkflowOperation<Ret, Args extends any[]>(
     if (internalOptions.responseLink != null) {
       // Attach the link the server returned (a WorkflowEvent link on success, or a Workflow link
       // when there is no history event, e.g. validation failure) as a handler link.
-      try {
-        ctx.outboundLinks.push(convertTemporalLinkToNexusLink(internalOptions.responseLink));
-      } catch (err) {
-        log.warn('failed to convert UpdateWorkflow response link to Nexus link', { error: err });
-      }
+      pushResponseLink(ctx, internalOptions.responseLink);
     }
 
     if (internalOptions.outcome != null) {

--- a/packages/test/src/test-nexus-temporal-operation.cloud-unavailable.ts
+++ b/packages/test/src/test-nexus-temporal-operation.cloud-unavailable.ts
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { randomUUID } from 'crypto';
 import * as nexus from 'nexus-rpc';
 import { ApplicationFailure, CancelledFailure, NexusOperationFailure } from '@temporalio/common';
+import type { ActivityClientInterceptor } from '@temporalio/client';
 import {
   ActivityExecutionFailedError,
   NexusOperationExecutionStatus,
@@ -120,6 +121,11 @@ export async function temporalRetryAfterFailedStartOpCaller(endpoint: string, wo
 export async function temporalActivityOpCaller(endpoint: string, activityId: string): Promise<string> {
   const client = workflow.createNexusServiceClient({ endpoint, service: temporalOpService });
   return await client.executeOperation('echoActivity', activityId);
+}
+
+export async function temporalSyncOpCallerWithInput(endpoint: string, input: string): Promise<string> {
+  const client = workflow.createNexusServiceClient({ endpoint, service: temporalOpService });
+  return await client.executeOperation('syncOp', input);
 }
 
 export async function temporalBlockingActivityOpCaller(endpoint: string, activityId: string): Promise<void> {
@@ -804,6 +810,408 @@ test('TemporalOperationHandler links a standalone Nexus operation and its backin
     t.is(nexusOperationLink?.namespace, client.options.namespace);
     t.is(nexusOperationLink?.operationId, operationDescription.operationId);
     t.is(nexusOperationLink?.runId, operationDescription.runId);
+  });
+});
+
+test('TemporalOperationHandler links Activities started through a raw ActivityClient - standalone caller', async (t) => {
+  const { createWorker, registerNexusEndpoint } = helpers(t);
+  const { client } = t.context.env;
+  const { endpointName } = await registerNexusEndpoint();
+
+  const worker = await createWorker({
+    activities,
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        syncOp: new temporalnexus.TemporalOperationHandler<string, string>({
+          async start(_ctx, nexusClient, input) {
+            const { taskQueue } = temporalnexus.operationInfo();
+            const [a, b] = await Promise.all([
+              nexusClient.client.activity.start('echo', {
+                id: `${input}-a`,
+                args: [`${input}-a`],
+                taskQueue,
+                scheduleToCloseTimeout: '10s',
+              }),
+              nexusClient.client.activity.start('echo', {
+                id: `${input}-b`,
+                args: [`${input}-b`],
+                taskQueue,
+                scheduleToCloseTimeout: '10s',
+              }),
+            ]);
+            const [resultA, resultB] = await Promise.all([a.result(), b.result()]);
+            return temporalnexus.TemporalOperationResult.sync(`${resultA}|${resultB}`);
+          },
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const input = randomUUID();
+    const nexusClient = client.nexus.createServiceClient({ endpoint: endpointName, service: temporalOpService });
+    const operation = await nexusClient.startOperation(temporalOpService.operations.syncOp, input, {
+      id: randomUUID(),
+      scheduleToCloseTimeout: '10s',
+    });
+    t.is(await operation.result(), `${input}-a|${input}-b`);
+
+    const [operationDescription, activityA, activityB] = await Promise.all([
+      operation.describe(),
+      client.activity.getHandle(`${input}-a`).describe(),
+      client.activity.getHandle(`${input}-b`).describe(),
+    ]);
+
+    // Backward: the completed operation's own description links to both Activities, not just one.
+    const linkedActivityIds = operationDescription.raw.links
+      ?.map((link) => link.activity)
+      .filter((link): link is NonNullable<typeof link> => link != null)
+      .map((link) => link.activityId);
+    t.deepEqual([...(linkedActivityIds ?? [])].sort(), [`${input}-a`, `${input}-b`].sort());
+
+    // Forward: each Activity's own record links back to the caller operation.
+    for (const activity of [activityA, activityB]) {
+      const nexusOperationLink = activity.rawInfo.links?.find((link) => link.nexusOperation != null)?.nexusOperation;
+      t.is(nexusOperationLink?.namespace, client.options.namespace);
+      t.is(nexusOperationLink?.operationId, operationDescription.operationId);
+      t.is(nexusOperationLink?.runId, operationDescription.runId);
+    }
+  });
+});
+
+test('TemporalOperationHandler links Activities started through getClient() directly', async (t) => {
+  const { createWorker, registerNexusEndpoint } = helpers(t);
+  const { client } = t.context.env;
+  const { endpointName } = await registerNexusEndpoint();
+
+  const worker = await createWorker({
+    activities,
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        syncOp: new temporalnexus.TemporalOperationHandler<string, string>({
+          async start(_ctx, _nexusClient, input) {
+            const { taskQueue } = temporalnexus.operationInfo();
+            // Note: not `nexusClient.client` — the module-level `getClient()` export, which a
+            // handler could reach without ever touching the TemporalNexusClient it was handed.
+            const [a, b] = await Promise.all([
+              temporalnexus.getClient().activity.start('echo', {
+                id: `${input}-a`,
+                args: [`${input}-a`],
+                taskQueue,
+                scheduleToCloseTimeout: '10s',
+              }),
+              temporalnexus.getClient().activity.start('echo', {
+                id: `${input}-b`,
+                args: [`${input}-b`],
+                taskQueue,
+                scheduleToCloseTimeout: '10s',
+              }),
+            ]);
+            const [resultA, resultB] = await Promise.all([a.result(), b.result()]);
+            return temporalnexus.TemporalOperationResult.sync(`${resultA}|${resultB}`);
+          },
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const input = randomUUID();
+    const nexusClient = client.nexus.createServiceClient({ endpoint: endpointName, service: temporalOpService });
+    const operation = await nexusClient.startOperation(temporalOpService.operations.syncOp, input, {
+      id: randomUUID(),
+      scheduleToCloseTimeout: '10s',
+    });
+    t.is(await operation.result(), `${input}-a|${input}-b`);
+
+    const [operationDescription, activityA, activityB] = await Promise.all([
+      operation.describe(),
+      client.activity.getHandle(`${input}-a`).describe(),
+      client.activity.getHandle(`${input}-b`).describe(),
+    ]);
+
+    const linkedActivityIds = operationDescription.raw.links
+      ?.map((link) => link.activity)
+      .filter((link): link is NonNullable<typeof link> => link != null)
+      .map((link) => link.activityId);
+    t.deepEqual([...(linkedActivityIds ?? [])].sort(), [`${input}-a`, `${input}-b`].sort());
+
+    for (const activity of [activityA, activityB]) {
+      const nexusOperationLink = activity.rawInfo.links?.find((link) => link.nexusOperation != null)?.nexusOperation;
+      t.is(nexusOperationLink?.namespace, client.options.namespace);
+      t.is(nexusOperationLink?.operationId, operationDescription.operationId);
+      t.is(nexusOperationLink?.runId, operationDescription.runId);
+    }
+  });
+});
+
+test('TemporalOperationHandler links an Activity started from an inbound startOperation interceptor', async (t) => {
+  const { createWorker, registerNexusEndpoint } = helpers(t);
+  const { client } = t.context.env;
+  const { endpointName } = await registerNexusEndpoint();
+
+  const worker = await createWorker({
+    activities,
+    interceptors: {
+      nexus: [
+        () => ({
+          inbound: {
+            async startOperation(input, next) {
+              // Started before the operation handler itself even runs, proving the linking scope
+              // covers the whole inbound-interceptor chain, not just TemporalOperationHandler.start().
+              const { taskQueue } = temporalnexus.operationInfo();
+              const opInput = input.input as string;
+              const handle = await temporalnexus.getClient().activity.start('echo', {
+                id: opInput,
+                args: [opInput],
+                taskQueue,
+                scheduleToCloseTimeout: '10s',
+              });
+              await handle.result();
+              return next(input);
+            },
+          },
+        }),
+      ],
+    },
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        syncOp: new temporalnexus.TemporalOperationHandler<string, string>({
+          async start(_ctx, _nexusClient, input) {
+            return temporalnexus.TemporalOperationResult.sync(input);
+          },
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const input = randomUUID();
+    const nexusClient = client.nexus.createServiceClient({ endpoint: endpointName, service: temporalOpService });
+    const operation = await nexusClient.startOperation(temporalOpService.operations.syncOp, input, {
+      id: randomUUID(),
+      scheduleToCloseTimeout: '10s',
+    });
+    t.is(await operation.result(), input);
+
+    const [operationDescription, activity] = await Promise.all([
+      operation.describe(),
+      client.activity.getHandle(input).describe(),
+    ]);
+
+    const linkedActivityIds = operationDescription.raw.links
+      ?.map((link) => link.activity)
+      .filter((link): link is NonNullable<typeof link> => link != null)
+      .map((link) => link.activityId);
+    t.true((linkedActivityIds ?? []).includes(input));
+
+    const nexusOperationLink = activity.rawInfo.links?.find((link) => link.nexusOperation != null)?.nexusOperation;
+    t.is(nexusOperationLink?.namespace, client.options.namespace);
+    t.is(nexusOperationLink?.operationId, operationDescription.operationId);
+    t.is(nexusOperationLink?.runId, operationDescription.runId);
+  });
+});
+
+test('TemporalOperationHandler preserves user-configured Activity interceptors on raw ActivityClient starts', async (t) => {
+  const { createWorker, registerNexusEndpoint } = helpers(t);
+  const { client } = t.context.env;
+  const { endpointName } = await registerNexusEndpoint();
+
+  const interceptorCalls: string[] = [];
+  const userInterceptor: ActivityClientInterceptor = {
+    async start(input, next) {
+      interceptorCalls.push('user');
+      return next(input);
+    },
+  };
+
+  let input = '';
+  const worker = await createWorker({
+    activities,
+    interceptors: { client: { activity: [userInterceptor] } },
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        syncOp: new temporalnexus.TemporalOperationHandler<string, string>({
+          async start(_ctx, nexusClient, opInput) {
+            const { taskQueue } = temporalnexus.operationInfo();
+            const handle = await nexusClient.client.activity.start('echo', {
+              id: opInput,
+              args: [opInput],
+              taskQueue,
+              scheduleToCloseTimeout: '10s',
+            });
+            return temporalnexus.TemporalOperationResult.sync(await handle.result());
+          },
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    input = randomUUID();
+    const nexusClient = client.nexus.createServiceClient({ endpoint: endpointName, service: temporalOpService });
+    const operation = await nexusClient.startOperation(temporalOpService.operations.syncOp, input, {
+      id: randomUUID(),
+      scheduleToCloseTimeout: '10s',
+    });
+    t.is(await operation.result(), input);
+  });
+
+  // The user-configured interceptor still ran for the raw ActivityClient start...
+  t.deepEqual(interceptorCalls, ['user']);
+
+  // ...and the SDK's own linking still ran too: the Activity's record links back to the operation.
+  const activity = await client.activity.getHandle(input).describe();
+  t.truthy(activity.rawInfo.links?.find((link) => link.nexusOperation != null));
+});
+
+test('TemporalOperationHandler links Activities started through a raw ActivityClient - Workflow caller', async (t) => {
+  const { createWorker, startWorkflow, registerNexusEndpoint } = helpers(t);
+  const { client } = t.context.env;
+  const { endpointName } = await registerNexusEndpoint();
+
+  const worker = await createWorker({
+    activities,
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        syncOp: new temporalnexus.TemporalOperationHandler<string, string>({
+          async start(_ctx, nexusClient, input) {
+            const { taskQueue } = temporalnexus.operationInfo();
+            const [a, b] = await Promise.all([
+              nexusClient.client.activity.start('echo', {
+                id: `${input}-a`,
+                args: [`${input}-a`],
+                taskQueue,
+                scheduleToCloseTimeout: '10s',
+              }),
+              nexusClient.client.activity.start('echo', {
+                id: `${input}-b`,
+                args: [`${input}-b`],
+                taskQueue,
+                scheduleToCloseTimeout: '10s',
+              }),
+            ]);
+            const [resultA, resultB] = await Promise.all([a.result(), b.result()]);
+            return temporalnexus.TemporalOperationResult.sync(`${resultA}|${resultB}`);
+          },
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const input = randomUUID();
+    const callerHandle = await startWorkflow(temporalSyncOpCallerWithInput, { args: [endpointName, input] });
+    t.is(await callerHandle.result(), `${input}-a|${input}-b`);
+
+    const callerHistory = await callerHandle.fetchHistory();
+    const completedEvent = callerHistory.events?.find((event) => event.nexusOperationCompletedEventAttributes != null);
+    const linkedActivityIds = completedEvent?.links
+      ?.map((link) => link.activity)
+      .filter((link): link is NonNullable<typeof link> => link != null)
+      .map((link) => link.activityId);
+    t.deepEqual([...(linkedActivityIds ?? [])].sort(), [`${input}-a`, `${input}-b`].sort());
+
+    for (const suffix of ['a', 'b']) {
+      const activityId = `${input}-${suffix}`;
+      const activity = await client.activity.getHandle(activityId).describe();
+      const callerLink = activity.rawInfo.links?.find((link) => link.workflowEvent != null)?.workflowEvent;
+      t.truthy(callerLink, `expected Activity ${activityId} to link back to the caller Workflow`);
+      t.is(callerLink?.workflowId, callerHandle.workflowId);
+      t.is(callerLink?.eventRef?.eventType, EventType.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED);
+    }
+  });
+});
+
+test('TemporalOperationHandler Activity started through a raw ActivityClient is redelivery-safe', async (t) => {
+  const { createWorker, startWorkflow, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+
+  let activityInvocationCount = 0;
+  let hasFailedOnce = false;
+  const worker = await createWorker({
+    activities: {
+      async countedEcho(input: string): Promise<string> {
+        activityInvocationCount++;
+        return input;
+      },
+    },
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        syncOp: new temporalnexus.TemporalOperationHandler<string, string>({
+          async start(_ctx, nexusClient, input) {
+            const { taskQueue } = temporalnexus.operationInfo();
+            // Starts through the raw Activity client, not TemporalNexusClient.startActivity().
+            const handle = await nexusClient.client.activity.start('countedEcho', {
+              id: input,
+              args: [input],
+              taskQueue,
+              scheduleToCloseTimeout: '10s',
+            });
+            const result = await handle.result();
+            if (!hasFailedOnce) {
+              hasFailedOnce = true;
+              // Force a Nexus-task redelivery after the Activity has already completed.
+              throw new nexus.HandlerError('INTERNAL', 'inject retry', { retryableOverride: true });
+            }
+            return temporalnexus.TemporalOperationResult.sync(result);
+          },
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const input = randomUUID();
+    const callerHandle = await startWorkflow(temporalSyncOpCallerWithInput, { args: [endpointName, input] });
+    t.is(await callerHandle.result(), input);
+    t.is(activityInvocationCount, 1, 'expected the Activity to run exactly once despite the handler redelivery');
+  });
+});
+
+test('TemporalOperationHandler Activity started through getClient() is redelivery-safe', async (t) => {
+  const { createWorker, startWorkflow, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+
+  let activityInvocationCount = 0;
+  let hasFailedOnce = false;
+  const worker = await createWorker({
+    activities: {
+      async countedEcho(input: string): Promise<string> {
+        activityInvocationCount++;
+        return input;
+      },
+    },
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        syncOp: new temporalnexus.TemporalOperationHandler<string, string>({
+          async start(_ctx, _nexusClient, input) {
+            const { taskQueue } = temporalnexus.operationInfo();
+            // Not `nexusClient.client` — the module-level `getClient()` export.
+            const handle = await temporalnexus.getClient().activity.start('countedEcho', {
+              id: input,
+              args: [input],
+              taskQueue,
+              scheduleToCloseTimeout: '10s',
+            });
+            const result = await handle.result();
+            if (!hasFailedOnce) {
+              hasFailedOnce = true;
+              // Force a Nexus-task redelivery after the Activity has already completed.
+              throw new nexus.HandlerError('INTERNAL', 'inject retry', { retryableOverride: true });
+            }
+            return temporalnexus.TemporalOperationResult.sync(result);
+          },
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const input = randomUUID();
+    const callerHandle = await startWorkflow(temporalSyncOpCallerWithInput, { args: [endpointName, input] });
+    t.is(await callerHandle.result(), input);
+    t.is(activityInvocationCount, 1, 'expected the Activity to run exactly once despite the handler redelivery');
   });
 });
 

--- a/packages/worker/src/nexus/index.ts
+++ b/packages/worker/src/nexus/index.ts
@@ -9,7 +9,7 @@ import {
   MetricMeterWithComposedTags,
 } from '@temporalio/common';
 import type { temporal, coresdk } from '@temporalio/proto';
-import { asyncLocalStorage } from '@temporalio/nexus/lib/context';
+import { asyncLocalStorage, runWithNexusStartOperationContext } from '@temporalio/nexus/lib/context';
 import { encodeToPayload } from '@temporalio/common/lib/internal-non-workflow';
 import { isAbortError } from '@temporalio/common/lib/type-helpers';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
@@ -126,7 +126,9 @@ export class NexusHandler {
         'startOperation',
         executeNextHandler
       );
-      const { result } = await executeWithInterceptors({ ctx, input });
+      // Lets any Activity started via getClient() during this task, including from an inbound
+      // interceptor, link back to this operation.
+      const { result } = await runWithNexusStartOperationContext(ctx, () => executeWithInterceptors({ ctx, input }));
 
       if (result.isAsync) {
         return {

--- a/packages/worker/src/worker-options.ts
+++ b/packages/worker/src/worker-options.ts
@@ -17,6 +17,7 @@ import type { LoggerSinks, WorkflowInfo } from '@temporalio/workflow';
 import type { Context } from '@temporalio/activity';
 import type { native } from '@temporalio/core-bridge';
 import { throwIfReservedName } from '@temporalio/common/lib/reserved';
+import { withNexusActivityLinking } from '@temporalio/nexus/lib/activity-start-interceptor';
 import { ActivityInboundLogInterceptor } from './activity-log-interceptor';
 import type { NativeConnection } from './connection';
 import type { CompiledWorkerInterceptors, WorkerInterceptors } from './interceptors';
@@ -885,6 +886,7 @@ function compileWorkerInterceptors({
     client: {
       workflow: client?.workflow ?? [],
       schedule: client?.schedule ?? [],
+      activity: withNexusActivityLinking(client?.activity ?? []),
     },
     activity: [...activityInbound.map((factory) => (ctx: Context) => ({ inbound: factory(ctx) })), ...activity],
     nexus: nexus ?? [],
@@ -1077,6 +1079,7 @@ function addDefaultWorkerOptions(
       client: {
         workflow: interceptors?.client?.workflow ?? [],
         schedule: interceptors?.client?.schedule ?? [],
+        activity: interceptors?.client?.activity ?? [],
       },
       activity: interceptors?.activity ?? [],
       nexus: interceptors?.nexus ?? [],


### PR DESCRIPTION
## Summary

`TemporalNexusClient.startActivity()` guards the one Activity start that can complete a Nexus operation, but a synchronous handler that starts additional Activities must call the raw `ActivityClient`. Those starts previously omitted the inbound Nexus request ID and links, so a Nexus-task redelivery could start a duplicate Activity instead of resolving to its original run.

Raw Activity starts now inherit the handler’s request ID and inbound links. Completion callbacks remain limited to the guarded start, since only that start can complete the operation.

Aligns with the [sdk-go PR #2633](https://github.com/temporalio/sdk-go/pull/2633) and [sdk-java PR #3048](https://github.com/temporalio/sdk-java/pull/3048).

## Changes

- Add an internal ambient Nexus Activity-start context for the duration of a `startOperation` handler invocation.
- Make raw `ActivityClient` starts inherit the inbound Nexus request ID and links.
- Forward server-provided Activity response links to the operation’s outbound links.
- Leave guarded-start completion-callback behavior unchanged.

## Testing

- Added a redelivery test showing that a raw Activity start runs exactly once after a retryable handler failure.
- Added link-propagation coverage for standalone Nexus and Workflow callers.
- Existing multiple-start and retry coverage continues to pass.