### PR TITLE
feat(bundler): Add SDK version tag on generated Workflow bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ to docs, or any other relevant information.
     on the legacy spelling. Note that we may choose to deprecate the legacy spelling at some point
     in the future to encourage adoption of protobufjs' roadmap.
 
+- A Worker will now refuse to load and execute a Workflow bundle produced with a different version
+  of the SDK. This practice has never been supported, but was never formally prevented, resulting
+  in various subtle, hard to diagnose issues.
+
 ### Added
 
 - **Experimental**: `@temporalio/openai-agents` can run OpenAI Agents `SandboxAgent`s as Temporal Workflows. SandboxAgent

--- a/packages/test/src/test-bundler.cloud-pending.ts
+++ b/packages/test/src/test-bundler.cloud-pending.ts
@@ -9,8 +9,10 @@ import { randomUUID } from 'crypto';
 import type { ExecutionContext } from 'ava';
 import test from 'ava';
 import { moduleMatches } from '@temporalio/worker/lib/workflow/bundler';
+import pkg from '@temporalio/worker/lib/pkg';
+import { parseWorkflowCode } from '@temporalio/worker/lib/worker';
 import type { LogEntry, WorkerOptions } from '@temporalio/worker';
-import { bundleWorkflowCode, DefaultLogger } from '@temporalio/worker';
+import { bundleWorkflowCode, DefaultLogger, Worker as BaseWorker } from '@temporalio/worker';
 import { Client } from '@temporalio/client';
 import { RUN_INTEGRATION_TESTS, Worker } from './helpers';
 import { issue516 } from './mocks/workflows-with-node-dependencies/issue-516';
@@ -22,6 +24,67 @@ test('moduleMatches works', (t) => {
   t.true(moduleMatches('fs', ['fs']));
   t.true(moduleMatches('fs/lib/foo', ['fs']));
   t.false(moduleMatches('fs', ['foo']));
+});
+
+class VersionValidationTestWorker extends BaseWorker {
+  static workflowCreatorWasCreated = false;
+
+  protected static override async createWorkflowCreator(): Promise<never> {
+    this.workflowCreatorWasCreated = true;
+    throw new Error('Workflow creator should not be created for an incompatible bundle');
+  }
+}
+
+test('Workflow bundle contains the SDK version annotation after minification', async (t) => {
+  const { code } = await bundleWorkflowCode({
+    workflowsPath: require.resolve('./workflows/preload-shared-counter'),
+    webpackConfigHook: (config) => ({ ...config, mode: 'production' }),
+  });
+
+  const annotation = `/* @temporalio/workflow-bundle ${JSON.stringify({ sdkVersion: pkg.version })} */\n`;
+  t.true(code.startsWith(annotation));
+  t.notThrows(() => parseWorkflowCode(code));
+});
+
+test('Workflow bundle from a different SDK version is rejected', async (t) => {
+  const { code } = await bundleWorkflowCode({
+    workflowsPath: require.resolve('./workflows/preload-shared-counter'),
+  });
+
+  const expectedAnnotation = `/* @temporalio/workflow-bundle ${JSON.stringify({ sdkVersion: pkg.version })} */`;
+  const mismatchedAnnotation = `/* @temporalio/workflow-bundle ${JSON.stringify({ sdkVersion: '0.0.0-test' })} */`;
+  const mismatchedCode = code.replace(expectedAnnotation, mismatchedAnnotation);
+
+  VersionValidationTestWorker.workflowCreatorWasCreated = false;
+  const err = await t.throwsAsync(
+    VersionValidationTestWorker.create({
+      taskQueue: 'incompatible-workflow-bundle',
+      workflowBundle: { code: mismatchedCode },
+    }),
+    {
+      instanceOf: TypeError,
+    }
+  );
+  t.false(VersionValidationTestWorker.workflowCreatorWasCreated);
+  t.true(err?.message.includes(`generated with Temporal SDK version '0.0.0-test'`) ?? false);
+  t.true(err?.message.includes(`Worker is running version '${pkg.version}'`) ?? false);
+});
+
+test('Workflow bundle without an SDK version annotation is rejected despite containing the old cache marker', (t) => {
+  const annotation = `/* @temporalio/workflow-bundle ${JSON.stringify({ sdkVersion: pkg.version })} */`;
+  const code = `void globalThis.__webpack_module_cache__;\n${annotation}`;
+
+  t.throws(() => parseWorkflowCode(code), {
+    instanceOf: TypeError,
+    message: /does not contain a Temporal SDK version annotation/,
+  });
+});
+
+test('Workflow bundle with a malformed SDK version annotation is rejected', (t) => {
+  t.throws(() => parseWorkflowCode('/* @temporalio/workflow-bundle invalid */\n'), {
+    instanceOf: TypeError,
+    message: /contains an invalid Temporal SDK version annotation/,
+  });
 });
 
 async function runPreloadSharedCounter(
@@ -299,6 +362,41 @@ test('Workflow bundle redirects the module cache when minified after webpack (#2
   });
   t.true(code.includes('globalThis.__webpack_module_cache__'), 'module cache should be redirected before minification');
 });
+
+test('Workflow bundle redirects the module cache regardless of assignment whitespace', async (t) => {
+  const { code } = await bundleWorkflowCode({
+    workflowsPath: require.resolve('./workflows/preload-shared-counter'),
+    webpackConfigHook: (config) => {
+      config.plugins = [new ModuleCacheRenderWhitespaceCollapsePlugin(), ...(config.plugins ?? [])];
+      return config;
+    },
+  });
+
+  t.true(code.includes('globalThis.__webpack_module_cache__'), 'module cache should be redirected');
+});
+
+/**
+ * A webpack plugin that changes the module-cache declaration before Temporal's
+ * render-time patch runs. This simulates webpack emitting `__webpack_module_cache__={}`
+ * instead of `__webpack_module_cache__ = {}`.
+ */
+class ModuleCacheRenderWhitespaceCollapsePlugin {
+  apply(compiler: any): void {
+    compiler.hooks.compilation.tap('ModuleCacheRenderWhitespaceCollapse', (compilation: any) => {
+      const hooks = compiler.webpack.javascript.JavascriptModulesPlugin.getCompilationHooks(compilation);
+
+      hooks.renderMain.tap('ModuleCacheRenderWhitespaceCollapse', (source: any) => {
+        const code = source.source().toString();
+        const replaced = new compiler.webpack.sources.ReplaceSource(source);
+        const re = /((?:var|let|const)\s+__webpack_module_cache__)\s*=\s*\{\}/g;
+        for (let match = re.exec(code); match !== null; match = re.exec(code)) {
+          replaced.replace(match.index, match.index + match[0].length - 1, `${match[1]}={}`);
+        }
+        return replaced;
+      });
+    });
+  }
+}
 
 /**
  * A webpack plugin that mimics a minifier (e.g. terser) added by a user through

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -97,6 +97,7 @@ import type {
 import { compileWorkerOptions, isCodeBundleOption, isPathBundleOption, toNativeWorkerOptions } from './worker-options';
 import { WorkflowCodecRunner } from './workflow-codec-runner';
 import { defaultWorkflowInterceptorModules, WorkflowCodeBundler } from './workflow/bundler';
+import { assertWorkflowBundleSdkVersion } from './workflow/bundle-metadata';
 import { isBunPre1_4 } from './workflow/bun';
 import type { Workflow, WorkflowCreator } from './workflow/interface';
 import { ReusableVMWorkflowCreator } from './workflow/reusable-vm';
@@ -2303,6 +2304,8 @@ export class Worker {
 }
 
 export function parseWorkflowCode(code: string, codePath?: string): WorkflowBundleWithSourceMapAndFilename {
+  assertWorkflowBundleSdkVersion(code, pkg.version);
+
   const [actualCode, sourceMapJson] = extractSourceMap(code);
   const sourceMap: RawSourceMap = JSON.parse(sourceMapJson);
 

--- a/packages/worker/src/workflow/bundle-metadata.ts
+++ b/packages/worker/src/workflow/bundle-metadata.ts
@@ -1,0 +1,65 @@
+const WORKFLOW_BUNDLE_ANNOTATION_PREFIX = '/* @temporalio/workflow-bundle ';
+const WORKFLOW_BUNDLE_ANNOTATION_SUFFIX = ' */';
+
+interface WorkflowBundleMetadata {
+  sdkVersion: string;
+}
+
+export function makeWorkflowBundleVersionAnnotation(sdkVersion: string): string {
+  return `${WORKFLOW_BUNDLE_ANNOTATION_PREFIX}${JSON.stringify({ sdkVersion })}${WORKFLOW_BUNDLE_ANNOTATION_SUFFIX}`;
+}
+
+export function getWorkflowBundleSdkVersion(code: string): string {
+  const firstLineEnd = code.indexOf('\n');
+  const firstLine = code.slice(0, firstLineEnd === -1 ? code.length : firstLineEnd).replace(/\r$/, '');
+
+  if (!firstLine.startsWith(WORKFLOW_BUNDLE_ANNOTATION_PREFIX)) {
+    throw new TypeError(
+      `The provided Workflow Bundle does not contain a Temporal SDK version annotation. ` +
+        `Make sure the bundle was generated with the same version of '@temporalio/worker' that is being used to ` +
+        `create the Worker.`
+    );
+  }
+
+  if (!firstLine.endsWith(WORKFLOW_BUNDLE_ANNOTATION_SUFFIX)) {
+    throw new TypeError(
+      `The provided Workflow Bundle contains an invalid Temporal SDK version annotation. ` +
+        `Rebuild the bundle with the same version of '@temporalio/worker' that is being used to create the Worker.`
+    );
+  }
+
+  const serializedMetadata = firstLine.slice(
+    WORKFLOW_BUNDLE_ANNOTATION_PREFIX.length,
+    -WORKFLOW_BUNDLE_ANNOTATION_SUFFIX.length
+  );
+  let metadata: WorkflowBundleMetadata;
+  try {
+    metadata = JSON.parse(serializedMetadata);
+  } catch (_err) {
+    throw new TypeError(
+      `The provided Workflow Bundle contains an invalid Temporal SDK version annotation. ` +
+        `Rebuild the bundle with the same version of '@temporalio/worker' that is being used to create the Worker.`
+    );
+  }
+
+  if (typeof metadata !== 'object' || metadata === null || typeof metadata.sdkVersion !== 'string') {
+    throw new TypeError(
+      `The provided Workflow Bundle contains an invalid Temporal SDK version annotation. ` +
+        `Rebuild the bundle with the same version of '@temporalio/worker' that is being used to create the Worker.`
+    );
+  }
+
+  return metadata.sdkVersion;
+}
+
+export function assertWorkflowBundleSdkVersion(code: string, expectedSdkVersion: string): void {
+  const actualSdkVersion = getWorkflowBundleSdkVersion(code);
+  if (actualSdkVersion !== expectedSdkVersion) {
+    throw new TypeError(
+      `The provided Workflow Bundle was generated with Temporal SDK version '${actualSdkVersion}', but the Worker ` +
+        `is running version '${expectedSdkVersion}'. The Workflow Bundle and Worker must use exactly the same SDK ` +
+        `version. Rebuild the bundle with the same version of '@temporalio/worker' that is being used to create the ` +
+        `Worker.`
+    );
+  }
+}

--- a/packages/worker/src/workflow/bundle-metadata.ts
+++ b/packages/worker/src/workflow/bundle-metadata.ts
@@ -5,6 +5,13 @@ interface WorkflowBundleMetadata {
   sdkVersion: string;
 }
 
+function invalidWorkflowBundleVersionAnnotation(): TypeError {
+  return new TypeError(
+    `The provided Workflow Bundle contains an invalid Temporal SDK version annotation. ` +
+      `Rebuild the bundle with the same version of '@temporalio/worker' that is being used to create the Worker.`
+  );
+}
+
 export function makeWorkflowBundleVersionAnnotation(sdkVersion: string): string {
   return `${WORKFLOW_BUNDLE_ANNOTATION_PREFIX}${JSON.stringify({ sdkVersion })}${WORKFLOW_BUNDLE_ANNOTATION_SUFFIX}`;
 }
@@ -22,10 +29,7 @@ export function getWorkflowBundleSdkVersion(code: string): string {
   }
 
   if (!firstLine.endsWith(WORKFLOW_BUNDLE_ANNOTATION_SUFFIX)) {
-    throw new TypeError(
-      `The provided Workflow Bundle contains an invalid Temporal SDK version annotation. ` +
-        `Rebuild the bundle with the same version of '@temporalio/worker' that is being used to create the Worker.`
-    );
+    throw invalidWorkflowBundleVersionAnnotation();
   }
 
   const serializedMetadata = firstLine.slice(
@@ -36,17 +40,11 @@ export function getWorkflowBundleSdkVersion(code: string): string {
   try {
     metadata = JSON.parse(serializedMetadata);
   } catch (_err) {
-    throw new TypeError(
-      `The provided Workflow Bundle contains an invalid Temporal SDK version annotation. ` +
-        `Rebuild the bundle with the same version of '@temporalio/worker' that is being used to create the Worker.`
-    );
+    throw invalidWorkflowBundleVersionAnnotation();
   }
 
   if (typeof metadata !== 'object' || metadata === null || typeof metadata.sdkVersion !== 'string') {
-    throw new TypeError(
-      `The provided Workflow Bundle contains an invalid Temporal SDK version annotation. ` +
-        `Rebuild the bundle with the same version of '@temporalio/worker' that is being used to create the Worker.`
-    );
+    throw invalidWorkflowBundleVersionAnnotation();
   }
 
   return metadata.sdkVersion;

--- a/packages/worker/src/workflow/bundler.ts
+++ b/packages/worker/src/workflow/bundler.ts
@@ -5,10 +5,12 @@ import util from 'node:util';
 import * as unionfs from 'unionfs';
 import * as memfs from 'memfs';
 import type { Configuration } from 'webpack';
-import { webpack, NormalModuleReplacementPlugin } from 'webpack';
+import { webpack, BannerPlugin, Compilation, NormalModuleReplacementPlugin } from 'webpack';
 import type { Logger } from '../logger';
 import { DefaultLogger, hasColorSupport } from '../logger';
+import pkg from '../pkg';
 import { toMB } from '../utils';
+import { makeWorkflowBundleVersionAnnotation } from './bundle-metadata';
 import {
   InjectWorkflowModuleCacheGlobalPlugin,
   assertWorkflowModuleCacheGlobalApplied,
@@ -240,6 +242,14 @@ exports.importInterceptors = function importInterceptors() {
         },
       },
       plugins: [
+        new BannerPlugin({
+          banner: makeWorkflowBundleVersionAnnotation(pkg.version),
+          raw: true,
+          entryOnly: true,
+          // Add the annotation after minimizers have run so it cannot be stripped, but before
+          // the inline source map is generated so its line offsets remain correct.
+          stage: Compilation.PROCESS_ASSETS_STAGE_DEV_TOOLING - 1,
+        }),
         // Redirect webpack's module cache to a runtime-injected global so that a single V8
         // context can be reused across Workflow executions while keeping module state isolated.
         new InjectWorkflowModuleCacheGlobalPlugin(),

--- a/packages/worker/src/workflow/bundler/patch-module-cache.ts
+++ b/packages/worker/src/workflow/bundler/patch-module-cache.ts
@@ -111,15 +111,16 @@ export class InjectWorkflowModuleCacheGlobalPlugin {
 
     const replaced = new sources.ReplaceSource(source);
 
-    // Redirect the top-level declaration to the runtime-injected global.
-    const declStart = declaration.index;
-    const declEndInclusive = declStart + declaration[0].length - 1;
-    replaced.replace(declStart, declEndInclusive, declaration[0].replace('= {}', `= ${MODULE_CACHE_GLOBAL}`));
+    // Redirect the top-level declaration to the runtime-injected global. The declaration regexp
+    // ends at the empty-object initializer, so replacing only those last two characters avoids
+    // making this replacement sensitive to whitespace around the assignment operator.
+    const initializerStart = declaration.index + declaration[0].length - '{}'.length;
+    replaced.replace(initializerStart, initializerStart + '{}'.length - 1, MODULE_CACHE_GLOBAL);
 
     // Strip the marker so it never ships.
     // Note that `ReplaceSource.replace()` takes character indices from the
-    // _original_ source; there's thereforre no need to adjust the indices to
-    // account for the replacement we just performed (`= {}` => MODULE_CACHE_GLOBAL).
+    // _original_ source; there's therefore no need to adjust the indices to
+    // account for the replacement we just performed (`{}` => MODULE_CACHE_GLOBAL).
     const markerEndInclusive = markerIndex + MARKER_COMMENT.length - 1;
     replaced.replace(markerIndex, markerEndInclusive, '');
 

--- a/packages/worker/src/workflow/reusable-vm.ts
+++ b/packages/worker/src/workflow/reusable-vm.ts
@@ -267,29 +267,6 @@ export class ReusableVMWorkflowCreator implements WorkflowCreator {
     registeredActivityNames: Set<string>,
     patchActivationCallback?: WorkflowPatchActivationCallback
   ): Promise<InstanceType<T>> {
-    // The Reusable V8 Context executor needs to take control of Webpack's require
-    // cache in order to provide per-Workflow isolation of non-shared modules.
-    // In order to achieve that, the Workflow Bundler must rewrites webpack's module
-    // cache declaration to initilize it with `globalThis.__webpack_module_cache__`
-    // instead of an empty object.
-    //
-    // Loading a bundle that does not correctly rewrite the webpack's module cache to
-    // `globalThis.__webpack_module_cache__` in the Reusable V8 Context executor will
-    // result in silent breakage of Workflow isolation. See #2170 and #2188 for details.
-    //
-    // The following is a sanity check to catch eventual regressions, or attempts by
-    // users to use the Reusable V8 Context executor with bundles that were not produced
-    // with a compatible Workflow Bundler.
-    if (!workflowBundle.code.includes('globalThis.__webpack_module_cache__')) {
-      throw new Error(
-        `The provided Workflow Bundle is not compatible with the Reusable V8 Context executor: it does ` +
-          `not route its module cache through 'globalThis.__webpack_module_cache__', which is required to ` +
-          `keep module state isolated across Workflow executions. Make sure the bundle was produced by a ` +
-          `compatible version of the Temporal SDK, or disable the Reusable V8 Context executor by setting ` +
-          `'WorkerOptions.reuseV8Context' to false.`
-      );
-    }
-
     const script = new vm.Script(workflowBundle.code, { filename: workflowBundle.filename });
     globalHandlers.install(); // Call is idempotent
     await globalHandlers.addWorkflowBundle(workflowBundle);


### PR DESCRIPTION
## What was changed

- Add an SDK version metadata in generated Workflow bundles.
- Worker now refuses to load and execute a bundle that has been produced by a different version of the SDK.

## Why?

- Running a Workflow Worker with a bundle produced by a different version of the SDK has never been supported.
- A Workflow bundles includes source files from the SDK packages that were used to produce that bundle. Those source files use and provide internal APIs from/to SDKs packages of the Worker. Those internal APIs may change in incompatible ways at any time, including between patch-level releases of the SDK.
- Use of incompatible workflow bundles is a recurring cause of bugs in production, yet extremely difficult to diagnose.
