### PR TITLE
feat(activity): Standalone Activities operator commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ to docs, or any other relevant information.
 
 ### Added
 
+- **Experimental**: New methods for `ActivityHandle`: `pause`, `unpause`, `updateOptions` and `restoreOriginalOptions`. 
 - **Experimental**: `@temporalio/openai-agents` can run OpenAI Agents `SandboxAgent`s as Temporal Workflows. SandboxAgent
   operations are Activities; hosted tool credentials and sandbox environment values that reference allowlisted Worker
   environment variables are resolved on Worker so their values are not recorded in Workflow history.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,6 @@ to docs, or any other relevant information.
 
 ### Changed
 
-- `ActivityClient` now passes serialization context to data converter when interacting with standalone activities.
 - A workflow query issued from inside a Nexus operation handler now propagates the link the server
   returns for the workflow that processed it, so the caller's Nexus operation event points back at
   the queried workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ to docs, or any other relevant information.
 
 ### Added
 
-- **Experimental**: New methods for `ActivityHandle`: `pause`, `unpause`, `updateOptions` and `restoreOriginalOptions`. 
+- **Experimental**: New methods for `ActivityHandle`: `pause`, `unpause`, `updateOptions` and `restoreOriginalOptions`.
 - **Experimental**: `@temporalio/openai-agents` can run OpenAI Agents `SandboxAgent`s as Temporal Workflows. SandboxAgent
   operations are Activities; hosted tool credentials and sandbox environment values that reference allowlisted Worker
   environment variables are resolved on Worker so their values are not recorded in Workflow history.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ to docs, or any other relevant information.
 
 ### Changed
 
+- `ActivityClient` now passes serialization context to data converter when interacting with standalone activities.
 - A workflow query issued from inside a Nexus operation handler now propagates the link the server
   returns for the workflow that processed it, so the caller's Nexus operation event points back at
   the queried workflow.

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -19,7 +19,7 @@ import {
   decompileRetryPolicy,
 } from '@temporalio/common';
 import type { Duration } from '@temporalio/common/lib/time';
-import { msOptionalToTs, msToNumber, optionalTsToDate, optionalTsToMs } from '@temporalio/common/lib/time';
+import { msOptionalToTs, msToNumber, optionalTsToDate, optionalTsToNonZeroMs } from '@temporalio/common/lib/time';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import {
   decodeTypedSearchAttributes,
@@ -48,8 +48,12 @@ import type {
   ActivityDescribeInput,
   ActivityGetResultInput,
   ActivityListInput,
+  ActivityPauseInput,
+  ActivityRestoreOriginalOptionsInput,
   ActivityStartInput,
   ActivityTerminateInput,
+  ActivityUnpauseInput,
+  ActivityUpdateOptionsInput,
 } from './interceptors';
 import type { AsyncCompletionClientOptions } from './async-completion-client';
 import { AsyncCompletionClient } from './async-completion-client';
@@ -110,6 +114,14 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       terminate: composeInterceptors(interceptors, 'terminate', this.terminateHandler.bind(this)),
       list: composeInterceptors(interceptors, 'list', this.listHandler.bind(this)),
       count: composeInterceptors(interceptors, 'count', this.countHandler.bind(this)),
+      pause: composeInterceptors(interceptors, 'pause', this.pauseHandler.bind(this)),
+      unpause: composeInterceptors(interceptors, 'unpause', this.unpauseHandler.bind(this)),
+      updateOptions: composeInterceptors(interceptors, 'updateOptions', this.updateOptionsHandler.bind(this)),
+      restoreOriginalOptions: composeInterceptors(
+        interceptors,
+        'restoreOriginalOptions',
+        this.restoreOriginalOptionsHandler.bind(this)
+      ),
     };
   }
 
@@ -265,6 +277,41 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
           activityId: this.activityId,
           activityRunId: this.runId ?? '',
           reason,
+          headers: {},
+        });
+      },
+
+      async pause(options?: ActivityPauseOptions): Promise<void> {
+        return await this.client.interceptedHandlers.pause({
+          activityId: this.activityId,
+          activityRunId: this.runId ?? '',
+          options: options || {},
+          headers: {},
+        });
+      },
+
+      async unpause(options?: ActivityUnpauseOptions): Promise<void> {
+        return await this.client.interceptedHandlers.unpause({
+          activityId: this.activityId,
+          activityRunId: this.runId ?? '',
+          options: options || {},
+          headers: {},
+        });
+      },
+
+      async updateOptions(options: ActivityOptionsUpdate): Promise<ActivityOptionsUpdate> {
+        return await this.client.interceptedHandlers.updateOptions({
+          activityId: this.activityId,
+          activityRunId: this.runId ?? '',
+          options,
+          headers: {},
+        });
+      },
+
+      async restoreOriginalOptions(): Promise<ActivityOptionsUpdate> {
+        return await this.client.interceptedHandlers.restoreOriginalOptions({
+          activityId: this.activityId,
+          activityRunId: this.runId ?? '',
           headers: {},
         });
       },
@@ -517,6 +564,124 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
     }
   }
 
+  protected async pauseHandler(input: ActivityPauseInput): Promise<void> {
+    if (!input.activityId) {
+      throw new TypeError('activityId is required');
+    }
+
+    try {
+      await this.workflowService.pauseActivityExecution({
+        namespace: this.options.namespace,
+        activityId: input.activityId,
+        runId: input.activityRunId || undefined,
+        identity: this.options.identity,
+        requestId: randomUUID(),
+        reason: input.options.reason || undefined,
+      });
+    } catch (err) {
+      this.rethrowGrpcError(err, 'Failed to request activity pause');
+    }
+  }
+
+  protected async unpauseHandler(input: ActivityUnpauseInput): Promise<void> {
+    if (!input.activityId) {
+      throw new TypeError('activityId is required');
+    }
+
+    try {
+      await this.workflowService.unpauseActivityExecution({
+        namespace: this.options.namespace,
+        activityId: input.activityId,
+        runId: input.activityRunId || undefined,
+        identity: this.options.identity,
+        requestId: randomUUID(),
+        reason: input.options.reason || undefined,
+        jitter: msOptionalToTs(input.options.jitter),
+      });
+    } catch (err) {
+      this.rethrowGrpcError(err, 'Failed to request activity unpause');
+    }
+  }
+
+  protected async updateOptionsHandler(input: ActivityUpdateOptionsInput): Promise<ActivityOptionsUpdate> {
+    if (!input.activityId) {
+      throw new TypeError('activityId is required');
+    }
+
+    const paths = [];
+    // != null because taskQueue can't be unset
+    if (input.options.taskQueue != null) {
+      paths.push('task_queue.name');
+    }
+    if (input.options.scheduleToCloseTimeout !== undefined) {
+      paths.push('schedule_to_close_timeout');
+    }
+    if (input.options.scheduleToStartTimeout !== undefined) {
+      paths.push('schedule_to_start_timeout');
+    }
+    if (input.options.startToCloseTimeout !== undefined) {
+      paths.push('start_to_close_timeout');
+    }
+    if (input.options.heartbeatTimeout !== undefined) {
+      paths.push('heartbeat_timeout');
+    }
+    if (input.options.retry !== undefined) {
+      paths.push('retry_policy');
+    }
+    if (input.options.priority !== undefined) {
+      paths.push('priority');
+    }
+    if (input.options.startDelay !== undefined) {
+      paths.push('start_delay');
+    }
+
+    try {
+      const resp = await this.workflowService.updateActivityExecutionOptions({
+        namespace: this.options.namespace,
+        activityId: input.activityId,
+        runId: input.activityRunId || undefined,
+        identity: this.options.identity,
+        requestId: randomUUID(),
+        activityOptions: {
+          taskQueue: input.options.taskQueue != null ? { name: input.options.taskQueue } : undefined,
+          scheduleToCloseTimeout: msOptionalToTs(input.options.scheduleToCloseTimeout),
+          scheduleToStartTimeout: msOptionalToTs(input.options.scheduleToStartTimeout),
+          startToCloseTimeout: msOptionalToTs(input.options.startToCloseTimeout),
+          heartbeatTimeout: msOptionalToTs(input.options.heartbeatTimeout),
+          retryPolicy: input.options.retry ? compileRetryPolicy(input.options.retry) : undefined,
+          priority: input.options.priority ? compilePriority(input.options.priority) : undefined,
+          startDelay: msOptionalToTs(input.options.startDelay),
+        },
+        updateMask: { paths },
+      });
+      return activityOptionsUpdateFromProto(resp.activityOptions);
+    } catch (err) {
+      this.rethrowGrpcError(err, 'Failed to request activity cancellation');
+    }
+  }
+
+  protected async restoreOriginalOptionsHandler(
+    input: ActivityRestoreOriginalOptionsInput
+  ): Promise<ActivityOptionsUpdate> {
+    if (!input.activityId) {
+      throw new TypeError('activityId is required');
+    }
+
+    try {
+      const resp = await this.workflowService.updateActivityExecutionOptions({
+        namespace: this.options.namespace,
+        activityId: input.activityId,
+        runId: input.activityRunId || undefined,
+        identity: this.options.identity,
+        requestId: randomUUID(),
+        restoreOriginal: true,
+      });
+      return activityOptionsUpdateFromProto(resp.activityOptions);
+    } catch (err) {
+      this.rethrowGrpcError(err, 'Failed to request activity cancellation');
+    }
+  }
+
   protected rethrowGrpcError(err: unknown, fallbackMessage: string): never {
     if (isGrpcServiceError(err)) {
       rethrowKnownErrorTypes(err);
@@ -564,6 +729,26 @@ export interface ActivityHandle<R = any> {
    * Terminates the Activity execution. Note that the worker is not immediately notified of termination and may continue running the activity.
    */
   terminate(reason: string): Promise<void>;
+  /**
+   * Requests Activity execution pause. Note that pausing is cooperative and not guaranteed to happen.
+   */
+  pause(options?: ActivityPauseOptions): Promise<void>;
+  /**
+   * Unpauses the Activity execution if it was previously paused.
+   */
+  unpause(options?: ActivityUnpauseOptions): Promise<void>;
+  /**
+   * Updates activity options of a running activity execution. See documentation for {@link ActivityOptionsUpdate}.
+   *
+   * Returns current options after applying the update.
+   */
+  updateOptions(options?: ActivityOptionsUpdate): Promise<ActivityOptionsUpdate>;
+  /**
+   * Restores activity options of a running activity execution that it was originally started with.
+   *
+   * Returns current options after restoring.
+   */
+  restoreOriginalOptions(): Promise<ActivityOptionsUpdate>;
 }
 
 /**
@@ -662,6 +847,65 @@ export interface GetActivityHandleOptions {
   typeInfo?: Pick<PayloadTypeInfo, 'outputType'>;
 }
 
+/**
+ * Options for {@link ActivityHandle.pause}.
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
+export interface ActivityPauseOptions {
+  /**
+   * Reason for pausing.
+   */
+  reason?: string;
+}
+
+/**
+ * Options for {@link ActivityHandle.unpause}.
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
+export interface ActivityUnpauseOptions {
+  /**
+   * Reason for unpausing.
+   */
+  reason?: string;
+
+  /**
+   * If set, the activity will be available for execution after a random delay between zero and specified duration.
+   */
+  jitter?: Duration;
+}
+
+/**
+ * Specifies activity options to change in {@link ActivityHandle.updateOptions} operation.
+ *
+ * If a field is assigned non-null value, the option will be set to that value.
+ * If a field is explicitly assigned null, the option will be cleared.
+ * If a field is undefined, the option will be left unchanged.
+ *
+ * In a return value, currently unset fields are undefined.
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
+export interface ActivityOptionsUpdate {
+  /** {@inheritDoc ActivityOptions.taskQueue} */
+  taskQueue?: string;
+  /** {@inheritDoc ActivityOptions.scheduleToCloseTimeout} */
+  scheduleToCloseTimeout?: Duration | null;
+  /** {@inheritDoc ActivityOptions.scheduleToStartTimeout} */
+  scheduleToStartTimeout?: Duration | null;
+  /** {@inheritDoc ActivityOptions.startToCloseTimeout} */
+  startToCloseTimeout?: Duration | null;
+  /** {@inheritDoc ActivityOptions.heartbeatTimeout} */
+  heartbeatTimeout?: Duration | null;
+  /** {@inheritDoc ActivityOptions.retry} */
+  retry?: RetryPolicy | null;
+  /** {@inheritDoc ActivityOptions.priority} */
+  priority?: Priority | null;
+  /** {@inheritDoc ActivityOptions.startDelay} */
+  startDelay?: Duration | null;
+}
+
 function validateActivityOptions(options: ActivityOptions): void {
   if (!options.id) {
     throw new TypeError('id is required');
@@ -689,7 +933,7 @@ function buildActivityExecutionInfoCommonPart(
     status: decodeActivityExecutionStatus(info.status)!,
     typedSearchAttributes: decodeTypedSearchAttributes(info.searchAttributes?.indexedFields),
     taskQueue: info.taskQueue!,
-    executionDurationMs: optionalTsToMs(info.executionDuration),
+    executionDurationMs: optionalTsToNonZeroMs(info.executionDuration),
   };
 }
 
@@ -723,17 +967,17 @@ function buildActivityDescription(
     rawInfo: info,
     rawCallbacks: callbacks,
     runState: decodePendingActivityState(info.runState),
-    scheduleToCloseTimeoutMs: optionalTsToMs(info.scheduleToCloseTimeout),
-    scheduleToStartTimeoutMs: optionalTsToMs(info.scheduleToStartTimeout),
-    startToCloseTimeoutMs: optionalTsToMs(info.startToCloseTimeout),
-    heartbeatTimeoutMs: optionalTsToMs(info.heartbeatTimeout),
+    scheduleToCloseTimeoutMs: optionalTsToNonZeroMs(info.scheduleToCloseTimeout),
+    scheduleToStartTimeoutMs: optionalTsToNonZeroMs(info.scheduleToStartTimeout),
+    startToCloseTimeoutMs: optionalTsToNonZeroMs(info.startToCloseTimeout),
+    heartbeatTimeoutMs: optionalTsToNonZeroMs(info.heartbeatTimeout),
     retryPolicy: decompileRetryPolicy(info.retryPolicy)!,
     lastHeartbeatTime: optionalTsToDate(info.lastHeartbeatTime),
     lastStartedTime: optionalTsToDate(info.lastStartedTime),
     attempt: info.attempt!,
     expirationTime: optionalTsToDate(info.expirationTime),
     lastWorkerIdentity: info.lastWorkerIdentity || undefined,
-    currentRetryIntervalMs: optionalTsToMs(info.currentRetryInterval),
+    currentRetryIntervalMs: optionalTsToNonZeroMs(info.currentRetryInterval),
     lastAttemptCompleteTime: optionalTsToDate(info.lastAttemptCompleteTime),
     nextAttemptScheduleTime: optionalTsToDate(info.nextAttemptScheduleTime),
     lastDeploymentVersion: convertDeploymentVersion(info.lastDeploymentVersion),
@@ -742,6 +986,21 @@ function buildActivityDescription(
 
     getHeartbeatDetails,
     getLastFailure,
+  };
+}
+
+function activityOptionsUpdateFromProto(
+  proto?: temporal.api.activity.v1.IActivityOptions | null
+): ActivityOptionsUpdate {
+  return {
+    taskQueue: proto?.taskQueue?.name || undefined,
+    scheduleToCloseTimeout: optionalTsToNonZeroMs(proto?.scheduleToCloseTimeout),
+    scheduleToStartTimeout: optionalTsToNonZeroMs(proto?.scheduleToStartTimeout),
+    startToCloseTimeout: optionalTsToNonZeroMs(proto?.startToCloseTimeout),
+    heartbeatTimeout: optionalTsToNonZeroMs(proto?.heartbeatTimeout),
+    retry: decompileRetryPolicy(proto?.retryPolicy),
+    priority: proto?.priority ? decodePriority(proto.priority) : undefined,
+    startDelay: optionalTsToNonZeroMs(proto?.startDelay),
   };
 }
 

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -299,7 +299,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
         });
       },
 
-      async updateOptions(options: ActivityOptionsUpdate): Promise<ActivityOptionsUpdate> {
+      async updateOptions(options: ActivityOptionsUpdate): Promise<ActivityOptionsUpdateResult> {
         return await this.client.interceptedHandlers.updateOptions({
           activityId: this.activityId,
           activityRunId: this.runId ?? '',
@@ -603,7 +603,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
     }
   }
 
-  protected async updateOptionsHandler(input: ActivityUpdateOptionsInput): Promise<ActivityOptionsUpdate> {
+  protected async updateOptionsHandler(input: ActivityUpdateOptionsInput): Promise<ActivityOptionsUpdateResult> {
     if (!input.activityId) {
       throw new TypeError('activityId is required');
     }
@@ -654,7 +654,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
         },
         updateMask: { paths },
       });
-      return activityOptionsUpdateFromProto(resp.activityOptions);
+      return buildActivityOptionsUpdateResult(resp.activityOptions);
     } catch (err) {
       this.rethrowGrpcError(err, 'Failed to update activity options');
     }
@@ -676,7 +676,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
         requestId: randomUUID(),
         restoreOriginal: true,
       });
-      return activityOptionsUpdateFromProto(resp.activityOptions);
+      return buildActivityOptionsUpdateResult(resp.activityOptions);
     } catch (err) {
       this.rethrowGrpcError(err, 'Failed to restore original activity options');
     }
@@ -911,7 +911,7 @@ export interface ActivityOptionsUpdate {
  */
 export type ActivityOptionsUpdateResult = {
   [K in keyof ActivityOptionsUpdate]: Exclude<ActivityOptionsUpdate[K], null>;
-}
+};
 
 function validateActivityOptions(options: ActivityOptions): void {
   if (!options.id) {
@@ -996,9 +996,9 @@ function buildActivityDescription(
   };
 }
 
-function activityOptionsUpdateFromProto(
+function buildActivityOptionsUpdateResult(
   proto?: temporal.api.activity.v1.IActivityOptions | null
-): ActivityOptionsUpdate {
+): ActivityOptionsUpdateResult {
   return {
     taskQueue: proto?.taskQueue?.name || undefined,
     scheduleToCloseTimeout: optionalTsToNonZeroMs(proto?.scheduleToCloseTimeout),

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -608,31 +608,54 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       throw new TypeError('activityId is required');
     }
 
-    const paths = [];
+    const activityOptions: temporal.api.activity.v1.IActivityOptions = {};
+    const paths: string[] = [];
     // != null because taskQueue can't be unset
     if (input.options.taskQueue != null) {
       paths.push('task_queue.name');
+      activityOptions.taskQueue = { name: input.options.taskQueue };
     }
     if (input.options.scheduleToCloseTimeout !== undefined) {
       paths.push('schedule_to_close_timeout');
+      if (input.options.scheduleToCloseTimeout != null) {
+        activityOptions.scheduleToCloseTimeout = msOptionalToTs(input.options.scheduleToCloseTimeout);
+      }
     }
     if (input.options.scheduleToStartTimeout !== undefined) {
       paths.push('schedule_to_start_timeout');
+      if (input.options.scheduleToStartTimeout != null) {
+        activityOptions.scheduleToStartTimeout = msOptionalToTs(input.options.scheduleToStartTimeout);
+      }
     }
     if (input.options.startToCloseTimeout !== undefined) {
       paths.push('start_to_close_timeout');
+      if (input.options.startToCloseTimeout != null) {
+        activityOptions.startToCloseTimeout = msOptionalToTs(input.options.startToCloseTimeout);
+      }
     }
     if (input.options.heartbeatTimeout !== undefined) {
       paths.push('heartbeat_timeout');
+      if (input.options.heartbeatTimeout != null) {
+        activityOptions.heartbeatTimeout = msOptionalToTs(input.options.heartbeatTimeout);
+      }
     }
     if (input.options.retry !== undefined) {
       paths.push('retry_policy');
+      if (input.options.retry != null) {
+        activityOptions.retryPolicy = compileRetryPolicy(input.options.retry);
+      }
     }
     if (input.options.priority !== undefined) {
       paths.push('priority');
+      if (input.options.priority != null) {
+        activityOptions.priority = compilePriority(input.options.priority);
+      }
     }
     if (input.options.startDelay !== undefined) {
       paths.push('start_delay');
+      if (input.options.startDelay != null) {
+        activityOptions.startDelay = msOptionalToTs(input.options.startDelay);
+      }
     }
 
     try {
@@ -642,16 +665,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
         runId: input.activityRunId || undefined,
         identity: this.options.identity,
         requestId: randomUUID(),
-        activityOptions: {
-          taskQueue: input.options.taskQueue != null ? { name: input.options.taskQueue } : undefined,
-          scheduleToCloseTimeout: msOptionalToTs(input.options.scheduleToCloseTimeout),
-          scheduleToStartTimeout: msOptionalToTs(input.options.scheduleToStartTimeout),
-          startToCloseTimeout: msOptionalToTs(input.options.startToCloseTimeout),
-          heartbeatTimeout: msOptionalToTs(input.options.heartbeatTimeout),
-          retryPolicy: input.options.retry ? compileRetryPolicy(input.options.retry) : undefined,
-          priority: input.options.priority ? compilePriority(input.options.priority) : undefined,
-          startDelay: msOptionalToTs(input.options.startDelay),
-        },
+        activityOptions,
         updateMask: { paths },
       });
       return buildActivityOptionsUpdateResult(resp.activityOptions);

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -635,27 +635,19 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
     }
     if (input.options.scheduleToCloseTimeout !== undefined) {
       paths.push('schedule_to_close_timeout');
-      if (input.options.scheduleToCloseTimeout != null) {
-        activityOptions.scheduleToCloseTimeout = msOptionalToTs(input.options.scheduleToCloseTimeout);
-      }
+      activityOptions.scheduleToCloseTimeout = msOptionalToTs(input.options.scheduleToCloseTimeout);
     }
     if (input.options.scheduleToStartTimeout !== undefined) {
       paths.push('schedule_to_start_timeout');
-      if (input.options.scheduleToStartTimeout != null) {
-        activityOptions.scheduleToStartTimeout = msOptionalToTs(input.options.scheduleToStartTimeout);
-      }
+      activityOptions.scheduleToStartTimeout = msOptionalToTs(input.options.scheduleToStartTimeout);
     }
     if (input.options.startToCloseTimeout !== undefined) {
       paths.push('start_to_close_timeout');
-      if (input.options.startToCloseTimeout != null) {
-        activityOptions.startToCloseTimeout = msOptionalToTs(input.options.startToCloseTimeout);
-      }
+      activityOptions.startToCloseTimeout = msOptionalToTs(input.options.startToCloseTimeout);
     }
     if (input.options.heartbeatTimeout !== undefined) {
       paths.push('heartbeat_timeout');
-      if (input.options.heartbeatTimeout != null) {
-        activityOptions.heartbeatTimeout = msOptionalToTs(input.options.heartbeatTimeout);
-      }
+      activityOptions.heartbeatTimeout = msOptionalToTs(input.options.heartbeatTimeout);
     }
     if (input.options.retry !== undefined) {
       paths.push('retry_policy');
@@ -671,9 +663,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
     }
     if (input.options.startDelay !== undefined) {
       paths.push('start_delay');
-      if (input.options.startDelay != null) {
-        activityOptions.startDelay = msOptionalToTs(input.options.startDelay);
-      }
+      activityOptions.startDelay = msOptionalToTs(input.options.startDelay);
     }
 
     try {

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -19,7 +19,7 @@ import {
   decompileRetryPolicy,
 } from '@temporalio/common';
 import type { Duration } from '@temporalio/common/lib/time';
-import { msOptionalToTs, msToNumber, optionalTsToDate, optionalTsToNonZeroMs } from '@temporalio/common/lib/time';
+import { msOptionalToTs, msToNumber, optionalTsToDate, optionalTsToMs } from '@temporalio/common/lib/time';
 import { composeInterceptors } from '@temporalio/common/lib/interceptors';
 import {
   decodeTypedSearchAttributes,
@@ -940,7 +940,7 @@ function buildActivityExecutionInfoCommonPart(
     status: decodeActivityExecutionStatus(info.status)!,
     typedSearchAttributes: decodeTypedSearchAttributes(info.searchAttributes?.indexedFields),
     taskQueue: info.taskQueue!,
-    executionDurationMs: optionalTsToNonZeroMs(info.executionDuration),
+    executionDurationMs: optionalTsToMs(info.executionDuration),
   };
 }
 
@@ -974,17 +974,17 @@ function buildActivityDescription(
     rawInfo: info,
     rawCallbacks: callbacks,
     runState: decodePendingActivityState(info.runState),
-    scheduleToCloseTimeoutMs: optionalTsToNonZeroMs(info.scheduleToCloseTimeout),
-    scheduleToStartTimeoutMs: optionalTsToNonZeroMs(info.scheduleToStartTimeout),
-    startToCloseTimeoutMs: optionalTsToNonZeroMs(info.startToCloseTimeout),
-    heartbeatTimeoutMs: optionalTsToNonZeroMs(info.heartbeatTimeout),
+    scheduleToCloseTimeoutMs: optionalTsToMs(info.scheduleToCloseTimeout),
+    scheduleToStartTimeoutMs: optionalTsToMs(info.scheduleToStartTimeout),
+    startToCloseTimeoutMs: optionalTsToMs(info.startToCloseTimeout),
+    heartbeatTimeoutMs: optionalTsToMs(info.heartbeatTimeout),
     retryPolicy: decompileRetryPolicy(info.retryPolicy)!,
     lastHeartbeatTime: optionalTsToDate(info.lastHeartbeatTime),
     lastStartedTime: optionalTsToDate(info.lastStartedTime),
     attempt: info.attempt!,
     expirationTime: optionalTsToDate(info.expirationTime),
     lastWorkerIdentity: info.lastWorkerIdentity || undefined,
-    currentRetryIntervalMs: optionalTsToNonZeroMs(info.currentRetryInterval),
+    currentRetryIntervalMs: optionalTsToMs(info.currentRetryInterval),
     lastAttemptCompleteTime: optionalTsToDate(info.lastAttemptCompleteTime),
     nextAttemptScheduleTime: optionalTsToDate(info.nextAttemptScheduleTime),
     lastDeploymentVersion: convertDeploymentVersion(info.lastDeploymentVersion),
@@ -1001,13 +1001,13 @@ function buildActivityOptionsUpdateResult(
 ): ActivityOptionsUpdateResult {
   return {
     taskQueue: proto?.taskQueue?.name || undefined,
-    scheduleToCloseTimeout: optionalTsToNonZeroMs(proto?.scheduleToCloseTimeout),
-    scheduleToStartTimeout: optionalTsToNonZeroMs(proto?.scheduleToStartTimeout),
-    startToCloseTimeout: optionalTsToNonZeroMs(proto?.startToCloseTimeout),
-    heartbeatTimeout: optionalTsToNonZeroMs(proto?.heartbeatTimeout),
+    scheduleToCloseTimeout: optionalTsToMs(proto?.scheduleToCloseTimeout),
+    scheduleToStartTimeout: optionalTsToMs(proto?.scheduleToStartTimeout),
+    startToCloseTimeout: optionalTsToMs(proto?.startToCloseTimeout),
+    heartbeatTimeout: optionalTsToMs(proto?.heartbeatTimeout),
     retry: decompileRetryPolicy(proto?.retryPolicy),
     priority: proto?.priority ? decodePriority(proto.priority) : undefined,
-    startDelay: optionalTsToNonZeroMs(proto?.startDelay),
+    startDelay: optionalTsToMs(proto?.startDelay),
   };
 }
 

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -656,7 +656,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       });
       return activityOptionsUpdateFromProto(resp.activityOptions);
     } catch (err) {
-      this.rethrowGrpcError(err, 'Failed to request activity cancellation');
+      this.rethrowGrpcError(err, 'Failed to update activity options');
     }
   }
 
@@ -678,7 +678,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       });
       return activityOptionsUpdateFromProto(resp.activityOptions);
     } catch (err) {
-      this.rethrowGrpcError(err, 'Failed to request activity cancellation');
+      this.rethrowGrpcError(err, 'Failed to restore original activity options');
     }
   }
 
@@ -742,7 +742,7 @@ export interface ActivityHandle<R = any> {
    *
    * Returns current options after applying the update.
    */
-  updateOptions(options?: ActivityOptionsUpdate): Promise<ActivityOptionsUpdate>;
+  updateOptions(options: ActivityOptionsUpdate): Promise<ActivityOptionsUpdateResult>;
   /**
    * Restores activity options of a running activity execution that it was originally started with.
    *
@@ -883,8 +883,6 @@ export interface ActivityUnpauseOptions {
  * If a field is explicitly assigned null, the option will be cleared.
  * If a field is undefined, the option will be left unchanged.
  *
- * In a return value, currently unset fields are undefined.
- *
  * @experimental Standalone Activities are experimental. APIs may be subject to change.
  */
 export interface ActivityOptionsUpdate {
@@ -904,6 +902,15 @@ export interface ActivityOptionsUpdate {
   priority?: Priority | null;
   /** {@inheritDoc ActivityOptions.startDelay} */
   startDelay?: Duration | null;
+}
+
+/**
+ * Contains current activity options after applying an update. Returned by {@link ActivityHandle.updateOptions}.
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
+export type ActivityOptionsUpdateResult = {
+  [K in keyof ActivityOptionsUpdate]: Exclude<ActivityOptionsUpdate[K], null>;
 }
 
 function validateActivityOptions(options: ActivityOptions): void {

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -33,7 +33,13 @@ import type {
   WorkflowExecution,
 } from './types';
 import type { CompiledWorkflowOptions, WorkflowUpdateOptions } from './workflow-options';
-import type { ActivityHandle, ActivityOptions } from './activity-client';
+import type {
+  ActivityHandle,
+  ActivityOptions,
+  ActivityOptionsUpdate,
+  ActivityPauseOptions,
+  ActivityUnpauseOptions,
+} from './activity-client';
 
 export { Headers, Next };
 
@@ -402,6 +408,28 @@ export interface ActivityClientInterceptor {
    * Intercept a service call to countActivityExecutions
    */
   count?: (input: ActivityCountInput, next: Next<this, 'count'>) => Promise<CountActivityExecutions>;
+  /**
+   * Intercept a service call to pauseActivityExecution
+   */
+  pause?: (input: ActivityPauseInput, next: Next<this, 'pause'>) => Promise<void>;
+  /**
+   * Intercept a service call to unpauseActivityExecution
+   */
+  unpause?: (input: ActivityUnpauseInput, next: Next<this, 'unpause'>) => Promise<void>;
+  /**
+   * Intercept a service call to updateActivityExecutionOptions(restoreOriginal=false)
+   */
+  updateOptions?: (
+    input: ActivityUpdateOptionsInput,
+    next: Next<this, 'updateOptions'>
+  ) => Promise<ActivityOptionsUpdate>;
+  /**
+   * Intercept a service call to updateActivityExecutionOptions(restoreOriginal=true)
+   */
+  restoreOriginalOptions?: (
+    input: ActivityRestoreOriginalOptionsInput,
+    next: Next<this, 'restoreOriginalOptions'>
+  ) => Promise<ActivityOptionsUpdate>;
 }
 
 /**
@@ -480,5 +508,52 @@ export interface ActivityListInput {
  */
 export interface ActivityCountInput {
   readonly query: string;
+  readonly headers: Headers;
+}
+
+/**
+ * Input for {@link ActivityClientInterceptor.pause}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
+export interface ActivityPauseInput {
+  readonly activityId: string;
+  readonly activityRunId: string;
+  readonly options: ActivityPauseOptions;
+  readonly headers: Headers;
+}
+
+/**
+ * Input for {@link ActivityClientInterceptor.unpause}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
+export interface ActivityUnpauseInput {
+  readonly activityId: string;
+  readonly activityRunId: string;
+  readonly options: ActivityUnpauseOptions;
+  readonly headers: Headers;
+}
+
+/**
+ * Input for {@link ActivityClientInterceptor.updateOptions}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
+export interface ActivityUpdateOptionsInput {
+  readonly activityId: string;
+  readonly activityRunId: string;
+  readonly options: ActivityOptionsUpdate;
+  readonly headers: Headers;
+}
+
+/**
+ * Input for {@link ActivityClientInterceptor.restoreOriginalOptions}
+ *
+ * @experimental Standalone Activities are experimental. APIs may be subject to change.
+ */
+export interface ActivityRestoreOriginalOptionsInput {
+  readonly activityId: string;
+  readonly activityRunId: string;
   readonly headers: Headers;
 }

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -37,6 +37,7 @@ import type {
   ActivityHandle,
   ActivityOptions,
   ActivityOptionsUpdate,
+  ActivityOptionsUpdateResult,
   ActivityPauseOptions,
   ActivityUnpauseOptions,
 } from './activity-client';
@@ -422,7 +423,7 @@ export interface ActivityClientInterceptor {
   updateOptions?: (
     input: ActivityUpdateOptionsInput,
     next: Next<this, 'updateOptions'>
-  ) => Promise<ActivityOptionsUpdate>;
+  ) => Promise<ActivityOptionsUpdateResult>;
   /**
    * Intercept a service call to updateActivityExecutionOptions(restoreOriginal=true)
    */

--- a/packages/common/src/time.ts
+++ b/packages/common/src/time.ts
@@ -114,3 +114,12 @@ export function optionalDateToTs(date: Date | null | undefined): Timestamp | und
   }
   return msToTs(date.getTime());
 }
+
+/**
+ * Lossy conversion function from Timestamp to number due to possible overflow.
+ * If ts is zero, null or undefined returns undefined.
+ */
+export function optionalTsToNonZeroMs(ts?: Timestamp | null): number | undefined {
+  const ms = optionalTsToMs(ts);
+  return ms === 0 ? undefined : ms;
+}

--- a/packages/common/src/time.ts
+++ b/packages/common/src/time.ts
@@ -114,12 +114,3 @@ export function optionalDateToTs(date: Date | null | undefined): Timestamp | und
   }
   return msToTs(date.getTime());
 }
-
-/**
- * Lossy conversion function from Timestamp to number due to possible overflow.
- * If ts is zero, null or undefined returns undefined.
- */
-export function optionalTsToNonZeroMs(ts?: Timestamp | null): number | undefined {
-  const ms = optionalTsToMs(ts);
-  return ms === 0 ? undefined : ms;
-}

--- a/packages/test/src/test-standalone-activities.cloud-pending.ts
+++ b/packages/test/src/test-standalone-activities.cloud-pending.ts
@@ -21,8 +21,9 @@ import type { Payload, PayloadCodec, PayloadTypeInfo } from '@temporalio/common'
 import { ApplicationFailure, CancelledFailure } from '@temporalio/common';
 import type { Info } from '@temporalio/activity';
 import { activityInfo } from '@temporalio/activity';
+import { msToNumber } from '@temporalio/common/lib/time';
 import type { TestWorkflowEnvironment } from './helpers';
-import { RUN_INTEGRATION_TESTS, waitUntil, Worker } from './helpers';
+import { assertEventually, RUN_INTEGRATION_TESTS, waitUntil, Worker } from './helpers';
 import { echo, throwAnError } from './activities';
 import { heartbeatCancellationDetailsActivity } from './activities/heartbeat-cancellation-details';
 import { createTestWorkflowEnvironment } from './helpers-integration';
@@ -862,5 +863,105 @@ if (RUN_INTEGRATION_TESTS) {
     };
 
     t.pass();
+  });
+
+  test('Pause and unpause activity', async (t) => {
+    const client = t.context.env.client.activity;
+    const activityId = randomUUID();
+    const handle = await client.start('nonexistent-activity', {
+      ...defaultOptions,
+      id: activityId,
+    });
+
+    async function assertStatus(status: ActivityExecutionStatus): Promise<void> {
+      await assertEventually(t, async (tt) => {
+        tt.is((await handle.describe()).status, status);
+      });
+    }
+
+    await assertStatus(ActivityExecutionStatus.RUNNING);
+    await handle.pause();
+    await assertStatus(ActivityExecutionStatus.PAUSED);
+    await handle.unpause();
+    await assertStatus(ActivityExecutionStatus.RUNNING);
+    await handle.terminate('test cleanup');
+  });
+
+  test('Update activity options', async (t) => {
+    const originalDuration = msToNumber('5m');
+    const updatedDuration = msToNumber('10m');
+
+    const client = t.context.env.client.activity;
+    const activityId = randomUUID();
+    const handle = await client.start('nonexistent-activity', {
+      id: activityId,
+      taskQueue: 'original-task-queue',
+      scheduleToCloseTimeout: undefined,
+      scheduleToStartTimeout: undefined,
+      startToCloseTimeout: originalDuration,
+      heartbeatTimeout: originalDuration,
+      retry: { initialInterval: originalDuration },
+      priority: { fairnessKey: 'original' },
+      startDelay: originalDuration,
+    });
+
+    const updatedOptions = await handle.updateOptions({
+      scheduleToStartTimeout: updatedDuration,
+      startToCloseTimeout: updatedDuration,
+      heartbeatTimeout: undefined,
+      retry: { maximumInterval: updatedDuration },
+      priority: null,
+      startDelay: null,
+    });
+    t.is(updatedOptions.taskQueue, 'original-task-queue');
+    t.is(updatedOptions.scheduleToCloseTimeout, undefined);
+    t.is(updatedOptions.scheduleToStartTimeout, updatedDuration);
+    t.is(updatedOptions.startToCloseTimeout, updatedDuration);
+    t.is(updatedOptions.heartbeatTimeout, originalDuration);
+    t.not(updatedOptions.retry?.initialInterval, originalDuration); // retry policy has defaults
+    t.is(updatedOptions.retry?.maximumInterval, updatedDuration);
+    t.is(updatedOptions.priority, undefined);
+    t.is(updatedOptions.startDelay, undefined);
+
+    await assertEventually(t, async (tt) => {
+      const desc = await handle.describe();
+      tt.is(desc.taskQueue, 'original-task-queue');
+      tt.is(desc.scheduleToCloseTimeoutMs, undefined);
+      tt.is(desc.scheduleToStartTimeoutMs, updatedDuration);
+      tt.is(desc.startToCloseTimeoutMs, updatedDuration);
+      tt.is(desc.heartbeatTimeoutMs, originalDuration);
+      tt.not(desc.retryPolicy.initialInterval, originalDuration);
+      tt.is(desc.retryPolicy.maximumInterval, updatedDuration);
+      tt.is(desc.priority.fairnessKey, undefined);
+      // TODO: uncomment when added
+      // tt.is(desc.startDelay, undefined);
+    });
+
+    const originalOptions = await handle.restoreOriginalOptions();
+    t.is(originalOptions.taskQueue, 'original-task-queue');
+    t.is(updatedOptions.scheduleToCloseTimeout, undefined);
+    t.is(originalOptions.scheduleToStartTimeout, undefined);
+    t.is(originalOptions.startToCloseTimeout, originalDuration);
+    t.is(originalOptions.heartbeatTimeout, originalDuration);
+    t.is(originalOptions.retry?.initialInterval, originalDuration);
+    t.not(originalOptions.retry?.maximumInterval, updatedDuration);
+    t.is(originalOptions.priority?.fairnessKey, 'original');
+    t.is(originalOptions.startDelay, originalDuration);
+
+    await assertEventually(t, async (tt) => {
+      const desc = await handle.describe();
+      tt.is(desc.taskQueue, 'original-task-queue');
+      tt.is(desc.scheduleToCloseTimeoutMs, undefined);
+      tt.is(desc.scheduleToStartTimeoutMs, undefined);
+      tt.is(desc.startToCloseTimeoutMs, originalDuration);
+      tt.is(desc.heartbeatTimeoutMs, originalDuration);
+      tt.is(desc.retryPolicy.initialInterval, originalDuration);
+      tt.not(desc.retryPolicy.maximumInterval, updatedDuration);
+      tt.is(desc.priority.fairnessKey, 'original');
+      // TODO: uncomment when added
+      // tt.is(desc.startDelay, undefined);
+    });
+
+    await handle.terminate('test cleanup');
   });
 }

--- a/packages/test/src/test-standalone-activities.cloud-pending.ts
+++ b/packages/test/src/test-standalone-activities.cloud-pending.ts
@@ -914,33 +914,33 @@ if (RUN_INTEGRATION_TESTS) {
       startDelay: null,
     });
     t.is(updatedOptions.taskQueue, 'original-task-queue');
-    t.is(updatedOptions.scheduleToCloseTimeout, undefined);
+    t.falsy(updatedOptions.scheduleToCloseTimeout);
     t.is(updatedOptions.scheduleToStartTimeout, updatedDuration);
     t.is(updatedOptions.startToCloseTimeout, updatedDuration);
     t.is(updatedOptions.heartbeatTimeout, originalDuration);
     t.not(updatedOptions.retry?.initialInterval, originalDuration); // retry policy has defaults
     t.is(updatedOptions.retry?.maximumInterval, updatedDuration);
-    t.is(updatedOptions.priority, undefined);
-    t.is(updatedOptions.startDelay, undefined);
+    t.falsy(updatedOptions.priority);
+    t.falsy(updatedOptions.startDelay);
 
     await assertEventually(t, async (tt) => {
       const desc = await handle.describe();
       tt.is(desc.taskQueue, 'original-task-queue');
-      tt.is(desc.scheduleToCloseTimeoutMs, undefined);
+      tt.falsy(desc.scheduleToCloseTimeoutMs);
       tt.is(desc.scheduleToStartTimeoutMs, updatedDuration);
       tt.is(desc.startToCloseTimeoutMs, updatedDuration);
       tt.is(desc.heartbeatTimeoutMs, originalDuration);
       tt.not(desc.retryPolicy.initialInterval, originalDuration);
       tt.is(desc.retryPolicy.maximumInterval, updatedDuration);
-      tt.is(desc.priority.fairnessKey, undefined);
+      tt.falsy(desc.priority.fairnessKey);
       // TODO: uncomment when added
       // tt.is(desc.startDelay, undefined);
     });
 
     const originalOptions = await handle.restoreOriginalOptions();
     t.is(originalOptions.taskQueue, 'original-task-queue');
-    t.is(originalOptions.scheduleToCloseTimeout, undefined);
-    t.is(originalOptions.scheduleToStartTimeout, undefined);
+    t.falsy(originalOptions.scheduleToCloseTimeout);
+    t.falsy(originalOptions.scheduleToStartTimeout);
     t.is(originalOptions.startToCloseTimeout, originalDuration);
     t.is(originalOptions.heartbeatTimeout, originalDuration);
     t.is(originalOptions.retry?.initialInterval, originalDuration);
@@ -951,8 +951,8 @@ if (RUN_INTEGRATION_TESTS) {
     await assertEventually(t, async (tt) => {
       const desc = await handle.describe();
       tt.is(desc.taskQueue, 'original-task-queue');
-      tt.is(desc.scheduleToCloseTimeoutMs, undefined);
-      tt.is(desc.scheduleToStartTimeoutMs, undefined);
+      tt.falsy(desc.scheduleToCloseTimeoutMs);
+      tt.falsy(desc.scheduleToStartTimeoutMs);
       tt.is(desc.startToCloseTimeoutMs, originalDuration);
       tt.is(desc.heartbeatTimeoutMs, originalDuration);
       tt.is(desc.retryPolicy.initialInterval, originalDuration);

--- a/packages/test/src/test-standalone-activities.cloud-pending.ts
+++ b/packages/test/src/test-standalone-activities.cloud-pending.ts
@@ -155,12 +155,7 @@ if (RUN_INTEGRATION_TESTS) {
   test.before(async (t) => {
     const env = await createTestWorkflowEnvironment({
       server: {
-        extraArgs: [
-          '--dynamic-config-value',
-          `activity.longPollTimeout="${LONG_POLL_TIMEOUT_MS}ms"`,
-          '--dynamic-config-value',
-          'activity.startDelayEnabled=true',
-        ],
+        extraArgs: ['--dynamic-config-value', `activity.longPollTimeout="${LONG_POLL_TIMEOUT_MS}ms"`],
       },
     });
 
@@ -1075,7 +1070,7 @@ if (RUN_INTEGRATION_TESTS) {
       tt.is(desc.retryPolicy.initialInterval, originalDuration);
       tt.not(desc.retryPolicy.maximumInterval, updatedDuration);
       tt.is(desc.priority.fairnessKey, 'original');
-      tt.falsy(desc.startDelayMs);
+      tt.is(desc.startDelayMs, originalDuration);
     });
 
     await handle.terminate('test cleanup');

--- a/packages/test/src/test-standalone-activities.cloud-pending.ts
+++ b/packages/test/src/test-standalone-activities.cloud-pending.ts
@@ -999,8 +999,7 @@ if (RUN_INTEGRATION_TESTS) {
       tt.not(desc.retryPolicy.initialInterval, originalDuration);
       tt.is(desc.retryPolicy.maximumInterval, updatedDuration);
       tt.falsy(desc.priority.fairnessKey);
-      // TODO: uncomment when added
-      // tt.is(desc.startDelay, undefined);
+      tt.falsy(desc.startDelayMs);
     });
 
     const originalOptions = await handle.restoreOriginalOptions();
@@ -1024,8 +1023,7 @@ if (RUN_INTEGRATION_TESTS) {
       tt.is(desc.retryPolicy.initialInterval, originalDuration);
       tt.not(desc.retryPolicy.maximumInterval, updatedDuration);
       tt.is(desc.priority.fairnessKey, 'original');
-      // TODO: uncomment when added
-      // tt.is(desc.startDelay, undefined);
+      tt.falsy(desc.startDelayMs);
     });
 
     await handle.terminate('test cleanup');

--- a/packages/test/src/test-standalone-activities.cloud-pending.ts
+++ b/packages/test/src/test-standalone-activities.cloud-pending.ts
@@ -939,7 +939,7 @@ if (RUN_INTEGRATION_TESTS) {
 
     const originalOptions = await handle.restoreOriginalOptions();
     t.is(originalOptions.taskQueue, 'original-task-queue');
-    t.is(updatedOptions.scheduleToCloseTimeout, undefined);
+    t.is(originalOptions.scheduleToCloseTimeout, undefined);
     t.is(originalOptions.scheduleToStartTimeout, undefined);
     t.is(originalOptions.startToCloseTimeout, originalDuration);
     t.is(originalOptions.heartbeatTimeout, originalDuration);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added operator commands `pause`, `unpause`, `updateOptions` and `restoreOriginalOptions` to `ActivityHandle`.

## Why?
<!-- Tell your future self why have you made these changes -->
Feature request: https://github.com/temporalio/features/issues/822

## Checklist
<!--- add/delete as needed --->

1. Closes #2061 

2. How was this tested:
New tests in `test-standalone-activities.cloud-pending.ts`