### PR TITLE
Document root workflow namespace omission

### DIFF
--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -60,6 +60,10 @@ export interface WorkflowExecutionInfo {
   searchAttributes: SearchAttributes;
   typedSearchAttributes: TypedSearchAttributes;
   parentExecution?: Required<proto.temporal.api.common.v1.IWorkflowExecution>;
+  /**
+   * Root workflow execution. Its namespace is not retained and may differ from this workflow's
+   * namespace for cross-namespace child workflows. Track it separately if needed.
+   */
   rootExecution?: Required<proto.temporal.api.common.v1.IWorkflowExecution>;
   raw: RawWorkflowExecutionInfo;
   priority?: Priority;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -81,6 +81,9 @@ export interface WorkflowInfo {
    * and therefore, whether the new workflow has the same root workflow as the original one
    * depends on whether it had a parent.
    *
+   * The root workflow's namespace is not retained and may differ from this workflow's namespace
+   * for cross-namespace child workflows. Track it separately if needed.
+   *
    */
   readonly root?: RootWorkflowInfo;
 
@@ -329,6 +332,10 @@ export interface ParentWorkflowInfo {
   namespace: string;
 }
 
+/**
+ * Root workflow information. The namespace is not retained and may differ from the current
+ * workflow's namespace for cross-namespace child workflows. Track it separately if needed.
+ */
 export interface RootWorkflowInfo {
   workflowId: string;
   runId: string;


### PR DESCRIPTION
## What was changed
Document that root workflow execution information omits its namespace. The root namespace may differ for cross-namespace child workflows and must be tracked separately.

## Why?
Completes the documentation requirement from temporalio/features#605.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes to public TypeScript types; no behavioral or API surface changes.
> 
> **Overview**
> Adds JSDoc on **root workflow** fields in the client and workflow packages so callers know the root’s **namespace is not retained** and may differ from the current workflow when using cross-namespace child workflows; namespace must be tracked separately if needed.
> 
> Updates **`WorkflowExecutionInfo.rootExecution`** in `@temporalio/client` and **`WorkflowInfo.root`** / **`RootWorkflowInfo`** in `@temporalio/workflow`. No runtime or type-shape changes—documentation only (temporalio/features#605).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c862fc64e82914eeb8504bcf34e97fdb154b3799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->