### PR TITLE
feat(common): add bidirectional RawValue TypeInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ to docs, or any other relevant information.
   arguments and results.
 - **Experimental**: Update definitions and named Update calls can use `TypeInfo` to convert Update arguments and
   results.
+- **Experimental**: Added `rawValueTypeInfo`, which allows `RawValue` inputs and results to be preserved across
+  serialization boundaries when explicitly configured on TypeInfo-aware APIs.
 - **Experimental**: `@temporalio/google-adk-agents` package for running Google ADK agents as durable Temporal Workflows,
   requiring `@google/adk@>=1.5.0 <1.6.0` as a peer dependency.
   ADK's OpenTelemetry agent-loop spans can be exported replay-safely from the Workflow sandbox by composing with

--- a/packages/common/src/__tests__/test-raw-value.ts
+++ b/packages/common/src/__tests__/test-raw-value.ts
@@ -1,0 +1,63 @@
+import test from 'ava';
+import { defaultDataConverter } from '../converter/data-converter';
+import type { PayloadCodec } from '../converter/payload-codec';
+import {
+  defaultPayloadConverter,
+  RawValue,
+  rawValueTypeInfo,
+  toPayloadWithTypeInfo,
+  type PayloadConverter,
+} from '../converter/payload-converter';
+import { ValueError } from '../errors';
+import type { Payload } from '../interfaces';
+import { decodeFromPayloadsAtIndex, encodeToPayload } from '../internal-non-workflow/codec-helpers';
+
+test('preserves RawValue TypeInfo around codecs without payload conversion', async (t) => {
+  const payload: Payload = {
+    metadata: {},
+    data: Uint8Array.from([1, 2, 3]),
+  };
+  const stages: string[] = [];
+  const payloadConverter: PayloadConverter = {
+    toPayload: () => {
+      throw new Error('Unexpected payload encoding');
+    },
+    fromPayload: () => {
+      throw new Error('Unexpected payload decoding');
+    },
+  };
+  const payloadCodec: PayloadCodec = {
+    async encode(payloads) {
+      stages.push('encode');
+      return payloads;
+    },
+    async decode(payloads) {
+      stages.push('decode');
+      return payloads;
+    },
+  };
+  const converter = { ...defaultDataConverter, payloadConverter, payloadCodecs: [payloadCodec] };
+
+  const encoded = await encodeToPayload(converter, RawValue.fromPayload(payload), undefined, rawValueTypeInfo);
+  const decoded = await decodeFromPayloadsAtIndex(converter, 0, [encoded], undefined, rawValueTypeInfo);
+
+  t.deepEqual(stages, ['encode', 'decode']);
+  t.is(encoded, payload);
+  t.true(decoded instanceof RawValue);
+  t.deepEqual(decoded.payload, payload);
+});
+
+test('rejects a non-RawValue with RawValue TypeInfo', (t) => {
+  const invalidValue = 'not a RawValue' as unknown as RawValue;
+
+  t.throws(() => toPayloadWithTypeInfo(defaultPayloadConverter, invalidValue, undefined, rawValueTypeInfo), {
+    instanceOf: ValueError,
+    message: 'RawValue TypeInfo requires a RawValue value',
+  });
+});
+
+test('preserves direct CompositePayloadConverter RawValue conversion', (t) => {
+  const value = new RawValue('test');
+
+  t.is(defaultPayloadConverter.toPayload(value), value.payload);
+});

--- a/packages/common/src/converter/payload-converter.ts
+++ b/packages/common/src/converter/payload-converter.ts
@@ -49,6 +49,12 @@ export function toPayloadWithTypeInfo<T, D = T>(
   context: SerializationContext | undefined,
   typeInfo: TypeInfo<T, D> | undefined
 ): Payload {
+  if (isRawValueTypeInfo(typeInfo)) {
+    if (!(value instanceof RawValue)) {
+      throw new ValueError('RawValue TypeInfo requires a RawValue value');
+    }
+    return value.payload;
+  }
   const transferValue = typeInfo?.transferTypeConverter ? typeInfo.transferTypeConverter.toTransferType(value) : value;
   return converter.toPayload(transferValue, context, typeInfo?.payloadConverterHint);
 }
@@ -64,6 +70,10 @@ export function fromPayloadWithTypeInfo<T, D = T>(
   context: SerializationContext | undefined,
   typeInfo: TypeInfo<T, D> | undefined
 ): T {
+  if (isRawValueTypeInfo(typeInfo)) {
+    // The private brand establishes T as RawValue, but this generic function cannot express that narrowing.
+    return RawValue.fromPayload(payload) as T;
+  }
   const transferValue = converter.fromPayload<D>(payload, context, typeInfo?.payloadConverterHint);
   return typeInfo?.transferTypeConverter
     ? typeInfo.transferTypeConverter.fromTransferType(transferValue)
@@ -212,6 +222,27 @@ export class RawValue<T = unknown> {
   }
 }
 
+const rawValueTypeInfoBrand: unique symbol = Symbol('rawValueTypeInfo');
+
+interface InternalRawValueTypeInfo extends TypeInfo<RawValue> {
+  readonly [rawValueTypeInfoBrand]: true;
+}
+
+/**
+ * Type information for preserving a {@link RawValue} across serialization boundaries.
+ *
+ * This bypasses the payload converter during encoding and decoding. Payload codecs are still applied.
+ *
+ * @experimental
+ */
+export const rawValueTypeInfo: TypeInfo<RawValue> = {
+  [rawValueTypeInfoBrand]: true,
+} as InternalRawValueTypeInfo;
+
+function isRawValueTypeInfo(typeInfo: TypeInfo | undefined): typeInfo is InternalRawValueTypeInfo {
+  return typeInfo !== undefined && rawValueTypeInfoBrand in typeInfo && typeInfo[rawValueTypeInfoBrand] === true;
+}
+
 export interface PayloadConverterWithEncoding {
   /**
    * Converts a value to a {@link Payload}.
@@ -265,6 +296,8 @@ export class CompositePayloadConverter implements PayloadConverter {
    */
   public toPayload<T>(value: T, context?: SerializationContext, hint?: ConverterHint<T>): Payload {
     if (value instanceof RawValue) {
+      // TypeInfo-aware calls bypass payload conversion in toPayloadWithTypeInfo. Keep this fallback for direct and
+      // legacy untyped calls; removing it would silently re-encode RawValue and may change Workflow replay payloads.
       return value.payload;
     }
     for (const converter of this.converters) {

--- a/packages/test/src/integration-workflows-common.ts
+++ b/packages/test/src/integration-workflows-common.ts
@@ -13,8 +13,8 @@ import {
   setHandler,
 } from '@temporalio/workflow';
 import { SdkFlags } from '@temporalio/workflow/lib/flags';
-import type { ActivityCancellationDetails } from '@temporalio/common';
-import { ApplicationFailure, encodingKeys, METADATA_ENCODING_KEY, RawValue } from '@temporalio/common';
+import type { ActivityCancellationDetails, PayloadTypeInfo } from '@temporalio/common';
+import { ApplicationFailure, RawValue, rawValueTypeInfo } from '@temporalio/common';
 import {
   TEMPORAL_RESERVED_PREFIX,
   STACK_TRACE_QUERY_NAME,
@@ -479,15 +479,29 @@ export async function completableWorkflow(completes: boolean): Promise<void> {
   await workflow.condition(() => completes);
 }
 
-export async function rawValueWorkflow(value: unknown, isPayload: boolean = false): Promise<RawValue> {
-  const { rawValueActivity } = workflow.proxyActivities({ startToCloseTimeout: '10s' });
-  const rv = isPayload
-    ? RawValue.fromPayload({
-        metadata: { [METADATA_ENCODING_KEY]: encodingKeys.METADATA_ENCODING_RAW },
-        data: value as Uint8Array,
-      })
-    : new RawValue(value);
-  return await rawValueActivity(rv, isPayload);
+export const rawValuePayloadTypeInfo: PayloadTypeInfo = {
+  inputTypes: [rawValueTypeInfo],
+  outputType: rawValueTypeInfo,
+};
+
+workflow.defineWorkflowOptions(rawValueWorkflow, {
+  staticOptions: { typeInfo: rawValuePayloadTypeInfo },
+});
+export async function rawValueWorkflow(value: RawValue): Promise<RawValue> {
+  if (!(value instanceof RawValue)) {
+    throw new TypeError('Expected RawValue Workflow input');
+  }
+  const { rawValueActivity } = workflow.proxyActivities<{
+    rawValueActivity(value: RawValue): Promise<RawValue>;
+  }>({
+    startToCloseTimeout: '3s',
+    activityTypeInfo: { rawValueActivity: rawValuePayloadTypeInfo },
+  });
+  const result = await rawValueActivity(value);
+  if (!(result instanceof RawValue)) {
+    throw new TypeError('Expected RawValue Activity result');
+  }
+  return result;
 }
 
 export async function ChildWorkflowInfo(): Promise<workflow.RootWorkflowInfo | undefined> {

--- a/packages/test/src/test-integration-workflow-info.ts
+++ b/packages/test/src/test-integration-workflow-info.ts
@@ -1,21 +1,16 @@
 import { randomUUID } from 'crypto';
+import { setActivityOptions } from '@temporalio/activity';
 import * as workflow from '@temporalio/workflow';
 import type { SearchAttributePair } from '@temporalio/common';
-import {
-  defineSearchAttributeKey,
-  encodingKeys,
-  METADATA_ENCODING_KEY,
-  RawValue,
-  SearchAttributeType,
-  TypedSearchAttributes,
-} from '@temporalio/common';
-import { encode } from '@temporalio/common/lib/encoding';
+import { defineSearchAttributeKey, RawValue, SearchAttributeType, TypedSearchAttributes } from '@temporalio/common';
+import { payloadToJSON } from '@temporalio/common/lib/proto-utils';
 import {
   buildIdTester,
   completableWorkflow,
   getBuildIdQuery,
   historySizeGrows,
   queryWorkflowMetadata,
+  rawValuePayloadTypeInfo,
   rawValueWorkflow,
   rootWorkflow,
   suggestedCAN,
@@ -180,37 +175,25 @@ test.serial('can register search attributes to dev server', async (t) => {
   await env.teardown();
 });
 
-test('workflow and activity can receive/return RawValue', async (t) => {
+test('workflow and activity preserve RawValue payloads', async (t) => {
   const { executeWorkflow, createWorker } = helpers(t);
+  async function rawValueActivity(value: RawValue): Promise<RawValue> {
+    if (!(value instanceof RawValue)) {
+      throw new TypeError('Expected RawValue Activity input');
+    }
+    return value;
+  }
+  setActivityOptions({ typeInfo: rawValuePayloadTypeInfo }, rawValueActivity);
   const worker = await createWorker({
-    activities: {
-      async rawValueActivity(value: unknown, isPayload: boolean = false): Promise<RawValue> {
-        const rv = isPayload
-          ? RawValue.fromPayload({
-              metadata: { [METADATA_ENCODING_KEY]: encodingKeys.METADATA_ENCODING_RAW },
-              data: value as Uint8Array,
-            })
-          : new RawValue(value);
-        return rv;
-      },
-    },
+    activities: { rawValueActivity },
   });
 
   await worker.runUntil(async () => {
-    const testValue = 'test';
-    const rawValue = new RawValue(testValue);
-    const rawValuePayload = RawValue.fromPayload({
-      metadata: { [METADATA_ENCODING_KEY]: encodingKeys.METADATA_ENCODING_RAW },
-      data: encode(testValue),
-    });
-    const res = await executeWorkflow(rawValueWorkflow, {
-      args: [rawValue],
-    });
-    t.deepEqual(res, testValue);
-    const res2 = await executeWorkflow(rawValueWorkflow, {
-      args: [rawValuePayload, true],
-    });
-    t.deepEqual(res2, encode(testValue));
+    const rawValue = new RawValue('test');
+    const result = await executeWorkflow(rawValueWorkflow, { args: [rawValue] });
+
+    t.true(result instanceof RawValue);
+    t.deepEqual(payloadToJSON(result.payload), payloadToJSON(rawValue.payload));
   });
 });
 


### PR DESCRIPTION
## What was changed

Added the experimental `rawValueTypeInfo` export so `RawValue` bypasses payload converters during decoding, after payload codecs have run. Encoding is unchanged because `RawValue` already bypasses payload converters in that direction.

The existing integration test now applies the same TypeInfo at the Workflow and Activity boundaries and verifies that both constructed and direct-payload `RawValue` instances survive the full client → Workflow → Activity → Workflow → client round trip.

## Why?

`RawValue` conversion was previously one-way. Callers could send an already-encoded payload without invoking the configured payload converter, but receivers had no runtime type information telling them to reconstruct a `RawValue`. The wrapper was therefore lost during decoding.

## Checklist

1. How was this tested:

   - Common TypeScript build and focused TypeInfo unit tests (5 passing).
   - Integration TypeScript build and focused Workflow/Activity round-trip test (1 passing).
   - Focused ESLint and Prettier checks.

2. Any docs updates needed?

   No external documentation changes are needed. The new experimental API is documented in `CHANGELOG.md`.
