### PR TITLE
fix(docs): normalize sidebar path separators for Windows

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -11,7 +11,8 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "test": "node --test sidebars.test.js"
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.1",

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -9,12 +9,23 @@ function titleCase(str) {
   return str.toLowerCase().replace(/\b(\w)/g, (s) => s.toUpperCase());
 }
 
+// Normalize the doc-relative path so it always uses forward slashes: on
+// Windows `path.relative` returns backslashes, breaking both the `/`-split
+// below and the doc IDs stored in the sidebar. Replacing both separator
+// forms keeps the result consistent on any platform.
+function relativeDocUrl(relative) {
+  return relative.replace(/\\/g, '/').replace(/\.md$/, '');
+}
+
 function nestMarkdownFiles() {
   return markdownFiles()
     .sort()
     .sort((a, b) => a.split('.').length - b.split('.').length)
     .reduce((acc, f) => {
-      const url = path.relative(path.join(__dirname, 'docs'), f).replace(/\.md$/, '');
+      // `path.relative` returns platform-specific separators, but the split
+      // below and the doc IDs stored in the sidebar always use forward slashes.
+      // Normalize so sidebar generation works on Windows too.
+      const url = relativeDocUrl(path.relative(path.join(__dirname, 'docs'), f));
       const category = titleCase(url.split('/')[1]);
       const basename = path.basename(url);
       const parts = basename.split('.');
@@ -63,6 +74,7 @@ function nestMarkdownFiles() {
 }
 
 module.exports = {
+  relativeDocUrl,
   referenceSidebar: [
     'index',
     {

--- a/packages/docs/sidebars.test.js
+++ b/packages/docs/sidebars.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { relativeDocUrl } = require('./sidebars');
+
+test('relativeDocUrl keeps forward-slash namespaced paths', () => {
+  assert.equal(relativeDocUrl('api/namespaces/client.md'), 'api/namespaces/client');
+  assert.equal(relativeDocUrl('api/namespaces/client'), 'api/namespaces/client');
+});
+
+test('relativeDocUrl normalizes Windows-style separators', () => {
+  // `path.relative` yields backslashes on Windows; the sidebar code splits and
+  // links on forward slashes, so the Windows form must be normalized too.
+  assert.equal(relativeDocUrl('api\\namespaces\\client.md'), 'api/namespaces/client');
+});
+
+test('relativeDocUrl strips only the trailing .md extension', () => {
+  assert.equal(relativeDocUrl('api\\namespaces\\workflowStreamsClient.md'), 'api/namespaces/workflowStreamsClient');
+  assert.equal(relativeDocUrl('api\\namespaces\\client.v1.md'), 'api/namespaces/client.v1');
+});


### PR DESCRIPTION
Fixes #2402: building the docs sidebar on Windows fails with `Cannot read properties of undefined (reading 'toLowerCase')` because `path.relative` returns backslash-separated paths on Windows, so `url.split('/')[1]` (the category) is undefined.

## What changed

- `packages/docs/sidebars.js`: normalize the doc-relative path to forward slashes (`\\` → `/`) before category extraction and doc-ID construction, via a small `relativeDocUrl` helper. The generated doc IDs remain forward-slash paths on all platforms.
- Added `packages/docs/sidebars.test.js` (Node's built-in `node:test` runner, no new dependencies) and a `test` script for `@temporalio/docs`. The tests cover forward-slash, Windows-style, and multi-dot basename inputs. CI's `pnpm run test` runs on `windows-x64` too, so this is a real regression test for the affected platform.

## Verification

- `node --test packages/docs/sidebars.test.js` → 3/3 pass.
- `prettier --check` clean on all changed files.
- Full `docusaurus build` requires a dependency install and POSIX shell for the `build-docs` env assignments, so it wasn't run locally; the bug reproduces purely in sidebar generation, which the unit tests exercise.

## AI disclosure

Code authored with the assistance of an AI coding agent.