### PR TITLE
feat(activity): add ActivityDescribeOptions for fetching payload fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ to docs, or any other relevant information.
 
 ### Added
 
+- **Experimental**: `ActivityHandle.describe` now accepts options that can be used to include additional data associated
+  with activity execution, such as input and result.
 - **Experimental**: `@temporalio/openai-agents` can run OpenAI Agents `SandboxAgent`s as Temporal Workflows. SandboxAgent
   operations are Activities; hosted tool credentials and sandbox environment values that reference allowlisted Worker
   environment variables are resolved on Worker so their values are not recorded in Workflow history.

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -27,6 +27,7 @@ import {
   searchAttributePayloadConverter,
 } from '@temporalio/common/lib/converter/payload-search-attributes';
 import {
+  decodeArrayFromPayloads,
   decodeFromPayloadsAtIndex,
   decodeOptionalFailureToOptionalError,
   encodeToPayloadsWithContext,
@@ -243,11 +244,17 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
         });
       },
 
-      async describe(): Promise<ActivityExecutionDescription> {
+      async describe(options?: ActivityDescribeOptions): Promise<ActivityExecutionDescription> {
         return await this.client.interceptedHandlers.describe({
           activityId: this.activityId,
           activityRunId: this.runId ?? '',
           headers: {},
+          options: {
+            includeInput: options?.includeInput || false,
+            includeOutcome: options?.includeOutcome || false,
+            includeHeartbeatDetails: options?.includeHeartbeatDetails || false,
+            includeLastFailure: options?.includeLastFailure || false,
+          },
         });
       },
 
@@ -422,15 +429,26 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       throw new TypeError('activityId is required');
     }
 
+    function hasInfo(resp: any): resp is { info: object } {
+      return !!resp.info;
+    }
+
     try {
       const resp = await this.workflowService.describeActivityExecution({
         namespace: this.options.namespace,
         activityId: input.activityId,
         runId: input.activityRunId || undefined,
+        includeInput: input.options.includeInput,
+        includeOutcome: input.options.includeInput,
+        includeHeartbeatDetails: input.options.includeInput,
+        includeLastFailure: input.options.includeLastFailure,
       });
+      if (!hasInfo(resp)) {
+        throw new ServiceError('Missing info in describeActivityExecution response');
+      }
       const externalStorage = this.dataConverter.externalStorage;
       await visit(resp, walkDescribeActivityExecutionResponse, extstoreInboundOptions(externalStorage));
-      return buildActivityDescription(resp.info!, resp.callbacks, this.dataConverter);
+      return buildActivityDescription(resp, this.dataConverter);
     } catch (err) {
       this.rethrowGrpcError(err, 'Failed to describe activity');
     }
@@ -525,6 +543,9 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       }
       throw new ServiceError(fallbackMessage, { cause: err });
     }
+    if (err instanceof ServiceError) {
+      throw err;
+    }
     throw new ServiceError('Unexpected error while making gRPC request');
   }
 }
@@ -555,7 +576,7 @@ export interface ActivityHandle<R = any> {
   /**
    * Returns information about the Activity execution.
    */
-  describe(): Promise<ActivityExecutionDescription>;
+  describe(options?: ActivityDescribeOptions): Promise<ActivityExecutionDescription>;
   /**
    * Requests cancellation of the Activity execution. Note that cancellations are cooperative and not guaranteed to happen.
    */
@@ -662,6 +683,18 @@ export interface GetActivityHandleOptions {
   typeInfo?: Pick<PayloadTypeInfo, 'outputType'>;
 }
 
+/**
+ * Options for {@link ActivityHandle.describe}.
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
+export interface ActivityDescribeOptions {
+  includeInput?: boolean;
+  includeOutcome?: boolean;
+  includeHeartbeatDetails?: boolean;
+  includeLastFailure?: boolean;
+}
+
 function validateActivityOptions(options: ActivityOptions): void {
   if (!options.id) {
     throw new TypeError('id is required');
@@ -701,47 +734,45 @@ function buildActivityExecutionInfo(info: temporal.api.activity.v1.IActivityExec
 }
 
 function buildActivityDescription(
-  info: temporal.api.activity.v1.IActivityExecutionInfo,
-  callbacks: temporal.api.activity.v1.ICallbackInfo[],
+  resp: temporal.api.workflowservice.v1.DescribeActivityExecutionResponse & { info: object },
   dataConverter: LoadedDataConverter
 ): ActivityExecutionDescription {
-  const getHeartbeatDetails: <T>() => Promise<T | undefined> = async <T>() => {
-    const payloads = info.heartbeatDetails?.payloads;
-    if (payloads && payloads.length > 0) {
-      return await decodeFromPayloadsAtIndex<T>(dataConverter, 0, info.heartbeatDetails?.payloads);
-    } else {
-      return undefined;
-    }
-  };
-
-  const getLastFailure: () => Promise<Error | undefined> = async () => {
-    return await decodeOptionalFailureToOptionalError(dataConverter, info.lastFailure);
-  };
-
   return {
-    ...buildActivityExecutionInfoCommonPart(info),
-    rawInfo: info,
-    rawCallbacks: callbacks,
-    runState: decodePendingActivityState(info.runState),
-    scheduleToCloseTimeoutMs: optionalTsToMs(info.scheduleToCloseTimeout),
-    scheduleToStartTimeoutMs: optionalTsToMs(info.scheduleToStartTimeout),
-    startToCloseTimeoutMs: optionalTsToMs(info.startToCloseTimeout),
-    heartbeatTimeoutMs: optionalTsToMs(info.heartbeatTimeout),
-    retryPolicy: decompileRetryPolicy(info.retryPolicy)!,
-    lastHeartbeatTime: optionalTsToDate(info.lastHeartbeatTime),
-    lastStartedTime: optionalTsToDate(info.lastStartedTime),
-    attempt: info.attempt!,
-    expirationTime: optionalTsToDate(info.expirationTime),
-    lastWorkerIdentity: info.lastWorkerIdentity || undefined,
-    currentRetryIntervalMs: optionalTsToMs(info.currentRetryInterval),
-    lastAttemptCompleteTime: optionalTsToDate(info.lastAttemptCompleteTime),
-    nextAttemptScheduleTime: optionalTsToDate(info.nextAttemptScheduleTime),
-    lastDeploymentVersion: convertDeploymentVersion(info.lastDeploymentVersion),
-    priority: decodePriority(info.priority),
-    canceledReason: info.canceledReason || undefined,
+    ...buildActivityExecutionInfoCommonPart(resp.info),
+    rawInfo: resp.info,
+    rawCallbacks: resp.callbacks,
+    runState: decodePendingActivityState(resp.info.runState),
+    scheduleToCloseTimeoutMs: optionalTsToMs(resp.info.scheduleToCloseTimeout),
+    scheduleToStartTimeoutMs: optionalTsToMs(resp.info.scheduleToStartTimeout),
+    startToCloseTimeoutMs: optionalTsToMs(resp.info.startToCloseTimeout),
+    heartbeatTimeoutMs: optionalTsToMs(resp.info.heartbeatTimeout),
+    retryPolicy: decompileRetryPolicy(resp.info.retryPolicy)!,
+    lastHeartbeatTime: optionalTsToDate(resp.info.lastHeartbeatTime),
+    lastStartedTime: optionalTsToDate(resp.info.lastStartedTime),
+    attempt: resp.info.attempt!,
+    expirationTime: optionalTsToDate(resp.info.expirationTime),
+    lastWorkerIdentity: resp.info.lastWorkerIdentity || undefined,
+    currentRetryIntervalMs: optionalTsToMs(resp.info.currentRetryInterval),
+    lastAttemptCompleteTime: optionalTsToDate(resp.info.lastAttemptCompleteTime),
+    nextAttemptScheduleTime: optionalTsToDate(resp.info.nextAttemptScheduleTime),
+    lastDeploymentVersion: convertDeploymentVersion(resp.info.lastDeploymentVersion),
+    priority: decodePriority(resp.info.priority),
+    canceledReason: resp.info.canceledReason || undefined,
+    startDelayMs: optionalTsToMs(resp.info.startDelay),
+    totalHeartbeatCount: resp.info.totalHeartbeatCount || undefined,
 
-    getHeartbeatDetails,
-    getLastFailure,
+    hasHeartbeatDetails: (resp.info.heartbeatDetails?.payloads?.length || 0) > 0,
+    hasLastFailure: !!resp.info.lastFailure,
+    hasInput: (resp.input?.payloads?.length || 0) > 0,
+    hasResult: (resp.outcome?.result?.payloads?.length || 0) > 0,
+    hasOutcomeFailure: !!resp.outcome?.failure,
+
+    getHeartbeatDetails: async <T>() =>
+      await decodeFromPayloadsAtIndex<T>(dataConverter, 0, resp.info.heartbeatDetails?.payloads),
+    getLastFailure: async () => await decodeOptionalFailureToOptionalError(dataConverter, resp.info.lastFailure),
+    getInput: async <T>() => (await decodeArrayFromPayloads(dataConverter, resp.input?.payloads)) as T,
+    getResult: async <T>() => await decodeFromPayloadsAtIndex<T>(dataConverter, 0, resp.outcome?.result?.payloads),
+    getOutcomeFailure: async () => await decodeOptionalFailureToOptionalError(dataConverter, resp.outcome?.failure),
   };
 }
 

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -689,9 +689,21 @@ export interface GetActivityHandleOptions {
  * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityDescribeOptions {
+  /**
+   * Include activity input in the response if available.
+   */
   includeInput?: boolean;
+  /**
+   * Include activity result or outcome failure in the response if available.
+   */
   includeOutcome?: boolean;
+  /**
+   * Include heartbeat details in the response if available.
+   */
   includeHeartbeatDetails?: boolean;
+  /**
+   * Include last failure in the response if available.
+   */
   includeLastFailure?: boolean;
 }
 

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -439,8 +439,8 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
         activityId: input.activityId,
         runId: input.activityRunId || undefined,
         includeInput: input.options.includeInput,
-        includeOutcome: input.options.includeInput,
-        includeHeartbeatDetails: input.options.includeInput,
+        includeOutcome: input.options.includeOutcome,
+        includeHeartbeatDetails: input.options.includeHeartbeatDetails,
         includeLastFailure: input.options.includeLastFailure,
       });
       if (!hasInfo(resp)) {
@@ -723,6 +723,7 @@ function buildActivityExecutionInfoCommonPart(
     typedSearchAttributes: decodeTypedSearchAttributes(info.searchAttributes?.indexedFields),
     taskQueue: info.taskQueue!,
     executionDurationMs: optionalTsToMs(info.executionDuration),
+    executionTime: optionalTsToDate(info.executionTime),
   };
 }
 
@@ -759,7 +760,7 @@ function buildActivityDescription(
     priority: decodePriority(resp.info.priority),
     canceledReason: resp.info.canceledReason || undefined,
     startDelayMs: optionalTsToMs(resp.info.startDelay),
-    totalHeartbeatCount: resp.info.totalHeartbeatCount || undefined,
+    totalHeartbeatCount: resp.info.totalHeartbeatCount?.toNumber() || undefined,
 
     hasHeartbeatDetails: (resp.info.heartbeatDetails?.payloads?.length || 0) > 0,
     hasLastFailure: !!resp.info.lastFailure,

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -694,7 +694,9 @@ export interface ActivityDescribeOptions {
    */
   includeInput?: boolean;
   /**
-   * Include activity result or outcome failure in the response if available.
+   * Include activity outcome failure in the response if available. If the activity is closed, this will populate
+   * either {@link ActivityExecutionDescription.getResult} or {@link ActivityExecutionDescription.getOutcomeFailure}
+   * depending on whether the activity succeeded or failed.
    */
   includeOutcome?: boolean;
   /**

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -33,7 +33,7 @@ import type {
   WorkflowExecution,
 } from './types';
 import type { CompiledWorkflowOptions, WorkflowUpdateOptions } from './workflow-options';
-import type { ActivityHandle, ActivityOptions } from './activity-client';
+import type { ActivityDescribeOptions, ActivityHandle, ActivityOptions } from './activity-client';
 
 export { Headers, Next };
 
@@ -437,6 +437,7 @@ export interface ActivityDescribeInput {
   readonly activityId: string;
   readonly activityRunId: string;
   readonly headers: Headers;
+  readonly options: Required<ActivityDescribeOptions>;
 }
 
 /**

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -261,6 +261,7 @@ export interface ActivityExecutionInfo {
   typedSearchAttributes: TypedSearchAttributes;
   taskQueue: string;
   executionDurationMs?: number;
+  executionTime?: Date;
 }
 
 /**
@@ -288,9 +289,20 @@ export interface ActivityExecutionDescription extends ActivityExecutionInfo {
   lastDeploymentVersion?: WorkerDeploymentVersion;
   priority: Priority;
   canceledReason?: string;
+  startDelayMs?: number;
+  totalHeartbeatCount?: Long;
+
+  hasHeartbeatDetails: boolean;
+  hasLastFailure: boolean;
+  hasInput: boolean;
+  hasResult: boolean;
+  hasOutcomeFailure: boolean;
 
   getHeartbeatDetails<T = any>(): Promise<T | undefined>;
   getLastFailure(): Promise<Error | undefined>;
+  getInput<T extends any[] = any[]>(): Promise<T | undefined>;
+  getResult<T = any>(): Promise<T | undefined>;
+  getOutcomeFailure(): Promise<Error | undefined>;
 }
 
 /**

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -290,7 +290,7 @@ export interface ActivityExecutionDescription extends ActivityExecutionInfo {
   priority: Priority;
   canceledReason?: string;
   startDelayMs?: number;
-  totalHeartbeatCount?: Long;
+  totalHeartbeatCount?: number;
 
   hasHeartbeatDetails: boolean;
   hasLastFailure: boolean;

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -292,16 +292,58 @@ export interface ActivityExecutionDescription extends ActivityExecutionInfo {
   startDelayMs?: number;
   totalHeartbeatCount?: number;
 
+  /**
+   * True if heartbeat details are available.
+   * Always false if {@link import('activity-client').ActivityDescribeOptions.includeHeartbeatDetails} was false.
+   */
   hasHeartbeatDetails: boolean;
+  /**
+   * True if last failure is available.
+   * Always false if {@link import('activity-client').ActivityDescribeOptions.includeLastFailure} was false.
+   */
   hasLastFailure: boolean;
+  /**
+   * True if activity input is available.
+   * Always false if {@link import('activity-client').ActivityDescribeOptions.includeInput} was false.
+   */
   hasInput: boolean;
+  /**
+   * True if activity result is available. The activity must have completed successfully for result to be available.
+   * Always false if {@link import('activity-client').ActivityDescribeOptions.includeOutcome} was false.
+   */
   hasResult: boolean;
+  /**
+   * True if outcome failure is available. The activity must have closed with a failure for outcome failure to be
+   * available. Always false if {@link import('activity-client').ActivityDescribeOptions.includeOutcome} was false.
+   */
   hasOutcomeFailure: boolean;
 
+  /**
+   * Deserializes heartbeat details. Returns undefined if heartbeat details are unavailable. Always returns undefined
+   * if {@link import('activity-client').ActivityDescribeOptions.includeHeartbeatDetails} was false.
+   */
   getHeartbeatDetails<T = any>(): Promise<T | undefined>;
+  /**
+   * Deserializes last failure. Returns undefined if last failure is unavailable.
+   * Always returns undefined if {@link import('activity-client').ActivityDescribeOptions.includeLastFailure} was false.
+   */
   getLastFailure(): Promise<Error | undefined>;
+  /**
+   * Deserializes activity input. Returns undefined if input is unavailable.
+   * Always returns undefined if {@link import('activity-client').ActivityDescribeOptions.includeInput} was false.
+   */
   getInput<T extends any[] = any[]>(): Promise<T | undefined>;
+  /**
+   * Deserializes activity result. Returns undefined if result is unavailable.
+   * The activity must have completed successfully for result to be available.
+   * Always returns undefined if {@link import('activity-client').ActivityDescribeOptions.includeOutcome} was false.
+   */
   getResult<T = any>(): Promise<T | undefined>;
+  /**
+   * Deserializes heartbeat details. Returns undefined if heartbeat details are unavailable.
+   * The activity must have closed with a failure for outcome failure to be available.
+   * Always returns undefined if {@link import('activity-client').ActivityDescribeOptions.includeOutcome} was false.
+   */
   getOutcomeFailure(): Promise<Error | undefined>;
 }
 

--- a/packages/test/src/test-standalone-activities.cloud-pending.ts
+++ b/packages/test/src/test-standalone-activities.cloud-pending.ts
@@ -20,7 +20,7 @@ import {
 import type { Payload, PayloadCodec, PayloadTypeInfo } from '@temporalio/common';
 import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
 import type { Info } from '@temporalio/activity';
-import { activityInfo } from '@temporalio/activity';
+import { activityInfo, heartbeat } from '@temporalio/activity';
 import type { TestWorkflowEnvironment } from './helpers';
 import { RUN_INTEGRATION_TESTS, waitUntil, Worker } from './helpers';
 import { echo, throwAnError } from './activities';
@@ -66,6 +66,13 @@ const activities = {
     if (info.workflowType !== undefined) {
       throw ApplicationFailure.nonRetryable('Expected workflowNamespace to be unset');
     }
+  },
+  heartbeatFailComplete: async (_input: string) => {
+    heartbeat('heartbeat details');
+    if (activityInfo().attempt === 1) {
+      throw ApplicationFailure.create({ message: 'first attempt failure' });
+    }
+    return 'result';
   },
 };
 
@@ -463,6 +470,65 @@ if (RUN_INTEGRATION_TESTS) {
       status: 'COMPLETED',
       taskQueue,
     });
+  });
+
+  test('Describe activity with payloads - success', async (t) => {
+    const client = t.context.env.client.activity;
+    const activityId = randomUUID();
+    const handle = await client.start('heartbeatFailComplete', {
+      ...defaultOptions,
+      id: activityId,
+      args: ['input'],
+    });
+
+    t.is(await handle.result(), 'result');
+
+    const description = await handle.describe({
+      includeInput: true,
+      includeOutcome: true,
+      includeHeartbeatDetails: true,
+      includeLastFailure: true,
+    });
+    t.true(description.hasInput);
+    t.true(description.hasResult);
+    t.true(description.hasHeartbeatDetails);
+    t.true(description.hasLastFailure);
+    t.false(description.hasOutcomeFailure);
+    t.deepEqual(await description.getInput<[string]>(), ['input']);
+    t.is(await description.getResult<string>(), 'result');
+    t.is(await description.getHeartbeatDetails<string>(), 'heartbeat details');
+    t.is((await description.getLastFailure())?.message, 'first attempt failure');
+    t.is(await description.getOutcomeFailure(), undefined);
+  });
+
+  test('Describe activity with payloads - failure', async (t) => {
+    const client = t.context.env.client.activity;
+    const activityId = randomUUID();
+    const handle = await client.start('heartbeatFailComplete', {
+      ...defaultOptions,
+      id: activityId,
+      args: ['input'],
+      retry: { maximumAttempts: 1 },
+    });
+
+    await t.throwsAsync(() => handle.result(), { instanceOf: ActivityExecutionFailedError });
+
+    const description = await handle.describe({
+      includeInput: true,
+      includeOutcome: true,
+      includeHeartbeatDetails: true,
+      includeLastFailure: true,
+    });
+    t.true(description.hasInput);
+    t.false(description.hasResult);
+    t.true(description.hasHeartbeatDetails);
+    t.true(description.hasLastFailure);
+    t.true(description.hasOutcomeFailure);
+    t.deepEqual(await description.getInput<[string]>(), ['input']);
+    t.is(await description.getResult<string>(), undefined);
+    t.is(await description.getHeartbeatDetails<string>(), 'heartbeat details');
+    t.is((await description.getLastFailure())?.message, 'first attempt failure');
+    t.is((await description.getOutcomeFailure())?.message, 'first attempt failure');
   });
 
   test('Cancel activity', async (t) => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Add `ActivityDescribeOptions` for `ActivityHandle.describe` that enable fetching optional payload fields.

## Why?
<!-- Tell your future self why have you made these changes -->
Implements support for new API feature.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
New tests in `test-standalone-activities.cloud-pending.ts`