### PR TITLE
fix: correct README package links

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ This monorepo contains the following packages:
 | [`packages/common/`](packages/common/)                                             | [`@temporalio/common`](https://www.npmjs.com/package/@temporalio/common)                                               |
 | [`packages/proto/`](packages/proto/)                                               | [`@temporalio/proto`](https://www.npmjs.com/package/@temporalio/proto)                                                 |
 | [`packages/test/`](packages/test/)                                                 | SDK internal tests                                                                                                     |
-| [`packages/create-project/`](packages/create-project/)                             | [`@temporalio/create`](https://www.npmjs.com/package/@temporalio/create-project)                                       |
+| [`packages/create-project/`](packages/create-project/)                             | [`@temporalio/create`](https://www.npmjs.com/package/@temporalio/create)                                               |
 | [`packages/docs/`](packages/docs/)                                                 | [API docs](https://typescript.temporal.io/)                                                                            |
-| [`packages/core-bridge/`](packages/core-bridge/)                                   | [`@temporalio/core-bridge`](https://www.npmjs.com/package/@temporalio/proto)                                           |
+| [`packages/core-bridge/`](packages/core-bridge/)                                   | [`@temporalio/core-bridge`](https://www.npmjs.com/package/@temporalio/core-bridge)                                     |
 | [`packages/envconfig/`](packages/envconfig/)                                       | [`@temporalio/envconfig`](https://www.npmjs.com/package/@temporalio/envconfig)                                         |
 | [`packages/nyc-test-coverage/`](packages/nyc-test-coverage/)                       | [`@temporalio/nyc-test-coverage`](https://www.npmjs.com/package/@temporalio/nyc-test-coverage)                         |
 | [`packages/plugin/`](packages/plugin/)                                             | [`@temporalio/plugin`](https://www.npmjs.com/package/@temporalio/plugin)                                               |


### PR DESCRIPTION
## What was changed

Corrected two npm links in the README's Repository Structure table:

- `packages/create-project` now links to `@temporalio/create`.
- `packages/core-bridge` now links to `@temporalio/core-bridge`.

## Why?

The existing links sent readers to a nonexistent package and the unrelated protobuf package. The corrected links now match the package names displayed in the table and declared in each package manifest.

## Checklist

1. Closes #2401

2. How was this tested:
   - `pnpm exec prettier --check README.md`
   - `git diff --check`
   - Verified both link targets match their package manifests.

3. Any docs updates needed?
   - No. This PR is the required README update.
