### PR TITLE
feat(google-adk-agents): MCP resources and in-sandbox model routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,20 +67,23 @@ to docs, or any other relevant information.
 
 ### Added
 
-- `@temporalio/google-adk-agents` supports Google ADK 2.0 inside Workflows:
-  - the Workflow bundle now uses ADK's web build, pinned regardless of the consumer's webpack
-    target, and ADK's UUIDs are generated from a named workflow random stream inside the sandbox,
-    so its ids are replay-stable;
+- `@temporalio/google-adk-agents` supports Google ADK 2.0's TypeScript feature set inside Workflows:
   - the workflow (graph) runtime — `Workflow`, `node()`, `JoinNode`, routing, dynamic nodes,
-    node-as-tool, node retries and timeouts — runs unchanged; `activityNode` makes a registered
-    Activity a graph node (its abort cancels the in-flight Activity);
+    `RequestInput`, node-as-tool, node retries and timeouts — runs unchanged; `activityNode` makes a
+    registered Activity a graph node (its abort cancels the in-flight Activity);
   - durable human-in-the-loop: `pendingHitlRequests`, `hitlInputResponse` and
     `hitlConfirmationResponse` supply ADK's wire format, and `activityAsTool` /
     `TemporalMCPToolset` gain `requireConfirmation` so an Activity or MCP tool call runs only once
     a human approves;
+  - MCP resources: `TemporalMCPToolset.listResources` / `readResource` and `loadMcpResourceTool`,
+    backed by `<name>-listResources` / `<name>-readResource` Activities;
+  - raw model strings (`model: 'gemini-2.5-flash'`) resolve to `TemporalModel` inside a Workflow
+    (`GoogleAdkPluginOptions.autoRouteModels`, default on);
   - ADK's runtime errors (`NodeTimeoutError`, `IntentMismatchError`, …) fail the Workflow with typed
     `ApplicationFailure`s (`ADK_RUNTIME_FAILURE_TYPES`) instead of retrying the Workflow Task
-    forever.
+    forever;
+  - ADK's UUIDs are generated from a named workflow random stream inside the sandbox, so interrupt
+    and function-call ids are replay-stable. The Workflow bundle now uses ADK's web build.
 - **Experimental**: `@temporalio/openai-agents` can run OpenAI Agents `SandboxAgent`s as Temporal Workflows. SandboxAgent
   operations are Activities; hosted tool credentials and sandbox environment values that reference allowlisted Worker
   environment variables are resolved on Worker so their values are not recorded in Workflow history.

--- a/contrib/google-adk-agents/README.md
+++ b/contrib/google-adk-agents/README.md
@@ -9,7 +9,7 @@ routes non-deterministic boundaries out to Activities:
 
 - every **model call** (`generateContentAsync`) becomes a retryable, observable
   Activity,
-- every **MCP tool call** (list-tools / call-tool) becomes an Activity,
+- every **MCP tool call**, resource listing and resource read becomes an Activity,
 - an **Activity** can be a graph node (`activityNode`) or a tool (`activityAsTool`).
 
 Regular ADK `FunctionTool`s still run in the Workflow. If a tool performs I/O,
@@ -36,12 +36,12 @@ Versions of this plugin for `@google/adk` 1.5 are not compatible with 2.0, and a
 Workflow started under 1.5 cannot be replayed by a Worker on 2.0: ADK's internals
 and its id generation changed. Drain in-flight Workflows before switching, or run
 the two versions on separate task queues. Nothing in your Workflow code has to
-change.
+change; raw model strings (`model: 'gemini-2.5-flash'`) now work inside a Workflow
+without `TemporalModel` (see [Model routing](#model-routing)).
 
 ## Hello world
 
-Wrap the agent model in `TemporalModel`, then register `GoogleAdkPlugin` on the
-Worker.
+Register `GoogleAdkPlugin` on the Worker. Everything else is ordinary ADK code.
 
 ### `workflows.ts`
 
@@ -52,7 +52,8 @@ import { TemporalModel } from '@temporalio/google-adk-agents/workflow';
 export async function askAgent(prompt: string): Promise<string> {
   const agent = new LlmAgent({
     name: 'assistant',
-    // The only change from a vanilla ADK agent:
+    // Optional — a raw 'gemini-2.5-flash' string works too; wrap it to set
+    // Activity options (timeouts, retries, streaming) for the model calls.
     model: new TemporalModel('gemini-2.5-flash'),
     instruction: 'You are a helpful assistant.',
   });
@@ -132,6 +133,23 @@ policy. To opt out, handle the error in an ADK `onModelErrorCallback`, pass
 that same error to `markModelFailureHandled`, and return a substitute event
 built with ADK's `createEvent`.
 
+### Model routing
+
+Inside a Workflow, ADK's built-in model classes (`Gemini`, `ApigeeLlm`) cannot run:
+they call the network from the sandbox. The plugin therefore re-registers their
+model-name patterns in the Workflow's `LLMRegistry` to a `TemporalModel`, so an
+agent configured with a raw string — `model: 'gemini-2.5-flash'`,
+`model: 'apigee/…'` — is durable without any change, using `TemporalModel`'s
+default Activity options (a one-minute `startToCloseTimeout`, no streaming). Wrap
+the string in `new TemporalModel(name, options)` to customize.
+
+The Worker is untouched: there the real class runs inside the model Activity, so
+`GoogleAdkPluginOptions.modelProvider` still resolves the same names.
+
+`RoutedLlm` holds model _instances_, so build it from `TemporalModel`s. Set
+`autoRouteModels: false` on the plugin only if you register your own sandbox-safe
+`BaseLlm` for one of those patterns.
+
 ### MCP tools
 
 Use `TemporalMCPToolset` in Workflow code and register the matching MCP factory
@@ -164,6 +182,32 @@ the factory's job — see `MCPToolsetFactory`.
 
 Gate the toolset's tools behind human approval with
 `requireConfirmation` — see [Durable human-in-the-loop](#durable-human-in-the-loop).
+
+### MCP resources
+
+ADK 2.0's `MCPToolset` lists and reads MCP resources. `TemporalMCPToolset` does
+the same through `<name>-listResources` / `<name>-readResource` Activities, and
+`loadMcpResourceTool` is the counterpart of ADK's `LoadMcpResourceTool`: the model
+asks for resources by name, and on the next model call the tool appends their
+contents to the request.
+
+```typescript
+const toolset = new TemporalMCPToolset({ name: 'filesystem' });
+const agent = new LlmAgent({
+  name: 'reader',
+  model: new TemporalModel('gemini-2.5-flash'),
+  tools: [toolset, loadMcpResourceTool(toolset)],
+});
+```
+
+ADK re-lists the server's resources before every model call; the plugin lists
+once per tool instance instead (each listing is an Activity), and
+`loadMcpResourceTool(toolset, { refreshResourceList: true })` restores ADK's
+behavior. As in ADK, resource contents are appended to one request only — the
+model must ask again to see them on a later turn — and a failed listing or read
+is logged and skipped, not raised. A factory-supplied toolset must be an
+`MCPToolset` (or expose `listResources` / `readResource`) for resources to work;
+connection params always do.
 
 ### Activities as tools
 
@@ -392,9 +436,12 @@ import { fakeModelProvider, mockMCPToolset } from '@temporalio/google-adk-agents
 const plugin = new GoogleAdkPlugin({
   modelProvider: fakeModelProvider(),
   mcpToolsets: {
-    weather: mockMCPToolset([
-      /* tool defs */
-    ]),
+    weather: mockMCPToolset(
+      [
+        /* tool defs */
+      ],
+      { resources: [{ name: 'readme', contents: [{ uri: 'file:///readme.md', text: '# Hi' }] }] }
+    ),
   },
 });
 ```
@@ -477,7 +524,7 @@ Cautions:
   `TemporalMCPToolset`), a2a, `DatabaseSessionService`, `GcsArtifactService` /
   `FileArtifactService`, telemetry setup, `LocalEnvironment`, the agent registry.
   Present but non-functional there: the skills loaders, the code executors, and
-  `ApigeeLlm` (replaced by an inert class; wrap it in `TemporalModel`).
+  `ApigeeLlm` (routed to `TemporalModel` by default).
 - **Thread-pool tool execution** and any ADK extension point that performs I/O;
   move it behind an Activity.
 
@@ -497,19 +544,18 @@ Cautions:
 
 ## Troubleshooting
 
-- A cryptic sandbox error during a model call — for example `fetch is not defined`,
-  or a `... is not a function` error from a worker-only module like
-  `google-auth-library` (the plugin's bundler config aliases such modules to an
-  empty module in the Workflow bundle) — almost always means a model was not
-  wrapped in `TemporalModel`. If an agent is configured with a raw model string
-  (`model: 'gemini-2.5-flash'`) instead of `model: new TemporalModel('gemini-2.5-flash')`,
-  ADK resolves the string through its `LLMRegistry` inside the Workflow sandbox and
-  attempts a live network call from there. The sandbox blocks that call, and the
-  resulting error points nowhere near the actual mistake. Wrap the model in
-  `TemporalModel` so the call is routed out to an Activity.
+- A Workflow that resolves a model **name** ADK does not know (a third-party
+  `BaseLlm` you registered on the Worker only) throws `Model … not found` inside
+  the sandbox. Wrap it: `model: new TemporalModel('my-model')`, and let
+  `GoogleAdkPluginOptions.modelProvider` build it on the Worker.
 - `X is not a constructor` / `X is not a function` for an ADK symbol inside a
   Workflow means the symbol is one of the node-only services above: the Workflow
   bundle resolves ADK's web surface, which omits it. Use it worker-side.
+- A cryptic sandbox error during a model call (`fetch is not defined`, or a
+  `… is not a function` from a worker-only module such as `google-auth-library`)
+  means a `BaseLlm` performed I/O inside the Workflow — for instance
+  `autoRouteModels: false` with a raw Gemini string, or a custom `BaseLlm`
+  instance placed directly on an agent. Route it through `TemporalModel`.
 
 ## License
 

--- a/contrib/google-adk-agents/src/__tests__/auto-route.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/auto-route.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Model auto-routing: inside a Workflow, ADK's built-in model patterns resolve
+ * to `TemporalModel`, so vanilla ADK code with a raw model string is durable.
+ */
+
+import test from 'ava';
+
+import { GoogleAdkPlugin } from '../index';
+import { countScheduledActivities, defaultTestProvider, setupTestEnv, uid, withWorker } from './helpers';
+import { rawModelStringAgent, registryResolveProbe, routedLlmAgent } from './graph-workflows';
+
+const getEnv = setupTestEnv(test);
+
+function makePlugin(autoRouteModels?: boolean): GoogleAdkPlugin {
+  return new GoogleAdkPlugin({ modelProvider: defaultTestProvider(), autoRouteModels });
+}
+
+test.serial('a raw Gemini model string runs through the model Activity', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-route-gemini');
+  const workflowId = uid('wf-route-gemini');
+  const result = await withWorker(env, { taskQueue, plugins: [makePlugin()] }, () =>
+    env.client.workflow.execute(rawModelStringAgent, { taskQueue, workflowId, args: ['gemini-2.5-flash'] })
+  );
+  t.is(result.text, 'fake-response:gemini-2.5-flash');
+  t.is(result.errorMessage, undefined);
+  const { events } = await env.client.workflow.getHandle(workflowId).fetchHistory();
+  t.is(countScheduledActivities(events ?? [], 'adk-invokeModel'), 1);
+});
+
+test.serial('a raw Apigee model string runs through the model Activity too', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-route-apigee');
+  const result = await withWorker(env, { taskQueue, plugins: [makePlugin()] }, () =>
+    env.client.workflow.execute(rawModelStringAgent, {
+      taskQueue,
+      workflowId: uid('wf-route-apigee'),
+      args: ['apigee/gemini-2.5-flash'],
+    })
+  );
+  t.is(result.text, 'fake-response:apigee/gemini-2.5-flash');
+});
+
+test.serial('the sandbox registry resolves every built-in pattern to the Temporal model class', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-route-registry');
+  const probe = await withWorker(env, { taskQueue, plugins: [makePlugin()] }, () =>
+    env.client.workflow.execute(registryResolveProbe, { taskQueue, workflowId: uid('wf-route-registry') })
+  );
+  t.is(probe.gemini, 'AutoRoutedTemporalModel');
+  t.is(probe.apigee, 'AutoRoutedTemporalModel');
+  t.false(probe.apigeeIsBuiltIn);
+});
+
+test.serial('RoutedLlm routes between TemporalModel instances', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-route-routed');
+  const text = await withWorker(env, { taskQueue, plugins: [makePlugin()] }, () =>
+    env.client.workflow.execute(routedLlmAgent, { taskQueue, workflowId: uid('wf-route-routed'), args: ['b'] })
+  );
+  t.is(text, 'fake-response:fake-b');
+});
+
+test.serial('autoRouteModels: false leaves the built-in classes registered in the sandbox', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-route-off');
+  // Only the registry is probed: with the real Gemini class resolving inside the
+  // sandbox, an actual model call cannot reach the network and its retry backoff
+  // becomes durable timers, so that path is the documented misconfiguration, not
+  // something to await in a test.
+  const probe = await withWorker(env, { taskQueue, plugins: [makePlugin(false)] }, () =>
+    env.client.workflow.execute(registryResolveProbe, { taskQueue, workflowId: uid('wf-route-off') })
+  );
+  t.is(probe.gemini, 'Gemini');
+  t.is(probe.apigee, 'ApigeeLlm');
+  t.true(probe.apigeeIsBuiltIn);
+});

--- a/contrib/google-adk-agents/src/__tests__/graph-workflows.ts
+++ b/contrib/google-adk-agents/src/__tests__/graph-workflows.ts
@@ -1,7 +1,7 @@
 /**
- * Workflow fixtures for ADK 2.0's workflow (graph) runtime, dynamic nodes and
- * durable human-in-the-loop. Bundled into the sandbox through `workflows.ts`,
- * which re-exports this module.
+ * Workflow fixtures for ADK 2.0's workflow (graph) runtime, dynamic nodes,
+ * durable human-in-the-loop, MCP resources and model auto-routing. Bundled
+ * into the sandbox through `workflows.ts`, which re-exports this module.
  *
  * Every fixture runs the *native* ADK runtime inside the Workflow; the plugin
  * routes only model, Activity-node, activity-tool and MCP I/O to Activities.
@@ -9,6 +9,7 @@
 
 import {
   App,
+  ApigeeLlm,
   BasePlugin,
   BaseTool,
   createEvent,
@@ -18,10 +19,12 @@ import {
   isFinalResponse,
   JoinNode,
   LlmAgent,
+  LLMRegistry,
   node,
   PolicyOutcome,
   RequestInput,
   requestInputTool,
+  RoutedLlm,
   SecurityPlugin,
   stringifyContent,
   TruncatingContextCompactor,
@@ -48,6 +51,7 @@ import {
   activityNode,
   hitlConfirmationResponse,
   hitlInputResponse,
+  loadMcpResourceTool,
   markModelFailureHandled,
   pendingHitlRequests,
   TemporalMCPToolset,
@@ -638,4 +642,80 @@ export async function dynamicResume(): Promise<RunOutcome & { turns: number }> {
     { name: 'driver', rerunOnResume: true }
   );
   return runWithHitl(new Workflow({ name: 'dynamic_resume', edges: [['START', driver]] }), 'go');
+}
+
+// ---------------------------------------------------------------------------
+// MCP resources
+// ---------------------------------------------------------------------------
+
+export async function mcpListResources(): Promise<string[]> {
+  return new TemporalMCPToolset({ name: 'testServer' }).listResources();
+}
+
+export async function mcpReadResource(name: string): Promise<unknown> {
+  // A single attempt, so an unknown resource fails the Workflow instead of retrying forever.
+  return new TemporalMCPToolset({ name: 'testServer', activity: { retry: { maximumAttempts: 1 } } }).readResource(name);
+}
+
+/** ADK's two-phase `load_mcp_resource` flow: ask for a resource, then answer with its contents. */
+export async function mcpLoadResourceAgent(turns: number, refreshResourceList = false): Promise<string[]> {
+  const toolset = new TemporalMCPToolset({ name: 'testServer' });
+  const agent = new LlmAgent({
+    name: 'assistant',
+    model: new TemporalModel('resource-model'),
+    instruction: 'Answer from resources.',
+    tools: [toolset, loadMcpResourceTool(toolset, { refreshResourceList })],
+  });
+  const runner = new InMemoryRunner({ agent });
+  const session = await runner.sessionService.createSession({ appName: runner.appName, userId: USER });
+  const texts: string[] = [];
+  for (let turn = 0; turn < turns; turn++) {
+    const { text } = await collect(
+      runner.runAsync({
+        userId: USER,
+        sessionId: session.id,
+        newMessage: { role: 'user', parts: [{ text: `turn-${turn}` }] },
+      })
+    );
+    texts.push(text);
+  }
+  return texts;
+}
+
+// ---------------------------------------------------------------------------
+// Model auto-routing
+// ---------------------------------------------------------------------------
+
+/** An agent configured with a raw model string, as in vanilla ADK code. */
+export async function rawModelStringAgent(model: string): Promise<{ text: string; errorMessage?: string }> {
+  const agent = new LlmAgent({ name: 'assistant', model, instruction: 'Help.' });
+  const runner = new InMemoryRunner({ agent });
+  let text = '';
+  let errorMessage: string | undefined;
+  for await (const event of runner.runEphemeral({
+    userId: USER,
+    newMessage: { role: 'user', parts: [{ text: 'hi' }] },
+  })) {
+    if (event.errorMessage) errorMessage = event.errorMessage;
+    if (isFinalResponse(event)) text = stringifyContent(event);
+  }
+  return { text, errorMessage };
+}
+
+/** A `RoutedLlm` over two `TemporalModel`s; the router picks by key. */
+export async function routedLlmAgent(pick: 'a' | 'b'): Promise<string> {
+  const model = new RoutedLlm({
+    models: { a: new TemporalModel('fake-a'), b: new TemporalModel('fake-b') },
+    router: () => pick,
+  });
+  const agent = new LlmAgent({ name: 'assistant', model, instruction: 'Help.' });
+  const { text } = await runOnce(agent, 'hi');
+  return text;
+}
+
+/** What the sandbox registry resolves built-in model patterns to. */
+export async function registryResolveProbe(): Promise<{ gemini: string; apigee: string; apigeeIsBuiltIn: boolean }> {
+  const gemini = LLMRegistry.resolve('gemini-2.5-flash');
+  const apigee = LLMRegistry.resolve('apigee/gemini-2.5-flash');
+  return { gemini: gemini.name, apigee: apigee.name, apigeeIsBuiltIn: apigee === (ApigeeLlm as unknown) };
 }

--- a/contrib/google-adk-agents/src/__tests__/mcp-resources.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/mcp-resources.test.ts
@@ -1,0 +1,164 @@
+/**
+ * ADK 2.0 MCP resources through the plugin: `TemporalMCPToolset.listResources` /
+ * `readResource` and the two-phase `loadMcpResourceTool`, against the in-memory
+ * mock and the stdio stub server.
+ */
+
+import { readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import test from 'ava';
+import { BaseToolset, type BaseTool, type MCPConnectionParams, type ReadonlyContext } from '@google/adk';
+import { ApplicationFailure } from '@temporalio/common';
+import { MockActivityEnvironment } from '@temporalio/testing';
+
+import { createMCPActivities } from '../activities';
+import { GoogleAdkPlugin } from '../index';
+import { mockMCPToolset, type MockMCPResourceDefinition } from '../testing';
+import { countScheduledActivities, echoDef, findInCauseChain, setupTestEnv, uid, withWorker } from './helpers';
+import { graphTestProvider } from './test-models';
+import { mcpListResources, mcpLoadResourceAgent, mcpReadResource } from './graph-workflows';
+
+const stubServerPath = path.resolve(__dirname, 'stub-mcp-server.js');
+
+const README_TEXT = '# Stub\n\nHello from the stub resource.';
+
+const readmeResource: MockMCPResourceDefinition = {
+  name: 'readme',
+  contents: [{ uri: 'file:///readme.md', mimeType: 'text/markdown', text: README_TEXT }],
+};
+
+function makePlugin(): GoogleAdkPlugin {
+  return new GoogleAdkPlugin({
+    modelProvider: graphTestProvider(),
+    mcpToolsets: { testServer: mockMCPToolset([echoDef], { resources: [readmeResource] }) },
+  });
+}
+
+function stubServerConnectionParams(log: string): MCPConnectionParams {
+  return {
+    type: 'StdioConnectionParams',
+    serverParams: { command: process.execPath, args: [stubServerPath], env: { MCP_STUB_LOG: log } },
+  };
+}
+
+function stubServerRecords(log: string): string[] {
+  return readFileSync(log, 'utf8').split('\n').filter(Boolean);
+}
+
+const getEnv = setupTestEnv(test);
+
+test.serial('listResources and readResource route through the resource Activities', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-res-list');
+  const listId = uid('wf-res-list');
+  const readId = uid('wf-res-read');
+  await withWorker(env, { taskQueue, plugins: [makePlugin()] }, async () => {
+    t.deepEqual(await env.client.workflow.execute(mcpListResources, { taskQueue, workflowId: listId }), ['readme']);
+    t.deepEqual(
+      await env.client.workflow.execute(mcpReadResource, { taskQueue, workflowId: readId, args: ['readme'] }),
+      readmeResource.contents
+    );
+  });
+  const { events: listEvents } = await env.client.workflow.getHandle(listId).fetchHistory();
+  t.is(countScheduledActivities(listEvents ?? [], 'testServer-listResources'), 1);
+  const { events: readEvents } = await env.client.workflow.getHandle(readId).fetchHistory();
+  t.is(countScheduledActivities(readEvents ?? [], 'testServer-readResource'), 1);
+});
+
+test.serial('an unknown resource fails as an MCP error', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-res-unknown');
+  const err = await withWorker(env, { taskQueue, plugins: [makePlugin()] }, () =>
+    t.throwsAsync(
+      env.client.workflow.execute(mcpReadResource, { taskQueue, workflowId: uid('wf-res-unknown'), args: ['nope'] })
+    )
+  );
+  const failure = findInCauseChain(err, ApplicationFailure);
+  t.is(failure?.type, 'GoogleAdkMCPError');
+  t.regex(failure?.message ?? '', /Resource with name 'nope' not found/);
+});
+
+test.serial('a factory-supplied toolset without resource methods fails non-retryably', async (t) => {
+  class PlainToolset extends BaseToolset {
+    constructor() {
+      super([]);
+    }
+    override async getTools(_context?: ReadonlyContext): Promise<BaseTool[]> {
+      return [];
+    }
+    override async close(): Promise<void> {}
+  }
+  const activities = createMCPActivities({ plain: () => new PlainToolset() });
+  const err = await t.throwsAsync(
+    new MockActivityEnvironment().run(activities['plain-listResources'] as () => Promise<string[]>)
+  );
+  t.true(err instanceof ApplicationFailure);
+  t.is((err as ApplicationFailure).type, 'GoogleAdkMCPResourcesUnsupported');
+  t.is((err as ApplicationFailure).nonRetryable, true);
+});
+
+test.serial('against connection params, listing uses one session and reading one more', async (t) => {
+  const log = path.join(os.tmpdir(), `${uid('adk-res-sessions')}.log`);
+  t.teardown(() => rmSync(log, { force: true }));
+  const activities = createMCPActivities({ testServer: () => stubServerConnectionParams(log) });
+  const mockEnv = new MockActivityEnvironment();
+
+  const names: string[] = await mockEnv.run(activities['testServer-listResources'] as () => Promise<string[]>);
+  t.deepEqual(names, ['readme']);
+
+  const contents = (await mockEnv.run(
+    activities['testServer-readResource'] as (args: { name: string }) => Promise<Array<{ text?: string }>>,
+    { name: 'readme' }
+  )) as Array<{ text?: string }>;
+  t.is(contents[0]?.text, README_TEXT);
+
+  // The read resolves the name to a URI and reads it over the SAME session (ADK's
+  // own `MCPToolset.readResource` opens two).
+  t.deepEqual(stubServerRecords(log), [
+    'open',
+    'resources/list',
+    'close',
+    'open',
+    'resources/list',
+    'resources/read',
+    'close',
+  ]);
+});
+
+test.serial(
+  'loadMcpResourceTool appends the requested resource on the next turn and memoizes the listing',
+  async (t) => {
+    const env = getEnv();
+    const taskQueue = uid('adk-res-tool');
+    const workflowId = uid('wf-res-tool');
+    const texts = await withWorker(env, { taskQueue, plugins: [makePlugin()] }, () =>
+      env.client.workflow.execute(mcpLoadResourceAgent, { taskQueue, workflowId, args: [2] })
+    );
+    // Turn 1: the model asked for `readme`, the tool answered with the "call again"
+    // status, and ADK appended the resource's contents to the model's next request.
+    t.is(texts[0], `resource=${README_TEXT}; listed=["readme"]`);
+    // Turn 2: as the tool's status says, the contents were "temporarily inserted and
+    // removed" — they were appended to that one request, not to the session — so a
+    // turn that does not ask again sees only the instruction listing the resources.
+    t.is(texts[1], `resource=missing; listed=["readme"]`);
+    const { events } = await env.client.workflow.getHandle(workflowId).fetchHistory();
+    t.is(countScheduledActivities(events ?? [], 'testServer-readResource'), 1);
+    // One listing for the tool instance's lifetime, across every model call of both turns.
+    t.is(countScheduledActivities(events ?? [], 'testServer-listResources'), 1);
+  }
+);
+
+test.serial('refreshResourceList re-lists the resources on every model call', async (t) => {
+  const env = getEnv();
+  const taskQueue = uid('adk-res-refresh');
+  const workflowId = uid('wf-res-refresh');
+  await withWorker(env, { taskQueue, plugins: [makePlugin()] }, () =>
+    env.client.workflow.execute(mcpLoadResourceAgent, { taskQueue, workflowId, args: [1, true] })
+  );
+  const { events } = await env.client.workflow.getHandle(workflowId).fetchHistory();
+  const modelCalls = countScheduledActivities(events ?? [], 'adk-invokeModel');
+  t.true(modelCalls >= 2);
+  t.is(countScheduledActivities(events ?? [], 'testServer-listResources'), modelCalls);
+});

--- a/contrib/google-adk-agents/src/__tests__/plugin.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/plugin.test.ts
@@ -10,6 +10,7 @@ import test from 'ava';
 import type { BundleOptions, WorkerOptions } from '@temporalio/worker';
 
 import { GoogleAdkPlugin } from '../index';
+import { interceptors as autoRouteInterceptors } from '../auto-route';
 import { interceptors as polyfillInterceptors } from '../load-polyfills';
 import { mockMCPToolset } from '../testing';
 import { sandboxCompatResolveHook } from './helpers';
@@ -58,22 +59,38 @@ test('configureBundler stubs ADK node-only packages and disallowed builtins', (t
   }
 });
 
-test('configureBundler brackets the user modules with the polyfill loader and failure interceptor', (t) => {
+test('configureBundler brackets the user modules with the polyfill loader, auto-route and failure interceptor', (t) => {
   const plugin = new GoogleAdkPlugin();
   const { workflowInterceptorModules } = plugin.configureBundler({
     workflowsPath: 'wf',
     workflowInterceptorModules: ['user-interceptors'],
   } as BundleOptions);
   // The polyfill loader must be first so the web globals install before any other
-  // per-workflow module (interceptors, then the user's workflows) evaluates.
+  // per-workflow module (interceptors, then the user's workflows) evaluates; the
+  // model auto-route follows it (it imports ADK) and precedes user code.
+  t.deepEqual(workflowInterceptorModules, [
+    require.resolve('../load-polyfills'),
+    require.resolve('../auto-route'),
+    'user-interceptors',
+    require.resolve('../absorbed-failure'),
+  ]);
+  // Both side-effect modules satisfy the documented interceptor-module contract
+  // (export an `interceptors` factory) while registering nothing.
+  t.deepEqual(polyfillInterceptors(), {});
+  t.deepEqual(autoRouteInterceptors(), {});
+});
+
+test('autoRouteModels: false leaves the auto-route module out of the bundle', (t) => {
+  const plugin = new GoogleAdkPlugin({ autoRouteModels: false });
+  const { workflowInterceptorModules } = plugin.configureBundler({
+    workflowsPath: 'wf',
+    workflowInterceptorModules: ['user-interceptors'],
+  } as BundleOptions);
   t.deepEqual(workflowInterceptorModules, [
     require.resolve('../load-polyfills'),
     'user-interceptors',
     require.resolve('../absorbed-failure'),
   ]);
-  // The module satisfies the documented interceptor-module contract (exports
-  // an `interceptors` factory) while registering nothing.
-  t.deepEqual(polyfillInterceptors(), {});
 });
 
 test('configureBundler appends the sandbox-compat plugin, preserving a user hook', (t) => {
@@ -192,7 +209,7 @@ test('configureBundler prepends the api pin to an array-form user alias list', (
   t.is(alias[2], userEntry);
 });
 
-test('configureWorker registers model activities, plus an MCP pair per toolset', (t) => {
+test('configureWorker registers model activities, plus the four MCP activities per toolset', (t) => {
   const modelOnly = new GoogleAdkPlugin().configureWorker({ taskQueue: 'tq' } as WorkerOptions).activities as Record<
     string,
     unknown
@@ -207,4 +224,6 @@ test('configureWorker registers model activities, plus an MCP pair per toolset',
   >;
   t.is(typeof activities['weather-listTools'], 'function');
   t.is(typeof activities['weather-callTool'], 'function');
+  t.is(typeof activities['weather-listResources'], 'function');
+  t.is(typeof activities['weather-readResource'], 'function');
 });

--- a/contrib/google-adk-agents/src/__tests__/published-artifact.test.ts
+++ b/contrib/google-adk-agents/src/__tests__/published-artifact.test.ts
@@ -21,6 +21,7 @@ test('cjsRequireExposesPublicExports', (t) => {
   t.is(typeof workflow.TemporalMCPToolset, 'function');
   t.is(typeof workflow.activityAsTool, 'function');
   t.is(typeof workflow.activityNode, 'function');
+  t.is(typeof workflow.loadMcpResourceTool, 'function');
   t.is(typeof workflow.pendingHitlRequests, 'function');
   t.is(typeof workflow.hitlInputResponse, 'function');
   t.is(typeof workflow.hitlConfirmationResponse, 'function');
@@ -30,6 +31,7 @@ test('cjsRequireExposesPublicExports', (t) => {
   t.is(workflow.MCP_ERROR_FAILURE_TYPE, 'GoogleAdkMCPError');
   t.is(workflow.STREAMING_TOPIC_REQUIRED_FAILURE_TYPE, 'GoogleAdkStreamingTopicRequired');
   t.is(workflow.UNSUPPORTED_FAILURE_TYPE, 'GoogleAdkUnsupported');
+  t.is(workflow.MCP_RESOURCES_UNSUPPORTED_FAILURE_TYPE, 'GoogleAdkMCPResourcesUnsupported');
   t.is(workflow.NODE_TIMEOUT_FAILURE_TYPE, 'GoogleAdkNodeTimeoutError');
   t.is(workflow.INTENT_MISMATCH_FAILURE_TYPE, 'GoogleAdkIntentMismatchError');
   t.is(workflow.ADK_RUNTIME_FAILURE_TYPES.NodeTimeoutError, 'GoogleAdkNodeTimeoutError');

--- a/contrib/google-adk-agents/src/__tests__/stub-mcp-server.ts
+++ b/contrib/google-adk-agents/src/__tests__/stub-mcp-server.ts
@@ -1,8 +1,9 @@
 /**
- * A stdio MCP server exposing one `echo` tool, recording its session boundaries and
- * tool requests to the file named by `MCP_STUB_LOG`. An unknown tool gets the reply a
- * real `McpServer` sends: a successful result carrying `isError: true`, never a
- * JSON-RPC error frame.
+ * A stdio MCP server exposing one `echo` tool and one `readme` resource, recording its
+ * session boundaries, tool and resource requests to the file named by `MCP_STUB_LOG`. An
+ * unknown tool gets the reply a real `McpServer` sends: a successful result carrying
+ * `isError: true`, never a JSON-RPC error frame. An unknown resource gets the JSON-RPC
+ * error a real server sends for `resources/read`.
  */
 
 import { appendFileSync } from 'node:fs';
@@ -19,6 +20,10 @@ const TOOLS = [
     description: 'Echoes the input value.',
     inputSchema: { type: 'object', properties: { value: { type: 'string' } }, required: ['value'] },
   },
+];
+
+const RESOURCES = [
+  { uri: 'file:///readme.md', name: 'readme', description: 'The stub README.', mimeType: 'text/markdown' },
 ];
 
 function record(entry: string): void {
@@ -40,7 +45,7 @@ function handle(message: JsonRpcMessage): void {
     case 'initialize':
       reply(message.id, {
         protocolVersion: message.params?.protocolVersion,
-        capabilities: { tools: {} },
+        capabilities: { tools: {}, resources: {} },
         serverInfo: { name: 'stub-mcp-server', version: '0.0.0' },
       });
       return;
@@ -59,6 +64,23 @@ function handle(message: JsonRpcMessage): void {
         return;
       }
       reply(message.id, { content: [{ type: 'text', text: JSON.stringify({ echoed: params.arguments?.value }) }] });
+      return;
+    }
+    case 'resources/list':
+      record('resources/list');
+      reply(message.id, { resources: RESOURCES });
+      return;
+    case 'resources/read': {
+      record('resources/read');
+      const params = (message.params ?? {}) as { uri?: string };
+      const resource = RESOURCES.find((candidate) => candidate.uri === params.uri);
+      if (!resource) {
+        replyError(message.id, -32002, `Resource not found: ${params.uri}`);
+        return;
+      }
+      reply(message.id, {
+        contents: [{ uri: resource.uri, mimeType: resource.mimeType, text: '# Stub\n\nHello from the stub resource.' }],
+      });
       return;
     }
     default:

--- a/contrib/google-adk-agents/src/__tests__/test-models.ts
+++ b/contrib/google-adk-agents/src/__tests__/test-models.ts
@@ -1,12 +1,12 @@
 /**
- * Scripted `BaseLlm` doubles for the graph / HITL tests, plus a
+ * Scripted `BaseLlm` doubles for the graph / HITL / MCP-resource tests, plus a
  * `modelProvider` that maps model names to them. Like the doubles in
  * `helpers.ts`, every model is rebuilt per Activity, so each derives its turn
  * from the request rather than from instance state.
  */
 
 import { BaseLlm, type BaseLlmConnection, type LlmRequest, type LlmResponse } from '@google/adk';
-import type { FunctionResponse } from '@google/genai';
+import type { Content, FunctionResponse } from '@google/genai';
 
 import { defaultTestProvider, ToolCallingLlm } from './helpers';
 
@@ -110,7 +110,43 @@ export class RequestInputLlm extends BaseLlm {
 }
 
 /**
- * The `modelProvider` for the graph / HITL suites. Names encode the
+ * Drives ADK's two-phase `load_mcp_resource` tool: first turn asks for the
+ * `readme` resource; the turn after reports the resource contents the tool
+ * appended to the request (`Resource readme is:` followed by the text part) and
+ * the instruction listing the available resources.
+ */
+export class ResourceLlm extends BaseLlm {
+  override async *generateContentAsync(
+    llmRequest: LlmRequest,
+    _stream?: boolean,
+    _abortSignal?: AbortSignal
+  ): AsyncGenerator<LlmResponse, void> {
+    const asked = functionResponses(llmRequest).some((r) => r.name === 'load_mcp_resource');
+    if (!asked) {
+      yield {
+        content: {
+          role: 'model',
+          parts: [{ functionCall: { name: 'load_mcp_resource', args: { resource_names: ['readme'] } } }],
+        },
+        turnComplete: true,
+      };
+      return;
+    }
+    const contents: Content[] = llmRequest.contents ?? [];
+    const marker = contents.findIndex((c) => c.role === 'user' && c.parts?.[0]?.text === 'Resource readme is:');
+    const resourceText = marker === -1 ? undefined : contents[marker]?.parts?.[1]?.text;
+    const instruction = String(llmRequest.config?.systemInstruction ?? '');
+    const listed = /You have a list of MCP resources:\n(\[[^\]]*\])/.exec(instruction)?.[1];
+    yield textResponse(`resource=${resourceText ?? 'missing'}; listed=${listed ?? 'none'}`);
+  }
+
+  override async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
+    throw new Error('ResourceLlm does not connect.');
+  }
+}
+
+/**
+ * The `modelProvider` for the graph / HITL / resource suites. Names encode the
  * scenario; everything else falls through to {@link defaultTestProvider}.
  */
 export function graphTestProvider(): (model: string) => BaseLlm {
@@ -131,6 +167,8 @@ export function graphTestProvider(): (model: string) => BaseLlm {
         return new ConfirmationLlm({ model, toolName: 'echo', toolArgs: { value: 'hello' } });
       case 'confirm-gate-model':
         return new ConfirmationLlm({ model, toolName: 'dynamicGate', toolArgs: { target: 'prod' } });
+      case 'resource-model':
+        return new ResourceLlm({ model });
       default:
         return fallback(model);
     }

--- a/contrib/google-adk-agents/src/activities.ts
+++ b/contrib/google-adk-agents/src/activities.ts
@@ -17,6 +17,7 @@ import {
   MCPToolset,
   isBaseToolset,
   type BaseLlm,
+  type BaseToolset,
   type Context as AdkToolContext,
   type LlmRequest,
   type LlmResponse,
@@ -28,9 +29,14 @@ import { ApplicationFailure } from '@temporalio/common';
 import { Context as ActivityContext } from '@temporalio/activity';
 import { WorkflowStreamClient } from '@temporalio/workflow-streams/client';
 
-import { MCP_ERROR_FAILURE_TYPE, MCP_TOOL_NOT_FOUND_FAILURE_TYPE, MODEL_ERROR_FAILURE_TYPE } from './error-types';
+import {
+  MCP_ERROR_FAILURE_TYPE,
+  MCP_RESOURCES_UNSUPPORTED_FAILURE_TYPE,
+  MCP_TOOL_NOT_FOUND_FAILURE_TYPE,
+  MODEL_ERROR_FAILURE_TYPE,
+} from './error-types';
 import type { InvokeModelArgs, InvokeModelStreamingArgs, ModelActivities, WireLlmRequest } from './model';
-import type { MCPCallToolArgs, MCPToolsetFactory } from './mcp';
+import type { MCPCallToolArgs, MCPReadResourceArgs, MCPResourceContents, MCPToolsetFactory } from './mcp';
 
 const DEFAULT_STREAM_BATCH_INTERVAL = '100 milliseconds';
 
@@ -99,7 +105,10 @@ export function createModelActivities(options: ModelActivitiesOptions = {}): Mod
   };
 }
 
-/** Builds the per-server `<name>-listTools` / `<name>-callTool` pairs. @internal */
+/**
+ * Builds the per-server `<name>-listTools` / `<name>-callTool` /
+ * `<name>-listResources` / `<name>-readResource` Activities. @internal
+ */
 export function createMCPActivities(
   toolsets: Record<string, MCPToolsetFactory> = {}
 ): Record<string, (args: never) => Promise<unknown>> {
@@ -108,6 +117,31 @@ export function createMCPActivities(
     Object.assign(activities, mcpActivitiesForName(name, factory));
   }
   return activities;
+}
+
+/** One live MCP session, as produced by ADK's `MCPSessionManager`. */
+type MCPSession = Awaited<ReturnType<MCPSessionManager['createSession']>>;
+
+/**
+ * The resource methods ADK 2.0 added to `MCPToolset`, duck-typed so a
+ * factory-supplied toolset (a real `MCPToolset`, or a test double) qualifies
+ * without a class check across two ADK copies.
+ */
+interface ResourceCapableToolset {
+  listResources(): Promise<string[]>;
+  readResource(name: string): Promise<MCPResourceContents[]>;
+}
+
+function resourceCapable(toolset: BaseToolset, name: string): ResourceCapableToolset {
+  const candidate = toolset as Partial<ResourceCapableToolset>;
+  if (typeof candidate.listResources === 'function' && typeof candidate.readResource === 'function') {
+    return candidate as ResourceCapableToolset;
+  }
+  throw ApplicationFailure.nonRetryable(
+    `The toolset registered for MCP server '${name}' cannot serve resources: it has no ` +
+      "'listResources' / 'readResource' methods. Return an MCPToolset (or MCPConnectionParams) from the factory.",
+    MCP_RESOURCES_UNSUPPORTED_FAILURE_TYPE
+  );
 }
 
 function mcpActivitiesForName(
@@ -144,7 +178,9 @@ function mcpActivitiesForName(
         const abortSignal = ActivityContext.current().cancellationSignal;
         const produced = factory();
         if (!isBaseToolset(produced)) {
-          return await callToolOverOneSession(produced, args, abortSignal);
+          return await withOneSession(produced, (session) =>
+            session.callTool({ name: args.toolName, arguments: args.args }, undefined, { signal: abortSignal })
+          );
         }
         const tools = await produced.getTools();
         const tool = tools.find((t) => t.name === args.toolName);
@@ -164,18 +200,62 @@ function mcpActivitiesForName(
         stopHeartbeat();
       }
     },
+
+    [`${name}-listResources`]: async (): Promise<string[]> => {
+      const stopHeartbeat = startAdaptiveHeartbeat();
+      try {
+        const abortSignal = ActivityContext.current().cancellationSignal;
+        const produced = factory();
+        if (!isBaseToolset(produced)) {
+          return await withOneSession(produced, async (session) => {
+            const result = await session.listResources(undefined, { signal: abortSignal });
+            return result.resources.map((resource) => resource.name);
+          });
+        }
+        return await resourceCapable(produced, name).listResources();
+      } catch (err) {
+        throw toApplicationFailure(err, MCP_ERROR_FAILURE_TYPE);
+      } finally {
+        stopHeartbeat();
+      }
+    },
+
+    [`${name}-readResource`]: async (args: MCPReadResourceArgs): Promise<MCPResourceContents[]> => {
+      const stopHeartbeat = startAdaptiveHeartbeat();
+      try {
+        const abortSignal = ActivityContext.current().cancellationSignal;
+        const produced = factory();
+        if (!isBaseToolset(produced)) {
+          // One session for the name → URI lookup and the read; ADK's own
+          // `MCPToolset.readResource(name)` opens two.
+          return await withOneSession(produced, async (session) => {
+            const listed = await session.listResources(undefined, { signal: abortSignal });
+            const resource = listed.resources.find((candidate) => candidate.name === args.name);
+            if (!resource) throw new Error(`Resource with name '${args.name}' not found.`);
+            if (!resource.uri) throw new Error(`Resource '${args.name}' has no URI.`);
+            const result = await session.readResource({ uri: resource.uri }, { signal: abortSignal });
+            return result.contents as MCPResourceContents[];
+          });
+        }
+        return await resourceCapable(produced, name).readResource(args.name);
+      } catch (err) {
+        throw toApplicationFailure(err, MCP_ERROR_FAILURE_TYPE);
+      } finally {
+        stopHeartbeat();
+      }
+    },
   };
 }
 
-async function callToolOverOneSession(
+/** Opens one MCP session for `fn` and closes it afterwards. */
+async function withOneSession<T>(
   connectionParams: MCPConnectionParams,
-  args: MCPCallToolArgs,
-  abortSignal: AbortSignal
-): Promise<unknown> {
+  fn: (session: MCPSession) => Promise<T>
+): Promise<T> {
   const sessions = new MCPSessionManager(connectionParams);
   const session = await sessions.createSession();
   try {
-    return await session.callTool({ name: args.toolName, arguments: args.args }, undefined, { signal: abortSignal });
+    return await fn(session);
   } finally {
     try {
       await sessions.closeSession(session);

--- a/contrib/google-adk-agents/src/auto-route.ts
+++ b/contrib/google-adk-agents/src/auto-route.ts
@@ -1,0 +1,64 @@
+/**
+ * Routes raw model strings through Temporal inside the Workflow sandbox.
+ *
+ * ADK resolves an agent's `model: 'gemini-2.5-flash'` through its `LLMRegistry`
+ * into a real `Gemini` (or `ApigeeLlm`) instance, which then attempts a live
+ * network call. Inside a Workflow that call has nowhere to go: the sandbox has
+ * no `fetch`, the auth libraries are aliased to empty modules, and the error
+ * names neither ADK nor the real mistake (see the README's troubleshooting
+ * entry). A model that performs I/O from Workflow code is *always* wrong there,
+ * so this module re-registers every built-in model class's patterns to a
+ * {@link TemporalModel} subclass — the same class a user gets by wrapping the
+ * string by hand — with default Activity options. Wrap explicitly
+ * (`new TemporalModel(name, options)`) to customize timeouts, retries or
+ * streaming.
+ *
+ * Registry mechanics this relies on (`@google/adk` `models/registry.ts`): the
+ * registry is a `Map` keyed by the `string | RegExp` entries of each class's
+ * `supportedModels`, matched first-registered-first, and `register` overwrites
+ * an entry only when the key is the **same object**. Spreading the built-in
+ * classes' own `supportedModels` arrays therefore replaces their entries in
+ * place instead of appending unreachable duplicates behind them.
+ *
+ * Scope: evaluated per Workflow (as a `workflowInterceptorModules` entry, after
+ * `load-polyfills`) with the activator installed, so `inWorkflowContext()` is
+ * true and the registration lands in that Workflow's private module state
+ * before any user code resolves a model name. On the worker, in tests, and in
+ * direct ADK use the gate is false and the real classes stay registered — which
+ * also keeps `TemporalModel`'s own outside-Workflow delegation to
+ * `LLMRegistry.newLlm` from recursing into itself.
+ *
+ * Disable with `GoogleAdkPluginOptions.autoRouteModels: false`, which leaves
+ * this module out of the bundle's interceptor list.
+ */
+
+import { ApigeeLlm, Gemini, LLMRegistry } from '@google/adk';
+import { inWorkflowContext, type WorkflowInterceptorsFactory } from '@temporalio/workflow';
+
+import { TemporalModel } from './model';
+
+/**
+ * The {@link TemporalModel} the registry constructs for a built-in model name.
+ * The registry instantiates with `new Cls({ model })`, hence the object-form
+ * constructor; options are the defaults.
+ */
+class AutoRoutedTemporalModel extends TemporalModel {
+  static override readonly supportedModels: Array<string | RegExp> = [
+    ...Gemini.supportedModels,
+    ...ApigeeLlm.supportedModels,
+  ];
+
+  constructor({ model }: { model: string }) {
+    super(model);
+  }
+}
+
+// Satisfies the documented interceptor-module contract (modules on
+// `workflowInterceptorModules` export an `interceptors` factory); this module
+// is on that list purely for its load-time side effect, so it registers none.
+// ts-prune-ignore-next (loaded by path from workflowInterceptorModules)
+export const interceptors: WorkflowInterceptorsFactory = () => ({});
+
+if (inWorkflowContext()) {
+  LLMRegistry.register(AutoRoutedTemporalModel);
+}

--- a/contrib/google-adk-agents/src/error-types.ts
+++ b/contrib/google-adk-agents/src/error-types.ts
@@ -69,6 +69,17 @@ export const MCP_ERROR_FAILURE_TYPE = 'GoogleAdkMCPError';
 export const ACTIVITY_NODE_OUTSIDE_WORKFLOW_FAILURE_TYPE = 'GoogleAdkActivityNodeOutsideWorkflow';
 
 /**
+ * Error type when a `<name>-listResources` / `<name>-readResource` Activity finds
+ * that the toolset its factory returned cannot serve MCP resources — it is a
+ * `BaseToolset` without ADK 2.0's `listResources` / `readResource` methods.
+ * Non-retryable, and raised inside the Activity, so it arrives wrapped in an
+ * `ActivityFailure`: match it through the `.cause` chain. A factory returning
+ * `MCPConnectionParams` never raises it: the plugin reads resources over a
+ * session it opens itself.
+ */
+export const MCP_RESOURCES_UNSUPPORTED_FAILURE_TYPE = 'GoogleAdkMCPResourcesUnsupported';
+
+/**
  * Error type for an ADK workflow-runtime node that exceeded its `timeout`.
  * ADK raises a plain `NodeTimeoutError`; the plugin converts it to a
  * non-retryable `ApplicationFailure` of this type as it leaves the Workflow

--- a/contrib/google-adk-agents/src/mcp.ts
+++ b/contrib/google-adk-agents/src/mcp.ts
@@ -3,11 +3,12 @@
  *
  * MCP is ADK's primary external-tool protocol. `TemporalMCPToolset` is a
  * drop-in `BaseToolset` (from `@google/adk`) that, inside a Workflow, routes
- * tool discovery to a `<name>-listTools` Activity and each tool call to a
- * `<name>-callTool` Activity. The full `FunctionDeclaration` (name +
- * description + parameter schema) round-trips, so the model still receives
- * argument schemas. The live MCP session is opened worker-side; call inputs
- * carry the tool name and the model's arguments.
+ * tool discovery to a `<name>-listTools` Activity, each tool call to a
+ * `<name>-callTool` Activity, and ADK 2.0's resource methods to
+ * `<name>-listResources` / `<name>-readResource` Activities. The full
+ * `FunctionDeclaration` (name + description + parameter schema) round-trips,
+ * so the model still receives argument schemas. The live MCP session is opened
+ * worker-side; call inputs carry the tool name and the model's arguments.
  *
  * IMPORTANT: this module is part of the Workflow-sandbox import graph (the
  * `./workflow` entry point re-exports it and user Workflows import
@@ -25,18 +26,21 @@
  * `undefined` in the sandbox.
  */
 
-import type { FunctionDeclaration } from '@google/genai';
+import type { FunctionDeclaration, Part } from '@google/genai';
+import { Type } from '@google/genai';
 import * as adk from '@google/adk';
 import {
   BaseTool,
   BaseToolset,
   type Context,
+  type LlmRequest,
   type MCPConnectionParams,
   type ReadonlyContext,
   type RunAsyncToolRequest,
+  type ToolProcessLlmRequest,
 } from '@google/adk';
 import { ApplicationFailure } from '@temporalio/common';
-import { type ActivityOptions, inWorkflowContext, proxyActivities } from '@temporalio/workflow';
+import { type ActivityOptions, inWorkflowContext, isCancellation, proxyActivities } from '@temporalio/workflow';
 
 import { gateOnConfirmation } from './confirmation';
 import { MCP_TOOLSET_OUTSIDE_WORKFLOW_FAILURE_TYPE } from './error-types';
@@ -51,6 +55,8 @@ import { activityOptionsFrom } from './model';
  * (including in-memory test doubles), at the cost of a real MCP toolset opening two
  * sessions per tool call — against a stdio server, two subprocesses. Returning
  * {@link MCPConnectionParams} lets the plugin open one session per call instead.
+ * Resources (`listResources` / `readResource`) need a toolset with ADK 2.0's
+ * resource methods — an `MCPToolset` — or connection params.
  *
  * The plugin calls the factory on every Activity invocation, and closes only what it
  * builds itself from {@link MCPConnectionParams}. A toolset holding a resource should
@@ -74,8 +80,9 @@ export type MCPRequireConfirmation =
 export interface TemporalMCPToolsetOptions {
   /**
    * Name selecting the worker-registered factory in
-   * `GoogleAdkPluginOptions.mcpToolsets`. Also names the pair of Activities
-   * (`<name>-listTools`, `<name>-callTool`).
+   * `GoogleAdkPluginOptions.mcpToolsets`. Also names the backing Activities
+   * (`<name>-listTools`, `<name>-callTool`, `<name>-listResources`,
+   * `<name>-readResource`).
    */
   name: string;
   /**
@@ -88,7 +95,7 @@ export interface TemporalMCPToolsetOptions {
   /** Per-call Activity configuration (timeouts, retry, task queue). */
   activity?: ActivityOptions;
   /**
-   * Connection params used only when `getTools()` runs **outside** a Workflow
+   * Connection params used only when the toolset runs **outside** a Workflow
    * (direct ADK use / tests), to construct a real `MCPToolset`.
    */
   connectionParams?: MCPConnectionParams;
@@ -111,14 +118,41 @@ export interface MCPCallToolArgs {
   args: Record<string, unknown>;
 }
 
+/** @internal */
+export interface MCPReadResourceArgs {
+  /** The resource's advertised name on the MCP server. */
+  name: string;
+}
+
+/**
+ * One item of an MCP resource's contents, as the server sends it: text, or a
+ * base64 `blob`. The shape of the MCP SDK's `TextResourceContents |
+ * BlobResourceContents`, declared here so Workflow code needs no MCP SDK types.
+ */
+export interface MCPResourceContents {
+  uri: string;
+  mimeType?: string;
+  text?: string;
+  blob?: string;
+}
+
 /** The dynamic Activity surface proxied for a named MCP server. */
-type MCPActivities = Record<string, (args: Record<string, unknown> | MCPCallToolArgs) => Promise<unknown>>;
+type MCPActivities = Record<
+  string,
+  (args: Record<string, unknown> | MCPCallToolArgs | MCPReadResourceArgs) => Promise<unknown>
+>;
+
+/** ADK's `MCPToolset`, as far as this module uses it. */
+type MCPToolsetLike = BaseToolset & {
+  listResources(): Promise<string[]>;
+  readResource(name: string): Promise<MCPResourceContents[]>;
+};
 
 type MCPToolsetCtor = new (
   connectionParams: MCPConnectionParams,
   toolFilter?: string[],
   prefix?: string
-) => BaseToolset;
+) => MCPToolsetLike;
 
 /**
  * Reads a named export off a module namespace without letting the bundler see
@@ -191,6 +225,36 @@ export class TemporalMCPToolset extends BaseToolset {
     return tools.filter((tool) => filter.includes(tool.name));
   }
 
+  /**
+   * Lists the names of the resources the server advertises (ADK 2.0
+   * `MCPToolset.listResources`). Inside a Workflow this proxies the
+   * `<name>-listResources` Activity.
+   */
+  async listResources(): Promise<string[]> {
+    if (!inWorkflowContext()) {
+      return this.realToolset('listResources').listResources();
+    }
+    const listResources = this.activities(`adk.mcp ${this.options.name}.listResources`)[
+      `${this.options.name}-listResources`
+    ] as (args: Record<string, unknown>) => Promise<string[]>;
+    return listResources({});
+  }
+
+  /**
+   * Reads the named resource's contents (ADK 2.0 `MCPToolset.readResource`).
+   * Inside a Workflow this proxies the `<name>-readResource` Activity, which
+   * resolves the name to a URI and reads it over one session.
+   */
+  async readResource(name: string): Promise<MCPResourceContents[]> {
+    if (!inWorkflowContext()) {
+      return this.realToolset('readResource').readResource(name);
+    }
+    const readResource = this.activities(`adk.mcp ${this.options.name}.readResource`)[
+      `${this.options.name}-readResource`
+    ] as (args: MCPReadResourceArgs) => Promise<MCPResourceContents[]>;
+    return readResource({ name });
+  }
+
   /** No-op: the workflow-side toolset holds no MCP session to close. */
   override async close(): Promise<void> {}
 
@@ -199,7 +263,7 @@ export class TemporalMCPToolset extends BaseToolset {
   }
 
   /** The real ADK toolset for the direct (non-Workflow) path. */
-  private realToolset(method: string): BaseToolset {
+  private realToolset(method: string): MCPToolsetLike {
     if (!this.options.connectionParams) {
       throw ApplicationFailure.nonRetryable(
         `TemporalMCPToolset('${this.options.name}').${method}() was called outside a ` +
@@ -265,4 +329,163 @@ class TemporalMCPTool extends BaseTool {
     const callTool = activities[`${this.toolsetOptions.name}-callTool`] as (args: MCPCallToolArgs) => Promise<unknown>;
     return callTool({ toolName: this.originalName, args: request.args });
   }
+}
+
+/** Options for {@link loadMcpResourceTool}. */
+export interface LoadMcpResourceToolOptions {
+  /**
+   * List the server's resources on every model turn, as ADK's own
+   * `LoadMcpResourceTool` does. Default `false`: the list is fetched once per
+   * tool instance (one `<name>-listResources` Activity), since every turn's
+   * listing would be an Activity and its history events.
+   */
+  refreshResourceList?: boolean;
+}
+
+const LOAD_MCP_RESOURCE_TOOL_NAME = 'load_mcp_resource';
+
+/**
+ * The Temporal counterpart of ADK 2.0's `LoadMcpResourceTool`, byte-for-byte
+ * in what the model sees: same declaration, same result, same injected
+ * instruction. It is a two-phase tool. The model calls `load_mcp_resource`
+ * with resource names; on the *next* turn, `processLlmRequest` reads those
+ * resources — through the toolset's `<name>-readResource` Activity — and
+ * appends their contents to the request. Each turn it also lists the server's
+ * resources (memoized unless `refreshResourceList`) and tells the model about
+ * them. Like ADK, a failed list or read is logged and skipped rather than
+ * failing the turn.
+ */
+class TemporalLoadMcpResourceTool extends BaseTool {
+  private readonly toolset: TemporalMCPToolset;
+  private readonly options: LoadMcpResourceToolOptions;
+  private resourceNames?: Promise<string[]>;
+
+  constructor(toolset: TemporalMCPToolset, options: LoadMcpResourceToolOptions) {
+    super({
+      name: LOAD_MCP_RESOURCE_TOOL_NAME,
+      description: 'Loads resources from the MCP server.\n\nNOTE: Call when you need access to resources.',
+    });
+    this.toolset = toolset;
+    this.options = options;
+  }
+
+  override _getDeclaration(): FunctionDeclaration {
+    return {
+      name: this.name,
+      description: this.description,
+      parameters: {
+        type: Type.OBJECT,
+        properties: {
+          resource_names: {
+            type: Type.ARRAY,
+            items: { type: Type.STRING },
+            description: 'The names of the MCP resources to load.',
+          },
+        },
+      },
+    };
+  }
+
+  override async runAsync({ args }: RunAsyncToolRequest): Promise<unknown> {
+    const resourceNames = (args['resource_names'] as string[]) || [];
+    return {
+      resource_names: resourceNames,
+      status:
+        'resource contents temporarily inserted and removed. to access these resources, call load_mcp_resource tool again.',
+    };
+  }
+
+  override async processLlmRequest(request: ToolProcessLlmRequest): Promise<void> {
+    await super.processLlmRequest(request);
+    await this.appendResourcesToLlmRequest(request.llmRequest);
+  }
+
+  private listResources(): Promise<string[]> {
+    if (this.options.refreshResourceList) return this.toolset.listResources();
+    if (this.resourceNames === undefined) {
+      this.resourceNames = this.toolset.listResources().catch((err: unknown) => {
+        // Don't pin a failure: the next turn lists again.
+        this.resourceNames = undefined;
+        throw err;
+      });
+    }
+    return this.resourceNames;
+  }
+
+  private async appendResourcesToLlmRequest(llmRequest: LlmRequest): Promise<void> {
+    try {
+      const availableResourceNames = await this.listResources();
+      if (availableResourceNames.length > 0) {
+        appendSystemInstruction(
+          llmRequest,
+          `You have a list of MCP resources:\n${JSON.stringify(availableResourceNames)}\n\n` +
+            'When the user asks questions about any of the resources, you should call the\n' +
+            '`load_mcp_resource` function to load the resource. Always call load_mcp_resource\n' +
+            'before answering questions related to the resources.'
+        );
+      }
+    } catch (err) {
+      if (isCancellation(err)) throw err;
+      console.warn(`Failed to list MCP resources: ${String(err)}`);
+    }
+
+    const lastContent = llmRequest.contents.at(-1);
+    const functionResponse = lastContent?.parts?.[0]?.functionResponse;
+    if (!functionResponse || functionResponse.name !== this.name) {
+      return;
+    }
+
+    const response = (functionResponse.response as Record<string, unknown>) || {};
+    const requestedResourceNames = (response['resource_names'] as string[]) || [];
+
+    for (const resourceName of requestedResourceNames) {
+      try {
+        const resourceContents = await this.toolset.readResource(resourceName);
+        for (const content of resourceContents) {
+          llmRequest.contents.push({
+            role: 'user',
+            parts: [{ text: `Resource ${resourceName} is:` }, mcpContentToPart(content)],
+          });
+        }
+      } catch (err) {
+        if (isCancellation(err)) throw err;
+        console.warn(`Failed to read MCP resource '${resourceName}': ${String(err)}`);
+      }
+    }
+  }
+}
+
+/** Mirrors ADK's `appendInstructions` (`models/llm_request.ts`), which the web surface does not export. */
+function appendSystemInstruction(llmRequest: LlmRequest, instruction: string): void {
+  if (!llmRequest.config) {
+    llmRequest.config = {};
+  }
+  if (llmRequest.config.systemInstruction) {
+    llmRequest.config.systemInstruction += '\n\n' + instruction;
+  } else {
+    llmRequest.config.systemInstruction = instruction;
+  }
+}
+
+/** Mirrors ADK's `LoadMcpResourceTool.mcpContentToPart`: text stays text, a blob becomes inline data. */
+function mcpContentToPart(content: MCPResourceContents): Part {
+  if (typeof content.text === 'string') {
+    return { text: content.text };
+  }
+  if (typeof content.blob === 'string') {
+    // The MCP blob and `Part.inlineData.data` are both base64 strings, so the
+    // blob is assigned directly with no decode/re-encode step.
+    return { inlineData: { data: content.blob, mimeType: content.mimeType ?? 'application/octet-stream' } };
+  }
+  return { text: JSON.stringify(content) };
+}
+
+/**
+ * ADK 2.0's `LoadMcpResourceTool` for a {@link TemporalMCPToolset}: lets the
+ * model list and load the MCP server's resources, reading them through the
+ * toolset's `<name>-listResources` / `<name>-readResource` Activities. Add the
+ * returned tool to the agent's `tools[]` alongside the toolset.
+ */
+export function loadMcpResourceTool(toolset: TemporalMCPToolset, options: LoadMcpResourceToolOptions = {}): BaseTool {
+  return new TemporalLoadMcpResourceTool(toolset, options);
 }

--- a/contrib/google-adk-agents/src/plugin.ts
+++ b/contrib/google-adk-agents/src/plugin.ts
@@ -234,14 +234,16 @@ const ASYNC_HOOKS_SHIM_SOURCE =
  * a method`, a syntax error for webpack (and V8), so the whole bundle fails to
  * build. The class is unusable in a Workflow anyway (it proxies Gemini over the
  * network), so this inert stand-in keeps the module graph loading: same
- * `supportedModels` pattern (the registry registers it at load), same `BaseLlm`
- * brand symbol, and methods that fail with a message naming the actual fix. The upstream web build is
+ * `supportedModels` pattern (the registry registers it at load, and the
+ * auto-route overwrites that entry), same `BaseLlm` brand symbol, and methods
+ * that fail with a message naming the actual fix. The upstream web build is
  * repaired in ADK 2.1 (it is bundled there).
  */
 const APIGEE_LLM_SHIM_SOURCE =
   "var BASE_MODEL_SYMBOL=Symbol.for('google.adk.baseModel');" +
   'var MESSAGE="@google/adk\'s ApigeeLlm cannot run inside a Temporal Workflow: it performs network I/O. "+' +
-  '"Wrap the model: new TemporalModel(\'apigee/…\').";' +
+  '"Model names matching apigee/* are routed to TemporalModel while GoogleAdkPluginOptions.autoRouteModels "+' +
+  '"is enabled (the default); with it disabled, wrap the model: new TemporalModel(\'apigee/…\').";' +
   'function ApigeeLlm(params){this.model=params&&params.model;this[BASE_MODEL_SYMBOL]=true;}' +
   'ApigeeLlm.supportedModels=[/apigee\\/.*/];' +
   'ApigeeLlm.prototype.maybeAppendUserContent=function(){};' +
@@ -550,12 +552,23 @@ export interface GoogleAdkPluginOptions {
    */
   modelProvider?: (model: string) => BaseLlm;
   /**
-   * Named MCP toolset factories. Each key `name` becomes a
-   * `<name>-listTools` / `<name>-callTool` Activity pair; the factory opens
-   * the real MCP session on the worker. The matching workflow-side handle is
+   * Named MCP toolset factories. Each key `name` becomes the
+   * `<name>-listTools` / `<name>-callTool` / `<name>-listResources` /
+   * `<name>-readResource` Activities; the factory opens the real MCP session on
+   * the worker. The matching workflow-side handle is
    * `new TemporalMCPToolset({ name })`.
    */
   mcpToolsets?: Record<string, MCPToolsetFactory>;
+  /**
+   * Whether a raw model string on an agent (`model: 'gemini-2.5-flash'`)
+   * resolves to a {@link TemporalModel} inside a Workflow instead of ADK's own
+   * network-calling model class, which cannot run in the sandbox. Default
+   * `true`. Auto-routed models use `TemporalModel`'s default Activity options;
+   * wrap the string explicitly (`new TemporalModel(name, options)`) to
+   * customize them. Set `false` only if you register your own sandbox-safe
+   * `BaseLlm` for a built-in model pattern.
+   */
+  autoRouteModels?: boolean;
 }
 
 /**
@@ -571,6 +584,8 @@ export interface GoogleAdkPluginOptions {
  * @experimental
  */
 export class GoogleAdkPlugin extends SimplePlugin {
+  private readonly autoRouteModels: boolean;
+
   /**
    * @param options Worker-side model + MCP configuration.
    */
@@ -585,6 +600,7 @@ export class GoogleAdkPlugin extends SimplePlugin {
         ...createMCPActivities(options.mcpToolsets),
       },
     });
+    this.autoRouteModels = options.autoRouteModels ?? true;
   }
 
   /**
@@ -596,7 +612,7 @@ export class GoogleAdkPlugin extends SimplePlugin {
    * recipe applies identically on both paths and there is no separate
    * `configureWorker`/`configureReplayWorker` bundler override.
    *
-   * The recipe has four parts, all required:
+   * The recipe has five parts, all required:
    *
    *  1. **`webpackConfigHook`** adds {@link googleAdkSandboxCompatPlugin} (the
    *     `node:` strip, the inline shim redirects, the ADK-scoped `crypto` and
@@ -632,7 +648,12 @@ export class GoogleAdkPlugin extends SimplePlugin {
    *     `@google/adk`/`@google/genai` must import
    *     `@temporalio/google-adk-agents/workflow` (or `./load-polyfills`) first
    *     to install the polyfills.
-   *  4. **`workflowInterceptorModules`** also gets the `absorbed-failure` module
+   *  4. **`workflowInterceptorModules`** next gets the `auto-route` module
+   *     (unless `autoRouteModels: false`), which re-registers ADK's built-in
+   *     model patterns to `TemporalModel` in this Workflow's `LLMRegistry` —
+   *     after the polyfills, because it imports ADK, and before any user module
+   *     can resolve a model name.
+   *  5. **`workflowInterceptorModules`** also gets the `absorbed-failure` module
    *     appended last — the module that re-raises a model failure ADK absorbed
    *     (`markModelFailureHandled` opts one back out) and converts ADK's
    *     workflow-runtime errors into typed `ApplicationFailure`s. Interceptor
@@ -656,6 +677,10 @@ export class GoogleAdkPlugin extends SimplePlugin {
       ignoreModules,
       workflowInterceptorModules: [
         require.resolve('./load-polyfills'),
+        // Registers the Temporal-routed model for ADK's built-in model patterns
+        // in this Workflow's registry — after the polyfills (it imports ADK)
+        // and before any user module resolves a model name.
+        ...(this.autoRouteModels ? [require.resolve('./auto-route')] : []),
         ...(base.workflowInterceptorModules ?? []),
         require.resolve('./absorbed-failure'),
       ],

--- a/contrib/google-adk-agents/src/testing.ts
+++ b/contrib/google-adk-agents/src/testing.ts
@@ -21,7 +21,7 @@ import {
   type RunAsyncToolRequest,
 } from '@google/adk';
 
-import type { MCPToolsetFactory } from './mcp';
+import type { MCPResourceContents, MCPToolsetFactory } from './mcp';
 
 /**
  * A deterministic {@link BaseLlm} test double. Yields the provided
@@ -79,20 +79,48 @@ export interface MockMCPToolDefinition {
   handler: (args: Record<string, unknown>) => unknown | Promise<unknown>;
 }
 
+/** A single MCP resource served by {@link mockMCPToolset}. */
+export interface MockMCPResourceDefinition {
+  /** The resource's advertised name. */
+  name: string;
+  /** What a read returns: text and/or base64 blob contents, as an MCP server sends them. */
+  contents: MCPResourceContents[];
+}
+
+/** Options for {@link mockMCPToolset}. */
+export interface MockMCPToolsetOptions {
+  /** Resources the toolset lists and reads (`TemporalMCPToolset.listResources` / `readResource`). */
+  resources?: MockMCPResourceDefinition[];
+}
+
 /**
- * An in-memory {@link BaseToolset} test double for MCP. Use via
+ * An in-memory {@link BaseToolset} test double for MCP, with ADK 2.0's
+ * `listResources` / `readResource` resource methods. Use via
  * {@link mockMCPToolset} as a `GoogleAdkPluginOptions.mcpToolsets` factory.
  */
 class MockMCPToolset extends BaseToolset {
   private readonly definitions: MockMCPToolDefinition[];
+  private readonly resources: MockMCPResourceDefinition[];
 
-  constructor(definitions: MockMCPToolDefinition[]) {
+  constructor(definitions: MockMCPToolDefinition[], resources: MockMCPResourceDefinition[]) {
     super([]);
     this.definitions = definitions;
+    this.resources = resources;
   }
 
   override async getTools(_context?: ReadonlyContext): Promise<BaseTool[]> {
     return this.definitions.map((def) => new MockMCPTool(def));
+  }
+
+  async listResources(): Promise<string[]> {
+    return this.resources.map((resource) => resource.name);
+  }
+
+  async readResource(name: string): Promise<MCPResourceContents[]> {
+    const resource = this.resources.find((candidate) => candidate.name === name);
+    // The same message ADK's `MCPToolset.getResourceInfo` raises for an unknown name.
+    if (!resource) throw new Error(`Resource with name '${name}' not found.`);
+    return resource.contents;
   }
 
   override async close(): Promise<void> {}
@@ -122,7 +150,10 @@ class MockMCPTool extends BaseTool {
  * — drop into `GoogleAdkPluginOptions.mcpToolsets` to test MCP routing without
  * a real server.
  */
-export function mockMCPToolset(definitions: MockMCPToolDefinition[]): MCPToolsetFactory {
-  const toolset = new MockMCPToolset(definitions);
+export function mockMCPToolset(
+  definitions: MockMCPToolDefinition[],
+  options: MockMCPToolsetOptions = {}
+): MCPToolsetFactory {
+  const toolset = new MockMCPToolset(definitions, options.resources ?? []);
   return () => toolset;
 }

--- a/contrib/google-adk-agents/src/workflow.ts
+++ b/contrib/google-adk-agents/src/workflow.ts
@@ -17,8 +17,13 @@ export type { TemporalModelOptions } from './model';
 
 export { markModelFailureHandled } from './absorbed-failure';
 
-export { TemporalMCPToolset } from './mcp';
-export type { TemporalMCPToolsetOptions, MCPToolsetFactory, MCPRequireConfirmation } from './mcp';
+export { TemporalMCPToolset, loadMcpResourceTool } from './mcp';
+export type {
+  TemporalMCPToolsetOptions,
+  MCPToolsetFactory,
+  LoadMcpResourceToolOptions,
+  MCPResourceContents,
+} from './mcp';
 
 export { activityAsTool } from './tools';
 export type { ActivityAsToolOptions } from './tools';
@@ -37,6 +42,7 @@ export {
   INTENT_MISMATCH_FAILURE_TYPE,
   INVOCATION_ABORTED_FAILURE_TYPE,
   MCP_ERROR_FAILURE_TYPE,
+  MCP_RESOURCES_UNSUPPORTED_FAILURE_TYPE,
   MCP_TOOL_NOT_FOUND_FAILURE_TYPE,
   MODEL_ERROR_FAILURE_TYPE,
   NODE_REPORTED_FAILURE_TYPE,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4384,6 +4384,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
@@ -8762,7 +8766,7 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
       hono: 4.12.5
@@ -8784,7 +8788,7 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
       hono: 4.12.5
@@ -11390,11 +11394,13 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.6: {}
+
   eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.0.6
 
   expand-template@2.0.3:
     optional: true


### PR DESCRIPTION
## What was changed

- MCP resources. `TemporalMCPToolset.listResources()` / `readResource(name)` route through new
  `<name>-listResources` / `<name>-readResource` Activities. A read resolves the name to a URI and
  reads it over one MCP session; ADK's own `MCPToolset.readResource` opens two.
- `loadMcpResourceTool(toolset)`, the counterpart of ADK's two-phase `LoadMcpResourceTool`: same
  declaration, same result, same injected instruction, and `processLlmRequest` appends the requested
  resource contents to the next model request. The listing is memoized per tool instance, since every
  model turn would otherwise be an Activity and its history events; `refreshResourceList: true`
  restores ADK's behavior. A failed listing or read is logged and skipped, as in ADK, and the resource
  Activities retry three times by default (`activity.retry` overrides it), so a server that is down
  cannot hang the turn. A cancelled listing or read stays a cancellation rather than becoming a
  retryable MCP failure.
  `mockMCPToolset` and the stdio stub server grow resources.
- Model auto-routing. A new per-Workflow interceptor module re-registers ADK's built-in model
  patterns to a `TemporalModel` subclass, so vanilla ADK code with a raw model string
  (`model: 'gemini-2.5-flash'`) is durable with no change, on `TemporalModel`'s default Activity
  options. `GoogleAdkPluginOptions.autoRouteModels` (default `true`) is the kill switch.

## Why

`Gemini` and `ApigeeLlm` cannot run inside a Workflow: they call the network from the sandbox, and
the error names neither ADK nor the real mistake. ADK's `LLMRegistry` is a `Map` keyed by the
`RegExp` objects in each class's `supportedModels`, resolved first-registered-first, so spreading the
built-in classes' own arrays replaces their entries in place rather than appending duplicates behind
them. The registration is gated on `inWorkflowContext()`, so the Worker keeps the real classes:
`modelProvider` still resolves the same names there, and `TemporalModel`'s own fallback to
`LLMRegistry.newLlm` cannot recurse into itself.

## Testing

Resource list and read against the mock and the stdio stub server (session boundaries asserted), an
unknown resource, a toolset without the resource methods, the two-phase `load_mcp_resource` flow with
the listing memoized and refreshed, a server whose Activities fail reaching the skip path on the
default retry policy, and a hanging read cancelled through the Activity's signal. For routing: raw Gemini and
Apigee strings running through the model Activity, a registry probe over every built-in pattern with
auto-routing on and off, and `RoutedLlm` over two `TemporalModel`s.

Stack: [1/4 bump](https://github.com/temporalio/sdk-typescript/pull/2416) → [2/4 graph runtime](https://github.com/temporalio/sdk-typescript/pull/2417) → [3/4 HITL](https://github.com/temporalio/sdk-typescript/pull/2418) → 4/4 MCP resources + model routing (this, #2419)

Ticket: [AI-510](https://temporalio.atlassian.net/browse/AI-510)


[AI-510]: https://temporalio.atlassian.net/browse/AI-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

