### PR TITLE
Fix Update-with-Start error stack messages

### DIFF
--- a/packages/client/src/helpers.ts
+++ b/packages/client/src/helpers.ts
@@ -155,6 +155,7 @@ export function rethrowKnownErrorTypes(err: GrpcServiceError): void {
           err.message = status.message ?? err.message;
           err.code = status.code || err.code;
           err.details = detail?.value?.toString() || err.details;
+          err.stack = err.stack?.replace(/^.*$/m, `${err.name}: ${err.code} ${grpcStatus[err.code]}: ${err.message}`);
           throw err;
         }
       }

--- a/packages/test/src/test-integration-update.ts
+++ b/packages/test/src/test-integration-update.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'crypto';
 import { status as grpcStatus } from '@grpc/grpc-js';
 import {
+  Client,
+  Connection,
   isGrpcServiceError,
   WorkflowUpdateStage,
   WorkflowUpdateRPCTimeoutOrCancelledError,
@@ -258,6 +260,9 @@ test('updateWithStart failure: update fails early due to limit on number of upda
   const workflowId = randomUUID();
   const { createWorker, taskQueue } = helpers(t);
   const worker = await createWorker();
+  const connection = await Connection.connect({ address: t.context.env.address, interceptors: [] });
+  t.teardown(() => connection.close());
+  const client = new Client({ connection });
   const makeStartOp = () =>
     new WithStartWorkflowOperation(workflowWithNeverReturningUpdate, {
       workflowId,
@@ -265,7 +270,7 @@ test('updateWithStart failure: update fails early due to limit on number of upda
       workflowIdConflictPolicy: 'USE_EXISTING',
     });
   const startUpdateWithStart = async (startOp: WithStartWorkflowOperation<typeof workflowWithNeverReturningUpdate>) => {
-    await t.context.env.client.workflow.startUpdateWithStart(neverReturningUpdate, {
+    await client.workflow.startUpdateWithStart(neverReturningUpdate, {
       waitForStage: 'ACCEPTED',
       startWorkflowOperation: startOp,
     });
@@ -279,13 +284,12 @@ test('updateWithStart failure: update fails early due to limit on number of upda
       await startOp.workflowHandle;
     }
     // The 11th call should fail with a gRPC error
-
-    // TODO: set gRPC retries to 1. This generates a RESOURCE_EXHAUSTED error,
-    // and by default these are retried 10 times.
     const startOp = makeStartOp();
     for (const promise of [startUpdateWithStart(startOp), startOp.workflowHandle()]) {
       const err = await t.throwsAsync(promise);
       t.true(isGrpcServiceError(err) && err.code === grpcStatus.RESOURCE_EXHAUSTED);
+      t.regex(err?.message ?? '', /limit on number of concurrent in-flight updates/i);
+      t.regex(err?.stack ?? '', /limit on number of concurrent in-flight updates/i);
     }
   });
 });


### PR DESCRIPTION
## Summary

Update-with-Start failures are logged as `Error: 8 RESOURCE_EXHAUSTED: Update-with-Start could not be executed.` even when the server returned a specific reason. The actionable message is available through `err.message`, but normal error logging reads the stale stack instead.

The client already decodes the underlying `MultiOperationExecutionFailure` and replaces the gRPC error's `message`, `code`, and `details`. Refreshing the stack's first line at the same point keeps the decoded message and the original call frames together.

Closes https://github.com/temporalio/sdk-typescript/issues/1721

## Testing

The server-backed test fills all ten in-flight update slots and submits an eleventh Update-with-Start request.

| State | Result |
| --- | --- |
| Before | `err.message` contained the nested `RESOURCE_EXHAUSTED` reason, but `err.stack` retained the generic message. |
| After | Both fields contain `limit on number of concurrent in-flight updates has been reached (10)`. |

```bash
pnpm -C packages/test exec ava ./lib/test-integration-update.js \
  --match='updateWithStart failure: update fails early due to limit on number of updates' \
  --timeout=2m
```

<details><summary>Raw logs</summary>

Before:

```text
time=2026-09-03T00:09:01.868 level=ERROR msg="service failures" operation=ExecuteMultiOperation grpc_code=ResourceExhausted error="MultiOperation could not be executed: Update failed: limit on number of concurrent in-flight updates has been reached (10)"

Value must match expression:
`Error: 8 RESOURCE_EXHAUSTED: Update-with-Start could not be executed.`

Regular expression:
/limit on number of concurrent in-flight updates/i

1 test failed
```

After:

```text
time=2026-09-03T02:46:37.862 level=ERROR msg="service failures" operation=ExecuteMultiOperation grpc_code=ResourceExhausted error="MultiOperation could not be executed: Update failed: limit on number of concurrent in-flight updates has been reached (10)"
1 test passed
```

</details>
