### PR TITLE
Retain failed Workflows until Core eviction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@ to docs, or any other relevant information.
 - Nexus handlers now report uncaught Workflow and standalone Activity already-started errors as
   non-retryable `INTERNAL` Handler Errors, preventing retries when ID reuse or conflict
   policies reject duplicate execution IDs.
+- Workflow activation failures now retain Workflow state until Core eviction, preventing premature
+  execution-context disposal after converter or codec errors.
 - Local Activities now fall back to a registered `default` activity when the requested type is not
   registered, matching non-local Activity dispatch. Previously the Workflow Task failed immediately
   with `ReferenceError` even if `default` was registered.

--- a/packages/test/src/mock-native-worker.ts
+++ b/packages/test/src/mock-native-worker.ts
@@ -197,7 +197,7 @@ export const defaultOptions: WorkerOptions = {
   taskQueue: 'test',
 };
 
-export function isolateFreeWorker(options: WorkerOptions = defaultOptions): Worker {
+export function isolateFreeWorker(options: WorkerOptions = defaultOptions, workflowCreator?: WorkflowCreator): Worker {
   const runtime = Runtime.instance();
   const logger = LoggerWithComposedMetadata.compose(runtime.logger, {
     sdkComponent: SdkComponent.worker,
@@ -208,7 +208,7 @@ export function isolateFreeWorker(options: WorkerOptions = defaultOptions): Work
     taskQueue: options.taskQueue ?? 'default',
   });
   return new Worker(
-    {
+    workflowCreator ?? {
       async createWorkflow() {
         throw new Error('Not implemented');
       },

--- a/packages/test/src/test-worker-lifecycle.ts
+++ b/packages/test/src/test-worker-lifecycle.ts
@@ -6,6 +6,9 @@
  */
 import { randomUUID } from 'crypto';
 import test from 'ava';
+import Long from 'long';
+import { createPayloadValidationError, defaultPayloadConverter, type PayloadCodec } from '@temporalio/common';
+import { msToTs } from '@temporalio/common/lib/time';
 import type { LogEntry, NativeConnection } from '@temporalio/worker';
 import { DefaultLogger, MetricsBuffer, Runtime } from '@temporalio/worker';
 import { isolateFreeWorker, Worker as MockWorker } from './mock-native-worker';
@@ -62,6 +65,88 @@ test.serial('Mocked run shuts down gracefully', async (t) => {
     await t.throwsAsync(worker.run(), { message: 'Poller was already started' });
   } finally {
     if (Runtime._instance) await Runtime._instance.shutdown();
+  }
+});
+
+test('Worker retains a failed Workflow until Core eviction', async (t) => {
+  const invalidPayload = defaultPayloadConverter.toPayload('invalid-payload');
+  const codec: PayloadCodec = {
+    async encode(payloads) {
+      if (payloads.some((payload) => defaultPayloadConverter.fromPayload(payload) === 'invalid-payload')) {
+        throw createPayloadValidationError({ field: 'nexus-input' });
+      }
+      return payloads;
+    },
+    async decode(payloads) {
+      return payloads;
+    },
+  };
+  let disposeCount = 0;
+  const worker = isolateFreeWorker(
+    {
+      taskQueue: t.title.replace(/ /g, '_'),
+      activities: {},
+      dataConverter: { payloadCodecs: [codec] },
+    },
+    {
+      async createWorkflow() {
+        return {
+          async activate() {
+            return {
+              successful: {
+                commands: [{ scheduleNexusOperation: { seq: 1, input: invalidPayload } }],
+              },
+            };
+          },
+          async getAndResetSinkCalls() {
+            return [];
+          },
+          async dispose() {
+            disposeCount++;
+          },
+        };
+      },
+      async destroy() {
+        // Nothing to destroy
+      },
+    }
+  );
+  const runId = randomUUID();
+  const now = msToTs(Date.now());
+  const run = worker.run();
+  try {
+    const failed = await worker.native.runWorkflowActivation({
+      runId,
+      timestamp: now,
+      jobs: [
+        {
+          initializeWorkflow: {
+            workflowId: 'workflow-id',
+            workflowType: 'test',
+            randomnessSeed: Long.ONE,
+            firstExecutionRunId: runId,
+            originalExecutionRunId: runId,
+            attempt: 1,
+            startTime: now,
+            workflowTaskTimeout: msToTs('10 seconds'),
+          },
+        },
+      ],
+    });
+
+    t.is(failed.failed?.failure?.applicationFailureInfo?.type, 'PayloadValidationError');
+    t.is(disposeCount, 0);
+
+    const evicted = await worker.native.runWorkflowActivation({
+      runId,
+      jobs: [{ removeFromCache: {} }],
+    });
+
+    t.truthy(evicted.successful);
+    t.is(disposeCount, 1);
+  } finally {
+    worker.shutdown();
+    await run;
   }
 });
 

--- a/packages/test/src/test-worker-lifecycle.ts
+++ b/packages/test/src/test-worker-lifecycle.ts
@@ -11,6 +11,7 @@ import { createPayloadValidationError, defaultPayloadConverter, type PayloadCode
 import { msToTs } from '@temporalio/common/lib/time';
 import type { LogEntry, NativeConnection } from '@temporalio/worker';
 import { DefaultLogger, MetricsBuffer, Runtime } from '@temporalio/worker';
+import { UnexpectedError } from '@temporalio/worker/lib/errors';
 import { isolateFreeWorker, Worker as MockWorker } from './mock-native-worker';
 
 test.serial('Worker.create debug log options are JSON serializable with buffered metrics and connection', async (t) => {
@@ -147,6 +148,80 @@ test('Worker retains a failed Workflow until Core eviction', async (t) => {
   } finally {
     worker.shutdown();
     await run;
+  }
+});
+
+test('Worker closes an evicted Workflow when disposal fails', async (t) => {
+  const disposeFailure = new Error('dispose failed');
+  let disposeCount = 0;
+  const worker = isolateFreeWorker(
+    {
+      taskQueue: t.title.replace(/ /g, '_'),
+      activities: {},
+    },
+    {
+      async createWorkflow() {
+        return {
+          async activate() {
+            return { successful: {} };
+          },
+          async getAndResetSinkCalls() {
+            return [];
+          },
+          async dispose() {
+            disposeCount++;
+            throw disposeFailure;
+          },
+        };
+      },
+      async destroy() {
+        // Nothing to destroy
+      },
+    }
+  );
+  const runId = randomUUID();
+  const now = msToTs(Date.now());
+  const run = worker.run();
+  try {
+    const started = await worker.native.runWorkflowActivation({
+      runId,
+      timestamp: now,
+      jobs: [
+        {
+          initializeWorkflow: {
+            workflowId: 'workflow-id',
+            workflowType: 'test',
+            randomnessSeed: Long.ONE,
+            firstExecutionRunId: runId,
+            originalExecutionRunId: runId,
+            attempt: 1,
+            startTime: now,
+            workflowTaskTimeout: msToTs('10 seconds'),
+          },
+        },
+      ],
+    });
+
+    t.truthy(started.successful);
+    t.is(worker.getStatus().numCachedWorkflows, 1);
+
+    const evicted = await worker.native.runWorkflowActivation({
+      runId,
+      jobs: [{ removeFromCache: {} }],
+    });
+
+    t.truthy(evicted.successful);
+    t.is(disposeCount, 1);
+    t.is(worker.getStatus().numCachedWorkflows, 0);
+
+    const error = await t.throwsAsync(run);
+    if (error === undefined) return;
+    t.assert(error instanceof UnexpectedError);
+    t.is(error.cause, disposeFailure);
+    t.is(worker.getState(), 'FAILED');
+  } finally {
+    if (worker.getState() === 'RUNNING') worker.shutdown();
+    await run.catch(() => undefined);
   }
 });
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -189,6 +189,8 @@ interface WorkflowWithLogAttributes {
   info: WorkflowInfo;
 }
 
+class WorkflowDisposeError extends UnexpectedError {}
+
 function addBuildIdIfMissing(options: CompiledWorkerOptions, bundleCode?: string): CompiledWorkerOptionsWithBuildId {
   const bid = options.buildId;
   if (bid != null) {
@@ -1532,7 +1534,11 @@ export class Worker {
       activation.jobs = jobs;
       if (jobs.length === 0) {
         this.logger.trace('Disposing workflow', workflow ? workflow.logAttributes : { runId: activation.runId });
-        await workflow?.workflow.dispose();
+        try {
+          await workflow?.workflow.dispose();
+        } catch (cause) {
+          throw new WorkflowDisposeError('Failed to dispose Workflow during eviction', cause);
+        }
         if (!close) {
           throw new IllegalStateError('Got a Workflow activation with no jobs');
         }
@@ -1631,6 +1637,16 @@ export class Worker {
         error,
         workflowExists: workflow !== undefined,
       });
+
+      if (error instanceof WorkflowDisposeError) {
+        const completion = synthetic
+          ? undefined
+          : coresdk.workflow_completion.WorkflowActivationCompletion.encodeDelimited({
+              runId: activation.runId,
+              successful: {},
+            }).finish();
+        return { state: undefined, output: { close: true, completion } };
+      }
 
       const completion = coresdk.workflow_completion.WorkflowActivationCompletion.encodeDelimited({
         runId: activation.runId,

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1641,7 +1641,7 @@ export class Worker {
 
       // We do not dispose of the Workflow yet, wait to be evicted from Core.
       // This is done to simplify the Workflow lifecycle so Core is the sole driver.
-      return { state: undefined, output: { close: true, completion } };
+      return { state: workflow, output: { close: false, completion } };
     }
   }
 


### PR DESCRIPTION
## Summary

- Retain the Workflow state when activation processing fails.
- Return `close: false` so Core remains responsible for eviction and disposal.
- Add a regression test that verifies the Workflow is disposed only after a `removeFromCache` activation.

## Why

The activation failure path already documents that Workflow disposal must wait for Core eviction, but it returned `state: undefined` and `close: true`. When an error occurred after the Workflow had been created, such as while encoding an outgoing Nexus input, Core could still send a cache-eviction activation after the worker had dropped the state. That violated the lifecycle contract and could trigger a Workflow execution-context disposal error.

Keeping the state and reporting the Workflow as open makes the implementation match the intended ownership model: Core is the sole driver of Workflow eviction.
