### PR TITLE
Preserve provider metadata

### DIFF
--- a/contrib/ai-sdk/src/__tests__/test-ai-sdk-streaming.ts
+++ b/contrib/ai-sdk/src/__tests__/test-ai-sdk-streaming.ts
@@ -176,3 +176,28 @@ test('invokeModelStreaming throws when the stream emits an error even if a finis
   t.regex(err!.message, /mid-stream provider failure/);
   t.notRegex(err!.message, /without a finish part/);
 });
+
+test('invokeModelStreaming keeps text-block provider metadata that arrives on text-start', async (t) => {
+  // Anthropic emits its compaction summary block as `text-start` carrying the marker,
+  // with a bare `text-end`; citations arrive on `text-end` instead.
+  const compaction = { anthropic: { type: 'compaction' } };
+  const citations = { anthropic: { citations: [{ type: 'char_location', cited_text: 'x' }] } };
+  const parts: LanguageModelV4StreamPart[] = [
+    { type: 'stream-start', warnings: [] },
+    { type: 'text-start', id: 'txt-1', providerMetadata: compaction },
+    { type: 'text-delta', id: 'txt-1', delta: 'summary' },
+    { type: 'text-end', id: 'txt-1' },
+    { type: 'text-start', id: 'txt-2', providerMetadata: compaction },
+    { type: 'text-delta', id: 'txt-2', delta: 'cited' },
+    { type: 'text-end', id: 'txt-2', providerMetadata: citations },
+    { type: 'finish', finishReason: { unified: 'stop', raw: undefined }, usage },
+  ];
+
+  const { result } = await runStreamingActivity(parts);
+
+  t.deepEqual(result.content, [
+    { type: 'text', text: 'summary', providerMetadata: compaction },
+    // Metadata on `text-end` still wins over `text-start`.
+    { type: 'text', text: 'cited', providerMetadata: citations },
+  ]);
+});

--- a/contrib/ai-sdk/src/activities.ts
+++ b/contrib/ai-sdk/src/activities.ts
@@ -5,6 +5,7 @@ import type {
   LanguageModelV4GenerateResult,
   LanguageModelV4Usage,
   EmbeddingModelV4Result,
+  SharedV4ProviderMetadata,
   SharedV4ProviderOptions,
   SharedV4Headers,
   SharedV4Warning,
@@ -272,7 +273,9 @@ export function createActivities(
       let sawError = false;
       let streamError: unknown;
 
-      const textBlocks = new Map<string, string>();
+      // Provider metadata for a text block may arrive on `text-start` (e.g. Anthropic compaction
+      // markers) rather than `text-end`, so keep it alongside the accumulated text.
+      const textBlocks = new Map<string, { text: string; providerMetadata: SharedV4ProviderMetadata | undefined }>();
       const reasoningBlocks = new Map<string, string>();
 
       const reader = streamResult.stream.getReader();
@@ -293,19 +296,26 @@ export function createActivities(
             warnings.push(...part.warnings);
             break;
           case 'text-start':
-            textBlocks.set(part.id, '');
+            textBlocks.set(part.id, { text: '', providerMetadata: part.providerMetadata });
             break;
-          case 'text-delta':
-            textBlocks.set(part.id, (textBlocks.get(part.id) ?? '') + part.delta);
+          case 'text-delta': {
+            const block = textBlocks.get(part.id);
+            textBlocks.set(part.id, {
+              text: (block?.text ?? '') + part.delta,
+              providerMetadata: block?.providerMetadata,
+            });
             break;
-          case 'text-end':
+          }
+          case 'text-end': {
+            const block = textBlocks.get(part.id);
             content.push({
               type: 'text',
-              text: textBlocks.get(part.id) ?? '',
-              providerMetadata: part.providerMetadata,
+              text: block?.text ?? '',
+              providerMetadata: part.providerMetadata ?? block?.providerMetadata,
             });
             textBlocks.delete(part.id);
             break;
+          }
           case 'reasoning-start':
             reasoningBlocks.set(part.id, '');
             break;

--- a/contrib/ai-sdk/src/provider.ts
+++ b/contrib/ai-sdk/src/provider.ts
@@ -132,7 +132,9 @@ export class TemporalLanguageModel implements LanguageModelV4 {
         for (const item of result.content ?? []) {
           const id = `part-${partIndex++}`;
           if (item.type === 'text') {
-            controller.enqueue({ type: 'text-start', id });
+            // Consumers initialize text-block provider metadata (e.g. Anthropic compaction
+            // markers) from the start part, so replay it there.
+            controller.enqueue({ type: 'text-start', id, providerMetadata: item.providerMetadata });
             controller.enqueue({ type: 'text-delta', id, delta: item.text });
             controller.enqueue({ type: 'text-end', id });
           } else if (item.type === 'reasoning') {


### PR DESCRIPTION
close #2406 

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Preserving providerMetadata loaded on 'text-start' chunk

## Why?
<!-- Tell your future self why have you made these changes -->

Some providerMetadata, like anthropic compaction, are loaded there.

It needs to work message compaction.

https://ai-sdk.dev/providers/ai-sdk-providers/anthropic#detecting-compaction-in-streams

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
2406

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->


3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
nothing