### PR TITLE
AI-282: Correct Google ADK API key environment variable

### DIFF
--- a/contrib/google-adk-agents/README.md
+++ b/contrib/google-adk-agents/README.md
@@ -25,7 +25,7 @@ keyed to what ADK reaches at module load, so an ADK minor outside this range can
 break the Workflow bundle.
 
 Provide Gemini credentials to the Worker as usual, for example with
-`GOOGLE_API_KEY` or `GEMINI_API_KEY`.
+`GOOGLE_GENAI_API_KEY` or `GEMINI_API_KEY`.
 
 ## Hello world
 

--- a/contrib/google-adk-agents/src/plugin.ts
+++ b/contrib/google-adk-agents/src/plugin.ts
@@ -416,8 +416,8 @@ function addSandboxCompat(
  * Worker-side configuration for {@link GoogleAdkPlugin}.
  *
  * API keys are NOT configured here — the model Activities read them from the
- * worker environment (e.g. `GOOGLE_API_KEY` / `GEMINI_API_KEY`) or via a custom
- * `modelProvider`. The plugin never puts them in workflow or activity inputs.
+ * worker environment (e.g. `GOOGLE_GENAI_API_KEY` / `GEMINI_API_KEY`) or via a
+ * custom `modelProvider`. The plugin never puts them in workflow or activity inputs.
  */
 export interface GoogleAdkPluginOptions {
   /**


### PR DESCRIPTION
This corrects the Google ADK integration README and public plugin API comment to name `GOOGLE_GENAI_API_KEY` instead of `GOOGLE_API_KEY`. The supported ADK 1.5.x implementation reads `GOOGLE_GENAI_API_KEY`, then `GEMINI_API_KEY`; it does not read `GOOGLE_API_KEY`.

No runtime change is needed because ADK reads the environment variable directly. Prettier and whitespace validation pass.