### PR TITLE
test: adapt bundler and coverage tests for Temporal Cloud

### DIFF
--- a/packages/test/src/test-bundler.ts
+++ b/packages/test/src/test-bundler.ts
@@ -12,7 +12,9 @@ import { moduleMatches } from '@temporalio/worker/lib/workflow/bundler';
 import type { LogEntry, WorkerOptions } from '@temporalio/worker';
 import { bundleWorkflowCode, DefaultLogger } from '@temporalio/worker';
 import { Client } from '@temporalio/client';
+import type { TestWorkflowEnvironment } from './helpers';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
+import { createTestWorkflowEnvironment } from './helpers-integration';
 import { issue516 } from './mocks/workflows-with-node-dependencies/issue-516';
 import { preloadSharedCounter } from './workflows/preload-shared-counter';
 import { workflowWithPrebundledDep } from './workflows/workflow-with-prebundled-dep';
@@ -24,13 +26,28 @@ test('moduleMatches works', (t) => {
   t.false(moduleMatches('fs', ['foo']));
 });
 
+let testEnv: TestWorkflowEnvironment | undefined;
+let testEnvPromise: Promise<TestWorkflowEnvironment> | undefined;
+
+async function getTestWorkflowEnvironment(): Promise<TestWorkflowEnvironment> {
+  testEnvPromise ??= createTestWorkflowEnvironment();
+  testEnv ??= await testEnvPromise;
+  return testEnv;
+}
+
 async function runPreloadSharedCounter(
   t: ExecutionContext,
+  env: TestWorkflowEnvironment,
   workerOptions: Pick<WorkerOptions, 'bundlerOptions' | 'workflowBundle' | 'workflowsPath'>
 ): Promise<[number, number]> {
   const taskQueue = `${t.title}-${randomUUID()}`;
-  const client = new Client();
+  const client = new Client({
+    connection: env.client.connection,
+    namespace: env.client.options.namespace,
+  });
   const worker = await Worker.create({
+    connection: env.nativeConnection,
+    namespace: env.client.options.namespace,
     taskQueue,
     reuseV8Context: true,
     ...workerOptions,
@@ -43,21 +60,32 @@ async function runPreloadSharedCounter(
 }
 
 if (RUN_INTEGRATION_TESTS) {
+  test.after.always(async () => {
+    await testEnv?.teardown();
+  });
+
   test('Worker can be created from bundle code', async (t) => {
+    const env = await getTestWorkflowEnvironment();
     const taskQueue = `${t.title}-${randomUUID()}`;
     const workflowBundle = await bundleWorkflowCode({
       workflowsPath: require.resolve('./workflows'),
     });
     const worker = await Worker.create({
+      connection: env.nativeConnection,
+      namespace: env.client.options.namespace,
       taskQueue,
       workflowBundle,
     });
-    const client = new Client();
+    const client = new Client({
+      connection: env.client.connection,
+      namespace: env.client.options.namespace,
+    });
     await worker.runUntil(client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
     t.pass();
   });
 
   test('Worker can be created from bundle path', async (t) => {
+    const env = await getTestWorkflowEnvironment();
     const taskQueue = `${t.title}-${randomUUID()}`;
     const { code } = await bundleWorkflowCode({
       workflowsPath: require.resolve('./workflows'),
@@ -67,10 +95,15 @@ if (RUN_INTEGRATION_TESTS) {
     await writeFile(codePath, code);
     const workflowBundle = { codePath };
     const worker = await Worker.create({
+      connection: env.nativeConnection,
+      namespace: env.client.options.namespace,
       taskQueue,
       workflowBundle,
     });
-    const client = new Client();
+    const client = new Client({
+      connection: env.client.connection,
+      namespace: env.client.options.namespace,
+    });
     try {
       await worker.runUntil(client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
     } finally {
@@ -80,16 +113,22 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Workflow bundle can be created from code using ignoreModules', async (t) => {
+    const env = await getTestWorkflowEnvironment();
     const taskQueue = `${t.title}-${randomUUID()}`;
     const workflowBundle = await bundleWorkflowCode({
       workflowsPath: require.resolve('./mocks/workflows-with-node-dependencies/issue-516'),
       ignoreModules: ['dns'],
     });
     const worker = await Worker.create({
+      connection: env.nativeConnection,
+      namespace: env.client.options.namespace,
       taskQueue,
       workflowBundle,
     });
-    const client = new Client();
+    const client = new Client({
+      connection: env.client.connection,
+      namespace: env.client.options.namespace,
+    });
     await worker.runUntil(client.workflow.execute(issue516, { taskQueue, workflowId: randomUUID() }));
     t.pass();
   });
@@ -148,7 +187,7 @@ if (RUN_INTEGRATION_TESTS) {
       preloadModules: [require.resolve('./workflows/preload-shared-counter-helper')],
     });
 
-    t.deepEqual(await runPreloadSharedCounter(t, { workflowBundle }), [1, 2]);
+    t.deepEqual(await runPreloadSharedCounter(t, await getTestWorkflowEnvironment(), { workflowBundle }), [1, 2]);
   });
 
   test('Workflow bundle keeps module state isolated without preloadModules', async (t) => {
@@ -156,7 +195,7 @@ if (RUN_INTEGRATION_TESTS) {
       workflowsPath: require.resolve('./workflows/preload-shared-counter'),
     });
 
-    t.deepEqual(await runPreloadSharedCounter(t, { workflowBundle }), [1, 1]);
+    t.deepEqual(await runPreloadSharedCounter(t, await getTestWorkflowEnvironment(), { workflowBundle }), [1, 1]);
   });
 
   test('Workflow bundle treats an empty preloadModules list as a no-op', async (t) => {
@@ -165,12 +204,12 @@ if (RUN_INTEGRATION_TESTS) {
       preloadModules: [],
     });
 
-    t.deepEqual(await runPreloadSharedCounter(t, { workflowBundle }), [1, 1]);
+    t.deepEqual(await runPreloadSharedCounter(t, await getTestWorkflowEnvironment(), { workflowBundle }), [1, 1]);
   });
 
   test('WorkerOptions.bundlerOptions.preloadModules works', async (t) => {
     t.deepEqual(
-      await runPreloadSharedCounter(t, {
+      await runPreloadSharedCounter(t, await getTestWorkflowEnvironment(), {
         workflowsPath: require.resolve('./workflows/preload-shared-counter'),
         bundlerOptions: {
           preloadModules: [require.resolve('./workflows/preload-shared-counter-helper')],
@@ -240,12 +279,22 @@ if (RUN_INTEGRATION_TESTS) {
   // module state must remain isolated even when a pre-bundled dependency (shipping
   // its own nested `__webpack_module_cache__`) is included in the Workflow bundle.
   test('Workflow bundle keeps module state isolated with a pre-bundled dependency (#2188)', async (t) => {
+    const env = await getTestWorkflowEnvironment();
     const taskQueue = `${t.title}-${randomUUID()}`;
     const workflowBundle = await bundleWorkflowCode({
       workflowsPath: require.resolve('./workflows/workflow-with-prebundled-dep'),
     });
-    const client = new Client();
-    const worker = await Worker.create({ taskQueue, reuseV8Context: true, workflowBundle });
+    const client = new Client({
+      connection: env.client.connection,
+      namespace: env.client.options.namespace,
+    });
+    const worker = await Worker.create({
+      connection: env.nativeConnection,
+      namespace: env.client.options.namespace,
+      taskQueue,
+      reuseV8Context: true,
+      workflowBundle,
+    });
     const results = await worker.runUntil(async () => {
       const first = await client.workflow.execute(workflowWithPrebundledDep, { taskQueue, workflowId: randomUUID() });
       const second = await client.workflow.execute(workflowWithPrebundledDep, { taskQueue, workflowId: randomUUID() });
@@ -265,7 +314,7 @@ if (RUN_INTEGRATION_TESTS) {
       },
     });
 
-    t.deepEqual(await runPreloadSharedCounter(t, { workflowBundle }), [1, 1]);
+    t.deepEqual(await runPreloadSharedCounter(t, await getTestWorkflowEnvironment(), { workflowBundle }), [1, 1]);
   });
 }
 

--- a/packages/test/src/test-nyc-coverage.ts
+++ b/packages/test/src/test-nyc-coverage.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from 'crypto';
-import test from 'ava';
 import * as libCoverage from 'istanbul-lib-coverage';
 import { bundleWorkflowCode, Worker } from '@temporalio/worker';
-import { Client, WorkflowClient } from '@temporalio/client';
 import { WorkflowCoverage } from '@temporalio/nyc-test-coverage';
+import type { TestWorkflowEnvironment } from './helpers';
 import { RUN_INTEGRATION_TESTS } from './helpers';
+import { createTestWorkflowEnvironment, makeConfigurableEnvironmentTestFn } from './helpers-integration';
 import { successString } from './workflows';
 
 declare global {
@@ -12,7 +12,13 @@ declare global {
 }
 
 if (RUN_INTEGRATION_TESTS) {
+  const test = makeConfigurableEnvironmentTestFn<{ env: TestWorkflowEnvironment }>({
+    createTestContext: async () => ({ env: await createTestWorkflowEnvironment() }),
+    teardown: async ({ env }) => env.teardown(),
+  });
+
   test('Istanbul injector execute correctly in Worker', async (t) => {
+    const { env } = t.context;
     // Make it believe that NYC has been loaded
     (global as any).__coverage__ = {};
 
@@ -21,12 +27,13 @@ if (RUN_INTEGRATION_TESTS) {
     const taskQueue = `${t.title}-${randomUUID()}`;
     const worker = await Worker.create(
       workflowCoverage.augmentWorkerOptions({
+        connection: env.nativeConnection,
+        namespace: env.client.options.namespace,
         taskQueue,
         workflowsPath: require.resolve('./workflows'),
       })
     );
-    const client = new Client();
-    await worker.runUntil(client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
+    await worker.runUntil(env.client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
 
     workflowCoverage.mergeIntoGlobalCoverage();
     const coverageMap = libCoverage.createCoverageMap(global.__coverage__);
@@ -38,6 +45,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Istanbul injector execute correctly in Bundler', async (t) => {
+    const { env } = t.context;
     const workflowCoverageBundler = new WorkflowCoverage();
     const { code } = await bundleWorkflowCode(
       workflowCoverageBundler.augmentBundleOptions({
@@ -52,12 +60,13 @@ if (RUN_INTEGRATION_TESTS) {
     const taskQueue = `${t.title}-${randomUUID()}`;
     const worker = await Worker.create(
       workflowCoverageWorker.augmentWorkerOptionsWithBundle({
+        connection: env.nativeConnection,
+        namespace: env.client.options.namespace,
         taskQueue,
         workflowBundle: { code },
       })
     );
-    const client = new Client();
-    await worker.runUntil(client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
+    await worker.runUntil(env.client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
 
     workflowCoverageBundler.mergeIntoGlobalCoverage();
     workflowCoverageWorker.mergeIntoGlobalCoverage();
@@ -69,6 +78,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Istanbul injector exclude non-user code', async (t) => {
+    const { env } = t.context;
     // Make it believe that NYC has been loaded
     (global as any).__coverage__ = {};
 
@@ -77,12 +87,13 @@ if (RUN_INTEGRATION_TESTS) {
     const taskQueue = `${t.title}-${randomUUID()}`;
     const worker = await Worker.create(
       workflowCoverage.augmentWorkerOptions({
+        connection: env.nativeConnection,
+        namespace: env.client.options.namespace,
         taskQueue,
         workflowsPath: require.resolve('./workflows'),
       })
     );
-    const client = new WorkflowClient();
-    await worker.runUntil(client.execute(successString, { taskQueue, workflowId: randomUUID() }));
+    await worker.runUntil(env.client.workflow.execute(successString, { taskQueue, workflowId: randomUUID() }));
 
     workflowCoverage.mergeIntoGlobalCoverage();
     const coverageMap = libCoverage.createCoverageMap(global.__coverage__);


### PR DESCRIPTION
## What was changed

The bundler and NYC coverage suites now connect their server-backed Workers and Clients through the configured integration-test environment. Their custom workflow bundles, bundler options, and coverage instrumentation remain unchanged.

Bundler integration cases lazily share one environment, so selecting its unit-only cases does not start a server. On this independent branch, the inventory changes from 68 Cloud candidates and 31 pending files to 70 candidates and 29 pending files.

## Why?

These suites test portable bundling and coverage behavior but previously relied on implicit localhost and default-namespace configuration. Environment-aware connections allow them to run against Temporal Cloud without changing their assertions or making the bundler's unit cases depend on a server.

## Checklist

1. Related issue: #2326. This PR contributes to the tracker but does not close it.

2. How was this tested:
   - `pnpm build`
   - `pnpm lint:check`
   - Focused local AVA run: 20 tests passed
   - Unit-only bundler run with `RUN_INTEGRATION_TESTS=false`: 1 test passed without starting a server
   - `pnpm cloud:inventory`: 70 candidates, 29 pending
   - Independent lifecycle and scope-isolation review

3. Any docs updates needed?
   - No. This changes test infrastructure only.
