### PR TITLE
fix(ci): unpin features branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,9 +413,6 @@ jobs:
       typescript-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
       version-is-repo-ref: true
-      # FIXME: Remove this once 1) our protobufjs v8 bump has been merged and included in a
-      # release, and 2) https://github.com/temporalio/features/pull/863 has been merged to main.
-      features-repo-ref: bump-protobufjs
 
   stress-tests-no-reuse-context:
     name: Stress Tests (No Reuse V8 Context)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

No longer pin to dedicated branch in features repo.

## Why?

- Currently pinned branch no longer exists.
- Use latest tests from features repo.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: CI