### PR TITLE
test: adapt custom data converter tests for Temporal Cloud

### DIFF
--- a/packages/test/src/test-custom-payload-codec.ts
+++ b/packages/test/src/test-custom-payload-codec.ts
@@ -45,225 +45,221 @@ function makeClient(t: ExecutionContext<Context>, dataConverter: DataConverter):
   });
 }
 
-function registerIntegrationTests(): void {
-  const test = makeTestFunction({ workflowsPath: require.resolve('./workflows') });
+const test = makeTestFunction({ workflowsPath: require.resolve('./workflows') });
 
-  test('Workflow arguments and retvals are encoded', async (t) => {
-    const { createWorker, taskQueue } = helpers(t);
-    const logs: string[] = [];
-    const sinks: InjectedSinks<LogSinks> = {
-      logger: {
-        log: {
-          fn(_, message) {
-            logs.push(message);
-          },
+test('Workflow arguments and retvals are encoded', async (t) => {
+  const { createWorker, taskQueue } = helpers(t);
+  const logs: string[] = [];
+  const sinks: InjectedSinks<LogSinks> = {
+    logger: {
+      log: {
+        fn(_, message) {
+          logs.push(message);
         },
       },
-    };
+    },
+  };
 
-    const dataConverter = { payloadCodecs: [new TestEncodeCodec()] };
-    const worker = await createWorker({
-      dataConverter,
-      sinks,
-    });
-    const client = makeClient(t, dataConverter);
-    await worker.runUntil(async () => {
-      const result = await client.execute(twoStrings, {
-        args: ['arg1', 'arg2'],
-        workflowId: randomUUID(),
-        taskQueue,
-      });
-
-      t.is(result, 'encoded'); // workflow retval encoded by worker
-    });
-    t.is(logs[0], 'encodedencoded'); // workflow args encoded by client
+  const dataConverter = { payloadCodecs: [new TestEncodeCodec()] };
+  const worker = await createWorker({
+    dataConverter,
+    sinks,
   });
+  const client = makeClient(t, dataConverter);
+  await worker.runUntil(async () => {
+    const result = await client.execute(twoStrings, {
+      args: ['arg1', 'arg2'],
+      workflowId: randomUUID(),
+      taskQueue,
+    });
 
-  test('Workflow arguments and retvals are decoded', async (t) => {
-    const { createWorker, taskQueue } = helpers(t);
-    const logs: string[] = [];
-    const sinks: InjectedSinks<LogSinks> = {
-      logger: {
-        log: {
-          fn(_, message) {
-            logs.push(message);
-          },
+    t.is(result, 'encoded'); // workflow retval encoded by worker
+  });
+  t.is(logs[0], 'encodedencoded'); // workflow args encoded by client
+});
+
+test('Workflow arguments and retvals are decoded', async (t) => {
+  const { createWorker, taskQueue } = helpers(t);
+  const logs: string[] = [];
+  const sinks: InjectedSinks<LogSinks> = {
+    logger: {
+      log: {
+        fn(_, message) {
+          logs.push(message);
         },
       },
-    };
+    },
+  };
 
-    const dataConverter = { payloadCodecs: [new TestDecodeCodec()] };
-    const worker = await createWorker({
-      dataConverter,
-      sinks,
-    });
-    const client = makeClient(t, dataConverter);
-    await worker.runUntil(async () => {
-      const result = await client.execute(twoStrings, {
-        args: ['arg1', 'arg2'],
-        workflowId: randomUUID(),
-        taskQueue,
-      });
-
-      t.is(result, 'decoded'); // workflow retval decoded by client
-    });
-    t.is(logs[0], 'decodeddecoded'); // workflow args decoded by worker
+  const dataConverter = { payloadCodecs: [new TestDecodeCodec()] };
+  const worker = await createWorker({
+    dataConverter,
+    sinks,
   });
+  const client = makeClient(t, dataConverter);
+  await worker.runUntil(async () => {
+    const result = await client.execute(twoStrings, {
+      args: ['arg1', 'arg2'],
+      workflowId: randomUUID(),
+      taskQueue,
+    });
 
-  test('Activity arguments and retvals are encoded', async (t) => {
-    const { createWorker, taskQueue } = helpers(t);
-    const workflowLogs: string[] = [];
-    const sinks: InjectedSinks<LogSinks> = {
-      logger: {
-        log: {
-          fn(_, message) {
-            workflowLogs.push(message);
-          },
+    t.is(result, 'decoded'); // workflow retval decoded by client
+  });
+  t.is(logs[0], 'decodeddecoded'); // workflow args decoded by worker
+});
+
+test('Activity arguments and retvals are encoded', async (t) => {
+  const { createWorker, taskQueue } = helpers(t);
+  const workflowLogs: string[] = [];
+  const sinks: InjectedSinks<LogSinks> = {
+    logger: {
+      log: {
+        fn(_, message) {
+          workflowLogs.push(message);
         },
       },
-    };
-    const activityLogs: string[] = [];
+    },
+  };
+  const activityLogs: string[] = [];
 
-    const dataConverter = { payloadCodecs: [new TestEncodeCodec()] };
-    const worker = await createWorker({
-      activities: createConcatActivity(activityLogs),
-      dataConverter,
-      sinks,
-    });
-    const client = makeClient(t, dataConverter);
-    await worker.runUntil(async () => {
-      await client.execute(twoStringsActivity, {
-        workflowId: randomUUID(),
-        taskQueue,
-      });
-    });
-    t.is(workflowLogs[0], 'encoded'); // activity retval encoded by worker
-    t.is(activityLogs[0], 'Activityencodedencoded'); // activity args encoded by worker
+  const dataConverter = { payloadCodecs: [new TestEncodeCodec()] };
+  const worker = await createWorker({
+    activities: createConcatActivity(activityLogs),
+    dataConverter,
+    sinks,
   });
+  const client = makeClient(t, dataConverter);
+  await worker.runUntil(async () => {
+    await client.execute(twoStringsActivity, {
+      workflowId: randomUUID(),
+      taskQueue,
+    });
+  });
+  t.is(workflowLogs[0], 'encoded'); // activity retval encoded by worker
+  t.is(activityLogs[0], 'Activityencodedencoded'); // activity args encoded by worker
+});
 
-  test('Activity arguments and retvals are decoded', async (t) => {
-    const { createWorker, taskQueue } = helpers(t);
-    const workflowLogs: string[] = [];
-    const sinks: InjectedSinks<LogSinks> = {
-      logger: {
-        log: {
-          fn(_, message) {
-            workflowLogs.push(message);
-          },
+test('Activity arguments and retvals are decoded', async (t) => {
+  const { createWorker, taskQueue } = helpers(t);
+  const workflowLogs: string[] = [];
+  const sinks: InjectedSinks<LogSinks> = {
+    logger: {
+      log: {
+        fn(_, message) {
+          workflowLogs.push(message);
         },
       },
-    };
-    const activityLogs: string[] = [];
+    },
+  };
+  const activityLogs: string[] = [];
 
-    const dataConverter = { payloadCodecs: [new TestDecodeCodec()] };
-    const worker = await createWorker({
-      activities: createConcatActivity(activityLogs),
-      dataConverter,
-      sinks,
-    });
-    const client = makeClient(t, dataConverter);
-    await worker.runUntil(async () => {
-      await client.execute(twoStringsActivity, {
-        workflowId: randomUUID(),
-        taskQueue,
-      });
-    });
-    t.is(workflowLogs[0], 'decoded'); // activity retval decoded by worker
-    t.is(activityLogs[0], 'Activitydecodeddecoded'); // activity args decoded by worker
+  const dataConverter = { payloadCodecs: [new TestDecodeCodec()] };
+  const worker = await createWorker({
+    activities: createConcatActivity(activityLogs),
+    dataConverter,
+    sinks,
   });
+  const client = makeClient(t, dataConverter);
+  await worker.runUntil(async () => {
+    await client.execute(twoStringsActivity, {
+      workflowId: randomUUID(),
+      taskQueue,
+    });
+  });
+  t.is(workflowLogs[0], 'decoded'); // activity retval decoded by worker
+  t.is(activityLogs[0], 'Activitydecodeddecoded'); // activity args decoded by worker
+});
 
-  test('Multiple encodes happen in the correct order', async (t) => {
-    const { createWorker, taskQueue } = helpers(t);
-    const logs: string[] = [];
-    const sinks: InjectedSinks<LogSinks> = {
-      logger: {
-        log: {
-          fn(_, message) {
-            logs.push(message);
-          },
+test('Multiple encodes happen in the correct order', async (t) => {
+  const { createWorker, taskQueue } = helpers(t);
+  const logs: string[] = [];
+  const sinks: InjectedSinks<LogSinks> = {
+    logger: {
+      log: {
+        fn(_, message) {
+          logs.push(message);
         },
       },
-    };
+    },
+  };
 
-    const dataConverter = {
-      payloadCodecs: [
-        new TestEncodeCodec(),
-        {
-          async encode(payloads: Payload[]): Promise<Payload[]> {
-            if (decode(payloads[0]!.data!) !== '"encoded"') {
-              throw new Error('wrong order');
-            }
-            return payloads;
-          },
-          async decode(payloads: Payload[]): Promise<Payload[]> {
-            return payloads;
-          },
+  const dataConverter = {
+    payloadCodecs: [
+      new TestEncodeCodec(),
+      {
+        async encode(payloads: Payload[]): Promise<Payload[]> {
+          if (decode(payloads[0]!.data!) !== '"encoded"') {
+            throw new Error('wrong order');
+          }
+          return payloads;
         },
-      ],
-    };
-    const worker = await createWorker({
-      dataConverter,
-      sinks,
-    });
-    const client = makeClient(t, dataConverter);
-    await worker.runUntil(async () => {
-      const result = await client.execute(twoStrings, {
-        args: ['arg1', 'arg2'],
-        workflowId: randomUUID(),
-        taskQueue,
-      });
-
-      t.is(result, 'encoded'); // workflow retval encoded by worker
-    });
-    t.is(logs[0], 'encodedencoded'); // workflow args encoded by client
-  });
-
-  test('Multiple decodes happen in the correct order', async (t) => {
-    const { createWorker, taskQueue } = helpers(t);
-    const logs: string[] = [];
-    const sinks: InjectedSinks<LogSinks> = {
-      logger: {
-        log: {
-          fn(_, message) {
-            logs.push(message);
-          },
+        async decode(payloads: Payload[]): Promise<Payload[]> {
+          return payloads;
         },
       },
-    };
-
-    const dataConverter = {
-      payloadCodecs: [
-        {
-          async encode(payloads: Payload[]): Promise<Payload[]> {
-            return payloads;
-          },
-          async decode(payloads: Payload[]): Promise<Payload[]> {
-            if (decode(payloads[0]!.data!) !== '"decoded"') {
-              throw new Error('wrong order');
-            }
-
-            return payloads;
-          },
-        },
-        new TestDecodeCodec(),
-      ],
-    };
-    const worker = await createWorker({
-      dataConverter,
-      sinks,
-    });
-    const client = makeClient(t, dataConverter);
-    await worker.runUntil(async () => {
-      const result = await client.execute(twoStrings, {
-        args: ['arg1', 'arg2'],
-        workflowId: randomUUID(),
-        taskQueue,
-      });
-
-      t.is(result, 'decoded'); // workflow retval decoded by client
-    });
-    t.is(logs[0], 'decodeddecoded'); // workflow args decoded by worker
+    ],
+  };
+  const worker = await createWorker({
+    dataConverter,
+    sinks,
   });
-}
+  const client = makeClient(t, dataConverter);
+  await worker.runUntil(async () => {
+    const result = await client.execute(twoStrings, {
+      args: ['arg1', 'arg2'],
+      workflowId: randomUUID(),
+      taskQueue,
+    });
 
-registerIntegrationTests();
+    t.is(result, 'encoded'); // workflow retval encoded by worker
+  });
+  t.is(logs[0], 'encodedencoded'); // workflow args encoded by client
+});
+
+test('Multiple decodes happen in the correct order', async (t) => {
+  const { createWorker, taskQueue } = helpers(t);
+  const logs: string[] = [];
+  const sinks: InjectedSinks<LogSinks> = {
+    logger: {
+      log: {
+        fn(_, message) {
+          logs.push(message);
+        },
+      },
+    },
+  };
+
+  const dataConverter = {
+    payloadCodecs: [
+      {
+        async encode(payloads: Payload[]): Promise<Payload[]> {
+          return payloads;
+        },
+        async decode(payloads: Payload[]): Promise<Payload[]> {
+          if (decode(payloads[0]!.data!) !== '"decoded"') {
+            throw new Error('wrong order');
+          }
+
+          return payloads;
+        },
+      },
+      new TestDecodeCodec(),
+    ],
+  };
+  const worker = await createWorker({
+    dataConverter,
+    sinks,
+  });
+  const client = makeClient(t, dataConverter);
+  await worker.runUntil(async () => {
+    const result = await client.execute(twoStrings, {
+      args: ['arg1', 'arg2'],
+      workflowId: randomUUID(),
+      taskQueue,
+    });
+
+    t.is(result, 'decoded'); // workflow retval decoded by client
+  });
+  t.is(logs[0], 'decodeddecoded'); // workflow args decoded by worker
+});

--- a/packages/test/src/test-custom-payload-codec.ts
+++ b/packages/test/src/test-custom-payload-codec.ts
@@ -5,7 +5,7 @@ import type { DataConverter, Payload, PayloadCodec } from '@temporalio/common';
 import { decode } from '@temporalio/common/lib/encoding';
 import type { InjectedSinks } from '@temporalio/worker';
 import { createConcatActivity } from './activities/create-concat-activity';
-import { RUN_INTEGRATION_TESTS, u8 } from './helpers';
+import { u8 } from './helpers';
 import type { Context } from './helpers-integration';
 import { helpers, makeTestFunction } from './helpers-integration';
 import type { LogSinks } from './workflows';
@@ -45,7 +45,7 @@ function makeClient(t: ExecutionContext<Context>, dataConverter: DataConverter):
   });
 }
 
-if (RUN_INTEGRATION_TESTS) {
+function registerIntegrationTests(): void {
   const test = makeTestFunction({ workflowsPath: require.resolve('./workflows') });
 
   test('Workflow arguments and retvals are encoded', async (t) => {
@@ -265,3 +265,5 @@ if (RUN_INTEGRATION_TESTS) {
     t.is(logs[0], 'decodeddecoded'); // workflow args decoded by worker
   });
 }
+
+registerIntegrationTests();

--- a/packages/test/src/test-custom-payload-codec.ts
+++ b/packages/test/src/test-custom-payload-codec.ts
@@ -1,12 +1,13 @@
 import { randomUUID } from 'crypto';
-import test from 'ava';
+import type { ExecutionContext } from 'ava';
 import { WorkflowClient } from '@temporalio/client';
-import type { Payload, PayloadCodec } from '@temporalio/common';
+import type { DataConverter, Payload, PayloadCodec } from '@temporalio/common';
 import { decode } from '@temporalio/common/lib/encoding';
 import type { InjectedSinks } from '@temporalio/worker';
 import { createConcatActivity } from './activities/create-concat-activity';
-import { RUN_INTEGRATION_TESTS, u8, Worker } from './helpers';
-import { defaultOptions } from './mock-native-worker';
+import { RUN_INTEGRATION_TESTS, u8 } from './helpers';
+import type { Context } from './helpers-integration';
+import { helpers, makeTestFunction } from './helpers-integration';
 import type { LogSinks } from './workflows';
 import { twoStrings, twoStringsActivity } from './workflows';
 
@@ -36,8 +37,19 @@ class TestDecodeCodec implements PayloadCodec {
   }
 }
 
+function makeClient(t: ExecutionContext<Context>, dataConverter: DataConverter): WorkflowClient {
+  return new WorkflowClient({
+    connection: t.context.env.client.connection,
+    namespace: t.context.env.client.options.namespace,
+    dataConverter,
+  });
+}
+
 if (RUN_INTEGRATION_TESTS) {
+  const test = makeTestFunction({ workflowsPath: require.resolve('./workflows') });
+
   test('Workflow arguments and retvals are encoded', async (t) => {
+    const { createWorker, taskQueue } = helpers(t);
     const logs: string[] = [];
     const sinks: InjectedSinks<LogSinks> = {
       logger: {
@@ -50,14 +62,11 @@ if (RUN_INTEGRATION_TESTS) {
     };
 
     const dataConverter = { payloadCodecs: [new TestEncodeCodec()] };
-    const taskQueue = 'test-workflow-encoded';
-    const worker = await Worker.create({
-      ...defaultOptions,
-      taskQueue,
+    const worker = await createWorker({
       dataConverter,
       sinks,
     });
-    const client = new WorkflowClient({ dataConverter });
+    const client = makeClient(t, dataConverter);
     await worker.runUntil(async () => {
       const result = await client.execute(twoStrings, {
         args: ['arg1', 'arg2'],
@@ -71,6 +80,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Workflow arguments and retvals are decoded', async (t) => {
+    const { createWorker, taskQueue } = helpers(t);
     const logs: string[] = [];
     const sinks: InjectedSinks<LogSinks> = {
       logger: {
@@ -83,14 +93,11 @@ if (RUN_INTEGRATION_TESTS) {
     };
 
     const dataConverter = { payloadCodecs: [new TestDecodeCodec()] };
-    const taskQueue = 'test-workflow-decoded';
-    const worker = await Worker.create({
-      ...defaultOptions,
-      taskQueue,
+    const worker = await createWorker({
       dataConverter,
       sinks,
     });
-    const client = new WorkflowClient({ dataConverter });
+    const client = makeClient(t, dataConverter);
     await worker.runUntil(async () => {
       const result = await client.execute(twoStrings, {
         args: ['arg1', 'arg2'],
@@ -104,6 +111,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Activity arguments and retvals are encoded', async (t) => {
+    const { createWorker, taskQueue } = helpers(t);
     const workflowLogs: string[] = [];
     const sinks: InjectedSinks<LogSinks> = {
       logger: {
@@ -117,15 +125,12 @@ if (RUN_INTEGRATION_TESTS) {
     const activityLogs: string[] = [];
 
     const dataConverter = { payloadCodecs: [new TestEncodeCodec()] };
-    const taskQueue = 'test-activity-encoded';
-    const worker = await Worker.create({
-      ...defaultOptions,
+    const worker = await createWorker({
       activities: createConcatActivity(activityLogs),
-      taskQueue,
       dataConverter,
       sinks,
     });
-    const client = new WorkflowClient({ dataConverter });
+    const client = makeClient(t, dataConverter);
     await worker.runUntil(async () => {
       await client.execute(twoStringsActivity, {
         workflowId: randomUUID(),
@@ -137,6 +142,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Activity arguments and retvals are decoded', async (t) => {
+    const { createWorker, taskQueue } = helpers(t);
     const workflowLogs: string[] = [];
     const sinks: InjectedSinks<LogSinks> = {
       logger: {
@@ -150,15 +156,12 @@ if (RUN_INTEGRATION_TESTS) {
     const activityLogs: string[] = [];
 
     const dataConverter = { payloadCodecs: [new TestDecodeCodec()] };
-    const taskQueue = 'test-activity-decoded';
-    const worker = await Worker.create({
-      ...defaultOptions,
+    const worker = await createWorker({
       activities: createConcatActivity(activityLogs),
-      taskQueue,
       dataConverter,
       sinks,
     });
-    const client = new WorkflowClient({ dataConverter });
+    const client = makeClient(t, dataConverter);
     await worker.runUntil(async () => {
       await client.execute(twoStringsActivity, {
         workflowId: randomUUID(),
@@ -170,6 +173,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Multiple encodes happen in the correct order', async (t) => {
+    const { createWorker, taskQueue } = helpers(t);
     const logs: string[] = [];
     const sinks: InjectedSinks<LogSinks> = {
       logger: {
@@ -197,14 +201,11 @@ if (RUN_INTEGRATION_TESTS) {
         },
       ],
     };
-    const taskQueue = 'test-workflow-encoded-order';
-    const worker = await Worker.create({
-      ...defaultOptions,
-      taskQueue,
+    const worker = await createWorker({
       dataConverter,
       sinks,
     });
-    const client = new WorkflowClient({ dataConverter });
+    const client = makeClient(t, dataConverter);
     await worker.runUntil(async () => {
       const result = await client.execute(twoStrings, {
         args: ['arg1', 'arg2'],
@@ -218,6 +219,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Multiple decodes happen in the correct order', async (t) => {
+    const { createWorker, taskQueue } = helpers(t);
     const logs: string[] = [];
     const sinks: InjectedSinks<LogSinks> = {
       logger: {
@@ -246,14 +248,11 @@ if (RUN_INTEGRATION_TESTS) {
         new TestDecodeCodec(),
       ],
     };
-    const taskQueue = 'test-workflow-decoded-order';
-    const worker = await Worker.create({
-      ...defaultOptions,
-      taskQueue,
+    const worker = await createWorker({
       dataConverter,
       sinks,
     });
-    const client = new WorkflowClient({ dataConverter });
+    const client = makeClient(t, dataConverter);
     await worker.runUntil(async () => {
       const result = await client.execute(twoStrings, {
         args: ['arg1', 'arg2'],

--- a/packages/test/src/test-custom-payload-converter.ts
+++ b/packages/test/src/test-custom-payload-converter.ts
@@ -6,7 +6,7 @@ import { toPayloads } from '@temporalio/common';
 import { coresdk } from '@temporalio/proto';
 import { ProtoActivityResult } from '../protos/root';
 import { protoActivity } from './activities';
-import { cleanOptionalStackTrace, RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { cleanOptionalStackTrace, Worker } from './helpers';
 import { defaultOptions, isolateFreeWorker } from './mock-native-worker';
 import { messageInstance, payloadConverter } from './payload-converters/proto-payload-converter';
 import { createTestWorkflowEnvironment } from './helpers-integration';
@@ -28,7 +28,7 @@ function compareCompletion(
   );
 }
 
-if (RUN_INTEGRATION_TESTS) {
+function registerIntegrationTests(): void {
   test('Client and Worker work with provided dataConverter', async (t) => {
     const env = await createTestWorkflowEnvironment();
     t.teardown(() => env.teardown());
@@ -90,6 +90,8 @@ if (RUN_INTEGRATION_TESTS) {
     );
   });
 }
+
+registerIntegrationTests();
 
 test('Worker throws on invalid payloadConverterPath', async (t) => {
   t.throws(

--- a/packages/test/src/test-custom-payload-converter.ts
+++ b/packages/test/src/test-custom-payload-converter.ts
@@ -28,70 +28,66 @@ function compareCompletion(
   );
 }
 
-function registerIntegrationTests(): void {
-  test('Client and Worker work with provided dataConverter', async (t) => {
-    const env = await createTestWorkflowEnvironment();
-    t.teardown(() => env.teardown());
-    const dataConverter = { payloadConverterPath: require.resolve('./payload-converters/proto-payload-converter') };
-    const taskQueue = `${__filename}/${t.title}`;
-    const worker = await Worker.create({
-      ...defaultOptions,
-      connection: env.nativeConnection,
-      namespace: env.client.options.namespace,
-      workflowsPath: require.resolve('./workflows/protobufs'),
+test('Client and Worker work with provided dataConverter', async (t) => {
+  const env = await createTestWorkflowEnvironment();
+  t.teardown(() => env.teardown());
+  const dataConverter = { payloadConverterPath: require.resolve('./payload-converters/proto-payload-converter') };
+  const taskQueue = `${__filename}/${t.title}`;
+  const worker = await Worker.create({
+    ...defaultOptions,
+    connection: env.nativeConnection,
+    namespace: env.client.options.namespace,
+    workflowsPath: require.resolve('./workflows/protobufs'),
+    taskQueue,
+    dataConverter,
+  });
+  const client = new WorkflowClient({
+    connection: env.client.connection,
+    namespace: env.client.options.namespace,
+    dataConverter,
+  });
+  await worker.runUntil(async () => {
+    const result = await client.execute(protobufWorkflow, {
+      args: [messageInstance],
+      workflowId: randomUUID(),
       taskQueue,
-      dataConverter,
     });
-    const client = new WorkflowClient({
-      connection: env.client.connection,
-      namespace: env.client.options.namespace,
-      dataConverter,
-    });
-    await worker.runUntil(async () => {
-      const result = await client.execute(protobufWorkflow, {
-        args: [messageInstance],
-        workflowId: randomUUID(),
+
+    t.deepEqual(result, ProtoActivityResult.create({ sentence: `Proto is 1 years old.` }));
+  });
+});
+
+test('fromPayload throws on Client when receiving result from client.execute()', async (t) => {
+  const env = await createTestWorkflowEnvironment();
+  t.teardown(() => env.teardown());
+  const taskQueue = `${__filename}/${t.title}`;
+  const worker = await Worker.create({
+    ...defaultOptions,
+    connection: env.nativeConnection,
+    namespace: env.client.options.namespace,
+    taskQueue,
+  });
+
+  const client = new WorkflowClient({
+    connection: env.client.connection,
+    namespace: env.client.options.namespace,
+    dataConverter: {
+      payloadConverterPath: require.resolve('./payload-converters/payload-converter-throws-from-payload'),
+    },
+  });
+  await worker.runUntil(
+    t.throwsAsync(
+      client.execute(workflows.successString, {
         taskQueue,
-      });
-
-      t.deepEqual(result, ProtoActivityResult.create({ sentence: `Proto is 1 years old.` }));
-    });
-  });
-
-  test('fromPayload throws on Client when receiving result from client.execute()', async (t) => {
-    const env = await createTestWorkflowEnvironment();
-    t.teardown(() => env.teardown());
-    const taskQueue = `${__filename}/${t.title}`;
-    const worker = await Worker.create({
-      ...defaultOptions,
-      connection: env.nativeConnection,
-      namespace: env.client.options.namespace,
-      taskQueue,
-    });
-
-    const client = new WorkflowClient({
-      connection: env.client.connection,
-      namespace: env.client.options.namespace,
-      dataConverter: {
-        payloadConverterPath: require.resolve('./payload-converters/payload-converter-throws-from-payload'),
-      },
-    });
-    await worker.runUntil(
-      t.throwsAsync(
-        client.execute(workflows.successString, {
-          taskQueue,
-          workflowId: randomUUID(),
-        }),
-        {
-          instanceOf: Error,
-          message: 'test fromPayload',
-        }
-      )
-    );
-  });
-}
-
-registerIntegrationTests();
+        workflowId: randomUUID(),
+      }),
+      {
+        instanceOf: Error,
+        message: 'test fromPayload',
+      }
+    )
+  );
+});
 
 test('Worker throws on invalid payloadConverterPath', async (t) => {
   t.throws(

--- a/packages/test/src/test-custom-payload-converter.ts
+++ b/packages/test/src/test-custom-payload-converter.ts
@@ -9,6 +9,7 @@ import { protoActivity } from './activities';
 import { cleanOptionalStackTrace, RUN_INTEGRATION_TESTS, Worker } from './helpers';
 import { defaultOptions, isolateFreeWorker } from './mock-native-worker';
 import { messageInstance, payloadConverter } from './payload-converters/proto-payload-converter';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import * as workflows from './workflows';
 import { protobufWorkflow } from './workflows/protobufs';
 
@@ -29,15 +30,23 @@ function compareCompletion(
 
 if (RUN_INTEGRATION_TESTS) {
   test('Client and Worker work with provided dataConverter', async (t) => {
+    const env = await createTestWorkflowEnvironment();
+    t.teardown(() => env.teardown());
     const dataConverter = { payloadConverterPath: require.resolve('./payload-converters/proto-payload-converter') };
-    const taskQueue = 'test-custom-payload-converter';
+    const taskQueue = `${__filename}/${t.title}`;
     const worker = await Worker.create({
       ...defaultOptions,
+      connection: env.nativeConnection,
+      namespace: env.client.options.namespace,
       workflowsPath: require.resolve('./workflows/protobufs'),
       taskQueue,
       dataConverter,
     });
-    const client = new WorkflowClient({ dataConverter });
+    const client = new WorkflowClient({
+      connection: env.client.connection,
+      namespace: env.client.options.namespace,
+      dataConverter,
+    });
     await worker.runUntil(async () => {
       const result = await client.execute(protobufWorkflow, {
         args: [messageInstance],
@@ -50,11 +59,19 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('fromPayload throws on Client when receiving result from client.execute()', async (t) => {
+    const env = await createTestWorkflowEnvironment();
+    t.teardown(() => env.teardown());
+    const taskQueue = `${__filename}/${t.title}`;
     const worker = await Worker.create({
       ...defaultOptions,
+      connection: env.nativeConnection,
+      namespace: env.client.options.namespace,
+      taskQueue,
     });
 
     const client = new WorkflowClient({
+      connection: env.client.connection,
+      namespace: env.client.options.namespace,
       dataConverter: {
         payloadConverterPath: require.resolve('./payload-converters/payload-converter-throws-from-payload'),
       },
@@ -62,7 +79,7 @@ if (RUN_INTEGRATION_TESTS) {
     await worker.runUntil(
       t.throwsAsync(
         client.execute(workflows.successString, {
-          taskQueue: 'test',
+          taskQueue,
           workflowId: randomUUID(),
         }),
         {


### PR DESCRIPTION
## What was changed

The custom payload codec and converter suites now bind their server-backed Workers and Workflow Clients to the configured test environment. Each Worker/client pair shares the same connection, namespace, data converter, and task queue.

The mixed converter file keeps its existing unit tests, while its server-backed cases now register unconditionally and select or provision their environment directly. On this independent branch, the inventory changes from 68 Cloud candidates and 31 pending files to 70 candidates and 29 pending files.

## Why?

The server-backed cases previously used implicit localhost and default-namespace configuration even though their converter behavior is portable. The new wiring allows them to run against Temporal Cloud while preserving every test case and assertion, without relying on the legacy selective integration-test gate.

## Checklist

1. Related issue: #2326. This PR contributes to the tracker but does not close it.

2. How was this tested:
   - `pnpm build`
   - `pnpm lint:check`
   - Focused local AVA run: 10 tests passed
   - Focused run with `RUN_INTEGRATION_TESTS=false`: all 10 tests passed
   - `pnpm cloud:inventory`: 70 candidates, 29 pending
   - Full CI is tracked by this draft PR's checks

3. Any docs updates needed?
   - No. This changes test infrastructure only.
