### PR TITLE
feat(core): ship musl (Alpine) prebuilt binaries and detect musl at runtime

### DIFF
--- a/.github/actions/setup-node-deps/action.yml
+++ b/.github/actions/setup-node-deps/action.yml
@@ -13,6 +13,13 @@ inputs:
     description: 'Whether to save the NPM cache at the end'
     required: false
     default: 'false'
+  install-node:
+    description: >-
+      Whether to install Node via actions/setup-node. Set to false when the job container already
+      provides the required Node build (e.g. musl-based images: setup-node only installs glibc
+      builds from the official dist).
+    required: false
+    default: 'true'
 
 outputs:
   cache-dir:
@@ -32,6 +39,7 @@ runs:
         run_install: false
 
     - name: Install Node
+      if: inputs.install-node == 'true'
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: ${{ inputs.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
   # Compile native bridge code for each target platform.
   # Uploads the native library for each target as a build artifact.
   compile-native-binaries-debug:
-    timeout-minutes: 20
+    # The musl rows build inside Docker without the Rust build cache, so a cold build needs
+    # more headroom than the cached host builds.
+    timeout-minutes: 30
     strategy:
       fail-fast: true
       matrix:
@@ -41,6 +43,16 @@ jobs:
           - platform: linux-arm
             runner: ubuntu-24.04-arm64-2-core
             target: aarch64-unknown-linux-gnu
+            out-file: libtemporal_sdk_typescript_bridge.so
+          - platform: linux-x64-musl
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            container: alpine:3.20
+            out-file: libtemporal_sdk_typescript_bridge.so
+          - platform: linux-arm-musl
+            runner: ubuntu-24.04-arm64-2-core
+            target: aarch64-unknown-linux-musl
+            container: alpine:3.20
             out-file: libtemporal_sdk_typescript_bridge.so
           - platform: macos-arm
             runner: macos-14
@@ -69,7 +81,7 @@ jobs:
           key: corebridge-artifactcache-debug-${{ matrix.platform }}-${{ hashFiles('./packages/core-bridge/**/Cargo.lock', './packages/core-bridge/**/*.rs') }}
 
       - name: Install protoc
-        if: steps.cached-artifact.outputs.cache-hit != 'true'
+        if: steps.cached-artifact.outputs.cache-hit != 'true' && !matrix.container
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
@@ -80,7 +92,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Rust Cargo and Build cache
-        if: steps.cached-artifact.outputs.cache-hit != 'true'
+        if: steps.cached-artifact.outputs.cache-hit != 'true' && !matrix.container
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-bin: false
@@ -91,13 +103,53 @@ jobs:
           save-if: ${{ env.IS_MAIN_OR_RELEASE == 'true' }}
 
       - name: Compile rust code
-        if: steps.cached-artifact.outputs.cache-hit != 'true'
+        if: steps.cached-artifact.outputs.cache-hit != 'true' && !matrix.container
         working-directory: ./packages/core-bridge
         run: |
           set -x
           cargo build --target ${{ matrix.target }}
           mkdir -p ./releases/${{ matrix.target }}
           cp target/${{ matrix.target }}/debug/${{ matrix.out-file }} ./releases/${{ matrix.target }}/index.node
+
+      # musl rows build inside Alpine — the same recipe as the release workflow — instead of
+      # cross-compiling from this glibc runner: rustc links cdylibs through the host cc, so a
+      # cross-compile silently produces a glibc-linked artifact that loads here but not on
+      # Alpine. RUSTFLAGS disables crt-static (musl's Rust default) so the addon is dynamically
+      # linked against musl libc, which Node requires to `dlopen` it as a native addon.
+      - name: Compile rust code (Docker, musl)
+        if: steps.cached-artifact.outputs.cache-hit != 'true' && matrix.container
+        working-directory: ./packages/core-bridge
+        run: |
+          docker run --rm -v "$(pwd):/workspace" -w /workspace \
+            ${{ matrix.container }} \
+            sh -c '
+                set -eux
+                apk add --no-cache curl build-base protobuf protobuf-dev
+                curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
+                export PATH="$PATH:$HOME/.cargo/bin"
+                export RUSTFLAGS="-C target-feature=-crt-static"
+
+                cargo build --target ${{ matrix.target }}
+            '
+          mkdir -p ./releases/${{ matrix.target }}
+          cp target/${{ matrix.target }}/debug/${{ matrix.out-file }} ./releases/${{ matrix.target }}/index.node
+
+      # Load the built musl binary on the runner arch that built it (also when it came from the
+      # artifact cache): proves the artifact is actually musl-linked before jobs consume it.
+      # This is the only load check for linux-arm-musl, which cannot run integration tests.
+      - name: Smoke test the musl binary on Alpine
+        if: matrix.container
+        working-directory: ./packages/core-bridge
+        run: |
+          docker run --rm -v "$(pwd):/workspace" node:22-alpine node -e '
+            const common = require("/workspace/common.js");
+            const target = common.getPrebuiltTargetName();
+            if (target !== "${{ matrix.target }}") {
+              throw new Error("expected ${{ matrix.target }}, got " + target);
+            }
+            require("/workspace/releases/" + target + "/index.node");
+            console.log("musl binary loaded from", target);
+          '
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -115,7 +167,14 @@ jobs:
       fail-fast: false
       matrix:
         node: [20, 24, bun] # Min and max officially supported Node versions + Bun
-        platform: [linux-x64, linux-arm, macos-arm, windows-x64]
+        # linux-arm-musl is compile-only (see compile-native-binaries-debug): the runner
+        # executes JS actions in Alpine containers with an injected musl Node it only ships
+        # for x64, so an arm64 Alpine container job fails on its first action.
+        platform: [linux-x64, linux-arm, macos-arm, windows-x64, linux-x64-musl]
+        exclude:
+          # Bun's musl support isn't covered here yet.
+          - platform: linux-x64-musl
+            node: bun
         include:
           - platform: linux-x64
             runner: ubuntu-latest
@@ -130,7 +189,14 @@ jobs:
           - platform: windows-x64
             runner: windows-latest
             reuse-v8-context: true
+          - platform: linux-x64-musl
+            runner: ubuntu-latest
+            reuse-v8-context: true
+            musl: true
     runs-on: ${{ matrix.runner }}
+    # The Node image provides the musl Node that `run` steps use; actions/setup-node cannot (it
+    # only installs glibc builds), and the runner-injected Alpine Node only executes actions.
+    container: ${{ matrix.musl && format('node:{0}-alpine', matrix.node) || '' }}
     # Allow Bun test failures since support is experimental
     continue-on-error: ${{ matrix.node == 'bun' }}
     name: Run Integration Tests (${{ matrix.platform }}, ${{ matrix.node == 'bun' && 'Bun' || format('Node {0}', matrix.node) }}, Reuse V8 Context ${{ matrix.reuse-v8-context }})
@@ -142,6 +208,13 @@ jobs:
       run:
         shell: bash
     steps:
+      # The container job needs `bash` and `git` before any other step (including checkout) can
+      # run; the Alpine-based Node images ship neither.
+      - name: Install bash and git (musl container)
+        if: matrix.musl
+        shell: sh
+        run: apk add --no-cache bash git
+
       # For some unknown reason, execution of TSC may sometime introduce a CRLF/LF mismatch on some
       # pure JS files that are preserved in the repo, which would later cause a failure when trying
       # to publish packages to Verdaccio, as `pnpm publish` requires that the Git repo be clean.
@@ -165,6 +238,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-release-override || matrix.node }}
           platform: ${{ matrix.platform }}
+          # The musl container image already provides the right Node build (see `container` above).
+          install-node: ${{ !matrix.musl }}
 
       - name: Setup Bun and Install Dependencies
         if: matrix.node == 'bun'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,20 @@ jobs:
             container: quay.io/pypa/manylinux_2_24_aarch64
             out-file: libtemporal_sdk_typescript_bridge.so
             protobuf-url: https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-aarch_64.zip
+          # alpine:3.20 is deliberately old, like manylinux_2_24 above for glibc: building
+          # against an older libc maximizes forward compatibility of the published binary.
+          - platform: linux-x64-musl
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            container: alpine:3.20
+            musl: true
+            out-file: libtemporal_sdk_typescript_bridge.so
+          - platform: linux-arm-musl
+            runner: ubuntu-24.04-arm64-2-core
+            target: aarch64-unknown-linux-musl
+            container: alpine:3.20
+            musl: true
+            out-file: libtemporal_sdk_typescript_bridge.so
           - platform: macos-x64
             runner: macos-15-intel
             target: x86_64-apple-darwin
@@ -102,7 +116,7 @@ jobs:
           cargo build --release --target ${{ matrix.target }}
 
       - name: Compile rust code (Docker)
-        if: steps.cached-artifact.outputs.cache-hit != 'true' && matrix.container
+        if: steps.cached-artifact.outputs.cache-hit != 'true' && matrix.container && !matrix.musl
         working-directory: ./packages/core-bridge
         run: |
           docker run --rm -v "$(pwd):/workspace" -w /workspace \
@@ -116,6 +130,29 @@ jobs:
                 cargo build --release --target ${{ matrix.target }}
             '
 
+      # musl targets are compiled natively on Alpine rather than cross-compiled from the
+      # manylinux (glibc) containers above: Alpine ships musl-gcc and a musl libc out of the
+      # box, and prebuilt protoc/glibc binaries won't run under musl without a compat shim.
+      #
+      # RUSTFLAGS disables crt-static (musl's Rust default) so the addon is dynamically linked
+      # against musl libc, which is required for Node to `dlopen` it as a native addon; symbols
+      # are stripped to keep the published package's growth to a few MB per target.
+      - name: Compile rust code (Docker, musl)
+        if: steps.cached-artifact.outputs.cache-hit != 'true' && matrix.musl
+        working-directory: ./packages/core-bridge
+        run: |
+          docker run --rm -v "$(pwd):/workspace" -w /workspace \
+            ${{ matrix.container }} \
+            sh -c '
+                set -eux
+                apk add --no-cache curl build-base protobuf protobuf-dev
+                curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
+                export PATH="$PATH:$HOME/.cargo/bin"
+                export RUSTFLAGS="-C target-feature=-crt-static -C strip=symbols"
+
+                cargo build --release --target ${{ matrix.target }}
+            '
+
       - name: Move built artifacts in place
         if: steps.cached-artifact.outputs.cache-hit != 'true'
         working-directory: ./packages/core-bridge
@@ -123,8 +160,25 @@ jobs:
           mkdir -p ./releases/${{ matrix.target }}
           cp target/${{ matrix.target }}/release/${{ matrix.out-file }} ./releases/${{ matrix.target }}/index.node
 
+      # Load the built musl binary on the runner arch that built it (also when it came from the
+      # artifact cache): proves both the runtime musl detection and that the artifact is
+      # actually musl-linked, for x64 and arm64 alike.
+      - name: Smoke test the musl binary on Alpine
+        if: matrix.musl
+        working-directory: ./packages/core-bridge
+        run: |
+          docker run --rm -v "$(pwd):/workspace" node:22-alpine node -e '
+            const common = require("/workspace/common.js");
+            const target = common.getPrebuiltTargetName();
+            if (target !== "${{ matrix.target }}") {
+              throw new Error("expected ${{ matrix.target }}, got " + target);
+            }
+            require("/workspace/releases/" + target + "/index.node");
+            console.log("musl binary loaded from", target);
+          '
+
       - name: Print required GLIBC version
-        if: startsWith(matrix.platform, 'linux')
+        if: startsWith(matrix.platform, 'linux') && !matrix.musl
         working-directory: ./packages/core-bridge
         run: |
           objdump -T ./releases/${{ matrix.target }}/index.node |

--- a/packages/core-bridge/common.js
+++ b/packages/core-bridge/common.js
@@ -14,6 +14,8 @@ const targets = [
   'aarch64-apple-darwin',
   'x86_64-unknown-linux-gnu',
   'aarch64-unknown-linux-gnu',
+  'x86_64-unknown-linux-musl',
+  'aarch64-unknown-linux-musl',
   // TODO: this is not supported on macos
   'x86_64-pc-windows-msvc',
   'x86_64-pc-windows-gnu',
@@ -29,6 +31,19 @@ class PrebuildError extends Error {
   }
 }
 
+let muslSystem;
+
+// glibc reports its runtime version in the process report header; a Linux build without it is
+// musl-based (e.g. Alpine). Same detection as the detect-libc package. On runtimes compiled
+// without report support, assume glibc.
+function isMuslSystem() {
+  if (muslSystem === undefined) {
+    const header = process.report?.getReport?.()?.header;
+    muslSystem = header != null && header.glibcVersionRuntime == null;
+  }
+  return muslSystem;
+}
+
 function getPrebuiltTargetName() {
   const arch = archAlias[os.arch()];
   if (arch === undefined) {
@@ -37,6 +52,9 @@ function getPrebuiltTargetName() {
   const platform = platformMapping[os.platform()];
   if (platform === undefined) {
     throw new PrebuildError(`No prebuilt module for platform ${os.platform()}`);
+  }
+  if (os.platform() === 'linux' && isMuslSystem()) {
+    return `${arch}-unknown-linux-musl`;
   }
   return `${arch}-${platform}`;
 }

--- a/packages/test/src/test-native-libc-detection.ts
+++ b/packages/test/src/test-native-libc-detection.ts
@@ -1,0 +1,63 @@
+import { createRequire } from 'node:module';
+import test from 'ava';
+
+const requireCommon = createRequire(__filename);
+const commonPath = requireCommon.resolve('@temporalio/core-bridge/common.js');
+
+interface CommonModule {
+  getPrebuiltTargetName(): string;
+}
+
+interface ProcessReportStub {
+  getReport(): unknown;
+}
+
+// common.js reads os.platform() through require('os'); an ESM namespace import compiles to a
+// getter-only view under esModuleInterop, so stubbing must go through the mutable CommonJS
+// module object instead.
+const nodeOs = requireCommon('node:os') as { platform(): NodeJS.Platform };
+
+// process.report is defined as a getter-only accessor; stubbing it requires redefining the
+// property, and restoring it requires the original descriptor.
+const reportDescriptor = Object.getOwnPropertyDescriptor(process, 'report');
+
+function targetNameWith(platform: NodeJS.Platform, report: ProcessReportStub | undefined): string {
+  const originalPlatform = nodeOs.platform;
+  try {
+    nodeOs.platform = () => platform;
+    if (report === undefined) {
+      Reflect.deleteProperty(process, 'report');
+    } else {
+      Object.defineProperty(process, 'report', { value: report, enumerable: true, configurable: true });
+    }
+    delete requireCommon.cache[commonPath];
+    const { getPrebuiltTargetName } = requireCommon(commonPath) as CommonModule;
+    return getPrebuiltTargetName();
+  } finally {
+    nodeOs.platform = originalPlatform;
+    Reflect.deleteProperty(process, 'report');
+    if (reportDescriptor !== undefined) {
+      Object.defineProperty(process, 'report', reportDescriptor);
+    }
+    delete requireCommon.cache[commonPath];
+  }
+}
+
+test.serial('getPrebuiltTargetName resolves the glibc prebuild on glibc Linux', (t) => {
+  const report = { getReport: () => ({ header: { glibcVersionRuntime: '2.31' } }) };
+  t.true(targetNameWith('linux', report).endsWith('-unknown-linux-gnu'));
+});
+
+test.serial('getPrebuiltTargetName resolves the musl prebuild on musl Linux', (t) => {
+  const report = { getReport: () => ({ header: {} }) };
+  t.true(targetNameWith('linux', report).endsWith('-unknown-linux-musl'));
+});
+
+test.serial('getPrebuiltTargetName falls back to the glibc prebuild without process report support', (t) => {
+  t.true(targetNameWith('linux', undefined).endsWith('-unknown-linux-gnu'));
+});
+
+test.serial('getPrebuiltTargetName ignores the libc check outside Linux', (t) => {
+  const report = { getReport: () => ({ header: {} }) };
+  t.true(targetNameWith('darwin', report).endsWith('-apple-darwin'));
+});


### PR DESCRIPTION
## What was changed

- `packages/core-bridge/common.js`: adds `x86_64-unknown-linux-musl` and
  `aarch64-unknown-linux-musl` to the target list. On Linux, `getPrebuiltTargetName()` resolves
  the musl prebuild when the process report carries no `glibcVersionCompiler` — absent on musl
  builds, present on glibc builds even when statically linked — memoized, and falling back to
  glibc on runtimes without report support.
  Unit tests cover the glibc, musl, absent-report, and non-Linux paths.
- `release.yml`: adds `linux-x64-musl` / `linux-arm-musl` to the release build matrix, compiled
  natively in an `alpine:3.20` container (deliberately old, like manylinux_2_24: older libc,
  wider compatibility) with `RUSTFLAGS="-C target-feature=-crt-static -C strip=symbols"` —
  crt-static off because Node cannot `dlopen` a static build, stripped to keep package growth
  to a few MB per target (~7 MB each per the measurement in #1271).
- `ci.yml`: adds both musl targets to the debug compile matrix using the same native-Alpine
  recipe (cross-compiling from a glibc host links the cdylib through the host cc and produces a
  glibc-linked artifact). `linux-x64-musl` also joins the integration-tests matrix, running in a
  `node:{20,24}-alpine` container so a musl Node loads the musl addon; `setup-node-deps` gained
  an `install-node` input since actions/setup-node only installs glibc builds. `linux-arm-musl`
  is compile-only: the GitHub runner cannot execute JS actions in arm64 Alpine containers
  (its injected Alpine Node ships for x64 only). Bun on musl is excluded for now.
- Each musl compile row (debug and release) smoke-loads its built binary in a `node:22-alpine`
  container on the arch that built it, so an artifact that compiles but cannot `dlopen` fails
  the build — this is the only load check for arm64, which cannot run the integration suite.

One deliberate asymmetry worth deciding on: the musl artifacts are stripped while the glibc
ones keep their symbol table (`[profile.release]` sets no `strip`), so a native crash on Alpine
shows bare addresses where Debian shows function names. If uniform behavior is preferred, I can
move `strip = "symbols"` into `[profile.release]` so every target shrinks and behaves the same.

## Why?

Closes #1621 (TypeScript part of temporalio/features#594). Running on Alpine currently requires
compiling core-bridge from source with the full Rust toolchain, which is painful in Docker
builds. #1271 marked the detection half of this as a good first contribution.

## Checklist

1. How was this tested:

   - `packages/test/src/test-native-libc-detection.ts` unit-tests `getPrebuiltTargetName()` for
     glibc, musl, absent-report (the glibc fallback), and non-Linux platforms.
   - Both musl compile rows smoke-load the built artifact on Alpine, x64 and arm64.
   - The integration-tests Alpine container path needs a CI run on this PR to shake out; known
     assumptions: the Temporal CLI's static Go binary runs under musl, and the cold Docker
     builds (no Rust cache) fit the raised 30-minute compile timeout.

2. Any docs updates needed?

   Once released, the "Do not use Alpine" section at
   https://docs.temporal.io/develop/typescript/workers/run-worker-process#do-not-use-alpine
   (and the "musl-based images are not supported" note in the same page's Docker section)
   should be updated. That lives in temporalio/documentation — happy to follow up there.