### PR TITLE
fix(nexus): make already-started errors non-retryable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,7 @@ to docs, or any other relevant information.
 ### Fixed
 
 - Nexus handlers now report uncaught Workflow and standalone Activity already-started errors as
-  non-retryable `INTERNAL` Handler Errors, preventing futile retries when ID reuse or conflict
+  non-retryable `INTERNAL` Handler Errors, preventing retries when ID reuse or conflict
   policies reject duplicate execution IDs.
 - Local Activities now fall back to a registered `default` activity when the requested type is not
   registered, matching non-local Activity dispatch. Previously the Workflow Task failed immediately

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- Nexus handlers now report uncaught Workflow and standalone Activity already-started errors as
+  non-retryable `INTERNAL` Handler Errors, preventing futile retries when ID reuse or conflict
+  policies reject duplicate execution IDs.
 - Local Activities now fall back to a registered `default` activity when the requested type is not
   registered, matching non-local Activity dispatch. Previously the Workflow Task failed immediately
   with `ReferenceError` even if `default` was registered.

--- a/packages/test/src/test-nexus-handler.ts
+++ b/packages/test/src/test-nexus-handler.ts
@@ -17,9 +17,10 @@ import {
   defaultFailureConverter,
   defaultPayloadConverter,
   defaultDataConverter,
+  WorkflowExecutionAlreadyStartedError,
 } from '@temporalio/common';
 import type { PayloadCodec } from '@temporalio/common/lib/converter/payload-codec';
-import { ServiceError } from '@temporalio/client';
+import { ActivityExecutionAlreadyStartedError, ServiceError } from '@temporalio/client';
 import {
   PAYLOAD_VALIDATION_ERROR_TYPE,
   coerceToHandlerError,
@@ -393,6 +394,21 @@ test('coerceToHandlerError maps gRPC status codes to expected HandlerError types
 test('coerceToHandlerError passes through HandlerError unchanged', (t) => {
   const original = new nexus.HandlerError('BAD_REQUEST', 'test');
   t.is(coerceToHandlerError(original), original);
+});
+
+test('coerceToHandlerError maps execution already-started errors to non-retryable INTERNAL', (t) => {
+  const errors = [
+    new WorkflowExecutionAlreadyStartedError('Workflow execution already started', 'workflow-id', 'workflow-type'),
+    new ActivityExecutionAlreadyStartedError('Activity execution already started', 'activity-id', 'activity-run-id'),
+  ];
+
+  for (const error of errors) {
+    const result = coerceToHandlerError(error);
+    t.is(result.type, 'INTERNAL');
+    t.is(result.retryableOverride, false);
+    t.false(result.retryable);
+    t.is(result.cause, error);
+  }
 });
 
 test('coerceToHandlerError maps non-retryable ApplicationFailure to INTERNAL', (t) => {

--- a/packages/test/src/test-nexus-temporal-operation.cloud-unavailable.ts
+++ b/packages/test/src/test-nexus-temporal-operation.cloud-unavailable.ts
@@ -97,6 +97,11 @@ export async function temporalAsyncOpCaller(endpoint: string): Promise<string> {
   return await client.executeOperation('asyncOp', 'hello');
 }
 
+export async function temporalAsyncOpInputCaller(endpoint: string, input: string): Promise<string> {
+  const client = workflow.createNexusServiceClient({ endpoint, service: temporalOpService });
+  return await client.executeOperation('asyncOp', input, { scheduleToCloseTimeout: '10s' });
+}
+
 export async function temporalSyncOpCaller(endpoint: string): Promise<string> {
   const client = workflow.createNexusServiceClient({ endpoint, service: temporalOpService });
   return await client.executeOperation('syncOp', 'hello');
@@ -115,6 +120,11 @@ export async function temporalRetryAfterFailedStartOpCaller(endpoint: string, wo
 export async function temporalActivityOpCaller(endpoint: string, activityId: string): Promise<string> {
   const client = workflow.createNexusServiceClient({ endpoint, service: temporalOpService });
   return await client.executeOperation('echoActivity', activityId);
+}
+
+export async function temporalBlockingActivityOpCaller(endpoint: string, activityId: string): Promise<void> {
+  const client = workflow.createNexusServiceClient({ endpoint, service: temporalOpService });
+  await client.executeOperation('blockingActivity', activityId, { scheduleToCloseTimeout: '10s' });
 }
 
 export async function temporalDefaultCancelWorkflowCaller(endpoint: string, targetWorkflowId: string): Promise<void> {
@@ -383,6 +393,195 @@ test('TemporalOperationHandler allows retry after failed async start', async (t)
       t.is(result, conflictWorkflowId);
     } finally {
       await conflictHandle.cancel();
+    }
+  });
+});
+
+test('TemporalOperationHandler workflow REJECT_DUPLICATE failure is non-retryable', async (t) => {
+  const { createWorker, startWorkflow, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+  const conflictWorkflowId = randomUUID();
+  let handlerInvocations = 0;
+
+  const worker = await createWorker({
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        asyncOp: new temporalnexus.TemporalOperationHandler<string, string>({
+          async start(_ctx, nexusClient, workflowId) {
+            handlerInvocations++;
+            return await nexusClient.startWorkflow(echoWorkflow, {
+              workflowId,
+              workflowIdReusePolicy: 'REJECT_DUPLICATE',
+              args: [workflowId],
+            });
+          },
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const existingHandle = await startWorkflow(echoWorkflow, {
+      workflowId: conflictWorkflowId,
+      args: [conflictWorkflowId],
+    });
+    await existingHandle.result();
+
+    const callerHandle = await startWorkflow(temporalAsyncOpInputCaller, {
+      args: [endpointName, conflictWorkflowId],
+    });
+    const err = await t.throwsAsync(callerHandle.result(), { instanceOf: WorkflowFailedError });
+    assert(err?.cause instanceof NexusOperationFailure);
+    assert(err.cause.cause instanceof nexus.HandlerError);
+    const inner = innermostHandlerError(err.cause.cause);
+    t.is(inner.type, 'INTERNAL');
+    t.false(inner.retryable);
+    t.is(handlerInvocations, 1);
+  });
+});
+
+test('TemporalOperationHandler workflow conflict failure is non-retryable', async (t) => {
+  const { createWorker, startWorkflow, registerNexusEndpoint } = helpers(t);
+  const { endpointName } = await registerNexusEndpoint();
+  const conflictWorkflowId = randomUUID();
+  let handlerInvocations = 0;
+
+  const worker = await createWorker({
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        asyncOp: new temporalnexus.TemporalOperationHandler<string, string>({
+          async start(_ctx, nexusClient, workflowId) {
+            handlerInvocations++;
+            return await nexusClient.startWorkflow(echoWorkflow, {
+              workflowId,
+              workflowIdConflictPolicy: 'FAIL',
+              args: [workflowId],
+            });
+          },
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const existingHandle = await startWorkflow(blockingTargetWorkflow, {
+      workflowId: conflictWorkflowId,
+    });
+    try {
+      const callerHandle = await startWorkflow(temporalAsyncOpInputCaller, {
+        args: [endpointName, conflictWorkflowId],
+      });
+      const err = await t.throwsAsync(callerHandle.result(), { instanceOf: WorkflowFailedError });
+      assert(err?.cause instanceof NexusOperationFailure);
+      assert(err.cause.cause instanceof nexus.HandlerError);
+      const inner = innermostHandlerError(err.cause.cause);
+      t.is(inner.type, 'INTERNAL');
+      t.false(inner.retryable);
+      t.is(handlerInvocations, 1);
+    } finally {
+      await existingHandle.cancel();
+    }
+  });
+});
+
+test('TemporalOperationHandler activity REJECT_DUPLICATE failure is non-retryable', async (t) => {
+  const { createWorker, startWorkflow, registerNexusEndpoint, taskQueue } = helpers(t);
+  const { client } = t.context.env;
+  const { endpointName } = await registerNexusEndpoint();
+  const conflictActivityId = randomUUID();
+  let handlerInvocations = 0;
+
+  const worker = await createWorker({
+    activities,
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        echoActivity: new temporalnexus.TemporalOperationHandler<string, string>({
+          async start(_ctx, nexusClient, activityId) {
+            handlerInvocations++;
+            return await nexusClient.typedActivity<typeof activities>().startActivity('echo', {
+              id: activityId,
+              idReusePolicy: 'REJECT_DUPLICATE',
+              args: [activityId],
+              scheduleToCloseTimeout: '10s',
+            });
+          },
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const existingHandle = await client.activity.start<string>('echo', {
+      id: conflictActivityId,
+      taskQueue,
+      args: [conflictActivityId],
+      scheduleToCloseTimeout: '10s',
+    });
+    await existingHandle.result();
+
+    const callerHandle = await startWorkflow(temporalActivityOpCaller, {
+      args: [endpointName, conflictActivityId],
+    });
+    const err = await t.throwsAsync(callerHandle.result(), { instanceOf: WorkflowFailedError });
+    assert(err?.cause instanceof NexusOperationFailure);
+    assert(err.cause.cause instanceof nexus.HandlerError);
+    const inner = innermostHandlerError(err.cause.cause);
+    t.is(inner.type, 'INTERNAL');
+    t.false(inner.retryable);
+    t.is(handlerInvocations, 1);
+  });
+});
+
+test.serial('TemporalOperationHandler activity conflict failure is non-retryable', async (t) => {
+  const { createWorker, startWorkflow, registerNexusEndpoint, taskQueue } = helpers(t);
+  const { client } = t.context.env;
+  const { endpointName } = await registerNexusEndpoint();
+  const conflictActivityId = randomUUID();
+  const [activityStarted, markActivityStarted] = createDeferred();
+  const cancellationActivities = createCancellationActivities(markActivityStarted);
+  let handlerInvocations = 0;
+
+  const worker = await createWorker({
+    activities: cancellationActivities,
+    defaultHeartbeatThrottleInterval: cancellationHeartbeatInterval,
+    nexusServices: [
+      makeTemporalOpServiceHandler({
+        blockingActivity: new temporalnexus.TemporalOperationHandler<string, void>({
+          async start(_ctx, nexusClient, activityId) {
+            handlerInvocations++;
+            return await nexusClient.startActivity('waitForCancellation', {
+              id: activityId,
+              idConflictPolicy: 'FAIL',
+              scheduleToCloseTimeout: '30s',
+            });
+          },
+        }),
+      }),
+    ],
+  });
+
+  await worker.runUntil(async () => {
+    const existingHandle = await client.activity.start<void>('waitForCancellation', {
+      id: conflictActivityId,
+      taskQueue,
+      scheduleToCloseTimeout: '30s',
+    });
+    await activityStarted;
+
+    try {
+      const callerHandle = await startWorkflow(temporalBlockingActivityOpCaller, {
+        args: [endpointName, conflictActivityId],
+      });
+      const err = await t.throwsAsync(callerHandle.result(), { instanceOf: WorkflowFailedError });
+      assert(err?.cause instanceof NexusOperationFailure);
+      assert(err.cause.cause instanceof nexus.HandlerError);
+      const inner = innermostHandlerError(err.cause.cause);
+      t.is(inner.type, 'INTERNAL');
+      t.false(inner.retryable);
+      t.is(handlerInvocations, 1);
+    } finally {
+      await existingHandle.cancel('test cleanup');
+      await t.throwsAsync(existingHandle.result(), { instanceOf: ActivityExecutionFailedError });
     }
   });
 });

--- a/packages/worker/src/nexus/conversions.ts
+++ b/packages/worker/src/nexus/conversions.ts
@@ -1,8 +1,13 @@
 import { status } from '@grpc/grpc-js';
 import * as nexus from 'nexus-rpc';
-import { isGrpcServiceError, ServiceError } from '@temporalio/client';
+import { ActivityExecutionAlreadyStartedError, isGrpcServiceError, ServiceError } from '@temporalio/client';
 import type { LoadedDataConverter, Payload, ProtoFailure, TypeInfo } from '@temporalio/common';
-import { ApplicationFailure, CancelledFailure, fromPayloadWithTypeInfo } from '@temporalio/common';
+import {
+  ApplicationFailure,
+  CancelledFailure,
+  fromPayloadWithTypeInfo,
+  WorkflowExecutionAlreadyStartedError,
+} from '@temporalio/common';
 import { encodeErrorToFailure, decodeOptionalSingle } from '@temporalio/common/lib/internal-non-workflow';
 import type { temporal } from '@temporalio/proto';
 
@@ -102,6 +107,10 @@ export async function handlerErrorToProto(
 export function coerceToHandlerError(err: unknown): nexus.HandlerError {
   if (err instanceof nexus.HandlerError) {
     return err;
+  }
+
+  if (err instanceof WorkflowExecutionAlreadyStartedError || err instanceof ActivityExecutionAlreadyStartedError) {
+    return new nexus.HandlerError('INTERNAL', undefined, { cause: err, retryableOverride: false });
   }
 
   // REVIEW: This check could be moved down and fold into the next one but will keep for now to help readability.


### PR DESCRIPTION
## What was changed

Map uncaught `WorkflowExecutionAlreadyStartedError` and `ActivityExecutionAlreadyStartedError` exceptions from Nexus handlers to `INTERNAL` handler errors with non-retryable behavior.

## Why?

The Workflow and Activity clients translate the server's gRPC `ALREADY_EXISTS` response into typed already-started exceptions before the error reaches the Nexus worker boundary. These exceptions did not pass the existing `ServiceError` status check, so they fell through to the generic retryable `INTERNAL` handler error.

Retrying cannot resolve an ID conflict under these policies. Classifying the typed exceptions directly preserves the intended non-retryable behavior and aligns TypeScript with the other SDKs.

## Checklist

1. Closes: N/A

2. How was this tested:

   - Existing tests
   - New unit an integration tests

