### PR TITLE
test: preserve pause when resetting activity

### DIFF
--- a/packages/test/src/activities/heartbeat-cancellation-details.ts
+++ b/packages/test/src/activities/heartbeat-cancellation-details.ts
@@ -32,7 +32,7 @@ export async function heartbeatCancellationDetailsActivity(
   // Pause AND reset the activity.
   if (state.pause && state.reset) {
     await client.workflowService.pauseActivity(req);
-    await client.workflowService.resetActivity(req);
+    await client.workflowService.resetActivity({ ...req, keepPaused: true });
     // Just pause.
   } else if (state.pause) {
     await client.workflowService.pauseActivity(req);


### PR DESCRIPTION
## Summary

- preserve the paused state when the combined pause-and-reset test resets the activity
- align the request with the expected cancellation details and the ResetActivity keepPaused contract
- address the remaining Cloud flake after pause and reset were serialized in #2367

## Testing

- pnpm -C packages/test run build:ts
- pnpm -C packages/test exec ava ./lib/test-integration-activities.js --match=Activity\ paused\ and\ reset\ returns\ expected\ cancellation\ details