### PR TITLE
fix(activity): Use serialization context in Standalone Activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ to docs, or any other relevant information.
 
 ### Changed
 
+- `ActivityClient` now passes serialization context to data converter when interacting with standalone activities.
 - A workflow query issued from inside a Nexus operation handler now propagates the link the server
   returns for the workflow that processed it, so the caller's Nexus operation event points back at
   the queried workflow.

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -772,7 +772,8 @@ function buildActivityExecutionInfo(info: temporal.api.activity.v1.IActivityExec
 
 function buildActivityDescription(
   resp: temporal.api.workflowservice.v1.DescribeActivityExecutionResponse & { info: object },
-  dataConverter: LoadedDataConverter
+  dataConverter: LoadedDataConverter,
+  serializationContext: ActivitySerializationContext
 ): ActivityExecutionDescription {
   return {
     ...buildActivityExecutionInfoCommonPart(resp.info),
@@ -805,11 +806,15 @@ function buildActivityDescription(
     hasOutcomeFailure: !!resp.outcome?.failure,
 
     getHeartbeatDetails: async <T>() =>
-      await decodeFromPayloadsAtIndex<T>(dataConverter, 0, resp.info.heartbeatDetails?.payloads),
-    getLastFailure: async () => await decodeOptionalFailureToOptionalError(dataConverter, resp.info.lastFailure),
-    getInput: async <T>() => (await decodeArrayFromPayloads(dataConverter, resp.input?.payloads)) as T,
-    getResult: async <T>() => await decodeFromPayloadsAtIndex<T>(dataConverter, 0, resp.outcome?.result?.payloads),
-    getOutcomeFailure: async () => await decodeOptionalFailureToOptionalError(dataConverter, resp.outcome?.failure),
+      await decodeFromPayloadsAtIndex<T>(dataConverter, 0, resp.info.heartbeatDetails?.payloads, serializationContext),
+    getLastFailure: async () =>
+      await decodeOptionalFailureToOptionalError(dataConverter, resp.info.lastFailure, serializationContext),
+    getInput: async <T>() =>
+      (await decodeArrayFromPayloads(dataConverter, resp.input?.payloads, serializationContext)) as T,
+    getResult: async <T>() =>
+      await decodeFromPayloadsAtIndex<T>(dataConverter, 0, resp.outcome?.result?.payloads, serializationContext),
+    getOutcomeFailure: async () =>
+      await decodeOptionalFailureToOptionalError(dataConverter, resp.outcome?.failure, serializationContext),
   };
 }
 

--- a/packages/client/src/activity-client.ts
+++ b/packages/client/src/activity-client.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { status as grpcStatus } from '@grpc/grpc-js';
 import type {
   ActivityFunction,
+  ActivitySerializationContext,
   LoadedDataConverter,
   Next,
   PayloadTypeInfo,
@@ -339,6 +340,13 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
 
     const internalOptions = (input.options as InternalActivityStartOptions)[InternalActivityStartOptionsSymbol];
 
+    const context: ActivitySerializationContext = {
+      type: 'activity',
+      namespace: this.options.namespace,
+      activityId: input.options.id,
+      isLocal: false,
+    };
+
     return {
       namespace: this.options.namespace,
       identity: this.options.identity,
@@ -354,7 +362,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       input: {
         payloads: await encodeToPayloadsWithContext(
           this.dataConverter,
-          undefined,
+          context,
           [...(input.options.args ?? [])],
           inputTypes
         ),
@@ -363,7 +371,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
       idConflictPolicy: encodeActivityIdConflictPolicy(input.options.idConflictPolicy),
       searchAttributes,
       header: { fields: input.headers },
-      userMetadata: await encodeUserMetadata(this.dataConverter, input.options.summary, undefined),
+      userMetadata: await encodeUserMetadata(this.dataConverter, input.options.summary, undefined, context),
       priority: input.options.priority ? compilePriority(input.options.priority) : undefined,
       startDelay: msOptionalToTs(input.options.startDelay),
       completionCallbacks: internalOptions?.completionCallbacks,
@@ -376,6 +384,13 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
     if (!input.activityId) {
       throw new TypeError('activityId is required');
     }
+
+    const context: ActivitySerializationContext = {
+      type: 'activity',
+      namespace: this.options.namespace,
+      activityId: input.activityId,
+      isLocal: false,
+    };
 
     const req: temporal.api.workflowservice.v1.IPollActivityExecutionRequest = {
       namespace: this.options.namespace,
@@ -394,7 +409,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
             this.dataConverter,
             0,
             resp.outcome.result.payloads,
-            undefined,
+            context,
             input.outputType
           );
         } else if (resp.outcome?.failure) {
@@ -402,7 +417,7 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
           // If it succeeds, we want to throw the ActivityExecutionFailedError directly, so outside of try/catch.
           failedErr = new ActivityExecutionFailedError(
             'Activity execution failed',
-            await decodeOptionalFailureToOptionalError(this.dataConverter, resp.outcome.failure),
+            await decodeOptionalFailureToOptionalError(this.dataConverter, resp.outcome.failure, context),
             input.activityId,
             resp.runId || input.activityRunId || undefined
           );
@@ -423,14 +438,21 @@ export class ActivityClient extends AsyncCompletionClient implements TypedActivi
     }
 
     try {
+      const namespace = this.options.namespace;
       const resp = await this.workflowService.describeActivityExecution({
-        namespace: this.options.namespace,
+        namespace,
         activityId: input.activityId,
         runId: input.activityRunId || undefined,
       });
       const externalStorage = this.dataConverter.externalStorage;
       await visit(resp, walkDescribeActivityExecutionResponse, extstoreInboundOptions(externalStorage));
-      return buildActivityDescription(resp.info!, resp.callbacks, this.dataConverter);
+      const context: ActivitySerializationContext = {
+        type: 'activity',
+        namespace,
+        activityId: input.activityId,
+        isLocal: false,
+      };
+      return buildActivityDescription(resp.info!, resp.callbacks, this.dataConverter, context);
     } catch (err) {
       this.rethrowGrpcError(err, 'Failed to describe activity');
     }
@@ -703,19 +725,25 @@ function buildActivityExecutionInfo(info: temporal.api.activity.v1.IActivityExec
 function buildActivityDescription(
   info: temporal.api.activity.v1.IActivityExecutionInfo,
   callbacks: temporal.api.activity.v1.ICallbackInfo[],
-  dataConverter: LoadedDataConverter
+  dataConverter: LoadedDataConverter,
+  serializationContext: ActivitySerializationContext
 ): ActivityExecutionDescription {
   const getHeartbeatDetails: <T>() => Promise<T | undefined> = async <T>() => {
     const payloads = info.heartbeatDetails?.payloads;
     if (payloads && payloads.length > 0) {
-      return await decodeFromPayloadsAtIndex<T>(dataConverter, 0, info.heartbeatDetails?.payloads);
+      return await decodeFromPayloadsAtIndex<T>(
+        dataConverter,
+        0,
+        info.heartbeatDetails?.payloads,
+        serializationContext
+      );
     } else {
       return undefined;
     }
   };
 
   const getLastFailure: () => Promise<Error | undefined> = async () => {
-    return await decodeOptionalFailureToOptionalError(dataConverter, info.lastFailure);
+    return await decodeOptionalFailureToOptionalError(dataConverter, info.lastFailure, serializationContext);
   };
 
   return {

--- a/packages/test/src/payload-converters/serialization-context-converter.ts
+++ b/packages/test/src/payload-converters/serialization-context-converter.ts
@@ -39,6 +39,10 @@ export function activityCtx(workflowId: string, activityId = '1', isLocal = fals
   return `activity.default.${workflowId}.${activityId}.${isLocal}`;
 }
 
+export function standaloneActivityCtx(activityId: string): string {
+  return `activity.default.${activityId}.${false}`;
+}
+
 export function enc(label: string, ctx: string): string {
   return `payload.encode.bound|${label}|${ctx}`;
 }

--- a/packages/test/src/test-standalone-activities.cloud-pending.ts
+++ b/packages/test/src/test-standalone-activities.cloud-pending.ts
@@ -2,12 +2,7 @@ import { randomUUID } from 'crypto';
 import type { ExecutionContext, TestFn } from 'ava';
 import anyTest from 'ava';
 import * as rxjs from 'rxjs';
-import type {
-  ActivityHandle,
-  ActivityOptions,
-  ClientOptions,
-  TypedActivityClient,
-} from '@temporalio/client';
+import type { ActivityHandle, ActivityOptions, ClientOptions, TypedActivityClient } from '@temporalio/client';
 import {
   ActivityExecutionStatus,
   ActivityExecutionAlreadyStartedError,
@@ -109,14 +104,16 @@ function assertReceipt(t: ExecutionContext, receipt: Receipt): void {
   t.is(typeof receipt.totalCents, 'bigint');
 }
 
-function makeClientWithOptions(
-  env: TestWorkflowEnvironment,
-  options: ClientOptions
-): Client {
-  return new Client(Object.assign({
-    connection: env.client.connection,
-    namespace: env.client.options.namespace,
-  }, options));
+function makeClientWithOptions(env: TestWorkflowEnvironment, options: ClientOptions): Client {
+  return new Client(
+    Object.assign(
+      {
+        connection: env.client.connection,
+        namespace: env.client.options.namespace,
+      },
+      options
+    )
+  );
 }
 
 class BlockingEncodePayloadCodec implements PayloadCodec {
@@ -302,25 +299,29 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Activity interceptors can provide input and result TypeInfo', async (t) => {
-    const client = makeClientWithOptions(t.context.env, { interceptors: { activity: [
-      {
-        async start(input, next) {
-          return await next({
-            ...input,
-            options: {
-              ...input.options,
-              typeInfo: { inputTypes: activityTypeInfo.convertOrder.inputTypes },
+    const client = makeClientWithOptions(t.context.env, {
+      interceptors: {
+        activity: [
+          {
+            async start(input, next) {
+              return await next({
+                ...input,
+                options: {
+                  ...input.options,
+                  typeInfo: { inputTypes: activityTypeInfo.convertOrder.inputTypes },
+                },
+              });
             },
-          });
-        },
-        async getResult(input, next) {
-          return await next({
-            ...input,
-            outputType: activityTypeInfo.convertOrder.outputType,
-          });
-        },
+            async getResult(input, next) {
+              return await next({
+                ...input,
+                outputType: activityTypeInfo.convertOrder.outputType,
+              });
+            },
+          },
+        ],
       },
-    ]}});
+    });
 
     const result = await client.activity.execute<Receipt>('convertOrder', {
       ...typeInfoActivityOptions,
@@ -703,23 +704,54 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Activity serialization context is used', async (t) => {
-    const client = makeClientWithOptions(t.context.env, { dataConverter: {
+    const ctxTaskQueue = taskQueue + '-with-serialization-context';
+
+    const dataConverter = {
       payloadConverterPath: require.resolve('./payload-converters/serialization-context-converter'),
       failureConverterPath: require.resolve('./payload-converters/serialization-context-converter'),
-    }});
+    };
+
+    const worker = await Worker.create({
+      activities,
+      taskQueue: ctxTaskQueue,
+      dataConverter,
+      connection: t.context.env.nativeConnection,
+    });
+    const runPromise = worker.run();
+
+    const client = makeClientWithOptions(t.context.env, { dataConverter });
 
     const activityId = randomUUID();
     const ctx = standaloneActivityCtx(activityId);
 
-    const trace = await client.activity.execute('echo', {
+    const handle = await client.activity.start('echo', {
       ...defaultOptions,
       id: activityId,
+      taskQueue: ctxTaskQueue,
       args: [makeContextTrace('input')],
     });
+
+    const trace = await handle.result();
     t.deepEqual(trace, {
       label: 'input',
-      trace: encdec('input', ctx),
+      trace: [...encdec('input', ctx), ...encdec('input', ctx)],
     });
+
+    const desc = await handle.describe({ includeInput: true, includeOutcome: true });
+    const input = await desc.getInput();
+    t.deepEqual(await desc.getInput(), [
+      {
+        label: 'input',
+        trace: encdec('input', ctx),
+      },
+    ]);
+    t.deepEqual(await desc.getResult(), {
+      label: 'input',
+      trace: [...encdec('input', ctx), ...encdec('input', ctx)],
+    });
+
+    worker.shutdown();
+    await runPromise;
   });
 
   test('Typed client - start activity', async (t) => {

--- a/packages/test/src/test-standalone-activities.cloud-pending.ts
+++ b/packages/test/src/test-standalone-activities.cloud-pending.ts
@@ -5,7 +5,7 @@ import * as rxjs from 'rxjs';
 import type {
   ActivityHandle,
   ActivityOptions,
-  ActivityClientInterceptor,
+  ClientOptions,
   TypedActivityClient,
 } from '@temporalio/client';
 import {
@@ -29,6 +29,7 @@ import { createTestWorkflowEnvironment } from './helpers-integration';
 import { convertOrder, createAsyncOrderActivities } from './workflows/type-info/activities';
 import { activityTypeInfo } from './workflows/type-info/activity-type-info';
 import { Order, Receipt } from './workflows/type-info/models';
+import { encdec, makeContextTrace, standaloneActivityCtx } from './payload-converters/serialization-context-converter';
 
 // Use a reduced server long-poll expiration timeout, in order to confirm that client
 // polling/retry strategies result in the expected behavior
@@ -101,15 +102,14 @@ function assertReceipt(t: ExecutionContext, receipt: Receipt): void {
   t.is(typeof receipt.totalCents, 'bigint');
 }
 
-function makeClientWithActivityInterceptors(
+function makeClientWithOptions(
   env: TestWorkflowEnvironment,
-  interceptors: ActivityClientInterceptor[]
+  options: ClientOptions
 ): Client {
-  return new Client({
+  return new Client(Object.assign({
     connection: env.client.connection,
     namespace: env.client.options.namespace,
-    interceptors: { activity: interceptors },
-  });
+  }, options));
 }
 
 class BlockingEncodePayloadCodec implements PayloadCodec {
@@ -295,7 +295,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   test('Activity interceptors can provide input and result TypeInfo', async (t) => {
-    const client = makeClientWithActivityInterceptors(t.context.env, [
+    const client = makeClientWithOptions(t.context.env, { interceptors: { activity: [
       {
         async start(input, next) {
           return await next({
@@ -313,7 +313,7 @@ if (RUN_INTEGRATION_TESTS) {
           });
         },
       },
-    ]);
+    ]}});
 
     const result = await client.activity.execute<Receipt>('convertOrder', {
       ...typeInfoActivityOptions,
@@ -634,6 +634,26 @@ if (RUN_INTEGRATION_TESTS) {
     const err = await t.throwsAsync(() => resultPromise, { instanceOf: ServiceError });
     t.assert(isGrpcCancelledError(err));
     t.context.activitySignalSubject.next(activityId);
+  });
+
+  test('Activity serialization context is used', async (t) => {
+    const client = makeClientWithOptions(t.context.env, { dataConverter: {
+      payloadConverterPath: require.resolve('./payload-converters/serialization-context-converter'),
+      failureConverterPath: require.resolve('./payload-converters/serialization-context-converter'),
+    }});
+
+    const activityId = randomUUID();
+    const ctx = standaloneActivityCtx(activityId);
+
+    const trace = await client.activity.execute('echo', {
+      ...defaultOptions,
+      id: activityId,
+      args: [makeContextTrace('input')],
+    });
+    t.deepEqual(trace, {
+      label: 'input',
+      trace: encdec('input', ctx),
+    });
   });
 
   test('Typed client - start activity', async (t) => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Change `ActivityClient` to use `ActivitySerializationContext` when de/serializing Standalone Activity payloads.
## Why?
<!-- Tell your future self why have you made these changes -->
Allows using context-aware data converters with Standalone Activities.