### PR TITLE
feat(worker): report external storage metrics on workflow task completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ to docs, or any other relevant information.
   is a new form of Workflow-level metadata that allows for improved
   visibility into a Workflow execution's history by grouping logically
   related Events together based on user-defined or system-inferred criteria.
+- **Experimental**: External Storage download and upload metrics are now reported to Core on Workflow Activation
+  completions and included in its workflow-task duration log.
 
 ### Changed
 

--- a/packages/common/src/__tests__/test-external-storage-metrics.ts
+++ b/packages/common/src/__tests__/test-external-storage-metrics.ts
@@ -1,0 +1,48 @@
+import test from 'ava';
+
+import { ExternalStorageMetricsAccumulator } from '../internal-non-workflow/external-storage-metrics';
+
+/** Milliseconds encoded in a proto Duration. */
+function durationMs(metrics: ReturnType<ExternalStorageMetricsAccumulator['toProto']>): number {
+  const d = metrics!.totalDuration!;
+  return (d.seconds as { toNumber(): number }).toNumber() * 1000 + (d.nanos ?? 0) / 1e6;
+}
+
+test('empty accumulator yields no metrics', (t) => {
+  t.is(new ExternalStorageMetricsAccumulator().toProto(), undefined);
+});
+
+test('aggregates count, size, and driver names', (t) => {
+  const acc = new ExternalStorageMetricsAccumulator();
+  acc.record('s3', 2, 1024, 0, 100);
+  acc.record('gcs', 3, 2048, 0, 100);
+  acc.record('s3', 1, 512, 0, 100); // same driver again -> deduped in names
+  const m = acc.toProto()!;
+  t.is(m.payloadCount!.toNumber(), 6);
+  t.is(m.totalSizeBytes!.toNumber(), 3584);
+  t.deepEqual(m.driverNames, ['gcs', 's3']); // sorted
+});
+
+test('duration counts overlapping operations once (no double-count)', (t) => {
+  const acc = new ExternalStorageMetricsAccumulator();
+  // Two fully-concurrent 100ms operations. Summing segments would give 200ms; the real
+  // wall-clock is 150ms.
+  acc.record('s3', 1, 1, 0, 100);
+  acc.record('gcs', 1, 1, 50, 150);
+  t.is(durationMs(acc.toProto()), 150);
+});
+
+test('duration sums genuinely-disjoint operations', (t) => {
+  const acc = new ExternalStorageMetricsAccumulator();
+  acc.record('s3', 1, 1, 0, 100);
+  acc.record('s3', 1, 1, 200, 300); // gap between ops is not counted
+  t.is(durationMs(acc.toProto()), 200);
+});
+
+test('duration merges adjacent and nested operations', (t) => {
+  const acc = new ExternalStorageMetricsAccumulator();
+  acc.record('s3', 1, 1, 0, 100);
+  acc.record('s3', 1, 1, 100, 200); // adjacent
+  acc.record('s3', 1, 1, 120, 180); // nested inside the merged span
+  t.is(durationMs(acc.toProto()), 200);
+});

--- a/packages/common/src/internal-non-workflow/external-storage-metrics.ts
+++ b/packages/common/src/internal-non-workflow/external-storage-metrics.ts
@@ -1,0 +1,77 @@
+/**
+ * Accumulates external-payload-storage operation metrics over a single activation's store or
+ * retrieve pass, to be reported to Core on the workflow activation completion.
+ *
+ * @module
+ */
+import Long from 'long';
+
+import type { coresdk } from '@temporalio/proto';
+
+/** A completed storage operation's wall-clock span, in monotonic milliseconds. */
+type Interval = readonly [start: number, end: number];
+
+/**
+ * Collects the count, total size, participating drivers, and duration of external-storage
+ * operations performed while processing one task, in one direction (all stores, or all retrieves).
+ *
+ * @internal
+ * @experimental
+ */
+export class ExternalStorageMetricsAccumulator {
+  private payloadCount = 0;
+  private totalSizeBytes = 0;
+  private readonly driverNames = new Set<string>();
+  private readonly intervals: Interval[] = [];
+
+  /**
+   * Record one completed driver operation: `payloadCount` payloads totalling `sizeBytes`, which
+   * ran over the monotonic-clock span `[startMs, endMs]`.
+   */
+  record(driverName: string, payloadCount: number, sizeBytes: number, startMs: number, endMs: number): void {
+    this.payloadCount += payloadCount;
+    this.totalSizeBytes += sizeBytes;
+    this.driverNames.add(driverName);
+    this.intervals.push([startMs, endMs]);
+  }
+
+  /**
+   * The proto metrics, or `undefined` when no external storage occurred (so the completion field
+   * is left unset).
+   */
+  toProto(): coresdk.common.IExternalStorageMetrics | undefined {
+    if (this.payloadCount === 0) return undefined;
+    // Wall-clock time storage was in flight: summing each operation's duration would
+    // double-count operations that ran in parallel.
+    const durationMs = unionLength(this.intervals);
+    return {
+      payloadCount: Long.fromNumber(this.payloadCount, true),
+      totalSizeBytes: Long.fromNumber(this.totalSizeBytes, true),
+      totalDuration: {
+        seconds: Long.fromNumber(Math.floor(durationMs / 1000)),
+        nanos: Math.round((durationMs % 1000) * 1e6),
+      },
+      driverNames: [...this.driverNames].sort(),
+    };
+  }
+}
+
+/** Total length of the union of the given intervals. */
+function unionLength(intervals: readonly Interval[]): number {
+  if (intervals.length === 0) return 0;
+  const sorted = [...intervals].sort((a, b) => a[0] - b[0]);
+  let total = 0;
+  let spanStart = sorted[0]![0];
+  let spanEnd = sorted[0]![1];
+  for (let i = 1; i < sorted.length; i++) {
+    const [start, end] = sorted[i]!;
+    if (start > spanEnd) {
+      total += spanEnd - spanStart;
+      spanStart = start;
+      spanEnd = end;
+    } else if (end > spanEnd) {
+      spanEnd = end;
+    }
+  }
+  return total + (spanEnd - spanStart);
+}

--- a/packages/common/src/internal-non-workflow/external-storage-runner.ts
+++ b/packages/common/src/internal-non-workflow/external-storage-runner.ts
@@ -3,6 +3,8 @@
  *
  * @module
  */
+import { performance } from 'node:perf_hooks';
+
 import { temporal } from '@temporalio/proto';
 
 import { StorageDriverClaim } from '../converter/extstore';
@@ -16,6 +18,7 @@ import type {
 } from '../converter/extstore';
 import { ValueError } from '../errors';
 import type { Payload } from '../interfaces';
+import type { ExternalStorageMetricsAccumulator } from './external-storage-metrics';
 import { decodeReferencePayload, encodeReferencePayload, isReferencePayload } from './extstore-helpers';
 
 const PayloadProto = temporal.api.common.v1.Payload;
@@ -41,7 +44,10 @@ export interface ExternalRetrieveOptions {
  * @experimental
  */
 export class ExternalStorageRunner {
-  constructor(private readonly externalStorage: ExternalStorage) {}
+  constructor(
+    private readonly externalStorage: ExternalStorage,
+    private readonly metrics?: ExternalStorageMetricsAccumulator
+  ) {}
 
   /**
    * Replace each payload above the configured size threshold with a reference payload.
@@ -86,7 +92,9 @@ export class ExternalStorageRunner {
     if (driverGroups.size === 0) return payloads;
 
     const result = payloads.slice();
+    const { metrics } = this;
     await runWithAbortOnFirstError(batchController, [...driverGroups.values()], async (group) => {
+      const startMs = metrics ? performance.now() : 0;
       const claims = await group.driver.store(
         storeCtx,
         group.items.map((it) => it.payload)
@@ -103,6 +111,10 @@ export class ExternalStorageRunner {
           claim,
           sizeBytes: item.size,
         });
+      }
+      if (metrics) {
+        const sizeBytes = group.items.reduce((sum, it) => sum + it.size, 0);
+        metrics.record(group.driver.name, group.items.length, sizeBytes, startMs, performance.now());
       }
     });
 
@@ -143,7 +155,9 @@ export class ExternalStorageRunner {
     if (driverGroups.size === 0) return payloads;
 
     const result = payloads.slice();
+    const { metrics } = this;
     await runWithAbortOnFirstError(batchController, [...driverGroups.values()], async (group) => {
+      const startMs = metrics ? performance.now() : 0;
       const retrieved = await group.driver.retrieve(
         retrieveCtx,
         group.items.map((it) => it.claim)
@@ -154,8 +168,12 @@ export class ExternalStorageRunner {
         );
       }
       for (const [j, retrievedPayload] of retrieved.entries()) {
-        const item = group.items[j]!;
-        result[item.index] = retrievedPayload;
+        result[group.items[j]!.index] = retrievedPayload;
+      }
+      // Sizing a retrieved payload re-encodes it, so only pay that cost when metrics are wanted.
+      if (metrics) {
+        const sizeBytes = retrieved.reduce((sum, p) => sum + payloadProtoSize(p), 0);
+        metrics.record(group.driver.name, group.items.length, sizeBytes, startMs, performance.now());
       }
     });
 

--- a/packages/common/src/internal-non-workflow/external-storage-runner.ts
+++ b/packages/common/src/internal-non-workflow/external-storage-runner.ts
@@ -134,6 +134,7 @@ export class ExternalStorageRunner {
     interface RetrieveItem {
       index: number;
       claim: StorageDriverClaim;
+      size: number;
     }
     const driverGroups = new Map<string, { driver: StorageDriver; items: RetrieveItem[] }>();
 
@@ -149,7 +150,7 @@ export class ExternalStorageRunner {
         group = { driver, items: [] };
         driverGroups.set(decoded.driverName, group);
       }
-      group.items.push({ index: i, claim: new StorageDriverClaim(decoded.claimData) });
+      group.items.push({ index: i, claim: new StorageDriverClaim(decoded.claimData), size: decoded.sizeBytes });
     }
 
     if (driverGroups.size === 0) return payloads;
@@ -168,11 +169,11 @@ export class ExternalStorageRunner {
         );
       }
       for (const [j, retrievedPayload] of retrieved.entries()) {
-        result[group.items[j]!.index] = retrievedPayload;
+        const item = group.items[j]!;
+        result[item.index] = retrievedPayload;
       }
-      // Sizing a retrieved payload re-encodes it, so only pay that cost when metrics are wanted.
       if (metrics) {
-        const sizeBytes = retrieved.reduce((sum, p) => sum + payloadProtoSize(p), 0);
+        const sizeBytes = group.items.reduce((sum, it) => sum + it.size, 0);
         metrics.record(group.driver.name, group.items.length, sizeBytes, startMs, performance.now());
       }
     });

--- a/packages/common/src/internal-non-workflow/external-storage-visitor.ts
+++ b/packages/common/src/internal-non-workflow/external-storage-visitor.ts
@@ -8,6 +8,7 @@ import type { ConcurrencyLimit } from '../concurrency/limit';
 import type { ExternalStorage, StorageDriverTargetInfo } from '../converter/extstore';
 import { ExternalStorageNotConfiguredError } from '../errors';
 import type { Payload } from '../interfaces';
+import type { ExternalStorageMetricsAccumulator } from './external-storage-metrics';
 import { ExternalStorageRunner } from './external-storage-runner';
 import { isReferencePayload } from './extstore-helpers';
 import type { ContextDeriver, VisitOptions } from './payload-visitor';
@@ -29,6 +30,8 @@ export interface ExternalStorageStoreOptions {
   limit?: ConcurrencyLimit;
   /** Aborts the walk and every in-flight driver call. */
   abortSignal?: AbortSignal;
+  /** Collects metrics of the store operations performed during the walk. */
+  metrics?: ExternalStorageMetricsAccumulator;
 }
 
 /**
@@ -37,9 +40,9 @@ export interface ExternalStorageStoreOptions {
  */
 export function extstoreStoreOptions(
   externalStorage: ExternalStorage,
-  { initialTarget, deriveContext, limit, abortSignal }: ExternalStorageStoreOptions = {}
+  { initialTarget, deriveContext, limit, abortSignal, metrics }: ExternalStorageStoreOptions = {}
 ): VisitOptions<StoreTarget> {
-  const runner = new ExternalStorageRunner(externalStorage);
+  const runner = new ExternalStorageRunner(externalStorage, metrics);
   return {
     transformPayloads: (payloads, target, signal) => runner.store(payloads, { target, abortSignal: signal }),
     transformPayload: (payload, target, signal) =>
@@ -55,9 +58,13 @@ export function extstoreStoreOptions(
 
 function extstoreRetrieveOptions(
   externalStorage: ExternalStorage,
-  { limit, abortSignal }: { limit?: ConcurrencyLimit; abortSignal?: AbortSignal } = {}
+  {
+    limit,
+    abortSignal,
+    metrics,
+  }: { limit?: ConcurrencyLimit; abortSignal?: AbortSignal; metrics?: ExternalStorageMetricsAccumulator } = {}
 ): VisitOptions<void> {
-  const runner = new ExternalStorageRunner(externalStorage);
+  const runner = new ExternalStorageRunner(externalStorage, metrics);
   return {
     transformPayloads: (payloads, _context, signal) => runner.retrieve(payloads, { abortSignal: signal }),
     transformPayload: (payload, _context, signal) =>
@@ -95,6 +102,9 @@ function extstoreDetectReferencesOptions(): VisitOptions<void> {
  * @internal
  * @experimental
  */
-export function extstoreInboundOptions(externalStorage: ExternalStorage | undefined): VisitOptions<void> {
-  return externalStorage ? extstoreRetrieveOptions(externalStorage) : extstoreDetectReferencesOptions();
+export function extstoreInboundOptions(
+  externalStorage: ExternalStorage | undefined,
+  { metrics }: { metrics?: ExternalStorageMetricsAccumulator } = {}
+): VisitOptions<void> {
+  return externalStorage ? extstoreRetrieveOptions(externalStorage, { metrics }) : extstoreDetectReferencesOptions();
 }

--- a/packages/common/src/internal-non-workflow/index.ts
+++ b/packages/common/src/internal-non-workflow/index.ts
@@ -7,6 +7,7 @@ export * from './codec-helpers';
 export * from './codec-types';
 export * from './data-converter-helpers';
 export * from './extstore-helpers';
+export * from './external-storage-metrics';
 export * from './external-storage-runner';
 export * from './external-storage-visitor';
 export * from './payload-visitor';

--- a/packages/test/src/test-extstore-runner.ts
+++ b/packages/test/src/test-extstore-runner.ts
@@ -3,7 +3,11 @@ import test from 'ava';
 import { ValueError, type Payload } from '@temporalio/common';
 import { ExternalStorage } from '@temporalio/common/lib/converter/extstore';
 import type { StorageDriverSelectContext, StorageDriverTargetInfo } from '@temporalio/common/lib/converter/extstore';
-import { ExternalStorageRunner, isReferencePayload } from '@temporalio/common/lib/internal-non-workflow';
+import {
+  ExternalStorageMetricsAccumulator,
+  ExternalStorageRunner,
+  isReferencePayload,
+} from '@temporalio/common/lib/internal-non-workflow';
 import { encode } from '@temporalio/common/lib/encoding';
 import { METADATA_ENCODING_KEY } from '@temporalio/common/lib/converter/types';
 import { makeFakeDriver } from './extstore-fake-driver';
@@ -206,6 +210,27 @@ test('store/retrieve round-trip preserves order across drivers', async (t) => {
 
   const retrievedPayloads = await runner.retrieve(storedPayloads);
   t.deepEqual(retrievedPayloads, inputPayloads);
+});
+
+test('store and retrieve report the same total size', async (t) => {
+  const driver = makeFakeDriver({ name: 's3' });
+  const storage = new ExternalStorage({ drivers: [driver], payloadSizeThreshold: 0 });
+
+  const uploadMetrics = new ExternalStorageMetricsAccumulator();
+  const storedPayloads = await new ExternalStorageRunner(storage, uploadMetrics).store([
+    makePayload(64),
+    makePayload(128),
+  ]);
+
+  const downloadMetrics = new ExternalStorageMetricsAccumulator();
+  await new ExternalStorageRunner(storage, downloadMetrics).retrieve(storedPayloads);
+
+  const uploaded = uploadMetrics.toProto()!;
+  const downloaded = downloadMetrics.toProto()!;
+  t.is(downloaded.payloadCount!.toNumber(), 2);
+  // retrieve takes each size from its reference, so both directions report the same bytes.
+  t.is(downloaded.totalSizeBytes!.toNumber(), uploaded.totalSizeBytes!.toNumber());
+  t.true(downloaded.totalSizeBytes!.toNumber() > 0);
 });
 
 test('retrieve raises ValueError when the driver name is unknown', async (t) => {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -38,6 +38,7 @@ import {
   decodeFromPayloadsAtIndex,
   encodeErrorToFailure,
   encodeToPayload,
+  ExternalStorageMetricsAccumulator,
   extstoreInboundOptions,
   extstoreStoreOptions,
   visit,
@@ -1559,7 +1560,15 @@ export class Worker {
         });
       }
       const { externalStorage } = this.options.loadedDataConverter;
-      await visit(activation, walkWorkflowActivation, extstoreInboundOptions(externalStorage));
+      // Measure external-storage work so Core can include it in its workflow-task duration log;
+      // Core measures the duration itself.
+      const downloadMetrics = externalStorage ? new ExternalStorageMetricsAccumulator() : undefined;
+      let uploadMetrics: ExternalStorageMetricsAccumulator | undefined;
+      await visit(
+        activation,
+        walkWorkflowActivation,
+        extstoreInboundOptions(externalStorage, { metrics: downloadMetrics })
+      );
       const decodedActivation = await workflowCodecRunner.decodeActivation(activation);
 
       if (workflow === undefined) {
@@ -1579,6 +1588,7 @@ export class Worker {
         // Skip extstore.store on replay: the completion is discarded and its payloads were already offloaded on the original run.
         if (externalStorage && !this.isReplayWorker) {
           const namespace = workflowCodecRunner.workflowContext.namespace;
+          uploadMetrics = new ExternalStorageMetricsAccumulator();
           await visit(
             encodedCompletion,
             walkWorkflowActivationCompletion,
@@ -1591,9 +1601,12 @@ export class Worker {
                 type: workflow.info.workflowType,
               },
               deriveContext: workflowCommandStoreTarget(namespace, workflow.info),
+              metrics: uploadMetrics,
             })
           );
         }
+        encodedCompletion.payloadDownloadMetrics = downloadMetrics?.toProto();
+        encodedCompletion.payloadUploadMetrics = uploadMetrics?.toProto();
         const completion =
           coresdk.workflow_completion.WorkflowActivationCompletion.encodeDelimited(encodedCompletion).finish();
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Accumulate storage driver duration metrics on workflow tasks and report them into core.

## Why?

Allow core to log storage driver durations when workflow tasks have a duration above the warning threshold.

## Checklist
<!--- add/delete as needed --->

1. Closes #2066

2. How was this tested: Unit tests

3. Any docs updates needed? No
