### PR TITLE
feat(google-adk-agents): run ADK 2.0 workflow graphs with Activity nodes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -20,3 +20,6 @@ packages/testing/proto/*
 
 # Ignored since it fails Windows CI
 packages/create-project/cli.js
+
+# Recorded Temporal histories replayed by the Google ADK plugin tests (re-recorded verbatim by UPDATE_ADK_HISTORIES=1)
+contrib/google-adk-agents/src/__tests__/histories/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,9 +67,16 @@ to docs, or any other relevant information.
 
 ### Added
 
-- `@temporalio/google-adk-agents` runs on Google ADK 2.0: the Workflow bundle now uses ADK's web
-  build, pinned regardless of the consumer's webpack target, and ADK's UUIDs are generated from a
-  named workflow random stream inside the sandbox, so its ids are replay-stable.
+- `@temporalio/google-adk-agents` supports Google ADK 2.0 inside Workflows:
+  - the Workflow bundle now uses ADK's web build, pinned regardless of the consumer's webpack
+    target, and ADK's UUIDs are generated from a named workflow random stream inside the sandbox,
+    so its ids are replay-stable;
+  - the workflow (graph) runtime — `Workflow`, `node()`, `JoinNode`, routing, dynamic nodes,
+    node-as-tool, node retries and timeouts — runs unchanged; `activityNode` makes a registered
+    Activity a graph node (its abort cancels the in-flight Activity);
+  - ADK's runtime errors (`NodeTimeoutError`, `IntentMismatchError`, …) fail the Workflow with typed
+    `ApplicationFailure`s (`ADK_RUNTIME_FAILURE_TYPES`) instead of retrying the Workflow Task
+    forever.
 - **Experimental**: `@temporalio/openai-agents` can run OpenAI Agents `SandboxAgent`s as Temporal Workflows. SandboxAgent
   operations are Activities; hosted tool credentials and sandbox environment values that reference allowlisted Worker
   environment variables are resolved on Worker so their values are not recorded in Workflow history.

--- a/contrib/google-adk-agents/README.md
+++ b/contrib/google-adk-agents/README.md
@@ -3,12 +3,14 @@
 Run [Google Agent Development Kit](https://github.com/google/adk-js) (`@google/adk`)
 agents as durable [Temporal](https://temporal.io) Workflows.
 
-Your ADK agent graph runs inside the Workflow and replays deterministically. The
-plugin routes non-deterministic boundaries out to Activities:
+Your ADK agent graph — agents, tools, plugins, and ADK 2.0's workflow (graph)
+runtime — runs inside the Workflow and replays deterministically. The plugin
+routes non-deterministic boundaries out to Activities:
 
 - every **model call** (`generateContentAsync`) becomes a retryable, observable
-  Activity, and
-- every **MCP tool call** (list-tools / call-tool) becomes an Activity.
+  Activity,
+- every **MCP tool call** (list-tools / call-tool) becomes an Activity,
+- an **Activity** can be a graph node (`activityNode`) or a tool (`activityAsTool`).
 
 Regular ADK `FunctionTool`s still run in the Workflow. If a tool performs I/O,
 wrap an existing Temporal Activity with `activityAsTool`.
@@ -175,6 +177,86 @@ const lookupTool = activityAsTool({
 });
 ```
 
+### Graph workflows
+
+ADK 2.0's workflow runtime — `Workflow`, `node()`, `JoinNode`, routing,
+`dynamicEntry`, `RequestInput` — is plain async code driven by session events,
+so it runs inside a Temporal Workflow unchanged. Use `activityNode` to make a
+registered Activity a node:
+
+```typescript
+import { JoinNode, Workflow, createEvent, node } from '@google/adk';
+import { activityNode } from '@temporalio/google-adk-agents/workflow';
+
+const fetchA = activityNode({ name: 'fetchData', nodeName: 'fetch_a', args: () => ['a'] });
+const fetchB = activityNode({ name: 'fetchData', nodeName: 'fetch_b', args: () => ['b'] });
+const join = new JoinNode({ name: 'join' });
+const summarize = activityNode({
+  name: 'summarize',
+  activity: { startToCloseTimeout: '2 minutes', retry: { maximumAttempts: 3 } },
+});
+
+const graph = new Workflow({
+  name: 'report',
+  edges: [
+    ['START', fetchA, join],
+    ['START', fetchB, join],
+    [join, summarize],
+  ],
+});
+const runner = new InMemoryRunner({ agent: graph });
+```
+
+- **Input and output.** By default the node's input is passed to the Activity as
+  its single argument and the Activity's result is the node's output; `args`
+  maps the input (and `NodeContext`, for state) to the Activity's argument list.
+- **Routing.** A node returns `createEvent({ route: 'approve', output })` and the
+  edge `[router, { approve: a, [DEFAULT_ROUTE]: b }]` picks the branch; only that
+  branch's Activity runs.
+- **Dynamic nodes.** Inside a `node(async (ctx, input) => …)` body,
+  `await ctx.runNode(activityNode(…), input)` runs the Activity as a child and
+  returns its result — in loops, in `Promise.all`, behind conditions.
+- **Node as tool.** A `Workflow` (or any node) in an `LlmAgent`'s `tools` becomes a
+  tool. Give it a Zod object `inputSchema` for real parameters; a genai `Schema`
+  advertises a single `request` string, which only a string-typed schema accepts.
+- **Retries and timeouts.** Prefer Temporal's `activity.retry` and timeouts. ADK's
+  `retryConfig` re-runs the whole node on top of them (match an Activity failure
+  with `exceptions: ['ActivityFailure']`; ADK matches error names), its backoff is
+  a durable timer, and its jitter is drawn from the Workflow's `Math.random()`.
+  A node `timeout` (seconds) is a durable timer that cancels the in-flight
+  Activity and fails the node with ADK's `NodeTimeoutError`.
+- **Resume.** ADK resumes a paused graph from the session's events: a node that
+  already produced output is fast-forwarded rather than re-run. `activityNode`
+  defaults `rerunOnResume` to `false`, so its Activity is not scheduled again;
+  ADK's `Workflow` and `LlmAgent` default it to `true`. Resume is at-least-once
+  for a dynamic node's body — put side effects in `activityNode` /
+  `activityAsTool` children, or make them idempotent.
+- `LongRunningFunctionTool`s (including a node-as-tool) cannot be used as a
+  `ToolNode`; ADK rejects that.
+
+### Failures
+
+A model or Activity failure ends the Workflow through its `ActivityFailure` as
+usual. ADK's own runtime errors are plain `Error`s, and the Temporal SDK treats an
+unexpected error as a Workflow _Task_ failure that retries forever; the plugin
+therefore converts the ones a graph produces as outcomes into non-retryable
+`ApplicationFailure`s (the ADK error is the `cause`):
+
+| ADK error                   | `ApplicationFailure.type`                                                                                                     |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `NodeTimeoutError`          | `GoogleAdkNodeTimeoutError`                                                                                                   |
+| `NodeReportedError`         | `GoogleAdkNodeReportedError` (or the recorded model `ActivityFailure` when a `TemporalModel` call was what the node absorbed) |
+| `NodeSchemaValidationError` | `GoogleAdkNodeSchemaValidationError`                                                                                          |
+| `IntentMismatchError`       | `GoogleAdkIntentMismatchError`                                                                                                |
+| `StateSchemaError`          | `GoogleAdkStateSchemaError`                                                                                                   |
+| `InvocationAbortedError`    | `GoogleAdkInvocationAbortedError`                                                                                             |
+| `DynamicNodeFailError`      | `GoogleAdkDynamicNodeFailError`                                                                                               |
+
+The mapping is exported as `ADK_RUNTIME_FAILURE_TYPES`. Anything else ADK throws
+— a malformed human reply, `StreamingMode.BIDI`, a reserved function _call_ in a
+client message — keeps the SDK's convention; use
+`WorkerOptions.workflowFailureErrorTypes` to fail the execution on more.
+
 ### Streaming
 
 Streaming requires `streamingTopic` on `TemporalModel`. Chunks are published via
@@ -236,9 +318,11 @@ const worker = await Worker.create({
 });
 ```
 
-You then get ADK's agent-loop spans nested under the same trace as the
-interceptor's own `RunWorkflow` / `StartActivity` spans. Export is replay-gated,
-so replaying a Workflow's history does not re-emit them.
+You then get ADK's spans — `invocation`, `invoke_agent <name>`, `call_llm`, and
+for the workflow runtime `invoke_workflow <name>`, `execute_node <name>`,
+`execute_node_attempt <name>` — nested under the same trace as the interceptor's
+own `RunWorkflow` / `StartActivity` spans. Export is replay-gated, so replaying a
+Workflow's history does not re-emit them.
 
 Cautions:
 
@@ -249,6 +333,9 @@ Cautions:
   task **retry** (a task that failed or timed out and re-executes) is not a
   replay, so its spans are re-emitted. Retries are rare in normal operation, but
   don't build alerting that assumes exact span counts.
+- ADK attaches its `adk.workflow.*` / `adk.node.*` attributes to the _active_
+  span, and no OpenTelemetry context manager runs inside the sandbox, so those
+  attributes are absent; span names and counts are reliable.
 - The agent-loop spans carry prompt content as span attributes, and ADK's
   `ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS=false` does not suppress it inside the
   sandbox. Point the span processor somewhere approved for prompt content, or
@@ -262,11 +349,16 @@ Cautions:
 ## Determinism notes
 
 - ADK generates ids — event, invocation and session ids, function-call ids — with
-  `randomUUID()`. The sandbox has no `crypto`, so the plugin serves ADK a `crypto`
-  module whose values come from a **named workflow random stream**: replay-stable,
-  and independent of the Workflow's own `Math.random()` sequence. Those ids are
-  **not cryptographically random** inside a Workflow; nor is ADK's OAuth2 `state`,
-  which is one reason credential flows are unsupported there.
+  `randomUUID()`. The sandbox has no `crypto`,
+  so the plugin serves ADK a `crypto` module whose values come from a **named
+  workflow random stream**: replay-stable, and independent of the Workflow's own
+  `Math.random()` sequence. Those ids are **not cryptographically random** inside
+  a Workflow; nor is ADK's OAuth2 `state`, which is one reason credential flows are
+  unsupported there.
+- ADK's node retry backoff and timeouts are durable timers; the retry jitter is
+  drawn from the Workflow's `Math.random()`.
+- ADK resumes a paused run from the session events: completed nodes are
+  fast-forwarded, a dynamic node's body re-runs.
 
 ## Not supported in Workflows
 

--- a/contrib/google-adk-agents/package.json
+++ b/contrib/google-adk-agents/package.json
@@ -87,7 +87,8 @@
     "@temporalio/testing": "workspace:*",
     "@temporalio/worker": "workspace:*",
     "@types/node": "^20.0.0",
-    "ava": "^5.3.1"
+    "ava": "^5.3.1",
+    "zod": "^4.2.1"
   },
   "engines": {
     "node": ">= 20.3.0"

--- a/contrib/google-adk-agents/src/__tests__/dynamic.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/dynamic.test.ts
@@ -1,0 +1,89 @@
+/**
+ * E2E tests for ADK 2.0 dynamic nodes (`ctx.runNode` from a node body) and
+ * workflow-as-tool inside a Temporal Workflow.
+ */
+
+import test from 'ava';
+
+import { GoogleAdkPlugin } from '../index';
+import { countScheduledActivities, setupTestEnv, uid, withWorker } from './helpers';
+import * as activities from './test-activities';
+import { graphTestProvider } from './test-models';
+import { dynamicGather, dynamicLoop, workflowAsTool } from './graph-workflows';
+
+const getEnv = setupTestEnv(test);
+
+function makePlugin(): GoogleAdkPlugin {
+  return new GoogleAdkPlugin({ modelProvider: graphTestProvider() });
+}
+
+test.serial('a dynamic node runs an Activity node in a loop', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-dyn-loop');
+  const workflowId = uid('wf-dyn-loop');
+  const result = await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, () =>
+    env.client.workflow.execute(dynamicLoop, { taskQueue, workflowId, args: [3] })
+  );
+  t.deepEqual(result.output, ['enriched-0', 'enriched-1', 'enriched-2']);
+  const { events } = await env.client.workflow.getHandle(workflowId).fetchHistory();
+  t.is(countScheduledActivities(events ?? [], 'enrichNumber'), 3);
+});
+
+test.serial('a dynamic node fans out Activity nodes with Promise.all', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-dyn-gather');
+  const workflowId = uid('wf-dyn-gather');
+  const result = await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, () =>
+    env.client.workflow.execute(dynamicGather, { taskQueue, workflowId })
+  );
+  t.deepEqual(result.output, ['enriched-1', 'enriched-2']);
+  const { events } = await env.client.workflow.getHandle(workflowId).fetchHistory();
+  // Both Activities were scheduled before either completed: concurrent, not sequential.
+  const scheduled = (events ?? []).map((e, i) => ({ e, i })).filter(({ e }) => e.activityTaskScheduledEventAttributes);
+  const firstCompleted = (events ?? []).findIndex((e) => e.activityTaskCompletedEventAttributes);
+  t.is(scheduled.length, 2);
+  t.true(scheduled.every(({ i }) => i < firstCompleted));
+});
+
+test.serial('a Workflow with a Zod inputSchema is a tool with real parameters', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-dyn-tool-zod');
+  const workflowId = uid('wf-dyn-tool-zod');
+  const { text } = await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, () =>
+    env.client.workflow.execute(workflowAsTool, { taskQueue, workflowId, args: ['zod'] })
+  );
+  // `ToolCallingLlm` reports the tool result it was fed and the declarations it saw.
+  t.true(text.includes('tool=enrich_flow'), text);
+  t.true(text.includes('enriched-7'), text);
+  t.true(text.includes('enrich_flow(value)'), text);
+  const { events } = await env.client.workflow.getHandle(workflowId).fetchHistory();
+  t.is(countScheduledActivities(events ?? [], 'enrichNumber'), 1);
+});
+
+test.serial('a Workflow with a genai Schema is a tool taking a single request string', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-dyn-tool-genai');
+  await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, async () => {
+    // A string-typed genai schema: ADK advertises `{request: string}` and hands the
+    // string to the graph, which accepts it.
+    const asString = await env.client.workflow.execute(workflowAsTool, {
+      taskQueue,
+      workflowId: uid('wf-dyn-tool-genai-string'),
+      args: ['genai-string'],
+    });
+    t.true(asString.text.includes('enriched-7'), asString.text);
+    t.true(asString.text.includes('enrich_flow(request)'), asString.text);
+    // An object-typed genai schema cannot be satisfied through that single string:
+    // the graph produces no output, and since a `NodeTool` is long-running, a
+    // missing result defers the tool response — the turn ends with nothing. Use a
+    // Zod object schema for real parameters.
+    const asObject = await env.client.workflow.execute(workflowAsTool, {
+      taskQueue,
+      workflowId: uid('wf-dyn-tool-genai-object'),
+      args: ['genai-object'],
+    });
+    t.is(asObject.text, '');
+    t.is(asObject.output, undefined);
+    t.is(asObject.errorMessage, undefined);
+  });
+});

--- a/contrib/google-adk-agents/src/__tests__/graph-workflows.ts
+++ b/contrib/google-adk-agents/src/__tests__/graph-workflows.ts
@@ -1,0 +1,341 @@
+/**
+ * Workflow fixtures for ADK 2.0's workflow (graph) runtime and dynamic nodes.
+ * Bundled into the sandbox through `workflows.ts`, which re-exports this module.
+ *
+ * Every fixture runs the *native* ADK runtime inside the Workflow; the plugin
+ * routes only model and Activity-node I/O to Activities.
+ */
+
+import {
+  App,
+  BasePlugin,
+  createEvent,
+  createResumabilityConfig,
+  DEFAULT_ROUTE,
+  InMemoryRunner,
+  isFinalResponse,
+  JoinNode,
+  LlmAgent,
+  node,
+  stringifyContent,
+  TruncatingContextCompactor,
+  Workflow,
+  type BaseNode,
+  type Event,
+  type LlmResponse,
+  type NodeContext,
+  type RunnableRoot,
+} from '@google/adk';
+import { Type } from '@google/genai';
+import { z } from 'zod';
+
+import { activityNode, markModelFailureHandled, TemporalModel, type TemporalModelOptions } from '../workflow';
+
+const USER = 'test-user';
+
+/** Per-turn Activity options: fail on the first attempt. */
+const SINGLE_ATTEMPT: TemporalModelOptions = { activity: { retry: { maximumAttempts: 1 } } };
+
+interface RunOutcome {
+  /** The last `output` any event carried — the graph's result. */
+  output: unknown;
+  /** The last final response's text. */
+  text: string;
+  /** Node names in the order their events were seen. */
+  nodes: string[];
+  /** The last `errorMessage` any event carried (an error ADK absorbed into an event). */
+  errorMessage?: string;
+}
+
+/** Runs one ephemeral turn against `root` and collects what came out. */
+async function runOnce(root: RunnableRoot, prompt: string, plugins?: BasePlugin[]): Promise<RunOutcome> {
+  const runner = new InMemoryRunner({ agent: root, plugins });
+  return collect(runner.runEphemeral({ userId: USER, newMessage: { role: 'user', parts: [{ text: prompt }] } }));
+}
+
+async function collect(events: AsyncIterable<Event>): Promise<RunOutcome> {
+  const outcome: RunOutcome = { output: undefined, text: '', nodes: [] };
+  for await (const event of events) {
+    if (event.errorMessage) outcome.errorMessage = event.errorMessage;
+    if (event.output !== undefined) outcome.output = event.output;
+    if (isFinalResponse(event)) outcome.text = stringifyContent(event);
+    const path = event.nodeInfo?.path;
+    if (path) outcome.nodes.push(path);
+  }
+  return outcome;
+}
+
+// ---------------------------------------------------------------------------
+// Graph runtime
+// ---------------------------------------------------------------------------
+
+/** START → fetchData → summarize, both Temporal Activities. */
+export async function graphSequential(query: string): Promise<RunOutcome> {
+  const graph = new Workflow({
+    name: 'sequential',
+    edges: [['START', activityNode({ name: 'fetchData', args: () => [query] }), activityNode({ name: 'summarize' })]],
+  });
+  return runOnce(graph, 'go');
+}
+
+/** A router node picks a route; only that branch's Activity runs. */
+export async function graphRouting(route: string): Promise<RunOutcome> {
+  const router = node((_ctx: NodeContext, _input: unknown) => createEvent({ route, output: route }), {
+    name: 'router',
+  });
+  const graph = new Workflow({
+    name: 'routing',
+    edges: [
+      ['START', router],
+      [
+        router,
+        {
+          approve: activityNode({ name: 'approveActivity', args: () => [] }),
+          [DEFAULT_ROUTE]: activityNode({ name: 'rejectActivity', args: () => [] }),
+        },
+      ],
+    ],
+  });
+  return runOnce(graph, 'go');
+}
+
+/** Two Activity nodes fan out from START and join; the join's input is keyed by node name. */
+export async function graphFanOutJoin(): Promise<RunOutcome> {
+  const enrichA = activityNode({ name: 'enrichItem', nodeName: 'enrich_a', args: () => ['alpha'] });
+  const enrichB = activityNode({ name: 'enrichItem', nodeName: 'enrich_b', args: () => ['beta'] });
+  const join = new JoinNode({ name: 'join' });
+  const final = node((_ctx: NodeContext, results: Record<string, unknown>) => results, { name: 'final' });
+  const graph = new Workflow({
+    name: 'fan_out_join',
+    edges: [
+      ['START', enrichA, join],
+      ['START', enrichB, join],
+      [join, final],
+    ],
+  });
+  return runOnce(graph, 'go');
+}
+
+/** An `LlmAgent` in task mode as a graph node; its `finish_task` call is the node's output. */
+export async function graphAgentTaskNode(prompt: string): Promise<RunOutcome> {
+  const agent = new LlmAgent({
+    name: 'tasker',
+    model: new TemporalModel('finish-task-model'),
+    mode: 'task',
+    instruction: 'Finish the task.',
+  });
+  const graph = new Workflow({ name: 'task_graph', edges: [['START', agent]] });
+  return runOnce(graph, prompt);
+}
+
+/** A 1-second node deadline around a 20-second Activity: ADK times the node out and cancels the Activity. */
+export async function graphTimeout(): Promise<RunOutcome> {
+  const graph = new Workflow({
+    name: 'timeout_graph',
+    edges: [
+      [
+        'START',
+        activityNode({
+          name: 'slowActivity',
+          args: () => [],
+          timeout: 1,
+          activity: { startToCloseTimeout: '30 seconds', retry: { maximumAttempts: 1 } },
+        }),
+      ],
+    ],
+  });
+  return runOnce(graph, 'go');
+}
+
+/** ADK's node retry (with jitter) re-runs a non-retryable Activity failure twice before it succeeds. */
+export async function graphRetry(jitter: number): Promise<RunOutcome> {
+  const graph = new Workflow({
+    name: 'retry_graph',
+    edges: [
+      [
+        'START',
+        activityNode({
+          name: 'flakyActivity',
+          args: () => [],
+          retryConfig: { maxAttempts: 3, initialDelay: 0.05, jitter, exceptions: ['ActivityFailure'] },
+          activity: { retry: { maximumAttempts: 1 } },
+        }),
+      ],
+    ],
+  });
+  return runOnce(graph, 'go');
+}
+
+/** A node whose Activity fails for good: the failure must fail the Workflow. */
+export async function graphActivityFailure(): Promise<RunOutcome> {
+  const graph = new Workflow({
+    name: 'failing_graph',
+    edges: [
+      ['START', activityNode({ name: 'failingActivity', args: () => [], activity: { retry: { maximumAttempts: 1 } } })],
+    ],
+  });
+  return runOnce(graph, 'go');
+}
+
+/** An ADK plugin that substitutes a response for a failed model call. */
+class RecoveringPlugin extends BasePlugin {
+  constructor() {
+    super('recovering');
+  }
+
+  override async onModelErrorCallback({ error }: { error: Error }): Promise<LlmResponse | undefined> {
+    markModelFailureHandled(error);
+    return createEvent({
+      author: 'assistant',
+      content: { role: 'model', parts: [{ text: 'recovered' }] },
+      turnComplete: true,
+    });
+  }
+}
+
+/**
+ * An `LlmAgent` node whose model call fails. ADK absorbs the model error and the
+ * node ends without output; the plugin surfaces the recorded model failure —
+ * unless an `onModelErrorCallback` recovers it.
+ */
+export async function graphAgentNodeModelFailure(model: string, recover: boolean): Promise<RunOutcome> {
+  const agent = new LlmAgent({
+    name: 'assistant',
+    model: new TemporalModel(model, SINGLE_ATTEMPT),
+    instruction: 'Help.',
+  });
+  const graph = new Workflow({ name: 'agent_node_graph', edges: [['START', agent]] });
+  return runOnce(graph, 'hi', recover ? [new RecoveringPlugin()] : undefined);
+}
+
+/** A plugin observing ADK 2.0's node callbacks. */
+class NodeCallbackPlugin extends BasePlugin {
+  readonly seen: string[] = [];
+
+  constructor() {
+    super('node-callbacks');
+  }
+
+  override async beforeNodeCallback({ node: n }: { node: BaseNode }): Promise<unknown> {
+    this.seen.push(`before:${n.name}`);
+    return undefined;
+  }
+
+  override async afterNodeCallback({ node: n }: { node: BaseNode }): Promise<unknown> {
+    this.seen.push(`after:${n.name}`);
+    return undefined;
+  }
+}
+
+export async function graphPluginNodeCallbacks(): Promise<string[]> {
+  const plugin = new NodeCallbackPlugin();
+  const graph = new Workflow({
+    name: 'callbacks_graph',
+    edges: [['START', activityNode({ name: 'fetchData', args: () => ['cb'] })]],
+  });
+  await runOnce(graph, 'go', [plugin]);
+  return plugin.seen;
+}
+
+/** An `App` root with resumability enabled, run through `InMemoryRunner({ app })`. */
+export async function appRoot(prompt: string): Promise<string> {
+  const app = new App({
+    name: 'adk_app',
+    rootAgent: new LlmAgent({ name: 'assistant', model: new TemporalModel('fake-model'), instruction: 'Help.' }),
+    resumabilityConfig: createResumabilityConfig({ isResumable: true }),
+  });
+  const runner = new InMemoryRunner({ app });
+  const { text } = await collect(
+    runner.runEphemeral({ userId: USER, newMessage: { role: 'user', parts: [{ text: prompt }] } })
+  );
+  return text;
+}
+
+/** Several turns in one session with a truncating context compactor attached to the agent. */
+export async function compactedAgent(turns: number): Promise<string[]> {
+  const agent = new LlmAgent({
+    name: 'assistant',
+    model: new TemporalModel('fake-model'),
+    instruction: 'Help.',
+    contextCompactors: [new TruncatingContextCompactor({ threshold: 2 })],
+  });
+  const runner = new InMemoryRunner({ agent });
+  const session = await runner.sessionService.createSession({ appName: runner.appName, userId: USER });
+  const texts: string[] = [];
+  for (let turn = 0; turn < turns; turn++) {
+    const { text } = await collect(
+      runner.runAsync({
+        userId: USER,
+        sessionId: session.id,
+        newMessage: { role: 'user', parts: [{ text: `turn-${turn}` }] },
+      })
+    );
+    texts.push(text);
+  }
+  return texts;
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic nodes
+// ---------------------------------------------------------------------------
+
+/** A dynamic entry node runs an Activity node `n` times in a loop. */
+export async function dynamicLoop(n: number): Promise<RunOutcome> {
+  const enrich = activityNode({ name: 'enrichNumber', nodeName: 'enrich' });
+  const driver = node(
+    async (ctx: NodeContext, _input: unknown) => {
+      const outputs: unknown[] = [];
+      for (let i = 0; i < n; i++) {
+        const result = await ctx.runNode(enrich, i);
+        outputs.push(result.output);
+      }
+      return outputs;
+    },
+    { name: 'driver', rerunOnResume: true }
+  );
+  return runOnce(new Workflow({ name: 'dynamic_loop', edges: [['START', driver]] }), 'go');
+}
+
+/** A dynamic entry node fans out two Activity nodes with `Promise.all`. */
+export async function dynamicGather(): Promise<RunOutcome> {
+  const enrich = activityNode({ name: 'enrichNumber', nodeName: 'enrich' });
+  const driver = node(
+    async (ctx: NodeContext, _input: unknown) => {
+      const results = await Promise.all([ctx.runNode(enrich, 1), ctx.runNode(enrich, 2)]);
+      return results.map((r) => r.output);
+    },
+    { name: 'driver', rerunOnResume: true }
+  );
+  return runOnce(new Workflow({ name: 'dynamic_gather', edges: [['START', driver]] }), 'go');
+}
+
+/**
+ * A `Workflow` as a tool: ADK wraps it in a `NodeTool`. With a Zod `inputSchema`
+ * the model sees real parameters; with a genai `Schema` ADK advertises a single
+ * `request` string and passes it as the node input.
+ */
+export async function workflowAsTool(schema: 'zod' | 'genai-string' | 'genai-object'): Promise<RunOutcome> {
+  const enrich = activityNode<unknown, string>({
+    name: 'enrichNumber',
+    nodeName: 'enrich',
+    args: (input) => [typeof input === 'object' && input !== null ? (input as { value: number }).value : Number(input)],
+  });
+  const flow = new Workflow({
+    name: 'enrich_flow',
+    description: 'Enriches a number.',
+    inputSchema:
+      schema === 'zod'
+        ? z.object({ value: z.number().describe('The number to enrich.') })
+        : schema === 'genai-string'
+          ? { type: Type.STRING, description: 'The number to enrich, as text.' }
+          : { type: Type.OBJECT, properties: { value: { type: Type.NUMBER } } },
+    edges: [['START', enrich]],
+  });
+  const agent = new LlmAgent({
+    name: 'assistant',
+    model: new TemporalModel(schema === 'zod' ? 'enrich-flow-model' : 'enrich-flow-genai-model'),
+    instruction: 'Use the tool.',
+    tools: [flow],
+  });
+  return runOnce(agent, 'enrich 7');
+}

--- a/contrib/google-adk-agents/src/__tests__/graph.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/graph.test.ts
@@ -1,0 +1,209 @@
+/**
+ * E2E tests for ADK 2.0's workflow (graph) runtime inside a Temporal Workflow:
+ * `activityNode`, routing, fan-out/join, agent nodes, node timeouts and retries,
+ * failure propagation, node-callback plugins, `App` roots and compactors.
+ */
+
+import test from 'ava';
+import { ActivityFailure, ApplicationFailure, TimeoutFailure } from '@temporalio/common';
+
+import { GoogleAdkPlugin } from '../index';
+import { countScheduledActivities, findInCauseChain, setupTestEnv, uid, withWorker } from './helpers';
+import * as activities from './test-activities';
+import { graphTestProvider } from './test-models';
+import {
+  appRoot,
+  compactedAgent,
+  graphActivityFailure,
+  graphAgentNodeModelFailure,
+  graphAgentTaskNode,
+  graphFanOutJoin,
+  graphPluginNodeCallbacks,
+  graphRetry,
+  graphRouting,
+  graphSequential,
+  graphTimeout,
+} from './graph-workflows';
+
+const getEnv = setupTestEnv(test);
+
+function makePlugin(): GoogleAdkPlugin {
+  return new GoogleAdkPlugin({ modelProvider: graphTestProvider() });
+}
+
+async function history(workflowId: string) {
+  const env = getEnv();
+  const { events } = await env.client.workflow.getHandle(workflowId).fetchHistory();
+  return events ?? [];
+}
+
+test.serial('sequential Activity nodes pass output downstream, one Activity each', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-graph-seq');
+  const workflowId = uid('wf-graph-seq');
+  const result = await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, () =>
+    env.client.workflow.execute(graphSequential, { taskQueue, workflowId, args: ['hello'] })
+  );
+  t.is(result.output, 'data-for-hello summarized');
+  const events = await history(workflowId);
+  t.is(countScheduledActivities(events, 'fetchData'), 1);
+  t.is(countScheduledActivities(events, 'summarize'), 1);
+  t.deepEqual(activities.executionsFor(workflowId), ['fetchData:hello', 'summarize:data-for-hello']);
+});
+
+test.serial('a route from a node runs only the matching branch Activity', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-graph-route');
+  const approved = uid('wf-graph-route-approve');
+  const other = uid('wf-graph-route-other');
+  await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, async () => {
+    t.is(
+      (await env.client.workflow.execute(graphRouting, { taskQueue, workflowId: approved, args: ['approve'] })).output,
+      'approved'
+    );
+    t.is(
+      (await env.client.workflow.execute(graphRouting, { taskQueue, workflowId: other, args: ['anything'] })).output,
+      'rejected'
+    );
+  });
+  const approvedEvents = await history(approved);
+  t.is(countScheduledActivities(approvedEvents, 'approveActivity'), 1);
+  t.is(countScheduledActivities(approvedEvents, 'rejectActivity'), 0);
+  const otherEvents = await history(other);
+  t.is(countScheduledActivities(otherEvents, 'approveActivity'), 0);
+  t.is(countScheduledActivities(otherEvents, 'rejectActivity'), 1);
+});
+
+test.serial('fan-out Activity nodes join, keyed by node name', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-graph-join');
+  const workflowId = uid('wf-graph-join');
+  const result = await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, () =>
+    env.client.workflow.execute(graphFanOutJoin, { taskQueue, workflowId })
+  );
+  t.deepEqual(result.output, { enrich_a: 'enriched-alpha', enrich_b: 'enriched-beta' });
+  t.is(countScheduledActivities(await history(workflowId), 'enrichItem'), 2);
+});
+
+test.serial('an LlmAgent node in task mode reports its finish_task result as the node output', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-graph-task');
+  const workflowId = uid('wf-graph-task');
+  const result = await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, () =>
+    env.client.workflow.execute(graphAgentTaskNode, { taskQueue, workflowId, args: ['do it'] })
+  );
+  t.deepEqual(result.output, { result: 'task-done' });
+  t.is(countScheduledActivities(await history(workflowId), 'adk-invokeModel'), 1);
+});
+
+test.serial('a node timeout cancels the in-flight Activity and fails the Workflow with a typed failure', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-graph-timeout');
+  const workflowId = uid('wf-graph-timeout');
+  const err = await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, () =>
+    t.throwsAsync(env.client.workflow.execute(graphTimeout, { taskQueue, workflowId }))
+  );
+  t.is((err as Error).name, 'WorkflowFailedError');
+  // ADK's plain `NodeTimeoutError` is converted, so the execution FAILS instead of
+  // retrying the Workflow Task forever.
+  const failure = findInCauseChain(err, ApplicationFailure);
+  t.is(failure?.type, 'GoogleAdkNodeTimeoutError');
+  t.is(failure?.nonRetryable, true);
+  t.is(findInCauseChain(err, TimeoutFailure), undefined);
+  // The abort bridge cancelled the Activity (rather than leaving it to its 30s timeout).
+  const events = await history(workflowId);
+  t.true(
+    events.some((e) => e.activityTaskCancelRequestedEventAttributes !== undefined),
+    'expected an ActivityTaskCancelRequested event'
+  );
+});
+
+test.serial('ADK node retries with jitter re-run a failed Activity and replay deterministically', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-graph-retry');
+  const workflowId = uid('wf-graph-retry');
+  const result = await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, () =>
+    env.client.workflow.execute(graphRetry, { taskQueue, workflowId, args: [1] })
+  );
+  t.is(result.output, 'ok-after-2');
+  const events = await history(workflowId);
+  t.is(countScheduledActivities(events, 'flakyActivity'), 3);
+  // The backoff between attempts is a durable timer whose jitter came from the
+  // Workflow's seeded `Math.random()`; the cache-disabled worker already replayed
+  // it on every task, and a full replay of the history must agree too.
+  const { Worker } = await import('@temporalio/worker');
+  const { REUSE_V8_CONTEXT, workflowsPath } = await import('./helpers');
+  await Worker.runReplayHistory(
+    { workflowsPath, reuseV8Context: REUSE_V8_CONTEXT, plugins: [makePlugin()] },
+    await env.client.workflow.getHandle(workflowId).fetchHistory()
+  );
+});
+
+test.serial('a permanently failing Activity node fails the Workflow through its ActivityFailure', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-graph-fail');
+  const workflowId = uid('wf-graph-fail');
+  const err = await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, () =>
+    t.throwsAsync(env.client.workflow.execute(graphActivityFailure, { taskQueue, workflowId }))
+  );
+  t.is((err as Error).name, 'WorkflowFailedError');
+  t.not(findInCauseChain(err, ActivityFailure), undefined);
+  t.is(findInCauseChain(err, ApplicationFailure)?.type, 'TestPermanentFailure');
+});
+
+test.serial('an agent node whose model call fails surfaces the recorded model failure', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-graph-agent-fail');
+  const workflowId = uid('wf-graph-agent-fail');
+  const err = await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, () =>
+    t.throwsAsync(
+      env.client.workflow.execute(graphAgentNodeModelFailure, { taskQueue, workflowId, args: ['boom', false] })
+    )
+  );
+  t.is((err as Error).name, 'WorkflowFailedError');
+  // ADK reports the absorbed model error as a `NodeReportedError`; the plugin raises
+  // the recorded `ActivityFailure` instead, keeping the model failure's status.
+  t.not(findInCauseChain(err, ActivityFailure), undefined);
+  t.is(findInCauseChain(err, ApplicationFailure)?.type, 'GoogleAdkModelError.400');
+});
+
+test.serial('an agent node recovered by onModelErrorCallback completes', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-graph-agent-recover');
+  const result = await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, () =>
+    env.client.workflow.execute(graphAgentNodeModelFailure, {
+      taskQueue,
+      workflowId: uid('wf-graph-agent-recover'),
+      args: ['boom', true],
+    })
+  );
+  t.is(result.text, 'recovered');
+});
+
+test.serial('plugins observe beforeNodeCallback / afterNodeCallback around an Activity node', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-graph-callbacks');
+  const seen = await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, () =>
+    env.client.workflow.execute(graphPluginNodeCallbacks, { taskQueue, workflowId: uid('wf-graph-callbacks') })
+  );
+  // The `Workflow` root is itself a node, so ADK reports it around its children.
+  t.deepEqual(seen, ['before:callbacks_graph', 'before:fetchData', 'after:fetchData', 'after:callbacks_graph']);
+});
+
+test.serial('an App root with resumability enabled runs through InMemoryRunner', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-graph-app');
+  const text = await withWorker(env, { taskQueue, plugins: [makePlugin()] }, () =>
+    env.client.workflow.execute(appRoot, { taskQueue, workflowId: uid('wf-graph-app'), args: ['hi'] })
+  );
+  t.is(text, 'fake-response:fake-model');
+});
+
+test.serial('a truncating context compactor runs across turns in one session', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-graph-compact');
+  const texts = await withWorker(env, { taskQueue, plugins: [makePlugin()] }, () =>
+    env.client.workflow.execute(compactedAgent, { taskQueue, workflowId: uid('wf-graph-compact'), args: [3] })
+  );
+  t.deepEqual(texts, ['fake-response:fake-model', 'fake-response:fake-model', 'fake-response:fake-model']);
+});

--- a/contrib/google-adk-agents/src/__tests__/histories/graph_workflow.json
+++ b/contrib/google-adk-agents/src/__tests__/histories/graph_workflow.json
@@ -1,0 +1,363 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-09-11T14:47:27.548454Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048587",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "graphSequential"
+        },
+        "taskQueue": {
+          "name": "adk-replay-graph-1789138046482-685186",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InJlcGxheSI="
+            }
+          ]
+        },
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "01a090f0-123c-76ed-b55a-55d1434459b7",
+        "identity": "76423@Davids-MacBook-Pro.local",
+        "firstExecutionRunId": "01a090f0-123c-76ed-b55a-55d1434459b7",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "wf-replay-graph-1789138046482-777527"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-09-11T14:47:27.548499Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048588",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "adk-replay-graph-1789138046482-685186",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-09-11T14:47:27.550138Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048593",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "76423@Davids-MacBook-Pro.local",
+        "requestId": "2a599092-4d1d-4627-baa4-7bccf04c982e",
+        "historySizeBytes": "364",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.23.0+e271ed9c4a853a86870909604fbfadec7c6f5ee549f96a1dbac372fb0d1aa492"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-09-11T14:47:27.608387Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048597",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "76423@Davids-MacBook-Pro.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.23.0+e271ed9c4a853a86870909604fbfadec7c6f5ee549f96a1dbac372fb0d1aa492"
+        },
+        "sdkMetadata": {
+          "coreUsedFlags": [
+            2,
+            1,
+            3
+          ],
+          "sdkName": "temporal-typescript",
+          "sdkVersion": "1.23.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-09-11T14:47:27.608464Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048598",
+      "userMetadata": {
+        "summary": {
+          "metadata": {
+            "encoding": "anNvbi9wbGFpbg=="
+          },
+          "data": "ImFkay5ub2RlIGZldGNoRGF0YSI="
+        }
+      },
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "1",
+        "activityType": {
+          "name": "fetchData"
+        },
+        "taskQueue": {
+          "name": "adk-replay-graph-1789138046482-685186",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InJlcGxheSI="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "60s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s"
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-09-11T14:47:27.609467Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048604",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "76423@Davids-MacBook-Pro.local",
+        "requestId": "17228632-f90b-4b94-b400-78fd765880dd",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.23.0+e271ed9c4a853a86870909604fbfadec7c6f5ee549f96a1dbac372fb0d1aa492"
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-09-11T14:47:27.613595Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048605",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "ImRhdGEtZm9yLXJlcGxheSI="
+            }
+          ]
+        },
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "76423@Davids-MacBook-Pro.local"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-09-11T14:47:27.613601Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048606",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "adk-replay-graph-1789138046482-685186",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-09-11T14:47:27.614265Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048609",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "76423@Davids-MacBook-Pro.local",
+        "requestId": "c227aa95-e6fa-4f0b-8e56-cb7f688e662c",
+        "historySizeBytes": "1350",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.23.0+e271ed9c4a853a86870909604fbfadec7c6f5ee549f96a1dbac372fb0d1aa492"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-09-11T14:47:27.628472Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048613",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "76423@Davids-MacBook-Pro.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.23.0+e271ed9c4a853a86870909604fbfadec7c6f5ee549f96a1dbac372fb0d1aa492"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-09-11T14:47:27.628496Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048614",
+      "userMetadata": {
+        "summary": {
+          "metadata": {
+            "encoding": "anNvbi9wbGFpbg=="
+          },
+          "data": "ImFkay5ub2RlIHN1bW1hcml6ZSI="
+        }
+      },
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "2",
+        "activityType": {
+          "name": "summarize"
+        },
+        "taskQueue": {
+          "name": "adk-replay-graph-1789138046482-685186",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "ImRhdGEtZm9yLXJlcGxheSI="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "60s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "10",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s"
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-09-11T14:47:27.629142Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048619",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "76423@Davids-MacBook-Pro.local",
+        "requestId": "e23e4b50-e5b2-4130-9f2e-96faec5a3568",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.23.0+e271ed9c4a853a86870909604fbfadec7c6f5ee549f96a1dbac372fb0d1aa492"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-09-11T14:47:27.630767Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048620",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "ImRhdGEtZm9yLXJlcGxheSBzdW1tYXJpemVkIg=="
+            }
+          ]
+        },
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "76423@Davids-MacBook-Pro.local"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-09-11T14:47:27.630771Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048621",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "adk-replay-graph-1789138046482-685186",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2026-09-11T14:47:27.631282Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048624",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "76423@Davids-MacBook-Pro.local",
+        "requestId": "7aedf881-3d95-49f4-852d-78227b710283",
+        "historySizeBytes": "2322",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.23.0+e271ed9c4a853a86870909604fbfadec7c6f5ee549f96a1dbac372fb0d1aa492"
+        }
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2026-09-11T14:47:27.647380Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048628",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "14",
+        "startedEventId": "15",
+        "identity": "76423@Davids-MacBook-Pro.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.23.0+e271ed9c4a853a86870909604fbfadec7c6f5ee549f96a1dbac372fb0d1aa492"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2026-09-11T14:47:27.647410Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1048629",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJvdXRwdXQiOiJkYXRhLWZvci1yZXBsYXkgc3VtbWFyaXplZCIsInRleHQiOiJkYXRhLWZvci1yZXBsYXkgc3VtbWFyaXplZCIsIm5vZGVzIjpbInNlcXVlbnRpYWwuZmV0Y2hEYXRhIiwic2VxdWVudGlhbC5zdW1tYXJpemUiXX0="
+            }
+          ]
+        },
+        "workflowTaskCompletedEventId": "16"
+      }
+    }
+  ]
+}

--- a/contrib/google-adk-agents/src/__tests__/published-artifact.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/published-artifact.test.ts
@@ -20,14 +20,19 @@ test('cjsRequireExposesPublicExports', (t) => {
   t.is(typeof workflow.TemporalModel, 'function');
   t.is(typeof workflow.TemporalMCPToolset, 'function');
   t.is(typeof workflow.activityAsTool, 'function');
+  t.is(typeof workflow.activityNode, 'function');
   t.is(typeof workflow.markModelFailureHandled, 'function');
   t.is(workflow.MODEL_ERROR_FAILURE_TYPE, 'GoogleAdkModelError');
   t.is(workflow.MCP_TOOL_NOT_FOUND_FAILURE_TYPE, 'GoogleAdkMCPToolNotFound');
   t.is(workflow.MCP_ERROR_FAILURE_TYPE, 'GoogleAdkMCPError');
   t.is(workflow.STREAMING_TOPIC_REQUIRED_FAILURE_TYPE, 'GoogleAdkStreamingTopicRequired');
   t.is(workflow.UNSUPPORTED_FAILURE_TYPE, 'GoogleAdkUnsupported');
+  t.is(workflow.NODE_TIMEOUT_FAILURE_TYPE, 'GoogleAdkNodeTimeoutError');
+  t.is(workflow.INTENT_MISMATCH_FAILURE_TYPE, 'GoogleAdkIntentMismatchError');
+  t.is(workflow.ADK_RUNTIME_FAILURE_TYPES.NodeTimeoutError, 'GoogleAdkNodeTimeoutError');
   t.false('MCP_TOOLSET_OUTSIDE_WORKFLOW_FAILURE_TYPE' in workflow);
   t.false('ACTIVITY_TOOL_OUTSIDE_WORKFLOW_FAILURE_TYPE' in workflow);
+  t.false('ACTIVITY_NODE_OUTSIDE_WORKFLOW_FAILURE_TYPE' in workflow);
 
   const testing = require('@temporalio/google-adk-agents/testing');
   t.is(typeof testing.fakeModelProvider, 'function');

--- a/contrib/google-adk-agents/src/__tests__/replay.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/replay.test.ts
@@ -1,13 +1,24 @@
 /**
- * Replay determinism. Runs a combined scenario (two model calls + an MCP
- * discovery + call) to produce a real history, then replays that history with
- * the plugin registered. ADK's event IDs / timestamps funnel through
+ * Replay determinism. Runs scenarios to produce real histories, then replays
+ * them with the plugin registered. ADK's event ids / timestamps funnel through
  * `Math.random()` / `Date.now()`, which the Workflow sandbox makes
- * deterministic — so replay must succeed without a custom determinism hook. A
- * determinism violation rejects `Worker.runReplayHistory`.
+ * deterministic, and ADK 2.0's UUIDs (interrupt ids, function-call ids) through
+ * the plugin's named-random-stream `crypto` shim — so replay must succeed
+ * without a custom determinism hook. A determinism violation rejects
+ * `Worker.runReplayHistory`.
+ *
+ * Besides replaying freshly recorded histories, the graph scenario is replayed
+ * from a history checked in under `histories/`, so a change to ADK's or the
+ * plugin's command stream is caught against a frozen recording. Refresh it with
+ * `UPDATE_ADK_HISTORIES=1 pnpm test`.
  */
 
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
 import test from 'ava';
+import { historyToJSON } from '@temporalio/common/lib/proto-utils';
+import type { TestWorkflowEnvironment } from '@temporalio/testing';
 import { Worker, type ReplayWorkerOptions } from '@temporalio/worker';
 
 import { GoogleAdkPlugin } from '../index';
@@ -21,13 +32,23 @@ import {
   withWorker,
   workflowsPath,
 } from './helpers';
+import * as activities from './test-activities';
+import { graphTestProvider } from './test-models';
+import { graphSequential } from './graph-workflows';
 import { replayScenario } from './workflows';
+
+const historiesDir = path.resolve(__dirname, '../../src/__tests__/histories');
+const UPDATE_HISTORIES = process.env.UPDATE_ADK_HISTORIES === '1';
 
 function makePlugin(): GoogleAdkPlugin {
   return new GoogleAdkPlugin({
-    modelProvider: defaultTestProvider(),
+    modelProvider: graphTestProvider(),
     mcpToolsets: { testServer: mockMCPToolset([echoDef]) },
   });
+}
+
+function replayOptions(): ReplayWorkerOptions {
+  return { workflowsPath, reuseV8Context: REUSE_V8_CONTEXT, plugins: [makePlugin()] };
 }
 
 const getEnv = setupTestEnv(test);
@@ -37,8 +58,12 @@ test.serial('replayWithPlugin', async (t) => {
   const env = getEnv();
   const taskQueue = uid('adk-replay');
   const workflowId = uid('wf-replay');
+  const plugin = new GoogleAdkPlugin({
+    modelProvider: defaultTestProvider(),
+    mcpToolsets: { testServer: mockMCPToolset([echoDef]) },
+  });
 
-  const liveResult = await withWorker(env, { taskQueue, plugins: [makePlugin()] }, () =>
+  const liveResult = await withWorker(env, { taskQueue, plugins: [plugin] }, () =>
     env.client.workflow.execute(replayScenario, { taskQueue, workflowId })
   );
   t.true(liveResult.includes('world'));
@@ -52,12 +77,7 @@ test.serial('replayWithPlugin', async (t) => {
   // `Worker.runReplayHistory` invokes each plugin's `configureBundler`),
   // and `GoogleAdkPlugin` is a `WorkerPlugin` via `SimplePlugin` — so this is
   // fully type-checked, no cast.
-  const replayOptions: ReplayWorkerOptions = {
-    workflowsPath,
-    reuseV8Context: REUSE_V8_CONTEXT,
-    plugins: [makePlugin()],
-  };
-  await Worker.runReplayHistory(replayOptions, history);
+  await Worker.runReplayHistory(replayOptions(), history);
 
   // `runReplayHistory` only verifies the command stream, not the workflow's
   // return value. Re-run the scenario with the workflow cache disabled
@@ -66,7 +86,7 @@ test.serial('replayWithPlugin', async (t) => {
   const replayTaskQueue = uid('adk-replay-nocache');
   const replayedResult = await withWorker(
     env,
-    { taskQueue: replayTaskQueue, plugins: [makePlugin()], maxCachedWorkflows: 0 },
+    { taskQueue: replayTaskQueue, plugins: [plugin], maxCachedWorkflows: 0 },
     () =>
       env.client.workflow.execute(replayScenario, {
         taskQueue: replayTaskQueue,
@@ -75,3 +95,38 @@ test.serial('replayWithPlugin', async (t) => {
   );
   t.deepEqual(replayedResult, liveResult);
 });
+
+/** Runs the graph scenario live and returns its history. */
+async function recordGraphHistory(env: TestWorkflowEnvironment) {
+  const taskQueue = uid('adk-replay-graph');
+  const workflowId = uid('wf-replay-graph');
+  const result = await withWorker(env, { taskQueue, plugins: [makePlugin()], activities }, () =>
+    env.client.workflow.execute(graphSequential, { taskQueue, workflowId, args: ['replay'] })
+  );
+  if (result.output !== 'data-for-replay summarized')
+    throw new Error(`unexpected graph result ${JSON.stringify(result)}`);
+  return env.client.workflow.getHandle(workflowId).fetchHistory();
+}
+
+const RECORDED: Array<{ file: string; record: (env: TestWorkflowEnvironment) => Promise<unknown> }> = [
+  { file: 'graph_workflow.json', record: recordGraphHistory },
+];
+
+for (const { file, record } of RECORDED) {
+  // Graph history replays live and from the checked-in fixture (E2E)
+  test.serial(`replays ${file} live and from the checked-in fixture`, async (t) => {
+    const env = getEnv();
+    const fixture = path.join(historiesDir, file);
+
+    const live = await record(env);
+    await Worker.runReplayHistory(replayOptions(), live);
+
+    if (UPDATE_HISTORIES) {
+      writeFileSync(fixture, historyToJSON(live as Parameters<typeof historyToJSON>[0]));
+      t.log(`re-recorded ${fixture}`);
+    }
+    // `runReplayHistory` accepts the JSON form and converts it itself.
+    const recorded: unknown = JSON.parse(readFileSync(fixture, 'utf8'));
+    await t.notThrowsAsync(Worker.runReplayHistory(replayOptions(), recorded), `replaying ${file}`);
+  });
+}

--- a/contrib/google-adk-agents/src/__tests__/telemetry.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/telemetry.test.ts
@@ -19,6 +19,8 @@ import { OpenTelemetryPlugin } from '@temporalio/interceptors-opentelemetry';
 
 import { GoogleAdkPlugin } from '../index';
 import { defaultTestProvider, setupTestEnv, uid, withWorker } from './helpers';
+import * as activities from './test-activities';
+import { graphRetry } from './graph-workflows';
 import { agentRunnerOneTurn, agentRunnerTwoTurnsWorkflow } from './workflows';
 
 const getEnv = setupTestEnv(test);
@@ -142,6 +144,44 @@ test.serial('adkSpansExportOncePerOperationUnderReplay', async (t) => {
     call_llm: 2,
     invocation: 2,
     'invoke_agent assistant': 2,
+  });
+});
+
+// ADK 2.0 workflow-runtime spans export once per operation too (E2E)
+test.serial('graphSpansExportOncePerOperationUnderReplay', async (t) => {
+  const env = getEnv();
+
+  const { exporter, events } = await scenarioWithRetryFreeHistory(t, async (exporter) => {
+    const taskQueue = uid('adk-otel-graph');
+    const workflowId = uid('wf-otel-graph');
+    const otelPlugin = new OpenTelemetryPlugin({
+      resource: new Resource({ 'service.name': 'adk-telemetry-test' }),
+      spanProcessor: new SimpleSpanProcessor(exporter),
+    });
+    // A graph whose one Activity node fails twice and is retried by ADK's node
+    // retry (jitter 0 keeps the backoff fixed): three attempts, one node, one
+    // workflow invocation — each a span, each exported exactly once although the
+    // cache-disabled worker replays the whole history on every task.
+    const result = await withWorker(
+      env,
+      { taskQueue, plugins: [otelPlugin, makeAdkPlugin()], activities, maxCachedWorkflows: 0 },
+      () => env.client.workflow.execute(graphRetry, { taskQueue, workflowId, args: [0] })
+    );
+    t.is(result.output, 'ok-after-2');
+
+    return (await env.client.workflow.getHandle(workflowId).fetchHistory()).events ?? [];
+  });
+
+  const workflowTasks = events.filter((e) => e.workflowTaskStartedEventAttributes != null).length;
+  t.true(workflowTasks >= 3, `expected >= 3 workflow tasks so replays occurred, got ${workflowTasks}`);
+
+  // Names only: ADK attaches the `adk.workflow.*` / `adk.node.*` attributes to the
+  // *active* span, and no OpenTelemetry context manager runs inside the sandbox.
+  assertAdkSpanCounts(t, exporter, {
+    invocation: 1,
+    'invoke_workflow retry_graph': 1,
+    'execute_node flakyActivity': 1,
+    'execute_node_attempt flakyActivity': 3,
   });
 });
 

--- a/contrib/google-adk-agents/src/__tests__/test-activities.ts
+++ b/contrib/google-adk-agents/src/__tests__/test-activities.ts
@@ -1,7 +1,7 @@
 /**
- * Worker-side Activities for the E2E tests. They run on the worker (never
- * bundled) and record their real executions per Workflow, so a test can tell an
- * Activity that ran from one that was replayed.
+ * Worker-side Activities for the graph / dynamic E2E tests. They run on the
+ * worker (never bundled) and record their real executions per Workflow, so a
+ * test can tell an Activity that ran from one that was replayed.
  */
 
 import { Context } from '@temporalio/activity';
@@ -24,6 +24,74 @@ function record(entry: string): void {
 /** The recorded executions for `workflowId`, in order. */
 export function executionsFor(workflowId: string): string[] {
   return executions.get(workflowId) ?? [];
+}
+
+export async function fetchData(query: string): Promise<string> {
+  record(`fetchData:${query}`);
+  return `data-for-${query}`;
+}
+
+export async function summarize(text: string): Promise<string> {
+  record(`summarize:${text}`);
+  return `${text} summarized`;
+}
+
+export async function combineParts(left: string, right: string): Promise<string> {
+  return `${left}+${right}`;
+}
+
+export async function enrichItem(item: string): Promise<string> {
+  record(`enrichItem:${item}`);
+  return `enriched-${item}`;
+}
+
+export async function enrichNumber(n: number): Promise<string> {
+  record(`enrichNumber:${n}`);
+  return `enriched-${n}`;
+}
+
+export async function approveActivity(): Promise<string> {
+  record('approveActivity');
+  return 'approved';
+}
+
+export async function rejectActivity(): Promise<string> {
+  record('rejectActivity');
+  return 'rejected';
+}
+
+/** Sleeps well past any test deadline, but stops at once when the Activity is cancelled. */
+export async function slowActivity(): Promise<string> {
+  record('slowActivity');
+  const { cancellationSignal } = Context.current();
+  await new Promise<void>((resolve) => {
+    if (cancellationSignal.aborted) return resolve();
+    const timer = setTimeout(resolve, 20_000);
+    cancellationSignal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true }
+    );
+  });
+  return 'too late';
+}
+
+/** Fails its first two calls per Workflow (non-retryably, so ADK's node retry is what re-runs it), then succeeds. */
+export async function flakyActivity(): Promise<string> {
+  const calls = executionsFor(currentWorkflowId()).filter((e) => e === 'flakyActivity');
+  record('flakyActivity');
+  if (calls.length < 2) {
+    throw ApplicationFailure.nonRetryable(`flaky failure #${calls.length + 1}`, 'TestFlakyFailure');
+  }
+  return `ok-after-${calls.length}`;
+}
+
+export async function failingActivity(): Promise<never> {
+  record('failingActivity');
+  throw ApplicationFailure.nonRetryable('permanent failure', 'TestPermanentFailure');
 }
 
 export async function echoId(id: string): Promise<string> {

--- a/contrib/google-adk-agents/src/__tests__/test-models.ts
+++ b/contrib/google-adk-agents/src/__tests__/test-models.ts
@@ -1,0 +1,30 @@
+/**
+ * Scripted `BaseLlm` doubles for the graph / dynamic tests, plus a
+ * `modelProvider` that maps model names to them. Like the doubles in
+ * `helpers.ts`, every model is rebuilt per Activity, so each derives its turn
+ * from the request rather than from instance state.
+ */
+
+import type { BaseLlm } from '@google/adk';
+
+import { defaultTestProvider, ToolCallingLlm } from './helpers';
+
+/**
+ * The `modelProvider` for the graph / dynamic suites. Names encode the
+ * scenario; everything else falls through to {@link defaultTestProvider}.
+ */
+export function graphTestProvider(): (model: string) => BaseLlm {
+  const fallback = defaultTestProvider();
+  return (model: string): BaseLlm => {
+    switch (model) {
+      case 'finish-task-model':
+        return new ToolCallingLlm({ model, toolName: 'finish_task', toolArgs: { result: 'task-done' } });
+      case 'enrich-flow-model':
+        return new ToolCallingLlm({ model, toolName: 'enrich_flow', toolArgs: { value: 7 } });
+      case 'enrich-flow-genai-model':
+        return new ToolCallingLlm({ model, toolName: 'enrich_flow', toolArgs: { request: '7' } });
+      default:
+        return fallback(model);
+    }
+  };
+}

--- a/contrib/google-adk-agents/src/__tests__/workflows.ts
+++ b/contrib/google-adk-agents/src/__tests__/workflows.ts
@@ -711,3 +711,6 @@ export async function cryptoShimProbe(): Promise<{ before: string; callId: strin
   await echoId(after);
   return { before, callId, after };
 }
+
+// ADK 2.0 workflow-runtime fixtures; bundled through this module.
+export * from './graph-workflows';

--- a/contrib/google-adk-agents/src/absorbed-failure.ts
+++ b/contrib/google-adk-agents/src/absorbed-failure.ts
@@ -9,10 +9,19 @@
  * is open surfaces there, and one recorded after a handler frame returned surfaces in the
  * main function's. One recorded after the main function returned never surfaces —
  * completing with unfinished handlers is a user error Temporal already warns about.
+ *
+ * The same interceptor also converts the errors ADK 2.0's workflow runtime *throws* —
+ * a node past its `timeout`, an output that failed its schema, an approval ADK refused
+ * to bind — from the plain `Error`s they are into non-retryable `ApplicationFailure`s.
+ * The Temporal SDK fails a Workflow only for a `TemporalFailure` (or a configured
+ * failure type); any other error fails the Workflow *Task*, which the server retries
+ * forever. These are expected runtime outcomes of a graph, not bugs, so they must end
+ * the execution (or reject the Update) with a typed failure instead.
  */
 
 import type { AsyncLocalStorage as ALS } from 'node:async_hooks';
 
+import { ApplicationFailure } from '@temporalio/common';
 import {
   AsyncLocalStorage,
   CancellationScope,
@@ -21,6 +30,8 @@ import {
   isCancellation,
   type WorkflowInterceptorsFactory,
 } from '@temporalio/workflow';
+
+import { ADK_RUNTIME_FAILURE_TYPES } from './error-types';
 
 // Held on the per-execution sandbox `globalThis` rather than in module scope: a
 // bundle can hold two copies of this module (the interceptor list registers its
@@ -112,6 +123,29 @@ function raiseAbsorbed(frame: Frame): void {
   if (frame.pending.length > 0) throw frame.pending[0];
 }
 
+/**
+ * The name of ADK's `NodeReportedError`: a graph node that ended without output because
+ * the agent it ran absorbed an error. When that error was a `TemporalModel` call the frame
+ * has it recorded, and the recording — an `ActivityFailure` carrying the model failure's
+ * status and cause chain — is the better thing to raise.
+ */
+const NODE_REPORTED_ERROR = 'NodeReportedError';
+
+/**
+ * Converts an ADK workflow-runtime error escaping a frame into the failure that should
+ * end the execution: the frame's recorded model failure when the error merely reports
+ * that a model call was absorbed, otherwise a non-retryable `ApplicationFailure` typed
+ * per {@link ADK_RUNTIME_FAILURE_TYPES} with the ADK error as its cause. Anything else —
+ * a `TemporalFailure`, a user's own error — is returned unchanged.
+ */
+function toWorkflowFailure(err: unknown, frame: Frame): unknown {
+  if (!(err instanceof Error)) return err;
+  const type = ADK_RUNTIME_FAILURE_TYPES[err.name];
+  if (type === undefined) return err;
+  if (err.name === NODE_REPORTED_ERROR && frame.pending.length > 0) return frame.pending[0];
+  return ApplicationFailure.create({ message: err.message, type, nonRetryable: true, cause: err });
+}
+
 async function surfaceAbsorbedFailure<T>(frame: Frame, next: () => Promise<T>): Promise<T> {
   let result: T;
   try {
@@ -125,7 +159,7 @@ async function surfaceAbsorbedFailure<T>(frame: Frame, next: () => Promise<T>): 
       const { main } = recorded();
       if (main !== undefined && main !== frame) raiseAbsorbed(main);
     }
-    throw err;
+    throw toWorkflowFailure(err, frame);
   } finally {
     frame.surfaced = true;
   }

--- a/contrib/google-adk-agents/src/error-types.ts
+++ b/contrib/google-adk-agents/src/error-types.ts
@@ -64,3 +64,63 @@ export const MODEL_ERROR_FAILURE_TYPE = 'GoogleAdkModelError';
  * `TemporalMCPToolsetOptions.activity.retry.maximumAttempts`.
  */
 export const MCP_ERROR_FAILURE_TYPE = 'GoogleAdkMCPError';
+
+/** @internal */
+export const ACTIVITY_NODE_OUTSIDE_WORKFLOW_FAILURE_TYPE = 'GoogleAdkActivityNodeOutsideWorkflow';
+
+/**
+ * Error type for an ADK workflow-runtime node that exceeded its `timeout`.
+ * ADK raises a plain `NodeTimeoutError`; the plugin converts it to a
+ * non-retryable `ApplicationFailure` of this type as it leaves the Workflow
+ * (or the Signal/Update handler) that ran the graph, so the execution fails
+ * instead of retrying the Workflow Task forever. The original error is the
+ * `cause`. The same conversion, under the types below, applies to every ADK
+ * runtime error listed in {@link ADK_RUNTIME_FAILURE_TYPES}.
+ */
+export const NODE_TIMEOUT_FAILURE_TYPE = 'GoogleAdkNodeTimeoutError';
+
+/**
+ * Error type for a graph node that finished without output because the agent
+ * it ran absorbed an error (ADK's `NodeReportedError`). When the absorbed
+ * error was a `TemporalModel` call, the plugin raises that call's
+ * `ActivityFailure` instead, so the model failure's HTTP status and cause
+ * chain survive.
+ */
+export const NODE_REPORTED_FAILURE_TYPE = 'GoogleAdkNodeReportedError';
+
+/** Error type for a node input/output/state that failed its ADK schema (`NodeSchemaValidationError`). */
+export const NODE_SCHEMA_VALIDATION_FAILURE_TYPE = 'GoogleAdkNodeSchemaValidationError';
+
+/**
+ * Error type for a human-in-the-loop approval ADK refused to bind to its gate
+ * (`IntentMismatchError`) — for example an approval naming a tool that does not
+ * require confirmation, or arguments that no longer match the pinned call.
+ */
+export const INTENT_MISMATCH_FAILURE_TYPE = 'GoogleAdkIntentMismatchError';
+
+/** Error type for a session-state write that failed its ADK `stateSchema` (`StateSchemaError`). */
+export const STATE_SCHEMA_FAILURE_TYPE = 'GoogleAdkStateSchemaError';
+
+/** Error type for an ADK invocation aborted through its `abortSignal` (`InvocationAbortedError`). */
+export const INVOCATION_ABORTED_FAILURE_TYPE = 'GoogleAdkInvocationAbortedError';
+
+/** Error type for a dynamic node ADK failed explicitly (`DynamicNodeFailError`). */
+export const DYNAMIC_NODE_FAIL_FAILURE_TYPE = 'GoogleAdkDynamicNodeFailError';
+
+/**
+ * The ADK runtime errors the plugin converts into non-retryable
+ * `ApplicationFailure`s, keyed by the error's `name` (ADK's own type guards
+ * match by name too; not every class is exported). Any other error that
+ * escapes a Workflow is left alone and follows the SDK's convention for
+ * unexpected errors: it fails the Workflow *Task*, which retries. Use
+ * `WorkerOptions.workflowFailureErrorTypes` to fail the execution on more.
+ */
+export const ADK_RUNTIME_FAILURE_TYPES: Readonly<Record<string, string>> = Object.freeze({
+  NodeTimeoutError: NODE_TIMEOUT_FAILURE_TYPE,
+  NodeReportedError: NODE_REPORTED_FAILURE_TYPE,
+  NodeSchemaValidationError: NODE_SCHEMA_VALIDATION_FAILURE_TYPE,
+  IntentMismatchError: INTENT_MISMATCH_FAILURE_TYPE,
+  StateSchemaError: STATE_SCHEMA_FAILURE_TYPE,
+  InvocationAbortedError: INVOCATION_ABORTED_FAILURE_TYPE,
+  DynamicNodeFailError: DYNAMIC_NODE_FAIL_FAILURE_TYPE,
+});

--- a/contrib/google-adk-agents/src/nodes.ts
+++ b/contrib/google-adk-agents/src/nodes.ts
@@ -1,0 +1,172 @@
+/**
+ * A Temporal Activity as a node in an ADK 2.0 workflow graph.
+ *
+ * ADK 2.0's workflow runtime (`Workflow`, `node()`, `JoinNode`, `dynamicEntry`,
+ * …) is plain async code driven by session events, so it runs inside the
+ * Workflow sandbox as-is. {@link activityNode} is the one piece it lacks: a node
+ * whose body is a registered Temporal Activity, the same way `activityAsTool`
+ * exposes an Activity to the model.
+ *
+ * Failure semantics: a node that throws fails the whole `Runner.runAsync` (ADK
+ * rethrows node errors; only an agent's model call is absorbed), so a failed
+ * Activity fails the Workflow through the usual `ActivityFailure` and needs no
+ * absorbed-failure recording. ADK's own graph errors (a `NodeTimeoutError`, …)
+ * are plain `Error`s that the plugin converts as they leave the Workflow — see
+ * `absorbed-failure.ts`.
+ *
+ * IMPORTANT: this module is part of the Workflow-sandbox import graph. It must
+ * not import any worker-only module.
+ */
+
+import {
+  FunctionNode,
+  type BaseNode,
+  type FunctionNodeConfig,
+  type NodeContext,
+  type RetryConfig,
+  type SchemaLike,
+} from '@google/adk';
+import { ApplicationFailure } from '@temporalio/common';
+import { CancellationScope, inWorkflowContext, proxyActivities, type ActivityOptions } from '@temporalio/workflow';
+
+import { ACTIVITY_NODE_OUTSIDE_WORKFLOW_FAILURE_TYPE } from './error-types';
+import { activityOptionsFrom } from './model';
+
+/** Options for {@link activityNode}. */
+export interface ActivityNodeOptions<TInput = unknown> {
+  /**
+   * The registered Activity type to run — an `@activity`-style function
+   * registered on the worker (e.g. via the worker's `activities`). Also the
+   * node's name unless `nodeName` is set.
+   */
+  name: string;
+  /** The graph node's name, when it must differ from the Activity's (e.g. two nodes running one Activity). */
+  nodeName?: string;
+  /** The node's description, advertised when the node is used as a tool. */
+  description?: string;
+  /**
+   * Per-call Temporal Activity configuration (timeouts, retry, task queue,
+   * summary). Prefer `retry` here over ADK's `retryConfig`: an ADK retry
+   * re-runs the whole node on top of Temporal's own Activity retries.
+   */
+  activity?: ActivityOptions;
+  /**
+   * Maps the node's input to the Activity's argument list. Defaults to passing
+   * the input as the single argument. TypeScript has no runtime signature
+   * introspection, so — unlike Python's `activity_node` — there is no
+   * named-parameter binding; use the `NodeContext` for state-bound values:
+   * `(input, ctx) => [ctx.state.get('customerId'), input]`.
+   */
+  args?: (input: TInput, ctx: NodeContext) => unknown[];
+
+  // --- ADK node configuration, passed through to the node ---
+  /**
+   * Whether the node re-runs when a paused (human-in-the-loop) run resumes.
+   * Default `false`: a node that already produced its output is fast-forwarded
+   * from the session and the Activity is not scheduled again. (ADK's `Workflow`
+   * and `LlmAgent` default to `true` for themselves.)
+   */
+  rerunOnResume?: boolean;
+  /** Fan-in: only produce output once every predecessor has triggered the node. */
+  waitForOutput?: boolean;
+  /**
+   * ADK graph-level retry. Its backoff becomes a durable Workflow timer; its
+   * jitter is drawn from the Workflow's `Math.random()`. Match a Temporal
+   * Activity failure with `exceptions: ['ActivityFailure']` (ADK matches error
+   * names).
+   */
+  retryConfig?: RetryConfig;
+  /**
+   * The node's deadline, in **seconds** (ADK semantics). A durable Workflow
+   * timer; when it fires, the in-flight Activity is cancelled and the node
+   * fails with ADK's `NodeTimeoutError`.
+   */
+  timeout?: number;
+  inputSchema?: SchemaLike;
+  outputSchema?: SchemaLike;
+  stateSchema?: SchemaLike;
+  isolationScope?: string | true;
+}
+
+/**
+ * Wraps a registered Temporal Activity as an ADK workflow graph node. Put the
+ * returned node on a `Workflow`'s `edges`, run it from a `dynamicEntry` with
+ * `ctx.runNode(node, input)`, or give it to an `LlmAgent`'s `tools` (ADK 2.0
+ * wraps a node in a `NodeTool`; that needs an `inputSchema`).
+ *
+ * Inside a Workflow the node's input (or the arguments `args` derives from it)
+ * is sent to the Activity and the Activity's result becomes the node's output,
+ * which flows to the successors. The node can only run inside a Workflow.
+ */
+export function activityNode<TInput = unknown, TOutput = unknown>(
+  options: ActivityNodeOptions<TInput>
+): BaseNode<TInput, TOutput> {
+  const { name, nodeName, description, activity, args } = options;
+
+  const handler = async (ctx: NodeContext, input: TInput): Promise<TOutput> => {
+    if (!inWorkflowContext()) {
+      throw ApplicationFailure.nonRetryable(
+        `activityNode('${name}') can only run inside a Temporal Workflow.`,
+        ACTIVITY_NODE_OUTSIDE_WORKFLOW_FAILURE_TYPE
+      );
+    }
+    const activities = proxyActivities<Record<string, (...activityArgs: unknown[]) => Promise<unknown>>>(
+      activityOptionsFrom(activity, `adk.node ${name}`)
+    );
+    // `proxyActivities` returns a Proxy that materializes a stub for any name,
+    // so the indexed access is always defined; `noUncheckedIndexedAccess`
+    // widens the static type to `| undefined`, hence the assertion.
+    const run = activities[name]!;
+    const activityArgs = args ? args(input, ctx) : [input];
+    return (await underNodeAbort(ctx, () => run(...activityArgs))) as TOutput;
+  };
+
+  const config: FunctionNodeConfig = {
+    rerunOnResume: options.rerunOnResume ?? false,
+  };
+  if (description !== undefined) config.description = description;
+  if (options.waitForOutput !== undefined) config.waitForOutput = options.waitForOutput;
+  if (options.retryConfig !== undefined) config.retryConfig = options.retryConfig;
+  if (options.timeout !== undefined) config.timeout = options.timeout;
+  if (options.inputSchema !== undefined) config.inputSchema = options.inputSchema;
+  if (options.outputSchema !== undefined) config.outputSchema = options.outputSchema;
+  if (options.stateSchema !== undefined) config.stateSchema = options.stateSchema;
+  if (options.isolationScope !== undefined) config.isolationScope = options.isolationScope;
+
+  return new FunctionNode<TInput, TOutput>(nodeName ?? name, handler, config);
+}
+
+/**
+ * Runs `body` so that the node's abort — its own `timeout`, or the
+ * invocation's — cancels the in-flight Activity. ADK signals both through
+ * `ctx.abortSignal` (always set for a node inside a `Workflow`); asyncio gives
+ * Python this for free, TypeScript has to bridge it: the abort cancels a
+ * `CancellationScope` the Activity runs in, which is a deterministic command.
+ *
+ * The cancellation is rethrown, never swallowed: on ADK's deadline path the
+ * runner has already raised `NodeTimeoutError` and ignores this late
+ * rejection; on the cooperative path (no deadline) the node must fail rather
+ * than complete with an `undefined` output that would flow to its successors.
+ * The listener is removed on the way out because the signal is shared by every
+ * node for the whole run, and its body never throws: it runs inside a host
+ * `EventTarget` dispatch, outside the Workflow's own error handling.
+ */
+async function underNodeAbort<T>(ctx: NodeContext, body: () => Promise<T>): Promise<T> {
+  const signal = ctx.abortSignal;
+  if (!signal) return body();
+  const scope = new CancellationScope({ cancellable: true });
+  const onAbort = (): void => {
+    try {
+      scope.cancel();
+    } catch {
+      /* cancelling an already-cancelled scope, or a scope with nothing in it, is not an error worth surfacing here */
+    }
+  };
+  if (signal.aborted) onAbort();
+  else signal.addEventListener('abort', onAbort, { once: true });
+  try {
+    return await scope.run(body);
+  } finally {
+    signal.removeEventListener('abort', onAbort);
+  }
+}

--- a/contrib/google-adk-agents/src/plugin.ts
+++ b/contrib/google-adk-agents/src/plugin.ts
@@ -634,12 +634,13 @@ export class GoogleAdkPlugin extends SimplePlugin {
    *     to install the polyfills.
    *  4. **`workflowInterceptorModules`** also gets the `absorbed-failure` module
    *     appended last — the module that re-raises a model failure ADK absorbed
-   *     (`markModelFailureHandled` opts one back out). Interceptor modules compose
-   *     first-is-outermost, so last means innermost, and the re-raise rejects
-   *     *through* the outer interceptors rather than past them: an observability
-   *     interceptor must not close its span OK on a Workflow about to fail. Being
-   *     last is order-dependent, not structural — so list `GoogleAdkPlugin` last in
-   *     `plugins`.
+   *     (`markModelFailureHandled` opts one back out) and converts ADK's
+   *     workflow-runtime errors into typed `ApplicationFailure`s. Interceptor
+   *     modules compose first-is-outermost, so last means innermost, and the
+   *     re-raise rejects *through* the outer interceptors rather than past them:
+   *     an observability interceptor must not close its span OK on a Workflow
+   *     about to fail. Being last is order-dependent, not structural — so list
+   *     `GoogleAdkPlugin` last in `plugins`.
    *
    * Tradeoff: putting **all** disallowed builtins in `ignoreModules` suppresses
    * the bundler's friendly "you imported a Node builtin in your Workflow"

--- a/contrib/google-adk-agents/src/workflow.ts
+++ b/contrib/google-adk-agents/src/workflow.ts
@@ -23,10 +23,21 @@ export type { TemporalMCPToolsetOptions, MCPToolsetFactory } from './mcp';
 export { activityAsTool } from './tools';
 export type { ActivityAsToolOptions } from './tools';
 
+export { activityNode } from './nodes';
+export type { ActivityNodeOptions } from './nodes';
+
 export {
+  ADK_RUNTIME_FAILURE_TYPES,
+  DYNAMIC_NODE_FAIL_FAILURE_TYPE,
+  INTENT_MISMATCH_FAILURE_TYPE,
+  INVOCATION_ABORTED_FAILURE_TYPE,
   MCP_ERROR_FAILURE_TYPE,
   MCP_TOOL_NOT_FOUND_FAILURE_TYPE,
   MODEL_ERROR_FAILURE_TYPE,
+  NODE_REPORTED_FAILURE_TYPE,
+  NODE_SCHEMA_VALIDATION_FAILURE_TYPE,
+  NODE_TIMEOUT_FAILURE_TYPE,
+  STATE_SCHEMA_FAILURE_TYPE,
   STREAMING_TOPIC_REQUIRED_FAILURE_TYPE,
   UNSUPPORTED_FAILURE_TYPE,
 } from './error-types';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,9 @@ importers:
       ava:
         specifier: ^5.3.1
         version: 5.3.1
+      zod:
+        specifier: ^4.2.1
+        version: 4.4.3
 
   contrib/interceptors-opentelemetry:
     dependencies:


### PR DESCRIPTION
## What was changed

ADK 2.0's workflow runtime (`Workflow`, `node()`, `JoinNode`, routing, dynamic nodes through `ctx.runNode`, node-as-tool, node retries and timeouts) is plain async code driven by session events, so it already runs inside a Temporal Workflow. This PR adds the piece it lacks and the failure semantics it needs.

- `activityNode(options)` in `src/nodes.ts` makes a registered Activity a graph node: a `FunctionNode` whose body is a `proxyActivities` call. The node's input is the Activity's argument unless `args` maps it, and the Activity's result is the node's output. A completed node is fast-forwarded on resume, as ADK does for every node, so a resumed run never schedules the Activity again. The node runs its own `timeout`: on the deadline it cancels the Activity's `CancellationScope`, waits for the cancellation to settle on the Activity's `cancellationType` terms, then throws ADK's `NodeTimeoutError`, so a retried attempt never overlaps a still-running one. An abort from the invocation or a failed sibling cancels the Activity the same way. Node names containing a dot are refused at construction, since ADK uses the dot as its node path separator.
- ADK's runtime errors (`NodeTimeoutError`, `NodeReportedError`, `NodeSchemaValidationError`, `IntentMismatchError`, `StateSchemaError`, `InvocationAbortedError`, `DynamicNodeFailError`) are plain `Error`s, and the SDK fails the Workflow _Task_ on an unexpected error, which retries forever. The absorbed-failure interceptor converts them into non-retryable `ApplicationFailure`s keyed by `ADK_RUNTIME_FAILURE_TYPES`, with the ADK error as the `cause`.
- Two of those carry something better than the wrapper, and that is what gets raised: a `NodeReportedError` reporting an absorbed `TemporalModel` call raises the recorded `ActivityFailure`, so the model failure's HTTP status survives; a `DynamicNodeFailError` over a Temporal failure raises that failure, so a cancelled Activity still ends the execution CANCELLED rather than FAILED.

## Testing

New `graph.test.ts` and `dynamic.test.ts` (25 cases): sequential Activity nodes, routing, fan-out and join, an Activity returning nothing, an `LlmAgent` task-mode node, a node timeout cancelling the Activity and waiting for the cancel before failing or retrying, ADK retry with jitter replayed from history, a model failure that a node retry recovers from, Activity failure propagation for both static and dynamic nodes, a cancelled Workflow, an absorbed model failure surfaced and recovered, a dotted node name refused, node callbacks, an `App` root, context compaction, and workflow-as-tool with Zod and genai schemas. Also graph spans in `telemetry.test.ts`, and a checked-in graph history replayed in `replay.test.ts` (`UPDATE_ADK_HISTORIES=1` re-records it). The package suite is 117 tests, green with `REUSE_V8_CONTEXT` both true and false.

Stack: [1/4 bump](https://github.com/temporalio/sdk-typescript/pull/2416) → **2/4 graph runtime (this, #2417)** → [3/4 HITL](https://github.com/temporalio/sdk-typescript/pull/2418) → [4/4 MCP resources + model routing](https://github.com/temporalio/sdk-typescript/pull/2419)

Ticket: [AI-510](https://temporalio.atlassian.net/browse/AI-510)


[AI-510]: https://temporalio.atlassian.net/browse/AI-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
