### PR TITLE
fix(ai-sdk): polyfill base64 globals in workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- `@temporalio/ai-sdk` now installs `atob` and `btoa` in the Workflow sandbox, allowing the AI SDK to process
+  image and file tool results containing base64 data.
 - Activity errors converted to `ApplicationFailure` now preserve native `Error.cause` chains in serialized failures.
 - Nexus handlers now report uncaught Workflow and standalone Activity already-started errors as
   non-retryable `INTERNAL` Handler Errors, preventing retries when ID reuse or conflict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,8 +125,8 @@ to docs, or any other relevant information.
 
 ### Fixed
 
-- `@temporalio/ai-sdk` now installs `atob` and `btoa` in the Workflow sandbox, allowing the AI SDK to process
-  image and file tool results containing base64 data.
+- The Workflow sandbox now exposes `atob` and `btoa`, allowing integrations such as `@temporalio/ai-sdk` to
+  process image and file tool results containing base64 data.
 - Activity errors converted to `ApplicationFailure` now preserve native `Error.cause` chains in serialized failures.
 - Nexus handlers now report uncaught Workflow and standalone Activity already-started errors as
   non-retryable `INTERNAL` Handler Errors, preventing retries when ID reuse or conflict

--- a/contrib/ai-sdk/src/__tests__/test-ai-sdk.ts
+++ b/contrib/ai-sdk/src/__tests__/test-ai-sdk.ts
@@ -53,6 +53,7 @@ import {
   embeddingWorkflow,
   generateObjectWorkflow,
   helloWorldAgent,
+  imageToolWorkflow,
   mcpSchemaTestWorkflow,
   mcpWorkflow,
   middlewareWorkflow,
@@ -327,6 +328,25 @@ test('Tools workflow can use AI tools', async (t) => {
       );
       t.assert(activityTypes.includes('getWeather'), 'getWeather activity should have been called');
     }
+  });
+});
+
+function* imageToolWorkflowGenerator(): Generator<ModelResponse> {
+  yield toolCallResponse('screenshot', '{}');
+  yield textResponse('A transparent image');
+}
+
+test('Image tool results are converted inside the workflow sandbox', async (t) => {
+  const { createWorker, executeWorkflow } = helpers(t);
+  const worker = await createWorker({
+    plugins: [new AiSdkPlugin({ modelProvider: new TestProvider(imageToolWorkflowGenerator()) })],
+  });
+
+  await worker.runUntil(async () => {
+    const result = await executeWorkflow(imageToolWorkflow, {
+      workflowExecutionTimeout: '10 seconds',
+    });
+    t.is(result, 'A transparent image');
   });
 });
 

--- a/contrib/ai-sdk/src/__tests__/workflows/ai-sdk.ts
+++ b/contrib/ai-sdk/src/__tests__/workflows/ai-sdk.ts
@@ -42,6 +42,39 @@ export async function toolsWorkflow(question: string): Promise<string> {
   return result.text;
 }
 
+const transparentPng =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+export async function imageToolWorkflow(): Promise<string> {
+  if (btoa(atob(transparentPng)) !== transparentPng) {
+    throw new Error('Base64 polyfill round trip failed');
+  }
+
+  const result = await generateText({
+    model: temporalProvider.languageModel('gpt-4o-mini'),
+    prompt: 'Call the screenshot tool, then describe the image.',
+    tools: {
+      screenshot: tool({
+        description: 'Take a screenshot',
+        inputSchema: z.object({}),
+        execute: async () => ({ data: transparentPng, mimeType: 'image/png' }),
+        toModelOutput: ({ output }) => ({
+          type: 'content',
+          value: [
+            {
+              type: 'file',
+              data: { type: 'data', data: output.data },
+              mediaType: output.mimeType,
+            },
+          ],
+        }),
+      }),
+    },
+    stopWhen: isStepCount(3),
+  });
+  return result.text;
+}
+
 export async function generateObjectWorkflow(): Promise<string> {
   const { output } = await generateText({
     model: temporalProvider.languageModel('gpt-4o-mini'),

--- a/contrib/ai-sdk/src/load-polyfills.ts
+++ b/contrib/ai-sdk/src/load-polyfills.ts
@@ -1,40 +1,11 @@
 import { Headers } from 'headers-polyfill';
 import structuredClonePolyfill from '@ungap/structured-clone';
 import * as webStreamsPolyfill from 'web-streams-polyfill';
-import { decodeBase64, encodeBase64 } from '@temporalio/workflow-streams/workflow';
-
-function atobPolyfill(input: string): string {
-  const encoded = String(input).replace(/[\t\n\f\r ]/g, '');
-  const paddingLength = encoded.match(/=+$/)?.[0].length ?? 0;
-  if (paddingLength > 0 && encoded.length % 4 !== 0) {
-    throw new TypeError('The string to be decoded is not correctly encoded.');
-  }
-
-  const bytes = decodeBase64(encoded);
-  let output = '';
-  for (const byte of bytes) {
-    output += String.fromCharCode(byte);
-  }
-  return output;
-}
-
-function btoaPolyfill(input: string): string {
-  const data = String(input);
-  const bytes = new Uint8Array(data.length);
-  for (let index = 0; index < data.length; index++) {
-    const byte = data.charCodeAt(index);
-    if (byte > 0xff) {
-      throw new TypeError('The string to be encoded contains characters outside of the Latin1 range.');
-    }
-    bytes[index] = byte;
-  }
-  return encodeBase64(bytes);
-}
 
 /**
  * Installs the Web-API globals that the AI SDK needs inside the workflow sandbox: `Headers`,
- * the Web Streams classes (`ReadableStream`, `WritableStream`, `TransformStream`, ...),
- * `structuredClone`, and the base64 helpers `atob` and `btoa`.
+ * the Web Streams classes (`ReadableStream`, `WritableStream`, `TransformStream`, ...), and
+ * `structuredClone`.
  *
  * Idempotent, and never overwrites globals that already exist — calling it outside the sandbox
  * (where Node.js provides all of these natively) is a no-op.
@@ -55,13 +26,5 @@ export function installPolyfills(): void {
 
   if (!('structuredClone' in globalThis)) {
     globalThis.structuredClone = structuredClonePolyfill as typeof globalThis.structuredClone;
-  }
-
-  if (typeof globalThis.atob === 'undefined') {
-    globalThis.atob = atobPolyfill;
-  }
-
-  if (typeof globalThis.btoa === 'undefined') {
-    globalThis.btoa = btoaPolyfill;
   }
 }

--- a/contrib/ai-sdk/src/load-polyfills.ts
+++ b/contrib/ai-sdk/src/load-polyfills.ts
@@ -1,11 +1,40 @@
 import { Headers } from 'headers-polyfill';
 import structuredClonePolyfill from '@ungap/structured-clone';
 import * as webStreamsPolyfill from 'web-streams-polyfill';
+import { decodeBase64, encodeBase64 } from '@temporalio/workflow-streams/workflow';
+
+function atobPolyfill(input: string): string {
+  const encoded = String(input).replace(/[\t\n\f\r ]/g, '');
+  const paddingLength = encoded.match(/=+$/)?.[0].length ?? 0;
+  if (paddingLength > 0 && encoded.length % 4 !== 0) {
+    throw new TypeError('The string to be decoded is not correctly encoded.');
+  }
+
+  const bytes = decodeBase64(encoded);
+  let output = '';
+  for (const byte of bytes) {
+    output += String.fromCharCode(byte);
+  }
+  return output;
+}
+
+function btoaPolyfill(input: string): string {
+  const data = String(input);
+  const bytes = new Uint8Array(data.length);
+  for (let index = 0; index < data.length; index++) {
+    const byte = data.charCodeAt(index);
+    if (byte > 0xff) {
+      throw new TypeError('The string to be encoded contains characters outside of the Latin1 range.');
+    }
+    bytes[index] = byte;
+  }
+  return encodeBase64(bytes);
+}
 
 /**
  * Installs the Web-API globals that the AI SDK needs inside the workflow sandbox: `Headers`,
- * the Web Streams classes (`ReadableStream`, `WritableStream`, `TransformStream`, ...), and
- * `structuredClone`.
+ * the Web Streams classes (`ReadableStream`, `WritableStream`, `TransformStream`, ...),
+ * `structuredClone`, and the base64 helpers `atob` and `btoa`.
  *
  * Idempotent, and never overwrites globals that already exist — calling it outside the sandbox
  * (where Node.js provides all of these natively) is a no-op.
@@ -26,5 +55,13 @@ export function installPolyfills(): void {
 
   if (!('structuredClone' in globalThis)) {
     globalThis.structuredClone = structuredClonePolyfill as typeof globalThis.structuredClone;
+  }
+
+  if (typeof globalThis.atob === 'undefined') {
+    globalThis.atob = atobPolyfill;
+  }
+
+  if (typeof globalThis.btoa === 'undefined') {
+    globalThis.btoa = btoaPolyfill;
   }
 }

--- a/packages/worker/src/workflow/vm-shared.ts
+++ b/packages/worker/src/workflow/vm-shared.ts
@@ -2,6 +2,7 @@ import v8 from 'node:v8';
 import vm from 'node:vm';
 import { AsyncLocalStorage as AsyncLocalStorageOriginal } from 'node:async_hooks';
 import assert from 'node:assert';
+import { atob, btoa } from 'node:buffer';
 import { URL, URLSearchParams } from 'node:url';
 import { TextDecoder, TextEncoder } from 'node:util';
 import { SourceMapConsumer } from 'source-map';
@@ -102,6 +103,8 @@ export function injectGlobals(context: vm.Context): void {
     TextEncoder,
     TextDecoder,
     AbortController,
+    atob,
+    btoa,
   };
   for (const [k, v] of Object.entries(globals)) {
     Object.defineProperty(sandboxGlobalThis, k, { value: v, writable: false, enumerable: true, configurable: false });


### PR DESCRIPTION
## What was changed

- Added deterministic, Workflow-safe `atob` and `btoa` polyfills to the AI SDK preload.
- Preserved native globals when they are already available.
- Added an end-to-end regression test for image content returned by an AI tool, including a base64 round trip in the Workflow sandbox.

## Why?

The Vercel AI SDK decodes base64 data while detecting the media type of file tool results. Temporal's Workflow isolate did not provide `atob` or `btoa`, causing image tool results to repeatedly fail their Workflow Task.

## Checklist

1. Closes #2408
2. How was this tested:
   - `pnpm run build`
   - `pnpm -C contrib/ai-sdk exec ava lib/__tests__/test-ai-sdk.js --match='Image tool results are converted inside the workflow sandbox'`
3. Any docs updates needed? No.
