### PR TITLE
fix(common): preserve Error.cause in
  activity failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- Activity errors converted to `ApplicationFailure` now preserve native `Error.cause` chains in serialized failures.
 - Local Activities now fall back to a registered `default` activity when the requested type is not
   registered, matching non-local Activity dispatch. Previously the Workflow Task failed immediately
   with `ReferenceError` even if `default` was registered.

--- a/packages/common/src/__tests__/test-failure.ts
+++ b/packages/common/src/__tests__/test-failure.ts
@@ -1,5 +1,48 @@
+import vm from 'vm';
 import test from 'ava';
-import { ApplicationFailure, createPayloadValidationError, defaultFailureConverter, defaultPayloadConverter } from '..';
+import {
+  ApplicationFailure,
+  createPayloadValidationError,
+  defaultFailureConverter,
+  defaultPayloadConverter,
+  ensureApplicationFailure,
+} from '..';
+
+test('ensureApplicationFailure preserves Error.cause through serialization', (t) => {
+  const cause = new Error('connection terminated');
+  const error = new Error('query failed', { cause });
+
+  const applicationFailure = ensureApplicationFailure(error);
+  const failure = defaultFailureConverter.errorToFailure(applicationFailure, defaultPayloadConverter);
+
+  t.is(applicationFailure.cause, cause);
+  t.is(failure.cause?.message, cause.message);
+});
+
+test('ensureApplicationFailure preserves cross-realm Error.cause chains', (t) => {
+  const cause = vm.runInNewContext(
+    `new Error('connection terminated', { cause: new Error('connection refused') })`
+  ) as Error;
+  const error = new Error('query failed', { cause });
+
+  const applicationFailure = ensureApplicationFailure(error);
+  const failure = defaultFailureConverter.errorToFailure(applicationFailure, defaultPayloadConverter);
+
+  t.false(cause instanceof Error);
+  t.is(applicationFailure.cause, cause);
+  t.is(failure.cause?.message, cause.message);
+  t.is(failure.cause?.cause?.message, 'connection refused');
+});
+
+test('ensureApplicationFailure omits an immediate non-Error cause', (t) => {
+  const error = new Error('query failed', { cause: 'connection terminated' });
+
+  const applicationFailure = ensureApplicationFailure(error);
+  const failure = defaultFailureConverter.errorToFailure(applicationFailure, defaultPayloadConverter);
+
+  t.is(applicationFailure.cause, undefined);
+  t.is(failure.cause, undefined);
+});
 
 test('createPayloadValidationError creates a serializable non-retryable ApplicationFailure', (t) => {
   const details = {

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -1,5 +1,5 @@
 import type { temporal } from '@temporalio/proto';
-import { errorMessage, isRecord, SymbolBasedInstanceOfError } from './type-helpers';
+import { errorMessage, isError, isRecord, SymbolBasedInstanceOfError } from './type-helpers';
 import type { Duration } from './time';
 import { makeProtoEnumConverters } from './internal-workflow';
 
@@ -182,6 +182,7 @@ export class ServerFailure extends TemporalFailure {
  * - `message` is set to `error.message`
  * - `nonRetryable` is set to false
  * - `details` are set to null
+ * - `cause` is set to `error.cause` when it is an `Error`
  * - stack trace is copied from the original error
  *
  * When an {@link https://docs.temporal.io/activity-execution#activity-execution | Activity Execution} fails, the
@@ -442,6 +443,7 @@ export class WorkflowExecutionAlreadyStartedError extends TemporalFailure {
  * - `message`: `error.message` or `String(error)`
  * - `type`: `error.constructor.name` or `error.name`
  * - `stack`: `error.stack` or `''`
+ * - `cause`: `error.cause` when it is an `Error`
  */
 export function ensureApplicationFailure(error: unknown): ApplicationFailure {
   if (error instanceof ApplicationFailure) {
@@ -450,7 +452,8 @@ export function ensureApplicationFailure(error: unknown): ApplicationFailure {
 
   const message = (isRecord(error) && String(error.message)) || String(error);
   const type = (isRecord(error) && (error.constructor?.name ?? error.name)) || undefined;
-  const failure = ApplicationFailure.create({ message, type, nonRetryable: false });
+  const cause = isRecord(error) && isError(error.cause) ? error.cause : undefined;
+  const failure = ApplicationFailure.create({ message, type, nonRetryable: false, cause });
   failure.stack = (isRecord(error) && String(error.stack)) || '';
   return failure;
 }

--- a/packages/test/src/activities/index.ts
+++ b/packages/test/src/activities/index.ts
@@ -47,11 +47,15 @@ export async function setup(): Promise<void> {}
  */
 export async function cleanup(_url: string): Promise<void> {}
 
-export async function throwAnError(useApplicationFailure: boolean, message: string): Promise<void> {
+export async function throwAnError(
+  useApplicationFailure: boolean,
+  message: string,
+  causeMessage?: string
+): Promise<void> {
   if (useApplicationFailure) {
     throw ApplicationFailure.nonRetryable(message, 'Error', 'details', 123, false);
   } else {
-    throw new Error(message);
+    throw new Error(message, causeMessage === undefined ? undefined : { cause: new Error(causeMessage) });
   }
 }
 

--- a/packages/test/src/test-integration-split-one.cloud-pending.ts
+++ b/packages/test/src/test-integration-split-one.cloud-pending.ts
@@ -141,7 +141,7 @@ export async function activityFailure(useApplicationFailure: boolean): Promise<v
   if (useApplicationFailure) {
     await throwAnError(true, 'Fail me');
   } else {
-    await throwAnError(false, 'Fail me');
+    await throwAnError(false, 'Fail me', 'Root cause');
   }
 }
 
@@ -169,6 +169,7 @@ test.serial('activity-failure with Error', configMacro, async (t, config) => {
     return;
   }
   t.is(err.cause.cause.message, 'Fail me');
+  t.is(err.cause.cause.cause?.message, 'Root cause');
   compareStackTrace(
     t,
     cleanOptionalStackTrace(err.cause.cause.stack)!,


### PR DESCRIPTION
## What changed

Activities convert non-`ApplicationFailure` errors before passing them to the configured failure converter. That conversion copied the error's message, type, and stack but discarded `Error.cause`, so the underlying cause chain never reached Workflow history.

This change preserves error-like causes using the SDK's realm-safe `isError` guard. The existing failure converter then serializes the chain through the standard failure `cause` field. Non-error causes remain omitted, and no protobuf or failure-converter behavior changes.

## Behavior

Before this change, an Activity that threw `new Error('query failed', { cause })` produced an `ApplicationFailure` containing only `query failed`. After this change, the serialized failure also contains the nested cause chain, including causes created in another JavaScript realm.

## Verification

- Built `@temporalio/common` and its dependencies.
- Ran the focused common failure suite: 5 tests passed.
- Ran focused ESLint and Prettier checks.
- Ran `git diff --check`.

Closes #2291.
